### PR TITLE
Rendi standalone i workflow intake e run candidate

### DIFF
--- a/workflows/intake-candidate.md
+++ b/workflows/intake-candidate.md
@@ -1,7 +1,7 @@
 # Workflow: intake-candidate
 
-Workflow pubblico/light di `dataset-incubator`.
-Versione: 0.1 - 2026-04-01
+Workflow canonico di `dataset-incubator`.
+Versione: 0.2 - 2026-04-07
 
 ## Obiettivo di fase
 
@@ -13,12 +13,14 @@ Questo workflow serve a rispondere a:
 - il caso e' abbastanza stretto per entrare in DI?
 - esiste una fonte reale e un perimetro iniziale difendibile?
 - l'output minimo atteso e' abbastanza chiaro?
+- il candidate puo' stare in DI senza sconfinare gia' in analisi?
 
 Non serve a:
 
 - fare puro scouting di una fonte ancora opaca
-- aprire automaticamente PR o pipeline complete
 - sostituire il primo source-check della fonte
+- nascondere dietro un intake un caso ancora troppo immaturo
+- costruire una pipeline completa oltre il minimo tecnico necessario
 
 ## Quando usarlo
 
@@ -28,28 +30,51 @@ Usalo quando hai gia':
 - una domanda guida o un uso previsto chiaro
 - un perimetro iniziale stretto
 - un prossimo passo tecnico concreto
+- un source-check reale oppure un equivalente leggero con verdetto esplicito
 
 Non usarlo quando:
 
 - la fonte e' ancora troppo larga o troppo opaca
 - non sai ancora se il caso regge da solo o solo come support dataset
 - manca ancora un output minimo leggibile
+- il caso e' gia' troppo analisi per stare in DI
+- il layer `clean` sarebbe gia' il taglio finale del mart
 
-## Prerequisiti minimi
+## Preconditions minime
 
-Prima di aprire un intake in DI dovrebbero esserci almeno:
+Prima di aprire o consolidare un intake in DI dovrebbero esserci almeno:
 
 - fonte principale verificata
 - perimetro iniziale stretto
 - output minimo atteso
 - prossimo passo operativo concreto
+- verdetto minimo sul source-check:
+  - `go candidate`
+  - oppure equivalente stretto che regga il passaggio in DI
+
+Per `equivalente stretto` intendiamo almeno:
+
+- fonte reale verificata
+- perimetro iniziale gia' formulato
+- domanda o uso previsto leggibile
+- rischio tecnico principale gia' esplicitato
 
 Nel dubbio:
 
-- se il caso e' ancora troppo esplorativo, resta prima in Discussion
-- se il caso e' molto pulito e gia' ben definito, apri direttamente la issue di intake
+- se il caso e' ancora troppo esplorativo, resta prima in Discussion o source-check
+- se il caso e' molto pulito e gia' ben definito, apri la issue di intake
 
-## Passi minimi
+## Stop rules
+
+Fermati e non forzare intake quando:
+
+- il source-check non regge ancora il passaggio in DI
+- il candidate e' gia' troppo analisi
+- il `clean` e' gia' un mart travestito
+- il perimetro cambia durante l'intake senza riallineamento completo di issue, README, notes, notebook e SQL
+- il caso appartiene in realta' a un altro repo o a una fase successiva
+
+## Passi canonici
 
 ### 1. Scegli il tipo di intake
 
@@ -61,7 +86,7 @@ Il template `new-candidate.yml` copre due casi:
 Usa `candidate` quando il caso ha una domanda civica e potenziale di promozione.
 Usa `support` quando il dataset serve soprattutto per join, controlli o arricchimenti.
 
-### 2. Apri la issue di intake
+### 2. Apri o allinea la issue di intake
 
 Usa:
 
@@ -77,7 +102,15 @@ Compila in modo stretto:
 - prossimo passo operativo
 - rischi noti
 
-### 3. Tieni il candidate minimale
+Se il candidate esiste gia', riallinea la issue al perimetro reale prima di andare avanti.
+
+Se esiste gia' una PR o un candidate aperto sullo stesso caso:
+
+- non aprire un doppione
+- riallinea prima il perimetro reale
+- chiarisci cosa stai aggiungendo o correggendo rispetto al lavoro gia' vivo
+
+### 3. Crea la struttura minima del candidate
 
 Nel caso single-source, la struttura tipica e':
 
@@ -98,7 +131,81 @@ Regola pratica:
 - meglio un primo candidate piccolo ma eseguibile
 - peggio un intake largo con perimetro ancora confuso
 
-### 4. Chiudi l'intake con uno stato chiaro
+### 4. Mantieni distinti i layer
+
+Durante l'intake:
+
+- `clean.sql` deve restare layer tecnico
+- `mart.sql` puo' portare il taglio della domanda
+- il notebook v0 deve verificare il mart reale, non anticipare gia' una mini-analisi
+
+Se il `clean` sta gia' facendo il lavoro del mart, fermati e correggi il boundary.
+
+### 5. Esegui il minimo tecnico necessario
+
+Prima di chiudere l'intake, fai almeno il minimo che renda il candidate verificabile:
+
+- verifica `root` e path effettivi
+- esegui un primo run reale oppure un dry-run credibile
+- se il run non regge, documenta un blocker tecnico specifico
+- non lasciare blocker vaghi o formulaici
+
+Sequenza minima consigliata, se non hai un motivo specifico per fare altro:
+
+1. verifica path e contract del config
+2. fai girare il layer `raw`
+3. se `raw` regge, passa a `clean`
+4. se `clean` regge, passa a `mart`
+5. costruisci o aggiorna il notebook v0 sul mart reale
+
+Esempio tipico:
+
+```bash
+cd toolkit
+python -m toolkit.cli.app inspect paths --config ../dataset-incubator/candidates/{slug}/dataset.yml
+python -m toolkit.cli.app run raw --config ../dataset-incubator/candidates/{slug}/dataset.yml
+python -m toolkit.cli.app run clean --config ../dataset-incubator/candidates/{slug}/dataset.yml
+python -m toolkit.cli.app run mart --config ../dataset-incubator/candidates/{slug}/dataset.yml
+```
+
+Se il candidate e' nested, usa il `dataset.yml` del source layer giusto.
+
+Per il dettaglio del run e dei blocker, il riferimento resta:
+
+- [run-candidate.md](./run-candidate.md)
+
+### 6. Aggiungi sempre un notebook v0 reale
+
+Il notebook v0 non e' opzionale.
+
+Deve:
+
+- partire dal template DI quando disponibile
+- essere coerente col mart reale
+- mostrare almeno un sanity check concreto
+- non restare placeholder o TODO
+
+### 7. Riallinea tutto se cambia il perimetro
+
+Se durante l'intake cambia:
+
+- granularita'
+- copertura temporale
+- domanda guida
+- naming del candidate
+
+allora riallinea subito:
+
+- issue
+- README
+- notes
+- notebook v0
+- SQL
+- dataset.yml
+
+Non lasciare un candidate tecnico e un framing pubblico che raccontano due cose diverse.
+
+### 8. Chiudi l'intake con uno stato chiaro
 
 Lo stato iniziale tipico e':
 
@@ -108,6 +215,14 @@ Quando il filone viene preso in carico sul serio, di solito passa a:
 
 - `incubating`
 
+Il candidate deve uscire almeno in uno di questi stati:
+
+- `runnable`
+- `scaffolded_with_blocker`
+- `wait`
+
+Non forzare `runnable` se il primo run non regge davvero.
+
 ## Output minimo atteso
 
 Un intake buono lascia:
@@ -116,11 +231,34 @@ Un intake buono lascia:
 - un perimetro iniziale difendibile
 - un candidate o support dataset ben impostato
 - issue intake e candidate coerenti tra loro
+- un notebook v0 reale
 - un prossimo passo tecnico esplicito
+
+## Definition of done
+
+Il workflow e' considerato chiuso bene quando:
+
+- il candidate resta nel boundary tecnico di `dataset-incubator`
+- non c'e' salto di fase nascosto in `clean`, `mart` o notebook
+- esiste almeno un run verificato oppure un blocker tecnico specifico
+- README, notes, notebook e mart sono coerenti sullo stesso perimetro
+- non ci sono file temporanei o macchina-specifici nel candidate
+
+## Prima di aprire o chiedere review sulla PR
+
+Prima di considerare l'intake abbastanza sano da aprire una PR o chiedere review, controlla almeno che:
+
+- issue intake e candidate siano coerenti
+- il perimetro sia stabile abbastanza
+- il notebook v0 sia reale e non placeholder
+- esista almeno un run verificato oppure un blocker tecnico specifico
+- il prossimo passo sia chiaro:
+  - `runnable`
+  - `scaffolded_with_blocker`
+  - `wait`
 
 ## Dove orientarsi
 
 - [CONTRIBUTING.md](../CONTRIBUTING.md)
 - [README.md](../README.md)
 - [new-candidate.yml](../.github/ISSUE_TEMPLATE/new-candidate.yml)
-- [scouting-checklist.md](../docs/scouting-checklist.md)

--- a/workflows/intake-candidate.md
+++ b/workflows/intake-candidate.md
@@ -1,3 +1,13 @@
+---
+name: intake-candidate
+description: Workflow canonico di dataset-incubator per decidere se una fonte o discussion abbastanza matura puo' entrare come candidate tecnico credibile.
+license: MIT
+metadata:
+  version: "0.2"
+  owner: "DataCivicLab"
+  tags: [dataset-incubator, intake, candidate, support-dataset]
+---
+
 # Workflow: intake-candidate
 
 Workflow canonico di `dataset-incubator`.
@@ -222,6 +232,15 @@ Il candidate deve uscire almeno in uno di questi stati:
 - `wait`
 
 Non forzare `runnable` se il primo run non regge davvero.
+
+## Errori tipici
+
+- aprire intake quando il caso e' ancora troppo esplorativo
+- usare un source-check troppo debole e chiamarlo comunque pronto per DI
+- lasciare mismatch tra issue, `dataset.yml`, README, notes e notebook
+- far fare a `clean` il lavoro che dovrebbe stare in `mart`
+- lasciare il notebook v0 come placeholder invece che come check reale
+- aprire o chiedere review sulla PR con perimetro ancora instabile
 
 ## Output minimo atteso
 

--- a/workflows/run-candidate.md
+++ b/workflows/run-candidate.md
@@ -1,3 +1,13 @@
+---
+name: run-candidate
+description: Workflow canonico di dataset-incubator per eseguire un candidate, verificare gli output e chiudere con uno stato tecnico chiaro.
+license: MIT
+metadata:
+  version: "0.2"
+  owner: "DataCivicLab"
+  tags: [dataset-incubator, run, candidate, validation]
+---
+
 # Workflow: run-candidate
 
 Workflow canonico di `dataset-incubator`.
@@ -45,20 +55,14 @@ Non usarlo quando:
 - la fonte non e' ancora abbastanza verificata
 - il lavoro vero e' ormai debugging complesso di pipeline e richiede un workflow piu' stretto
 
-## Input minimi
-
-Per partire servono almeno:
-
-- slug del candidate
-- config entrypoint chiaro
-- struttura minima del candidate
-- accesso al repo `toolkit`
-- aspettativa minima su cosa dovrebbe produrre il run
-
 ## Preconditions minime
 
 Prima del run dovrebbero esserci almeno:
 
+- slug del candidate
+- config entrypoint chiaro
+- accesso al repo `toolkit`
+- aspettativa minima su cosa dovrebbe produrre il run
 - candidate esistente in `candidates/{slug}/`
 - `dataset.yml` presente e coerente col layer che vuoi eseguire
 - `sql/` presenti se il candidate prevede `clean` e `mart`

--- a/workflows/run-candidate.md
+++ b/workflows/run-candidate.md
@@ -1,42 +1,87 @@
 # Workflow: run-candidate
 
-Workflow pubblico/light di `dataset-incubator`.
-Versione: 0.1 - 2026-04-01
+Workflow canonico di `dataset-incubator`.
+Versione: 0.2 - 2026-04-08
 
 ## Obiettivo di fase
 
-Eseguire un candidate in `dataset-incubator` in modo end-to-end e capire se
-produce output leggibili.
+Eseguire un candidate in `dataset-incubator` in modo reale e capire, in modo
+disciplinato, se:
 
-Questo workflow serve a rispondere a:
+- il candidate gira davvero
+- i layer `raw`, `clean` e `mart` vengono prodotti
+- gli output risultano leggibili
+- il problema, se c'e', e' un blocker tecnico chiaro oppure solo rumore
 
-- quale config usare
-- quale comando lanciare
-- dove leggere `raw`, `clean` e `mart`
-- come capire se il candidate e' andato a buon fine
+Questo workflow serve a:
+
+- scegliere il config giusto
+- fare un run reale o il minimo check eseguibile
+- capire dove guardare gli output
+- distinguere tra `runnable`, `scaffolded_with_blocker` e `wait`
 
 Non serve a:
 
-- fare scouting della fonte
-- rifattorizzare il candidate in grande
-- nascondere un blocker dietro run casuali
+- fare scouting di una fonte ancora opaca
+- rifare il candidate da zero
+- trasformare il run in refactor largo
+- nascondere un blocker dietro tentativi casuali
 
 ## Quando usarlo
 
-Usalo quando:
+Usalo quando hai gia':
 
-- il candidate esiste gia'
-- vuoi farlo girare davvero
-- vuoi vedere i dati prodotti
-- vuoi distinguere tra run riuscito e blocco tecnico reale
+- un candidate con struttura minima reale
+- un `dataset.yml` chiaro da usare come entrypoint
+- un motivo preciso per eseguirlo:
+  - validazione tecnica
+  - primo run reale
+  - verifica dopo fix
 
 Non usarlo quando:
 
-- il candidate non ha ancora una struttura minima
-- sei ancora al livello discussion/source-check
-- il lavoro vero e' ormai fix di pipeline complessa
+- il candidate e' ancora nella fase di intake immaturo
+- manca ancora il boundary tra `clean` e `mart`
+- la fonte non e' ancora abbastanza verificata
+- il lavoro vero e' ormai debugging complesso di pipeline e richiede un workflow piu' stretto
 
-## Workflow step-by-step
+## Input minimi
+
+Per partire servono almeno:
+
+- slug del candidate
+- config entrypoint chiaro
+- struttura minima del candidate
+- accesso al repo `toolkit`
+- aspettativa minima su cosa dovrebbe produrre il run
+
+## Preconditions minime
+
+Prima del run dovrebbero esserci almeno:
+
+- candidate esistente in `candidates/{slug}/`
+- `dataset.yml` presente e coerente col layer che vuoi eseguire
+- `sql/` presenti se il candidate prevede `clean` e `mart`
+- un `README.md` o `notes.md` che dica almeno qual e' il perimetro
+
+Nel dubbio:
+
+- se il candidate non ha ancora una forma minima verificabile, fermati e torna prima al workflow di intake
+
+## Stop rules
+
+Fermati e non forzare il run quando:
+
+- il candidate non ha ancora una struttura minima
+- non e' chiaro quale config sia l'entrypoint reale
+- il problema e' ancora di fase precedente:
+  - scouting
+  - source-check
+  - boundary del candidate
+- il `clean` e' gia' un mart travestito e il run starebbe solo nascondendo il problema
+- dopo un primo errore reale stai gia' cambiando troppe cose insieme senza aver isolato il blocker
+
+## Passi canonici
 
 ### 1. Controlla la struttura minima
 
@@ -44,16 +89,19 @@ Verifica che il candidate abbia almeno:
 
 - `README.md`
 - `notes.md`
-- `dataset.yml` oppure config rilevanti in `sources/`
+- `dataset.yml`
 
-Se la struttura minima manca, fermati prima del run.
+e, se previsti:
 
-### 2. Scegli il config giusto
+- `sql/clean.sql`
+- `sql/mart.sql`
+- notebook v0
 
-Chiarisci:
+Se manca la struttura minima, fermati prima del run.
 
-- se il candidate e' single-source o multi-source
-- quale `dataset.yml` usare come entrypoint
+### 2. Scegli l'entrypoint giusto
+
+Chiarisci subito quale config vuoi eseguire.
 
 Caso tipico single-source:
 
@@ -66,68 +114,149 @@ Caso tipico multi-source:
 
 Regola pratica:
 
-- non partire dal compose se i source layer non sono ancora chiari
+- non partire dal compose se i source layer non sono ancora chiari o verificati
+- se non hai un motivo specifico per fare altro, parti da `run all` sul `dataset.yml` principale del candidate
 
-### 3. Lancia il candidate
+### 3. Fai prima un controllo path/config
+
+Prima di lanciare tutto, verifica almeno:
+
+- che il config punti ai path attesi
+- che `root` e cartelle di output siano coerenti
+- che il candidate non stia leggendo o scrivendo in percorsi inattesi
+
+Se il contract dei path non e' chiaro, fermati prima del run completo.
+
+### 4. Lancia il run minimo giusto
+
 Il run tipico usa `toolkit` sul config del candidate.
 
-Esempio:
+Esempio single-source:
 
 ```bash
 cd toolkit
 python -m toolkit.cli.app run all --config ../dataset-incubator/candidates/{slug}/dataset.yml
 ```
 
-Per candidate nested:
+Esempio nested:
 
 ```bash
 cd toolkit
 python -m toolkit.cli.app run all --config ../dataset-incubator/candidates/{slug}/sources/{source}/dataset.yml
 ```
 
-### 4. Guarda gli output
+Regola:
+
+- partire dal minimo run che risponde alla domanda tecnica del momento
+- non fare subito piu' run diversi se il primo non e' ancora chiaro
+
+### 5. Controlla gli output
 
 Dopo il run, controlla almeno:
 
-- se il comando ha completato senza errori
-- se il candidate ha prodotto dati sotto `dataset-incubator/out/`
+- se il comando e' completato senza errori
+- se `raw`, `clean` e `mart` sono stati prodotti dove atteso
 - qual e' il primo file utile da aprire
 
-In genere il percorso utile e' uno tra:
+I percorsi tipici sono dentro:
 
 - `out/data/raw/...`
 - `out/data/clean/...`
 - `out/data/mart/...`
 
-Il file piu' utile da guardare per primo e' quasi sempre il `mart`, se esiste.
+Se esiste, il primo file piu' utile da guardare e' spesso il `mart`.
 
-### 5. Se fallisce, isola il primo errore vero
+Segnale minimo di output leggibile:
 
-Se il run non regge, non allargare subito il lavoro.
-Isola prima:
+- il file si apre
+- non e' vuoto
+- le colonne principali sono coerenti con la domanda o col layer atteso
+- non ci sono rotture evidenti o valori palesemente fuori posto
 
-- primo errore vero
-- file coinvolti
-- se il blocco e' di accesso, config o SQL
+### 6. Se fallisce, isola il primo errore vero
+
+Se il run non regge:
+
+- isola il primo errore vero
+- annota file e layer coinvolti
+- distingui tra:
+  - accesso fonte
+  - config/path
+  - parsing
+  - SQL
+  - validazione
+
+Se utile, chiudi il blocker con una formula semplice:
+
+- `blocco fonte`
+- `blocco config/path`
+- `blocco parsing`
+- `blocco SQL`
+- `blocco validazione`
 
 Non usare questo workflow per:
 
 - cambiare la domanda civica
-- rifare il candidate da zero
-- aggiungere complessita' non necessaria
+- allargare il candidate
+- fare refactor larghi prima di aver capito il blocker
+
+### 7. Chiudi con uno stato chiaro
+
+Il workflow dovrebbe uscire in uno di questi stati:
+
+- `runnable`
+- `scaffolded_with_blocker`
+- `wait`
+
+`runnable`:
+
+- il candidate gira davvero e produce output leggibili
+
+`scaffolded_with_blocker`:
+
+- la struttura regge, ma esiste un blocker tecnico preciso
+
+`wait`:
+
+- manca ancora un pezzo di fase precedente e non ha senso insistere col run
+
+## Errori tipici
+
+- partire dal config sbagliato
+- lanciare `compose` troppo presto
+- non controllare i path prima del run
+- guardare solo il codice di uscita e non gli output reali
+- cambiare troppe cose insieme dopo il primo errore
+- usare il run per coprire un candidate ancora immaturo
 
 ## Output minimo atteso
 
 Un run utile lascia:
 
-- comando eseguito
 - config usato
-- conferma che il candidate produce output leggibili oppure primo errore vero
-- primo file o layer da guardare
-- prossimo passo consigliato
+- esito del run
+- layer prodotti o primo blocker reale
+- primo file o output da guardare
+- prossimo passo tecnico chiaro
+
+## Definition of done
+
+Il workflow e' chiuso bene quando:
+
+- l'entrypoint usato e' chiaro
+- l'esito e' classificato in modo netto
+- esiste almeno un output verificato oppure un blocker tecnico preciso
+- non sono stati nascosti problemi di boundary del candidate dietro il run
+- il prossimo passo e' esplicito e piccolo
+
+## Stati finali ammessi
+
+- `runnable`
+- `scaffolded_with_blocker`
+- `wait`
 
 ## Dove orientarsi
 
-- [CONTRIBUTING.md](../CONTRIBUTING.md)
 - [README.md](../README.md)
-- [PROMOTION_CHECKLIST.md](../PROMOTION_CHECKLIST.md)
+- [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [intake-candidate.md](./intake-candidate.md)


### PR DESCRIPTION
## Sintesi

Questa PR rende piu' standalone e coerenti i workflow `intake-candidate` e `run-candidate` in `dataset-incubator`, riallineandoli al template comune e ai test reali eseguiti nel workspace.

## Cosa cambia

- rafforza `workflows/intake-candidate.md`
- rafforza `workflows/run-candidate.md`
- uniforma i workflow al template rivisto
- aggiorna il candidate `dipendenti-pubblici` dove serviva per restare coerente con il workflow eseguito davvero

## Perche'

I workflow non sono piu' solo documentazione teorica:

- `run-candidate` e' stato eseguito davvero su `dipendenti-pubblici`
- `intake-candidate` e' stato esercitato davvero su un caso difficile (`ispra-balneazione`)

Questa PR consolida quindi il lato procedurale che ha gia' retto in pratica.

## Note

- PR limitata ai workflow DI e ai micro-riallineamenti connessi
- `ispra-balneazione` resta fuori da questa PR
- eventuali follow-up su semantic sufficiency o source ping candidate-level restano separati
