### PR TITLE
ci: enforce repo_root guard in effective_root validation

### DIFF
--- a/scripts/validate_effective_root.py
+++ b/scripts/validate_effective_root.py
@@ -1,39 +1,28 @@
 from __future__ import annotations
 
-import json
-import subprocess
 import sys
 from pathlib import Path
 
 
-def inspect_root(repo_root: Path, config_path: Path) -> Path:
-    cmd = [
-        sys.executable,
-        "-m",
-        "toolkit.cli.app",
-        "inspect",
-        "paths",
-        "--config",
-        str(config_path),
-        "--json",
-    ]
-    result = subprocess.run(
-        cmd,
-        cwd=repo_root,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    payload = json.loads(result.stdout)
-    if isinstance(payload, list):
-        root = payload[0]["root"]
-    else:
-        root = payload["root"]
-    return Path(root).resolve()
+def inspect_root(repo_root: Path, toolkit_dir: Path, config_path: Path) -> Path:
+    toolkit_root = toolkit_dir.resolve()
+    if str(toolkit_root) not in sys.path:
+        sys.path.insert(0, str(toolkit_root))
+
+    try:
+        from toolkit.core.config import load_config
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "Toolkit import failed. Install toolkit in the current Python environment first, "
+            "for example: python -m pip install -e ./toolkit"
+        ) from exc
+
+    cfg = load_config(config_path, repo_root=repo_root)
+    return cfg.root.resolve()
 
 
 def main() -> int:
-    if len(sys.argv) < 3:
+    if len(sys.argv) < 4:
         print(
             "Usage: validate_effective_root.py <repo_root> <toolkit_dir> <dataset.yml> [<dataset.yml> ...]",
             file=sys.stderr,
@@ -48,11 +37,19 @@ def main() -> int:
     failures: list[str] = []
 
     for config_path in config_paths:
-        actual_root = inspect_root(repo_root, config_path)
-        print(f"{config_path.relative_to(repo_root)} -> {actual_root}")
+        rel_config = config_path.relative_to(repo_root)
+        try:
+            actual_root = inspect_root(repo_root, toolkit_dir, config_path)
+        except Exception as exc:
+            failures.append(
+                f"{rel_config} failed root validation: {type(exc).__name__}: {exc}"
+            )
+            continue
+
+        print(f"{rel_config} -> {actual_root}")
         if actual_root != expected_root:
             failures.append(
-                f"{config_path.relative_to(repo_root)} resolves root to {actual_root}, expected {expected_root}"
+                f"{rel_config} resolves root to {actual_root}, expected {expected_root}"
             )
 
     if failures:


### PR DESCRIPTION
Closes #82

## Summary

Collega `dataset-incubator#82` al supporto introdotto in `dataciviclab/toolkit#54` per validare `root` rispetto a un `repo_root` esplicito.

In pratica, lo script CI `validate_effective_root.py` non usa più `toolkit inspect paths` via subprocess per leggere `effective_root`, ma carica direttamente la config del toolkit con il guard `repo_root`.

## What Changed

- usa `toolkit.core.config.load_config(..., repo_root=repo_root)` nello script CI
- mantiene il controllo specifico di `dataset-incubator` su `root == <repo>/out`
- fa fallire esplicitamente il check se `dataset.yml` risolve `root` fuori dalla repo
- migliora il messaggio di errore quando lo script viene eseguito con un Python senza toolkit installato

## Why

Finché `dataset-incubator` non usava il guard del toolkit, il vincolo "`root` deve stare dentro la repo" era testato nel toolkit ma non enforcement reale in CI.

Questa PR chiude quel gap e rende esplicito il collegamento tra:
- `dataset-incubator#82`
- `dataciviclab/toolkit#54`

## Verification

Verificato localmente che:

- i layout reali supportati continuano a passare:
  - candidate depth-2
  - `sources/*` depth-3
  - support dataset
- un `root` assoluto fuori repo fallisce con errore esplicito
- lo script continua a dare un output leggibile in CI
- se il toolkit non è installato nell'ambiente Python corrente, lo script mostra un messaggio utile con istruzione di setup