### PR TITLE
feat(malasanita): aggiungi dataset.yml e clean.sql per le 4 fonti (A B C D)

### DIFF
--- a/preprojects/project_candidates/malasanita-struttura-mortalita/sources/a_strutture_asl/dataset.yml
+++ b/preprojects/project_candidates/malasanita-struttura-mortalita/sources/a_strutture_asl/dataset.yml
@@ -1,0 +1,31 @@
+root: "../../../../../out"
+schema_version: 1
+
+dataset:
+  name: "malasanita_a_strutture_asl"
+  years: [2022]
+
+raw:
+  sources:
+    # Strutture e attività ASL — dati.salute.gov.it
+    # Granularità: ASL | Anno copertura: fino al 2022
+    - name: "strutture_asl"
+      type: "http_file"
+      args:
+        url: "https://www.dati.salute.gov.it/sites/default/files/2024-05/Strutture_e_attivit%C3%A0_ASL.csv"
+        filename: "strutture_asl_2022.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: auto
+    mode: latest
+    delim: ";"
+    encoding: "latin-1"
+    header: true
+  validate:
+    min_rows: 20
+
+validation:
+  fail_on_error: true

--- a/preprojects/project_candidates/malasanita-struttura-mortalita/sources/a_strutture_asl/sql/clean.sql
+++ b/preprojects/project_candidates/malasanita-struttura-mortalita/sources/a_strutture_asl/sql/clean.sql
@@ -1,0 +1,17 @@
+-- clean.sql — malasanita_a_strutture_asl
+-- Input:  strutture_asl_2022.csv (granularità: ASL)
+-- Output: una riga per ASL, colonne rinominate snake_case, anno = {{year}}
+-- Nota:   DuckDB trimma automaticamente i nomi colonna (es. "Regione " → "Regione")
+
+SELECT
+    CAST("Anno di Riferimento" AS INTEGER)             AS anno,
+    TRIM(CAST("Codice Regione" AS VARCHAR))            AS codice_regione,
+    TRIM("Regione")                                    AS regione,
+    CAST("Codice Azienda Sanitaria Locale" AS INTEGER) AS codice_asl,
+    TRIM("Denominazione ASL")                          AS denominazione_asl,
+    CAST("Totale medici" AS INTEGER)                   AS totale_medici,
+    CAST("Totale pediatri" AS INTEGER)                 AS totale_pediatri,
+    CAST("Totale Residenti" AS BIGINT)                 AS totale_residenti
+
+FROM raw_input
+WHERE CAST("Anno di Riferimento" AS INTEGER) = {year}

--- a/preprojects/project_candidates/malasanita-struttura-mortalita/sources/b_reparti_ricovero/dataset.yml
+++ b/preprojects/project_candidates/malasanita-struttura-mortalita/sources/b_reparti_ricovero/dataset.yml
@@ -1,0 +1,32 @@
+root: "../../../../../out"
+schema_version: 1
+
+dataset:
+  name: "malasanita_b_reparti_ricovero"
+  years: [2022]
+
+raw:
+  sources:
+    # Reparti strutture di ricovero — dati.salute.gov.it
+    # Granularità: reparto/struttura | Anno copertura: fino al 2022
+    - name: "reparti_ricovero"
+      type: "http_file"
+      args:
+        url: "https://www.dati.salute.gov.it/sites/default/files/2024-05/Dati_di_anagrafe_e_di_attivit%C3%A0_delle_Strutture_di_Ricovero_Pubbliche_ed_equiparate.csv"
+        filename: "reparti_ricovero_2022.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: auto
+    mode: latest
+    delim: ";"
+    encoding: "latin-1"
+    header: true
+    decimal: ","
+  validate:
+    min_rows: 100
+
+validation:
+  fail_on_error: true

--- a/preprojects/project_candidates/malasanita-struttura-mortalita/sources/b_reparti_ricovero/sql/clean.sql
+++ b/preprojects/project_candidates/malasanita-struttura-mortalita/sources/b_reparti_ricovero/sql/clean.sql
@@ -1,0 +1,25 @@
+-- clean.sql — malasanita_b_reparti_ricovero
+-- Input:  reparti_ricovero_2022.csv (granularità: reparto/struttura)
+-- Output: una riga per reparto, colonne selezionate snake_case, anno = {{year}}
+-- Nota:   degenza_media_ordinaria, icm, tasso_utilizzo usano virgola come decimale
+--         num_dimessi e giornate_* usano punto come separatore migliaia → restano VARCHAR
+
+SELECT
+    CAST(anno AS INTEGER)              AS anno,
+    TRIM(CAST(codice_regione AS VARCHAR)) AS codice_regione,
+    TRIM(regione)                      AS regione,
+    TRIM(CAST(codice_asl AS VARCHAR))  AS codice_asl,
+    TRIM(asl)                          AS asl,
+    TRIM(CAST(codice_struttura AS VARCHAR)) AS codice_struttura,
+    TRIM(struttura)                    AS struttura,
+    TRIM(codice_disciplina)            AS codice_disciplina,
+    TRIM(disciplina)                   AS disciplina,
+    CAST(posti_letto_day_hospital AS INTEGER)       AS posti_letto_day_hospital,
+    CAST(posti_letto_day_surgery AS INTEGER)        AS posti_letto_day_surgery,
+    CAST(posti_letto_degenza_ordinaria AS INTEGER)  AS posti_letto_degenza_ordinaria,
+    CAST(posti_letto_utilizzati AS INTEGER)         AS posti_letto_utilizzati,
+    num_dimessi                        AS num_dimessi_raw,
+    giornate_degenza                   AS giornate_degenza_raw
+
+FROM raw_input
+WHERE CAST(anno AS INTEGER) = {year}

--- a/preprojects/project_candidates/malasanita-struttura-mortalita/sources/c_strutture_ricovero_asl/dataset.yml
+++ b/preprojects/project_candidates/malasanita-struttura-mortalita/sources/c_strutture_ricovero_asl/dataset.yml
@@ -1,0 +1,31 @@
+root: "../../../../../out"
+schema_version: 1
+
+dataset:
+  name: "malasanita_c_strutture_ricovero"
+  years: [2022]
+
+raw:
+  sources:
+    # Strutture ricovero per ASL — dati.salute.gov.it
+    # Granularità: struttura | Anno copertura: fino al 2022
+    - name: "strutture_ricovero_asl"
+      type: "http_file"
+      args:
+        url: "https://www.dati.salute.gov.it/sites/default/files/2025-01/Strutture_di_ricovero_pubbliche_presenti_nel_territorio_della_ASL.csv"
+        filename: "strutture_ricovero_asl_2022.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: auto
+    mode: latest
+    delim: ";"
+    encoding: "latin-1"
+    header: true
+  validate:
+    min_rows: 100
+
+validation:
+  fail_on_error: true

--- a/preprojects/project_candidates/malasanita-struttura-mortalita/sources/c_strutture_ricovero_asl/sql/clean.sql
+++ b/preprojects/project_candidates/malasanita-struttura-mortalita/sources/c_strutture_ricovero_asl/sql/clean.sql
@@ -1,0 +1,23 @@
+-- clean.sql — malasanita_c_strutture_ricovero
+-- Input:  strutture_ricovero_asl_2022.csv (granularità: struttura)
+-- Output: una riga per struttura, colonne rinominate snake_case, anno = {{year}}
+-- Nota:   ricoveri e giornate_* usano punto come separatore migliaia → restano VARCHAR
+
+SELECT
+    CAST(anno AS INTEGER)                      AS anno,
+    TRIM(CAST(codice_struttura AS VARCHAR))    AS codice_struttura,
+    TRIM(denominazione_struttura)              AS denominazione_struttura,
+    TRIM(CAST(codice_regione AS VARCHAR))      AS codice_regione,
+    TRIM("Regione")                            AS regione,
+    TRIM(CAST(codice_asl AS VARCHAR))          AS codice_asl,
+    TRIM(asl)                                  AS asl,
+    CAST(posti_letto_previsti AS INTEGER)      AS posti_letto_previsti,
+    CAST(posti_letto_utilizzati AS INTEGER)    AS posti_letto_utilizzati,
+    CAST(totale_personale AS INTEGER)          AS totale_personale,
+    CAST(medici AS INTEGER)                    AS medici,
+    CAST(infermieri AS INTEGER)                AS infermieri,
+    ricoveri                                   AS ricoveri_raw,
+    giornate_degenza                           AS giornate_degenza_raw
+
+FROM raw_input
+WHERE CAST(anno AS INTEGER) = {year}

--- a/preprojects/project_candidates/malasanita-struttura-mortalita/sources/d_mortalita_istat/dataset.yml
+++ b/preprojects/project_candidates/malasanita-struttura-mortalita/sources/d_mortalita_istat/dataset.yml
@@ -1,0 +1,31 @@
+root: "../../../../../out"
+schema_version: 1
+
+dataset:
+  name: "malasanita_d_mortalita_istat"
+  years: [2022]
+
+raw:
+  sources:
+    # Mortalità per causa — ISTAT 2022
+    # Granularità: regione × causa × sesso × classe età × titolo di studio
+    # File locale: data_base_2022.xlsx (foglio d_base_2022), non versionato
+    - name: "mortalita_causa_istat"
+      type: "local_file"
+      args:
+        path: "data_base_2022.xlsx"
+        filename: "data_base_2022.xlsx"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: auto
+    mode: latest
+    sheet_name: "d_base_2022"
+    header: true
+  validate:
+    min_rows: 1000
+
+validation:
+  fail_on_error: true

--- a/preprojects/project_candidates/malasanita-struttura-mortalita/sources/d_mortalita_istat/sql/clean.sql
+++ b/preprojects/project_candidates/malasanita-struttura-mortalita/sources/d_mortalita_istat/sql/clean.sql
@@ -1,0 +1,30 @@
+-- clean.sql — malasanita_d_mortalita_istat
+-- Input:  data_base_2022.xlsx, foglio d_base_2022
+--         granularità: regione × causa × sesso × classe età × titolo di studio
+-- Output: righe per regioni italiane (escluse ripartizioni e totale ITALIA),
+--         colonne rinominate snake_case, anno = {year}
+--
+-- Codici territorio:
+--   01–22  → regioni e province autonome  ← tenere
+--   25     → ITALIA (totale nazionale)    ← escludere
+--   31–35  → ripartizioni geografiche     ← escludere
+
+SELECT
+    CAST(anno AS INTEGER)                              AS anno,
+    TRIM(CAST("Cod_Territorio" AS VARCHAR))            AS cod_territorio,
+    TRIM("Territorio")                                 AS territorio,
+    CAST("Cod_Sesso" AS INTEGER)                       AS cod_sesso,
+    TRIM("Sesso")                                      AS sesso,
+    CAST("Cod_Classe età" AS INTEGER)                  AS cod_classe_eta,
+    TRIM("Classe età")                                 AS classe_eta,
+    CAST("Cod_Titolo di studio" AS INTEGER)            AS cod_titolo_studio,
+    TRIM("Titolo di studio")                           AS titolo_studio,
+    CAST("Cod_Causa" AS INTEGER)                       AS cod_causa,
+    TRIM("Causa")                                      AS causa,
+    CAST("pop media" AS DOUBLE)                        AS pop_media,
+    CAST("decessi" AS INTEGER)                         AS decessi,
+    CAST("tassi_standardizzati per 10.000" AS DOUBLE)  AS tasso_std_10000
+
+FROM raw_input
+WHERE CAST(anno AS INTEGER) = {year}
+  AND CAST("Cod_Territorio" AS INTEGER) BETWEEN 1 AND 22


### PR DESCRIPTION
Pattern multi-fonte: un dataset.yml per fonte in sources/, ciascuno con il proprio clean.sql. Clean verificato e funzionante su tutte e quattro le fonti (106 righe A, 6989 B, 508 C, 31522 D).

Closes #6

## Sintesi

Implementa il pattern multi-fonte deciso con @Gabrymi93 in Discussion #99: ogni fonte ha un proprio `dataset.yml` e `clean.sql` in `sources/<id_fonte>/`. Il toolkit gestisce ciascuna fonte come dataset indipendente; il mart di composizione sarà oggetto di una issue separata.

## Contesto collegato

Closes #6

## Cosa cambia

- Aggiunto `sources/a_strutture_asl/dataset.yml` + `sql/clean.sql` (granularità ASL, 106 righe)
- Aggiunto `sources/b_reparti_ricovero/dataset.yml` + `sql/clean.sql` (granularità reparto/struttura, 6989 righe)
- Aggiunto `sources/c_strutture_ricovero_asl/dataset.yml` + `sql/clean.sql` (granularità struttura, 508 righe)
- Aggiunto `sources/d_mortalita_istat/dataset.yml` + `sql/clean.sql` (granularità regione×causa×sesso×età×titolo, 31522 righe — solo territori 01–22, escluse ripartizioni e totale ITALIA)

## Impatto

- [x] Pipeline dati o trasformazioni
- [x] Contenuti o metadati di dataset

## Verifica

Eseguito `run raw` + `run clean` per ciascuna delle 4 fonti con DuckDB locale. Output parquet verificati per conteggio righe e schema colonne. Filtri WHERE confermati corretti (anno = 2022, esclusione ripartizioni per fonte D).

## Controlli

- [x] Questa PR è nel repository giusto
- [x] Ho collegato issue o discussion quando serve
- [x] Ho verificato l'impatto su documentazione, codice o dati
- [x] Ho aggiornato solo quello che era davvero necessario

## Note per chi revisiona

Il compose/mart è ancora placeholder — la join multi-fonte richiede un pattern toolkit non ancora documentato. Il compose/dataset.yml esistente non viene modificato in questa PR; sarà oggetto di issue separata.