### PR TITLE
feat(malasanita): mart regionale — join A+C+D, 21 regioni, tassi per 100k

### DIFF
--- a/preprojects/project_candidates/malasanita-struttura-mortalita/compose/dataset.yml
+++ b/preprojects/project_candidates/malasanita-struttura-mortalita/compose/dataset.yml
@@ -1,66 +1,24 @@
-root: "../../../../out"
-schema_version: 1
-
-dataset:
-  name: "malasanita_struttura_mortalita"
-  years: [2022]  # anno pivot — unico anno di sovrapposizione completa tra tutte le fonti
-
-raw:
-  sources:
-    # Fonte A: Strutture e attivita ASL — dati.salute.gov.it
-    # Colonne chiave: Codice Regione, Regione, Totale medici, Totale pediatri
-    # Granularita: ASL
-    - name: "strutture_asl"
-      type: "http_file"
-      args:
-        url: "https://www.dati.salute.gov.it/sites/default/files/2024-05/Strutture_e_attivit%C3%A0_ASL.csv"
-        filename: "strutture_asl_2022.csv"
-      primary: true
-
-    # Fonte B: Reparti strutture di ricovero — dati.salute.gov.it
-    # Colonne chiave: codice_regione, regione, disciplina, posti_letto_*, num_dimessi
-    # Granularita: reparto / struttura
-    - name: "reparti_ricovero"
-      type: "http_file"
-      args:
-        url: "https://www.dati.salute.gov.it/sites/default/files/2024-05/Dati_di_anagrafe_e_di_attivit%C3%A0_delle_Strutture_di_Ricovero_Pubbliche_ed_equiparate.csv"
-        filename: "reparti_ricovero_2022.csv"
-
-    # Fonte C: Strutture ricovero per ASL — dati.salute.gov.it
-    # Colonne chiave: codice_regione, Regione, totale_personale, medici, infermieri
-    # Granularita: struttura
-    - name: "strutture_ricovero_asl"
-      type: "http_file"
-      args:
-        url: "https://www.dati.salute.gov.it/sites/default/files/2025-01/Strutture_di_ricovero_pubbliche_presenti_nel_territorio_della_ASL.csv"
-        filename: "strutture_ricovero_asl_2022.csv"
-
-    # Fonte D: Mortalita per causa — ISTAT 2022
-    # ZIP contenente data_base_2022.xlsx, foglio d_base_2022
-    # Colonne chiave: Territorio, Causa, decessi, tassi_standardizzati per 10.000
-    # Nota: richiede aggregazione (somma su sesso, eta, titolo di studio) per ottenere totali regionali
-    # Nota: join con A/B/C solo su nome regione testuale (no codice numerico)
-    - name: "mortalita_causa_istat"
-      type: "http_file"
-      args:
-        url: "https://www.istat.it/wp-content/uploads/2025/09/Tavole.zip"
-      extractor:
-        type: "unzip_first"
-
-clean:
-  sql: "sql/clean.sql"
-  read:
-    source: auto  # usa la fonte primaria configurata
-    mode: latest
-    header: true
-    delim: ";"
-  validate: {}
-
-mart:
-  tables:
-    - name: "mart_regioni_2022"
-      sql: "sql/mart.sql"
-  validate: {}
-
-validation:
-  fail_on_error: true
+# compose/dataset.yml — malasanita-struttura-mortalita
+#
+# Questo file NON è un dataset.yml runnable.
+# È un riferimento documentale per l'architettura multi-fonte.
+#
+# Come eseguire il mart:
+#   cd dataset-incubator
+#   py -m toolkit.cli.app run mart --config preprojects/project_candidates/malasanita-struttura-mortalita/sources/a_strutture_asl/dataset.yml
+#
+# Perché il mart è in sources/a_strutture_asl/dataset.yml e non qui:
+#   Il toolkit richiede che esista un clean layer per il dataset indicato
+#   prima di poter eseguire il mart. Il compose non ha un raw/clean proprio.
+#   La soluzione adottata: aggiungere la sezione mart al dataset.yml della
+#   fonte A (che ha già il suo clean), con sql: "../../compose/sql/mart.sql".
+#   Il mart legge A via clean_input e C/D via read_parquet() con path relativi
+#   alla CWD del toolkit (dataset-incubator/).
+#
+# Fonti nel mart:
+#   clean_input → malasanita_a_strutture_asl (personale MMG, pop residente)
+#   read_parquet → malasanita_c_strutture_ricovero (personale ospedaliero, posti letto)
+#   read_parquet → malasanita_d_mortalita_istat (decessi per regione)
+#   (fonte B reparti → Opzione 3, Power BI, fuori dalla preanalysis)
+#
+# Output mart: out/data/mart/malasanita_a_strutture_asl/2022/mart_regioni.parquet

--- a/preprojects/project_candidates/malasanita-struttura-mortalita/compose/sql/clean.sql
+++ b/preprojects/project_candidates/malasanita-struttura-mortalita/compose/sql/clean.sql
@@ -1,12 +1,4 @@
--- clean.sql — malasanita_struttura_mortalita
--- TODO: definire dopo verifica CSV A/B/C/D
---
--- Struttura attesa:
---   - normalizzare codice_regione (2 cifre, chiave di join)
---   - selezionare colonne rilevanti per personale sanitario (fonti A, B, C)
---   - selezionare colonne mortalita evitabile (fonte D)
---   - filtrare su anno = 2022
-
-select
-  *
-from raw_input
+-- clean.sql — compose/malasanita_struttura_mortalita
+-- NON USATO: il compose non ha un clean layer proprio.
+-- Il mart viene eseguito da sources/a_strutture_asl/dataset.yml.
+-- Vedere compose/dataset.yml per dettagli architetturali.

--- a/preprojects/project_candidates/malasanita-struttura-mortalita/compose/sql/mart.sql
+++ b/preprojects/project_candidates/malasanita-struttura-mortalita/compose/sql/mart.sql
@@ -1,12 +1,7 @@
--- mart.sql — malasanita_struttura_mortalita — mart_regioni_2022
--- TODO: definire dopo verifica CSV A/B/C/D e stabilizzazione del clean
+-- compose/sql/mart.sql — STUB DOCUMENTALE
+-- Il mart SQL effettivo si trova in:
+--   sources/a_strutture_asl/sql/mart.sql
 --
--- Struttura attesa:
---   - join regionale tra personale sanitario (fonti A/B/C) e mortalita evitabile (fonte D)
---   - chiave di join: codice_regione ISTAT (2 cifre)
---   - output: una riga per regione con indicatori chiave 2022
---   - escludere Emilia-Romagna dall'analisi principale (benchmark opzionale)
-
-select
-  *
-from clean_input
+-- Motivo: il toolkit richiede che il file SQL del mart sia sotto la base_dir
+-- del dataset.yml che lo esegue (sources/a_strutture_asl/).
+-- Vedere compose/dataset.yml per i dettagli architetturali.

--- a/preprojects/project_candidates/malasanita-struttura-mortalita/notes.md
+++ b/preprojects/project_candidates/malasanita-struttura-mortalita/notes.md
@@ -61,6 +61,36 @@ Opzioni per la fonte D:
 
 **Definizione "mortalità evitabile":** non è una colonna diretta — va operazionalizzata selezionando le cause pertinenti tra le 25 disponibili (es. metodologia Euro-2013 o scelta ragionata). Questo è un passaggio metodologico da documentare esplicitamente.
 
+## Architettura mart — pattern multi-fonte
+
+Il toolkit richiede un clean layer per il dataset indicato nel dataset.yml prima di eseguire il mart.
+Il compose non ha un raw/clean proprio, quindi il mart è agganciato a `sources/a_strutture_asl/dataset.yml`.
+
+**Come eseguire il mart:**
+```
+cd dataset-incubator
+py -m toolkit.cli.app run mart --config preprojects/project_candidates/malasanita-struttura-mortalita/sources/a_strutture_asl/dataset.yml
+```
+
+**SQL:** `compose/sql/mart.sql` (referenziato dal dataset.yml di A con `sql: "../../compose/sql/mart.sql"`)
+
+**Prerequisiti:** i clean di A, C, D devono essere già stati eseguiti (i parquet devono esistere in `out/`).
+
+**Output:** `out/data/mart/malasanita_a_strutture_asl/2022/mart_regioni.parquet`
+
+### Opzione 1 — mart flat regionale (implementato, preanalysis)
+
+Una riga per regione (21 righe). Fonti: A (medici MMG, pop), C (personale ospedaliero, posti letto), D (decessi totali). Join A+C su codice_regione; join con D su nome regione normalizzato.
+
+### Opzione 3 — due tabelle mart separate (Power BI / approfondimento futuro)
+
+Separare `mart_strutture` (A+C aggregato per regione) e `mart_mortalita` (D per regione×causa) senza join nel mart. Il join viene fatto in Power BI o nel notebook, dove si può:
+- filtrare per causa specifica (es. mortalità evitabile secondo metodologia Euro-2013)
+- espandere per disciplina da fonte B (reparti) → correlazione per specialità
+- drill-down per ASL invece che per regione
+
+Questa opzione è interessante per la dashboard Power BI finale ma è fuori scope per la preanalysis.
+
 ## Chiave di join regionale
 
 - Fonti A/B/C usano codice regione numerico 3 cifre (es. `010` per Piemonte)

--- a/preprojects/project_candidates/malasanita-struttura-mortalita/sources/a_strutture_asl/dataset.yml
+++ b/preprojects/project_candidates/malasanita-struttura-mortalita/sources/a_strutture_asl/dataset.yml
@@ -27,5 +27,14 @@ clean:
   validate:
     min_rows: 20
 
+mart:
+  tables:
+    - name: "mart_regioni"
+      sql: "sql/mart.sql"
+  validate:
+    table_rules:
+      mart_regioni:
+        min_rows: 18
+
 validation:
   fail_on_error: true

--- a/preprojects/project_candidates/malasanita-struttura-mortalita/sources/a_strutture_asl/sql/mart.sql
+++ b/preprojects/project_candidates/malasanita-struttura-mortalita/sources/a_strutture_asl/sql/mart.sql
@@ -1,0 +1,140 @@
+-- mart.sql — malasanita_struttura_mortalita — mart_regioni
+-- Eseguito da: sources/a_strutture_asl/dataset.yml (sezione mart)
+-- Input:
+--   clean_input → malasanita_a_strutture_asl (granularità ASL)
+--   read_parquet → malasanita_c_strutture_ricovero (granularità struttura)
+--   read_parquet → malasanita_d_mortalita_istat (granularità regione×causa×sesso×età×titolo)
+-- Output: una riga per regione (21 righe attese: 19 regioni + 2 PA)
+--
+-- Opzione 1 — mart flat regionale per preanalysis
+-- Risponde a: "Le regioni con meno personale sanitario hanno tassi di mortalità più alti?"
+--
+-- Opzione 3 (Power BI / approfondimento futuro):
+--   Separare mart_strutture (A+C aggregato per regione) e mart_mortalita (D per regione×causa)
+--   senza join nel mart. Il join viene fatto in Power BI o nel notebook, dove si può:
+--   - filtrare per causa specifica (es. mortalità evitabile secondo metodologia Euro-2013)
+--   - espandere per disciplina da fonte B (reparti) → correlazione per specialità
+--   - drill-down per ASL invece che per regione
+--
+-- Nota tecnica: i path read_parquet sono relativi alla CWD del processo toolkit.
+--   Eseguire sempre da dataset-incubator/ (come da CLAUDE.md e README).
+--
+-- Chiave di join A+C → D: nome regione normalizzato (UPPER TRIM + eccezioni CASE).
+--   ⚠️ Verificare dopo primo run che tutte le 21 righe abbiano join_d_ok = true.
+--   Se alcune righe hanno join_d_ok = false, aggiornare il CASE WHEN nel CTE lookup_d.
+
+WITH
+
+-- ─── Fonte A: personale MMG/pediatri per ASL → aggregato per regione ──────────
+asl AS (
+    SELECT
+        anno,
+        codice_regione,
+        regione,
+        SUM(totale_medici)    AS medici_mmg,
+        SUM(totale_pediatri)  AS pediatri,
+        SUM(totale_residenti) AS pop_residente
+    FROM clean_input
+    GROUP BY anno, codice_regione, regione
+),
+
+-- ─── Fonte C: strutture ricovero → personale e posti letto per regione ────────
+strutture_raw AS (
+    SELECT * FROM read_parquet(
+        'out/data/clean/malasanita_c_strutture_ricovero/{year}/malasanita_c_strutture_ricovero_{year}_clean.parquet'
+    )
+),
+strutture AS (
+    SELECT
+        anno,
+        codice_regione,
+        SUM(totale_personale)       AS personale_ospedaliero,
+        SUM(medici)                 AS medici_ospedalieri,
+        SUM(infermieri)             AS infermieri,
+        SUM(posti_letto_previsti)   AS posti_letto_previsti,
+        SUM(posti_letto_utilizzati) AS posti_letto_utilizzati
+    FROM strutture_raw
+    GROUP BY anno, codice_regione
+),
+
+-- ─── Fonte D: mortalità ISTAT → totale decessi per regione ───────────────────
+-- Aggregazione su tutte le cause × sessi × classi età × titoli studio.
+-- Assumiamo righe non sovrapponibili (ogni decesso in una sola cella).
+-- ⚠️ Se la fonte D contiene righe di subtotale "Totale" per sesso/età/titolo,
+--    aggiungere filtri WHERE per escluderle (es. cod_sesso NOT IN (0,9)).
+mortalita_raw AS (
+    SELECT * FROM read_parquet(
+        'out/data/clean/malasanita_d_mortalita_istat/{year}/malasanita_d_mortalita_istat_{year}_clean.parquet'
+    )
+),
+mortalita AS (
+    SELECT
+        anno,
+        cod_territorio,
+        territorio,
+        SUM(decessi) AS decessi_totali
+    FROM mortalita_raw
+    GROUP BY anno, cod_territorio, territorio
+),
+
+-- ─── Lookup: nome regione A (MinSalute) → nome territorio D (ISTAT) ──────────
+-- Nomi verificati su dati reali dopo primo run (2026-03-09):
+--   A usa backtick in "VALLE D`AOSTA", D usa apostrofo "VALLE D'AOSTA"
+--   A ha "PROV. AUTON. BOLZANO/TRENTO", D ha solo "Bolzano"/"Trento" (Title Case)
+--   A ha "FRIULI VENEZIA GIULIA", D ha "FRIULI V.G." (abbreviato)
+lookup_d AS (
+    SELECT
+        a.codice_regione,
+        UPPER(TRIM(
+            CASE UPPER(TRIM(a.regione))
+                WHEN 'VALLE D`AOSTA'            THEN 'VALLE D''AOSTA'
+                WHEN 'PROV. AUTON. BOLZANO'     THEN 'BOLZANO'
+                WHEN 'PROV. AUTON. TRENTO'      THEN 'TRENTO'
+                WHEN 'FRIULI VENEZIA GIULIA'    THEN 'FRIULI V.G.'
+                ELSE UPPER(TRIM(a.regione))
+            END
+        )) AS territorio_norm
+    FROM asl a
+)
+
+-- ─── Join finale ──────────────────────────────────────────────────────────────
+SELECT
+    a.anno,
+    a.codice_regione,
+    a.regione,
+
+    -- Personale territoriale (fonte A)
+    a.medici_mmg,
+    a.pediatri,
+    a.pop_residente,
+
+    -- Personale e dotazione ospedaliera (fonte C)
+    c.personale_ospedaliero,
+    c.medici_ospedalieri,
+    c.infermieri,
+    c.posti_letto_previsti,
+    c.posti_letto_utilizzati,
+
+    -- Mortalità (fonte D)
+    d.decessi_totali,
+
+    -- Tassi per 100.000 residenti (denominatore: pop_residente da fonte A)
+    ROUND(a.medici_mmg * 100000.0        / NULLIF(a.pop_residente, 0), 2) AS medici_mmg_per_100k,
+    ROUND(c.medici_ospedalieri * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS medici_osp_per_100k,
+    ROUND(c.infermieri * 100000.0         / NULLIF(a.pop_residente, 0), 2) AS infermieri_per_100k,
+    ROUND(d.decessi_totali * 100000.0     / NULLIF(a.pop_residente, 0), 2) AS tasso_mortalita_per_100k,
+
+    -- Flag diagnostico: true = join con D riuscito, false = territorio non trovato
+    CASE WHEN d.territorio IS NOT NULL THEN true ELSE false END AS join_d_ok
+
+FROM asl a
+LEFT JOIN strutture c
+    ON  a.codice_regione = c.codice_regione
+    AND a.anno = c.anno
+LEFT JOIN lookup_d l
+    ON  a.codice_regione = l.codice_regione
+LEFT JOIN mortalita d
+    ON  UPPER(TRIM(d.territorio)) = l.territorio_norm
+    AND d.anno = a.anno
+
+ORDER BY a.codice_regione


### PR DESCRIPTION
Closes #10

## Sintesi

Implementa il mart di composizione (Opzione 1 — flat regionale) che unisce le 4 fonti clean in un'unica tabella analitica a granularità regionale, pronta per la preanalysis.

## Contesto collegato

Closes #10

## Cosa cambia

- Aggiunto `sources/a_strutture_asl/sql/mart.sql` con join A+C+D (21 regioni, tassi per 100k)
- Aggiunto sezione `mart` in `sources/a_strutture_asl/dataset.yml` (punta a mart.sql)
- Aggiornato `compose/dataset.yml` a documentazione architetturale (non più runnable)
- Aggiornato `compose/sql/mart.sql` a stub documentale (SQL reale in sources/a/sql/)
- Aggiornato `compose/sql/clean.sql` — marcato come non usato
- Aggiornato `notes.md` con sezione architettura mart e nota Opzione 3 Power BI

## Impatto

- [x] Pipeline dati o trasformazioni
- [x] Documentazione o testi

## Verifica

Mart eseguito localmente: 21/21 righe con `join_d_ok = true`. Lookup CASE WHEN verificato su nomi reali (Valle d'Aosta backtick, Prov. Auton. Bolzano/Trento, Friuli V.G.).

Output: `out/data/mart/malasanita_a_strutture_asl/2022/mart_regioni.parquet`

## Controlli

- [x] Questa PR è nel repository giusto
- [x] Ho collegato issue o discussion quando serve
- [x] Ho verificato l'impatto su documentazione, codice o dati
- [x] Ho aggiornato solo quello che era davvero necessario

## Note per chi revisiona

Il mart SQL è in `sources/a_strutture_asl/sql/mart.sql` e non in `compose/sql/` per un vincolo del toolkit: il file SQL del mart deve essere sotto la `base_dir` del dataset.yml che lo esegue. Documentato in `compose/dataset.yml` e `notes.md`.

Fonte B (reparti) non inclusa nell'Opzione 1 — dettaglio per disciplina rimandato all'Opzione 3 (Power BI).