### PR TITLE
feat: estrarre la serie incrementi ISPRA 2006-2024

### DIFF
--- a/candidates/ispra-consumo-suolo/README.md
+++ b/candidates/ispra-consumo-suolo/README.md
@@ -6,7 +6,7 @@
 **Formato:** XLSX (foglio Comuni_2006_2024)
 **Granularita:** comune
 
-**Issue di riferimento:** [dataset-incubator #32](https://github.com/dataciviclab/dataset-incubator/issues/32)
+**Issue di riferimento:** [dataset-incubator #32](https://github.com/dataciviclab/dataset-incubator/issues/32), [dataset-incubator #70](https://github.com/dataciviclab/dataset-incubator/issues/70)
 
 ## Come eseguire
 
@@ -19,3 +19,14 @@ toolkit/.venv/Scripts/python.exe -m toolkit.cli.app run all \
 ## Output
 
 - `out/data/mart/ispra_consumo_suolo/2024/mart_comuni.parquet`
+
+## Nota dati
+
+Il `clean` e il `mart` espongono ora tutti gli incrementi netti e lordi per periodo presenti nel foglio ISPRA `Comuni_2006_2024`.
+
+I periodi non sono uniformi:
+- `2006-2012`
+- `2012-2015`
+- poi annuali fino a `2023-2024`
+
+Questi campi vanno quindi letti come sequenza di intervalli eterogenei, non come serie annuale gia normalizzata.

--- a/candidates/ispra-consumo-suolo/notebooks/ispra_consumo_suolo_v0.ipynb
+++ b/candidates/ispra-consumo-suolo/notebooks/ispra_consumo_suolo_v0.ipynb
@@ -14,7 +14,7 @@
     "- Metrica principale: `stock_pct_2024` (% suolo consumato su superficie comunale)\n",
     "- Dinamica recente: `incremento_ha_2023_2024` (delta ultimo anno disponibile)\n",
     "\n",
-    "**Nota:** il file ISPRA contiene una serie di incrementi 2006-2024, non estratta in questa versione.\n",
+    "**Nota:** il file ISPRA contiene anche la serie di incrementi 2006-2024, ora estratta nel dataset ma non ancora letta in questo notebook `v0`.\n",
     "Il `v1` coprirà la lettura multi-periodo (issue #70).\n"
    ]
   },
@@ -492,7 +492,7 @@
     "**Denominatore superficie:** fornito da ISPRA, non da ISTAT anagrafe. Può differire per comuni con variazioni territoriali recenti.\n",
     "\n",
     "**Cosa non c'è nel v0:**\n",
-    "- serie storica incrementi 2006-2023 (vedi issue #70);\n",
+    "- lettura analitica della serie incrementi 2006-2024 nel notebook `v1` (vedi issue #70);\n",
     "- i periodi ISPRA non sono uniformi: il file contiene intervalli misti (`2006-2012`, `2012-2015`, poi annuali fino a `2023-2024`) — non è una time series annuale pronta;\n",
     "- medie regionali sensibili agli outlier comunali: utili come primo orientamento, non come misura robusta definitiva;\n",
     "- join demografico (popolazione da ISTAT);\n",

--- a/candidates/ispra-consumo-suolo/notes.md
+++ b/candidates/ispra-consumo-suolo/notes.md
@@ -3,7 +3,8 @@
 ## Stato
 
 Scaffold v0 creato (Marzo 2026).
-Pipeline non ancora eseguita — da verificare lettura XLSX.
+Pipeline eseguita con lettura XLSX verificata.
+Issue tecnica aperta: estrazione completa della serie incrementi per periodo (`#70`).
 
 ## Esecuzione
 
@@ -19,7 +20,7 @@ toolkit/.venv/Scripts/python.exe -m toolkit.cli.app run all \
 - Foglio target: `Comuni_2006_2024`
 - La riga 1 (dopo header) potrebbe contenere unita di misura — filtrata in clean.sql
 
-## Colonne nel mart_comuni
+## Colonne chiave nel mart_comuni
 
 | Campo | Descrizione |
 |---|---|
@@ -28,9 +29,26 @@ toolkit/.venv/Scripts/python.exe -m toolkit.cli.app run all \
 | provincia | Nome provincia |
 | regione | Nome regione |
 | incremento_ha_2023_2024 | Incremento netto consumo suolo 2023-2024 [ha] |
+| incremento_netto_ha_<periodo> | Serie degli incrementi netti per periodo ISPRA [ha] |
+| incremento_lordo_ha_<periodo> | Serie degli incrementi lordi per periodo ISPRA [ha] |
 | stock_ha_2024 | Suolo consumato cumulato 2024 [ha] |
 | stock_pct_2024 | Suolo consumato 2024 [% superficie] |
+
+### Periodi disponibili
+
+- `2006_2012`
+- `2012_2015`
+- `2015_2016`
+- `2016_2017`
+- `2017_2018`
+- `2018_2019`
+- `2019_2020`
+- `2020_2021`
+- `2021_2022`
+- `2022_2023`
+- `2023_2024`
 
 ## Issue di riferimento
 
 - dataset-incubator #32 — intake originale
+- dataset-incubator #70 — estensione serie incrementi 2006-2024

--- a/candidates/ispra-consumo-suolo/sources/a_consumo_suolo/sql/clean.sql
+++ b/candidates/ispra-consumo-suolo/sources/a_consumo_suolo/sql/clean.sql
@@ -2,14 +2,13 @@
 --
 -- Input: foglio Comuni_2006_2024 dal file XLSX ISPRA (rilascio 2025, anni 2006-2024)
 -- La riga 0 del foglio contiene header ISPRA originali.
--- Colonne selezionate (perimetro minimo v0):
---   pro_com                  — codice ISTAT comune (6 cifre: 3 provincia + 3 comune)
---   comune                   — nome comune
---   provincia                — nome provincia
---   regione                  — nome regione
---   incremento_ha_2023_2024  — incremento netto consumo suolo 2023-2024 [ettari]
---   stock_ha_2024            — suolo consumato cumulato 2024 [ettari]
---   stock_pct_2024           — suolo consumato 2024 [% superficie]
+-- Colonne selezionate:
+--   pro_com / comune / provincia / regione
+--   incremento_netto_ha_<periodo>  — incremento netto consumo suolo [ettari]
+--   incremento_lordo_ha_<periodo>  — incremento lordo consumo suolo [ettari]
+--   incremento_ha_2023_2024        — alias backward-compatible del netto 2023-2024
+--   stock_ha_2024                  — suolo consumato cumulato 2024 [ettari]
+--   stock_pct_2024                 — suolo consumato 2024 [% superficie]
 --
 -- Nomi colonne verificati sul file reale (rilascio 2025): unita = [ettari], non [ha].
 
@@ -20,9 +19,119 @@ SELECT
     TRIM(CAST("Nome_Regione"   AS VARCHAR))              AS regione,
     TRY_CAST(
         REPLACE(
+            TRIM(CAST("Incremento netto 2006-2012 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_netto_ha_2006_2012,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento lordo 2006-2012 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_lordo_ha_2006_2012,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento netto 2012-2015 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_netto_ha_2012_2015,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento lordo 2012-2015 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_lordo_ha_2012_2015,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento netto 2015-2016 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_netto_ha_2015_2016,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento lordo 2015-2016 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_lordo_ha_2015_2016,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento netto 2016-2017 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_netto_ha_2016_2017,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento lordo 2016-2017 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_lordo_ha_2016_2017,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento netto 2017-2018 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_netto_ha_2017_2018,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento lordo 2017-2018 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_lordo_ha_2017_2018,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento netto 2018-2019 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_netto_ha_2018_2019,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento lordo 2018-2019 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_lordo_ha_2018_2019,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento netto 2019-2020 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_netto_ha_2019_2020,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento lordo 2019-2020 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_lordo_ha_2019_2020,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento netto 2020-2021 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_netto_ha_2020_2021,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento lordo 2020-2021 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_lordo_ha_2020_2021,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento netto 2021-2022 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_netto_ha_2021_2022,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento lordo 2021-2022 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_lordo_ha_2021_2022,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento netto 2022-2023 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_netto_ha_2022_2023,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento lordo 2022-2023 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_lordo_ha_2022_2023,
+    TRY_CAST(
+        REPLACE(
             TRIM(CAST("Incremento netto 2023-2024 [ettari]" AS VARCHAR)), ',', '.'
         ) AS DOUBLE
     )                                                    AS incremento_ha_2023_2024,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento netto 2023-2024 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_netto_ha_2023_2024,
+    TRY_CAST(
+        REPLACE(
+            TRIM(CAST("Incremento lordo 2023-2024 [ettari]" AS VARCHAR)), ',', '.'
+        ) AS DOUBLE
+    )                                                    AS incremento_lordo_ha_2023_2024,
     TRY_CAST(
         REPLACE(
             TRIM(CAST("Suolo consumato 2024 [ettari]"  AS VARCHAR)), ',', '.'

--- a/candidates/ispra-consumo-suolo/sources/a_consumo_suolo/sql/mart.sql
+++ b/candidates/ispra-consumo-suolo/sources/a_consumo_suolo/sql/mart.sql
@@ -1,14 +1,36 @@
 -- mart.sql — ispra_consumo_suolo
--- mart_comuni: un record per comune, dati stock e incremento 2024
+-- mart_comuni: un record per comune, snapshot 2024 piu serie incrementi per periodo
 
 SELECT
-    pro_com,
-    comune,
-    provincia,
-    regione,
-    ROUND(incremento_ha_2023_2024, 4) AS incremento_ha_2023_2024,
-    ROUND(stock_ha_2024,           2) AS stock_ha_2024,
-    ROUND(stock_pct_2024,          4) AS stock_pct_2024
+    clean.pro_com,
+    clean.comune,
+    clean.provincia,
+    clean.regione,
+    ROUND(clean.incremento_netto_ha_2006_2012, 4) AS incremento_netto_ha_2006_2012,
+    ROUND(clean.incremento_lordo_ha_2006_2012, 4) AS incremento_lordo_ha_2006_2012,
+    ROUND(clean.incremento_netto_ha_2012_2015, 4) AS incremento_netto_ha_2012_2015,
+    ROUND(clean.incremento_lordo_ha_2012_2015, 4) AS incremento_lordo_ha_2012_2015,
+    ROUND(clean.incremento_netto_ha_2015_2016, 4) AS incremento_netto_ha_2015_2016,
+    ROUND(clean.incremento_lordo_ha_2015_2016, 4) AS incremento_lordo_ha_2015_2016,
+    ROUND(clean.incremento_netto_ha_2016_2017, 4) AS incremento_netto_ha_2016_2017,
+    ROUND(clean.incremento_lordo_ha_2016_2017, 4) AS incremento_lordo_ha_2016_2017,
+    ROUND(clean.incremento_netto_ha_2017_2018, 4) AS incremento_netto_ha_2017_2018,
+    ROUND(clean.incremento_lordo_ha_2017_2018, 4) AS incremento_lordo_ha_2017_2018,
+    ROUND(clean.incremento_netto_ha_2018_2019, 4) AS incremento_netto_ha_2018_2019,
+    ROUND(clean.incremento_lordo_ha_2018_2019, 4) AS incremento_lordo_ha_2018_2019,
+    ROUND(clean.incremento_netto_ha_2019_2020, 4) AS incremento_netto_ha_2019_2020,
+    ROUND(clean.incremento_lordo_ha_2019_2020, 4) AS incremento_lordo_ha_2019_2020,
+    ROUND(clean.incremento_netto_ha_2020_2021, 4) AS incremento_netto_ha_2020_2021,
+    ROUND(clean.incremento_lordo_ha_2020_2021, 4) AS incremento_lordo_ha_2020_2021,
+    ROUND(clean.incremento_netto_ha_2021_2022, 4) AS incremento_netto_ha_2021_2022,
+    ROUND(clean.incremento_lordo_ha_2021_2022, 4) AS incremento_lordo_ha_2021_2022,
+    ROUND(clean.incremento_netto_ha_2022_2023, 4) AS incremento_netto_ha_2022_2023,
+    ROUND(clean.incremento_lordo_ha_2022_2023, 4) AS incremento_lordo_ha_2022_2023,
+    ROUND(clean.incremento_ha_2023_2024, 4) AS incremento_ha_2023_2024,
+    ROUND(clean.incremento_netto_ha_2023_2024, 4) AS incremento_netto_ha_2023_2024,
+    ROUND(clean.incremento_lordo_ha_2023_2024, 4) AS incremento_lordo_ha_2023_2024,
+    ROUND(clean.stock_ha_2024, 2) AS stock_ha_2024,
+    ROUND(clean.stock_pct_2024, 4) AS stock_pct_2024
 
 FROM clean
 


### PR DESCRIPTION
Closes #70

## Sintesi

Estende il candidate `ispra-consumo-suolo` per esporre nel dataset tutti gli incrementi ISPRA disponibili per periodo, mantenendo intatto il contratto v0 sullo snapshot `2024`.

In pratica:
- il `clean` non estrae più solo l'ultimo delta `2023-2024`
- vengono aggiunti tutti gli incrementi netti e lordi dal `2006-2012` fino al `2023-2024`
- il `mart` fa pass-through degli stessi campi in modo additive-only
- il campo storico `incremento_ha_2023_2024` resta disponibile come alias backward-compatible del netto `2023-2024`

## Cosa cambia

**SQL del source `a_consumo_suolo`**
- estende `candidates/ispra-consumo-suolo/sources/a_consumo_suolo/sql/clean.sql` con la serie completa degli incrementi ISPRA
- aggiunge sia i campi `incremento_netto_ha_<periodo>` sia `incremento_lordo_ha_<periodo>`
- mantiene `incremento_ha_2023_2024` per non rompere notebook e letture già esistenti
- aggiorna `candidates/ispra-consumo-suolo/sources/a_consumo_suolo/sql/mart.sql` per esporre la stessa serie nel parquet finale

**Documentazione del candidate**
- aggiorna `candidates/ispra-consumo-suolo/README.md` per chiarire che i periodi sono eterogenei e non costituiscono una serie annuale uniforme
- aggiorna `candidates/ispra-consumo-suolo/notes.md` con il nuovo perimetro dei campi disponibili
- corregge una nota nel notebook `v0` che diceva ancora che la serie non era estratta

## Perché

Il file ISPRA `Comuni_2006_2024` contiene una serie storica utile oltre allo stock 2024, ma il candidate v0 esponeva solo:
- `incremento_ha_2023_2024`
- `stock_ha_2024`
- `stock_pct_2024`

Questa PR chiude quel gap e prepara il `v1` senza spostare nel `clean` la logica più pesante di ricostruzione degli stock storici, che resta fuori scope.

## Verifica

Verificato localmente che:
- il file XLSX reale contiene tutti gli 11 periodi attesi (`2006-2012`, `2012-2015`, poi annuali fino a `2023-2024`)
- `run clean` completa correttamente con il dataset aggiornato
- il parquet CLEAN contiene `23` colonne `incremento_*`:
  - `11` netti
  - `11` lordi
  - `1` alias backward-compatible (`incremento_ha_2023_2024`)
- `incremento_ha_2023_2024 == incremento_netto_ha_2023_2024` sul dataset generato
- `mart.sql` valida correttamente contro il clean fresco e restituisce `7896` righe

Comandi usati:
- `python -m toolkit.cli.app run clean --config candidates\ispra-consumo-suolo\sources\a_consumo_suolo\dataset.yml --years 2024`
- verifica schema CLEAN via DuckDB su `out/data/clean/ispra_consumo_suolo/2024/ispra_consumo_suolo_2024_clean.parquet`
- verifica `mart.sql` via DuckDB contro il clean fresco


