### PR TITLE
docs: clarify clean vs mart boundary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,45 @@ Regola pratica:
 - non complicare la struttura se una fonte sola basta
 - usa `sources/` solo quando ci sono davvero piu' contratti tecnici separati
 
+## Confine minimo tra clean e mart
+
+Regola di fondo:
+
+- `clean` serve a normalizzare il `raw`
+- `mart` serve a interpretare, restringere, aggregare e leggere il dato
+
+In `clean` sono normalmente accettabili:
+
+- rinomina colonne
+- cast e tipizzazione
+- trim, normalizzazione minima di stringhe e null
+- rimozione di righe spurie, header ripetuti, unita di misura o record chiaramente fuori contratto
+- aggiunta di poche colonne tecniche utili a stabilizzare il dato
+
+In `clean` non dovrebbero entrare di default:
+
+- aggregazioni
+- labeling analitico
+- benchmark, cluster o categorie interpretative
+- join con altre fonti
+- riduzioni forti del dataset guidate gia' dalla domanda analitica
+
+Filtri o trasformazioni piu' forti sono accettabili solo quando servono a
+rendere il dato coerente con il suo contratto tecnico minimo e non con il
+risultato analitico finale.
+
+Esempi tipici di area grigia:
+
+- dedup prudente
+- esclusioni per evitare doppio conteggio
+- restringimenti di perimetro gia' orientati a un compose o a un join
+
+Quando succede, la scelta va spiegata in `notes.md` con una riga chiara:
+
+- che cosa viene escluso o trasformato
+- perche' non basta lasciarlo al `mart`
+- quale rischio si evita
+
 ## Setup minimo per contribuire
 
 La configurazione locale minima del Lab e' documentata in:


### PR DESCRIPTION
## Cosa cambia

Aggiunge una sezione `Confine minimo tra clean e mart` in `CONTRIBUTING.md`.

Fissa 5-6 regole pratiche leggere su cosa appartiene al layer clean e cosa al mart, con trattamento esplicito dei casi grigi (dedup prudente, esclusioni per doppio conteggio, restringimenti orientati a join/compose) e richiesta di documentare le eccezioni in `notes.md`.

## Contesto

Emerso dall'audit trasversale sui candidate esistenti (issue #66). Nessun refactor dei candidate esistenti — solo la regola operativa che li guida in avanti.

## Tipo

docs-only — solo `CONTRIBUTING.md`, nessun cambio a candidate, SQL o struttura.

Closes #66