### PR TITLE
docs: add public workflows for dataset-incubator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,12 @@ Questa guida vale per la repo `dataset-incubator`.
 Per le regole GitHub condivise dell'organizzazione, parti prima da
 [`.github`](https://github.com/dataciviclab/.github).
 
+Workflow pubblici del repo:
+
+- [workflows/README.md](workflows/README.md)
+- [workflows/intake-candidate.md](workflows/intake-candidate.md)
+- [workflows/run-candidate.md](workflows/run-candidate.md)
+
 ## A cosa serve questa repo
 
 `dataset-incubator` e' il luogo di intake e incubazione tecnica leggera dei

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Il lavoro qui serve a validare la fonte, restringere la domanda e stabilizzare l
 Se vuoi contribuire operativamente in questa repo:
 
 - leggi [CONTRIBUTING.md](CONTRIBUTING.md)
+- vedi anche [workflows/README.md](workflows/README.md)
 
 Non serve per:
 
@@ -169,3 +170,14 @@ Regola pratica:
 
 - usa `out/data/...` per il runtime reale
 - usa `registry/` e le cartelle `candidates/`, `support_datasets/` per il contenuto della repo
+
+## Workflow pubblici del repo
+
+I workflow ricorrenti e propri di `dataset-incubator` stanno in:
+
+- [workflows/README.md](workflows/README.md)
+
+Per ora:
+
+- [intake-candidate.md](workflows/intake-candidate.md)
+- [run-candidate.md](workflows/run-candidate.md)

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,15 @@
+# Workflows - dataset-incubator
+
+I workflow pubblici del repo stanno in `dataset-incubator/workflows/`.
+
+Per ora includono:
+
+- `intake-candidate.md`
+- `run-candidate.md`
+
+Nel repo:
+
+- `intake-candidate.md` spiega come entra un nuovo filone o support dataset in DI
+- `run-candidate.md` spiega come eseguire un candidate end-to-end e leggere gli output
+
+I workflow cross-repo piu' completi del Lab restano in `lab-ops`.

--- a/workflows/intake-candidate.md
+++ b/workflows/intake-candidate.md
@@ -1,0 +1,126 @@
+# Workflow: intake-candidate
+
+Workflow pubblico/light di `dataset-incubator`.
+Versione: 0.1 - 2026-04-01
+
+## Obiettivo di fase
+
+Decidere se una fonte o una discussion gia' abbastanza matura puo' entrare in
+`dataset-incubator` come candidate tecnico credibile.
+
+Questo workflow serve a rispondere a:
+
+- il caso e' abbastanza stretto per entrare in DI?
+- esiste una fonte reale e un perimetro iniziale difendibile?
+- l'output minimo atteso e' abbastanza chiaro?
+
+Non serve a:
+
+- fare puro scouting di una fonte ancora opaca
+- aprire automaticamente PR o pipeline complete
+- sostituire il primo source-check della fonte
+
+## Quando usarlo
+
+Usalo quando hai gia':
+
+- una fonte ufficiale o una discussion abbastanza matura
+- una domanda guida o un uso previsto chiaro
+- un perimetro iniziale stretto
+- un prossimo passo tecnico concreto
+
+Non usarlo quando:
+
+- la fonte e' ancora troppo larga o troppo opaca
+- non sai ancora se il caso regge da solo o solo come support dataset
+- manca ancora un output minimo leggibile
+
+## Prerequisiti minimi
+
+Prima di aprire un intake in DI dovrebbero esserci almeno:
+
+- fonte principale verificata
+- perimetro iniziale stretto
+- output minimo atteso
+- prossimo passo operativo concreto
+
+Nel dubbio:
+
+- se il caso e' ancora troppo esplorativo, resta prima in Discussion
+- se il caso e' molto pulito e gia' ben definito, apri direttamente la issue di intake
+
+## Passi minimi
+
+### 1. Scegli il tipo di intake
+
+Il template `new-candidate.yml` copre due casi:
+
+- `candidate`
+- `support`
+
+Usa `candidate` quando il caso ha una domanda civica e potenziale di promozione.
+Usa `support` quando il dataset serve soprattutto per join, controlli o arricchimenti.
+
+### 2. Apri la issue di intake
+
+Usa:
+
+- `.github/ISSUE_TEMPLATE/new-candidate.yml`
+
+Compila in modo stretto:
+
+- domanda guida o uso previsto
+- fonte principale
+- perimetro iniziale
+- perche' vale la pena incubarlo
+- output minimo atteso
+- prossimo passo operativo
+- rischi noti
+
+### 3. Tieni il candidate minimale
+
+Nel caso single-source, la struttura tipica e':
+
+```text
+candidates/caso/
+  dataset.yml
+  README.md
+  notes.md
+  notebooks/
+    caso_v0.ipynb
+  sql/
+    clean.sql
+    mart.sql
+```
+
+Regola pratica:
+
+- meglio un primo candidate piccolo ma eseguibile
+- peggio un intake largo con perimetro ancora confuso
+
+### 4. Chiudi l'intake con uno stato chiaro
+
+Lo stato iniziale tipico e':
+
+- label `intake`
+
+Quando il filone viene preso in carico sul serio, di solito passa a:
+
+- `incubating`
+
+## Output minimo atteso
+
+Un intake buono lascia:
+
+- una issue intake chiara
+- un perimetro iniziale difendibile
+- un candidate o support dataset ben impostato
+- issue intake e candidate coerenti tra loro
+- un prossimo passo tecnico esplicito
+
+## Dove orientarsi
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [README.md](../README.md)
+- [new-candidate.yml](../.github/ISSUE_TEMPLATE/new-candidate.yml)
+- [scouting-checklist.md](../docs/scouting-checklist.md)

--- a/workflows/run-candidate.md
+++ b/workflows/run-candidate.md
@@ -1,0 +1,133 @@
+# Workflow: run-candidate
+
+Workflow pubblico/light di `dataset-incubator`.
+Versione: 0.1 - 2026-04-01
+
+## Obiettivo di fase
+
+Eseguire un candidate in `dataset-incubator` in modo end-to-end e capire se
+produce output leggibili.
+
+Questo workflow serve a rispondere a:
+
+- quale config usare
+- quale comando lanciare
+- dove leggere `raw`, `clean` e `mart`
+- come capire se il candidate e' andato a buon fine
+
+Non serve a:
+
+- fare scouting della fonte
+- rifattorizzare il candidate in grande
+- nascondere un blocker dietro run casuali
+
+## Quando usarlo
+
+Usalo quando:
+
+- il candidate esiste gia'
+- vuoi farlo girare davvero
+- vuoi vedere i dati prodotti
+- vuoi distinguere tra run riuscito e blocco tecnico reale
+
+Non usarlo quando:
+
+- il candidate non ha ancora una struttura minima
+- sei ancora al livello discussion/source-check
+- il lavoro vero e' ormai fix di pipeline complessa
+
+## Workflow step-by-step
+
+### 1. Controlla la struttura minima
+
+Verifica che il candidate abbia almeno:
+
+- `README.md`
+- `notes.md`
+- `dataset.yml` oppure config rilevanti in `sources/`
+
+Se la struttura minima manca, fermati prima del run.
+
+### 2. Scegli il config giusto
+
+Chiarisci:
+
+- se il candidate e' single-source o multi-source
+- quale `dataset.yml` usare come entrypoint
+
+Caso tipico single-source:
+
+- `candidates/{slug}/dataset.yml`
+
+Caso tipico multi-source:
+
+- `candidates/{slug}/sources/{source}/dataset.yml`
+- eventuale `compose/dataset.yml` come layer finale
+
+Regola pratica:
+
+- non partire dal compose se i source layer non sono ancora chiari
+
+### 3. Lancia il candidate
+Il run tipico usa `toolkit` sul config del candidate.
+
+Esempio:
+
+```bash
+cd toolkit
+python -m toolkit.cli.app run all --config ../dataset-incubator/candidates/{slug}/dataset.yml
+```
+
+Per candidate nested:
+
+```bash
+cd toolkit
+python -m toolkit.cli.app run all --config ../dataset-incubator/candidates/{slug}/sources/{source}/dataset.yml
+```
+
+### 4. Guarda gli output
+
+Dopo il run, controlla almeno:
+
+- se il comando ha completato senza errori
+- se il candidate ha prodotto dati sotto `dataset-incubator/out/`
+- qual e' il primo file utile da aprire
+
+In genere il percorso utile e' uno tra:
+
+- `out/data/raw/...`
+- `out/data/clean/...`
+- `out/data/mart/...`
+
+Il file piu' utile da guardare per primo e' quasi sempre il `mart`, se esiste.
+
+### 5. Se fallisce, isola il primo errore vero
+
+Se il run non regge, non allargare subito il lavoro.
+Isola prima:
+
+- primo errore vero
+- file coinvolti
+- se il blocco e' di accesso, config o SQL
+
+Non usare questo workflow per:
+
+- cambiare la domanda civica
+- rifare il candidate da zero
+- aggiungere complessita' non necessaria
+
+## Output minimo atteso
+
+Un run utile lascia:
+
+- comando eseguito
+- config usato
+- conferma che il candidate produce output leggibili oppure primo errore vero
+- primo file o layer da guardare
+- prossimo passo consigliato
+
+## Dove orientarsi
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [README.md](../README.md)
+- [PROMOTION_CHECKLIST.md](../PROMOTION_CHECKLIST.md)


### PR DESCRIPTION
## Cosa cambia
- aggiunge una sezione pubblica `workflows/` in `dataset-incubator`
- introduce i workflow pubblici `intake-candidate` e `run-candidate`
- collega i nuovi workflow da `README.md` e `CONTRIBUTING.md`

## Perché
`dataset-incubator` e' la repo giusta per possedere i workflow pubblici ricorrenti di intake e di esecuzione end-to-end dei candidate. Questo rende piu' leggibile il funnel per contributor esterni senza spostare qui la logica core-team di `lab-ops`.

## Come verificare
- leggere `workflows/README.md`
- leggere `workflows/intake-candidate.md`
- leggere `workflows/run-candidate.md`
- verificare i link da `README.md` e `CONTRIBUTING.md`

## Rischi residui
- `run-candidate` resta volutamente light e potra' essere rafforzato in seguito
- restano ancora alcuni materiali legacy di scouting in `docs/` che potranno essere riallineati in un follow-up separato