### PR TITLE
intake: aggiungi candidate terna-capacita-rinnovabile

### DIFF
--- a/candidates/terna-capacita-rinnovabile/README.md
+++ b/candidates/terna-capacita-rinnovabile/README.md
@@ -1,0 +1,39 @@
+# Terna capacita rinnovabile per territorio
+
+## Domanda
+
+Dove si concentra la capacita rinnovabile installata in Italia e quali territori risultano piu attrezzati, a fine anno, per fonte e nel confronto minimo 2023-2024?
+
+## Dataset
+
+- Fonte: Terna, download center ufficiale sulla capacita installata delle fonti rinnovabili
+- Formato: XLSX, sheet `Export`
+- Livello disponibile in raw: provincia
+- Perimetro intake: dicembre 2023 e dicembre 2024
+
+## Perche vale la pena testarlo
+
+- fonte ufficiale forte e tema civico leggibile
+- filone complementare al candidate Terna gia esistente sulla generazione
+- primo taglio territoriale semplice senza forzare join o letture causali
+
+## Output minimo atteso
+
+- candidate DI riproducibile per 2023-2024
+- clean provinciale coerente con il tracciato Terna
+- mart v0 su capacita netta aggregata per regione e fonte
+- notebook v0 di sanity check sul mart
+
+## Criterio di promozione
+
+- raw, clean e mart rigenerabili per entrambi gli anni
+- documentazione coerente con il perimetro reale
+- notebook v0 eseguibile senza trasformarlo in analisi pubblica
+
+## Stato
+
+- intake
+
+## Prossimo passo
+
+- verificare il run completo 2023-2024 e lasciare il candidate pronto per review DI

--- a/candidates/terna-capacita-rinnovabile/dataset.yml
+++ b/candidates/terna-capacita-rinnovabile/dataset.yml
@@ -1,0 +1,39 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "terna_capacita_rinnovabile"
+  years: [2023, 2024]
+
+raw:
+  sources:
+    - name: "terna_capacity_renewable_sources_xlsx"
+      type: "http_file"
+      args:
+        url: "https://dati.terna.it/api/sitecore/dati/downloadcenter/records?f=xlsx&filterDataset=CapacityRenewableSources&filterYear={year}&filterMonth=12&orderByColumn=Anno&orderByDir=desc&db=dati&pageSize=1160"
+        filename: "terna_capacita_rinnovabile_{year}_12.xlsx"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: "auto"
+    mode: "latest"
+    header: true
+    sheet_name: "Export"
+  validate:
+    min_rows: 1000
+
+mart:
+  tables:
+    - name: "mart_regioni_fonti_nette"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_regioni_fonti_nette"
+  validate: {}
+
+validation:
+  fail_on_error: true
+
+output:
+  artifacts: "minimal"

--- a/candidates/terna-capacita-rinnovabile/notebooks/terna_capacita_rinnovabile_v0.ipynb
+++ b/candidates/terna-capacita-rinnovabile/notebooks/terna_capacita_rinnovabile_v0.ipynb
@@ -1,0 +1,376 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# terna_capacita_rinnovabile - notebook v0\n",
+    "\n",
+    "Notebook v0 di validazione del mart in `dataset-incubator`.\n",
+    "\n",
+    "- scopo: sanity check e lettura base del mart\n",
+    "- non sostituisce l'analisi pubblica\n",
+    "- evitare output pesanti o immagini embeddate nel commit\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "setup",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-28T23:42:17.418633Z",
+     "iopub.status.busy": "2026-03-28T23:42:17.417164Z",
+     "iopub.status.idle": "2026-03-28T23:42:20.053080Z",
+     "shell.execute_reply": "2026-03-28T23:42:20.053080Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Candidate dir: terna-capacita-rinnovabile\n",
+      "Mart table: mart_regioni_fonti_nette.parquet\n",
+      "Anno target: 2024\n"
+     ]
+    }
+   ],
+   "source": [
+    "import duckdb\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from pathlib import Path\n",
+    "\n",
+    "SLUG = \"terna_capacita_rinnovabile\"\n",
+    "MART_TABLE = \"mart_regioni_fonti_nette\"\n",
+    "METRICA = \"potenza_totale_mw\"\n",
+    "ANNO_TARGET = 2024\n",
+    "\n",
+    "candidate_dir = Path.cwd()\n",
+    "if not (candidate_dir / \"dataset.yml\").exists():\n",
+    "    if (candidate_dir.parent / \"dataset.yml\").exists():\n",
+    "        candidate_dir = candidate_dir.parent\n",
+    "    else:\n",
+    "        raise FileNotFoundError(\n",
+    "            f\"dataset.yml non trovato in {Path.cwd()} o nella cartella parent.\"\n",
+    "        )\n",
+    "\n",
+    "mart_root = candidate_dir.parents[1] / \"out\" / \"data\" / \"mart\" / SLUG / str(ANNO_TARGET)\n",
+    "parquet_path = mart_root / f\"{MART_TABLE}.parquet\"\n",
+    "if not parquet_path.exists():\n",
+    "    raise FileNotFoundError(\n",
+    "        f\"Mart non trovato per {SLUG}/{MART_TABLE} sotto {mart_root}. Eseguire prima toolkit run all.\"\n",
+    "    )\n",
+    "\n",
+    "PARQUET_PATH = parquet_path\n",
+    "print(f\"Candidate dir: {candidate_dir.name}\")\n",
+    "print(f\"Mart table: {PARQUET_PATH.name}\")\n",
+    "print(f\"Anno target: {ANNO_TARGET}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "shape-schema",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-28T23:42:20.059302Z",
+     "iopub.status.busy": "2026-03-28T23:42:20.056776Z",
+     "iopub.status.idle": "2026-03-28T23:42:20.117867Z",
+     "shell.execute_reply": "2026-03-28T23:42:20.117867Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shape: (100, 5)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "anno                   int32\n",
+       "regione                  str\n",
+       "fonti                    str\n",
+       "potenza_totale_mw    float64\n",
+       "record_count           int64\n",
+       "dtype: object"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "con = duckdb.connect()\n",
+    "df = con.execute(\"SELECT * FROM read_parquet(?)\", [str(PARQUET_PATH)]).df()\n",
+    "print(f\"Shape: {df.shape}\")\n",
+    "display(df.dtypes)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "head",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-28T23:42:20.123550Z",
+     "iopub.status.busy": "2026-03-28T23:42:20.121641Z",
+     "iopub.status.idle": "2026-03-28T23:42:20.145675Z",
+     "shell.execute_reply": "2026-03-28T23:42:20.144304Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>anno</th>\n",
+       "      <th>regione</th>\n",
+       "      <th>fonti</th>\n",
+       "      <th>potenza_totale_mw</th>\n",
+       "      <th>record_count</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>Lombardia</td>\n",
+       "      <td>Idrico</td>\n",
+       "      <td>5155.33814</td>\n",
+       "      <td>12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>Lombardia</td>\n",
+       "      <td>Fotovoltaico</td>\n",
+       "      <td>4959.29800</td>\n",
+       "      <td>12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>Veneto</td>\n",
+       "      <td>Fotovoltaico</td>\n",
+       "      <td>3747.83800</td>\n",
+       "      <td>7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>Puglia</td>\n",
+       "      <td>Fotovoltaico</td>\n",
+       "      <td>3626.85700</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>Emilia-Romagna</td>\n",
+       "      <td>Fotovoltaico</td>\n",
+       "      <td>3574.10600</td>\n",
+       "      <td>9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>Trentino-Alto Adige</td>\n",
+       "      <td>Idrico</td>\n",
+       "      <td>3563.05590</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>Lazio</td>\n",
+       "      <td>Fotovoltaico</td>\n",
+       "      <td>3295.05000</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>Puglia</td>\n",
+       "      <td>Eolico</td>\n",
+       "      <td>3228.22300</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>Piemonte</td>\n",
+       "      <td>Fotovoltaico</td>\n",
+       "      <td>3083.35700</td>\n",
+       "      <td>8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>Piemonte</td>\n",
+       "      <td>Idrico</td>\n",
+       "      <td>2787.24987</td>\n",
+       "      <td>8</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   anno              regione         fonti  potenza_totale_mw  record_count\n",
+       "0  2024            Lombardia        Idrico         5155.33814            12\n",
+       "1  2024            Lombardia  Fotovoltaico         4959.29800            12\n",
+       "2  2024               Veneto  Fotovoltaico         3747.83800             7\n",
+       "3  2024               Puglia  Fotovoltaico         3626.85700             6\n",
+       "4  2024       Emilia-Romagna  Fotovoltaico         3574.10600             9\n",
+       "5  2024  Trentino-Alto Adige        Idrico         3563.05590             2\n",
+       "6  2024                Lazio  Fotovoltaico         3295.05000             5\n",
+       "7  2024               Puglia        Eolico         3228.22300             6\n",
+       "8  2024             Piemonte  Fotovoltaico         3083.35700             8\n",
+       "9  2024             Piemonte        Idrico         2787.24987             8"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(df.head(10))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "checks",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-28T23:42:20.149544Z",
+     "iopub.status.busy": "2026-03-28T23:42:20.149544Z",
+     "iopub.status.idle": "2026-03-28T23:42:20.163556Z",
+     "shell.execute_reply": "2026-03-28T23:42:20.163556Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Null per colonna:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "anno                 0\n",
+       "regione              0\n",
+       "fonti                0\n",
+       "potenza_totale_mw    2\n",
+       "record_count         0\n",
+       "dtype: int64"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Range potenza_totale_mw: min=0.0, max=5155.338140000001, negativi=0\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Null per colonna:\")\n",
+    "display(df.isnull().sum())\n",
+    "\n",
+    "negativi = int((df[METRICA] < 0).sum()) if pd.api.types.is_numeric_dtype(df[METRICA]) else \"n/a\"\n",
+    "print(\n",
+    "    f\"\\nRange {METRICA}: min={df[METRICA].min()}, max={df[METRICA].max()}, negativi={negativi}\"\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "chart",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-28T23:42:20.167133Z",
+     "iopub.status.busy": "2026-03-28T23:42:20.167133Z",
+     "iopub.status.idle": "2026-03-28T23:42:20.791826Z",
+     "shell.execute_reply": "2026-03-28T23:42:20.791826Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    df.groupby(\"regione\")[METRICA]\n",
+    "    .sum()\n",
+    "    .sort_values(ascending=False)\n",
+    "    .plot(kind=\"bar\", figsize=(12, 5), title=f\"{METRICA} per regione ({ANNO_TARGET})\")\n",
+    ")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "notes",
+   "metadata": {},
+   "source": [
+    "## Note v0\n",
+    "\n",
+    "- Slug: `terna_capacita_rinnovabile`\n",
+    "- Tabella mart: `mart_regioni_fonti_nette`\n",
+    "- Metrica guida: `potenza_totale_mw`\n",
+    "- Perimetro: dicembre 2023-2024; notebook puntato al mart 2024\n",
+    "- Questo notebook resta esplorativo e validativo in DI.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/candidates/terna-capacita-rinnovabile/notes.md
+++ b/candidates/terna-capacita-rinnovabile/notes.md
@@ -1,0 +1,29 @@
+# Notes
+
+## Tecnico
+
+- Fonte raw: endpoint XLSX Terna `CapacityRenewableSources` con `filterMonth=12`
+- Sheet letto: `Export`
+- Colonne osservate nel workbook: `Anno`, `Tipo capacità`, `Regione`, `Provincia`, `Fonti`, `Potenza efficiente (MW)`
+- Ultima riga del file e un footer testuale `Applied filters...` da scartare in clean
+- Il clean mantiene la granularita provinciale e sia `Netta` sia `Lorda`
+- Il mart v0 restringe a `Tipo capacità = Netta` e aggrega per `anno`, `regione`, `fonti`
+- Run reale eseguito con successo su `2023` e `2024`
+- Shape osservate:
+  - clean 2023: `1160` righe
+  - clean 2024: `1070` righe
+  - mart 2023: `100` righe
+  - mart 2024: `100` righe
+- Notebook v0 eseguito sul mart `2024` e salvato con output leggeri, senza blob grafici
+
+## Analitico
+
+- Il candidate descrive capacita installata, non produzione
+- Il confronto minimo 2023-2024 serve solo a vedere distribuzione territoriale e ordine di grandezza
+- Eventuali letture su divari o performance andranno motivate solo in `analisi/`
+
+## Cautele
+
+- La serie storica completa non e ancora estesa oltre il biennio intake
+- I valori nulli in `Potenza efficiente (MW)` vanno trattati come dato mancante, non zero implicito
+- `Netta` e `Lorda` non vanno sommate tra loro

--- a/candidates/terna-capacita-rinnovabile/sql/clean.sql
+++ b/candidates/terna-capacita-rinnovabile/sql/clean.sql
@@ -1,0 +1,11 @@
+select
+    cast("Anno" as integer) as anno,
+    trim(cast("Tipo capacità" as varchar)) as tipo_capacita,
+    trim(cast("Regione" as varchar)) as regione,
+    trim(cast("Provincia" as varchar)) as provincia,
+    trim(cast("Fonti" as varchar)) as fonti,
+    cast("Potenza efficiente (MW)" as double) as potenza_mw
+from raw_input
+where try_cast("Anno" as integer) is not null
+  and trim(cast("Regione" as varchar)) <> ''
+  and trim(cast("Provincia" as varchar)) <> ''

--- a/candidates/terna-capacita-rinnovabile/sql/mart.sql
+++ b/candidates/terna-capacita-rinnovabile/sql/mart.sql
@@ -1,0 +1,10 @@
+select
+    anno,
+    regione,
+    fonti,
+    sum(potenza_mw) as potenza_totale_mw,
+    count(*) as record_count
+from clean_input
+where tipo_capacita = 'Netta'
+group by 1, 2, 3
+order by anno, potenza_totale_mw desc, regione, fonti


### PR DESCRIPTION
## Contesto

Questa PR porta il candidate `terna-capacita-rinnovabile` nel formato intake standard di `dataset-incubator`, seguendo il branch pulito `intake/terna-capacita-rinnovabile`.

Nasce come proposta tecnica pulita dopo il confronto in #97, per evitare altro rumore sulla PR originaria e avere un candidate coerente con il flusso canonico del Lab.

## Cosa include

- struttura candidate completa
- `dataset.yml` coerente
- `clean.sql`
- `mart.sql`
- `README.md`
- `notes.md`
- notebook v0 validativo

## Perimetro

- anni: `2023-2024`
- fonte: Terna `CapacityRenewableSources`
- raw XLSX diretto
- clean provinciale con scarto del footer
- mart v0 su `Netta` aggregato per `anno`, `regione`, `fonti`

## Verifiche fatte

- `toolkit_inspect_paths`: ok
- `toolkit run all --years 2023`: ok
- `toolkit run all --years 2024`: ok
- mart verificato
- notebook v0 eseguito sul mart 2024

## Note

Questa PR e' pensata anche come riferimento pratico per i prossimi intake, in particolare su:
- struttura minima del candidate
- `clean.sql`
- notebook v0

Closes #47
