### PR TITLE
fix: ISPRA consumo suolo — pipeline RAW→CLEAN→MART verificata end-to-end

### DIFF
--- a/candidates/ispra-consumo-suolo/sources/a_consumo_suolo/sql/clean.sql
+++ b/candidates/ispra-consumo-suolo/sources/a_consumo_suolo/sql/clean.sql
@@ -2,16 +2,16 @@
 --
 -- Input: foglio Comuni_2006_2024 dal file XLSX ISPRA (rilascio 2025, anni 2006-2024)
 -- La riga 0 del foglio contiene header ISPRA originali.
--- La riga 1 contiene tipicamente le unita di misura: filtrata qui sotto.
---
 -- Colonne selezionate (perimetro minimo v0):
---   pro_com       — codice ISTAT comune (6 cifre: 3 provincia + 3 comune)
---   comune        — nome comune
---   provincia     — nome provincia
---   regione       — nome regione
+--   pro_com                  — codice ISTAT comune (6 cifre: 3 provincia + 3 comune)
+--   comune                   — nome comune
+--   provincia                — nome provincia
+--   regione                  — nome regione
 --   incremento_ha_2023_2024  — incremento netto consumo suolo 2023-2024 [ettari]
 --   stock_ha_2024            — suolo consumato cumulato 2024 [ettari]
 --   stock_pct_2024           — suolo consumato 2024 [% superficie]
+--
+-- Nomi colonne verificati sul file reale (rilascio 2025): unita = [ettari], non [ha].
 
 SELECT
     CAST(TRIM(CAST("PRO_COM" AS VARCHAR))               AS VARCHAR) AS pro_com,
@@ -20,12 +20,12 @@ SELECT
     TRIM(CAST("Nome_Regione"   AS VARCHAR))              AS regione,
     TRY_CAST(
         REPLACE(
-            TRIM(CAST("Incremento netto 2023-2024 [ha]" AS VARCHAR)), ',', '.'
+            TRIM(CAST("Incremento netto 2023-2024 [ettari]" AS VARCHAR)), ',', '.'
         ) AS DOUBLE
     )                                                    AS incremento_ha_2023_2024,
     TRY_CAST(
         REPLACE(
-            TRIM(CAST("Suolo consumato 2024 [ha]"  AS VARCHAR)), ',', '.'
+            TRIM(CAST("Suolo consumato 2024 [ettari]"  AS VARCHAR)), ',', '.'
         ) AS DOUBLE
     )                                                    AS stock_ha_2024,
     TRY_CAST(
@@ -36,7 +36,6 @@ SELECT
 
 FROM raw_input
 
--- Filtra riga di unita misura (spesso contiene '[ha]' o simili nel campo pro_com)
 WHERE
     "PRO_COM" IS NOT NULL
     AND TRY_CAST("PRO_COM" AS INTEGER) IS NOT NULL


### PR DESCRIPTION
## Cosa fa questa PR

Corregge i nomi di colonna in `clean.sql` per il candidato `ispra-consumo-suolo`.

### Bug fix

Lo scaffold (PR #59) usava `[ha]` nei nomi colonna, ma il file XLSX reale (rilascio 2025, anni 2006-2024) usa `[ettari]`:

| Scaffold (errato) | File reale |
|---|---|
| `Incremento netto 2023-2024 [ha]` | `Incremento netto 2023-2024 [ettari]` |
| `Suolo consumato 2024 [ha]` | `Suolo consumato 2024 [ettari]` |

### Verifica

Pipeline eseguita end-to-end sul file scaricato da `www.isprambiente.gov.it` (il blocco precedente era VPN locale, non un problema lato server):

- **RAW**: download OK, ~1.7 MB
- **CLEAN**: 7.896 comuni, validazione OK (min_rows: 7.000 ✅)
- **MART** (`mart_comuni`): 7.896 righe, validazione OK ✅

Valori di esempio: Roma 30.397 ha (23.7%), Milano 10.668 ha (58.7%), Casavatore top per % (91.8%).

Chiude #32.