### PR TITLE
Aggiungi Dependabot per le dipendenze Python di dataset-incubator

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Sintesi

Aggiunge `Dependabot` per le dipendenze Python di `dataset-incubator`.

## Cosa cambia

- nuovo file `.github/dependabot.yml`
- check settimanale delle dipendenze `pip`
- massimo 5 PR aperte insieme

## Perche'

`dataset-incubator` ha codice Python vivo su workflow di validazione, tooling locale e script di supporto. Questo riduce il rischio di dipendenze stale senza aggiungere manutenzione manuale.

## Note

- PR volutamente minima
- nessun cambiamento ai workflow esistenti
- stesso pattern gia' usato su `toolkit` e `source-observatory`
