### PR TITLE
docs: cita toolkit_blocker_hints e toolkit_review_readiness nei workflow DI

### DIFF
--- a/workflows/intake-candidate.md
+++ b/workflows/intake-candidate.md
@@ -180,6 +180,11 @@ python -m toolkit.cli.app run mart --config ../dataset-incubator/candidates/{slu
 
 Se il candidate e' nested, usa il `dataset.yml` del source layer giusto.
 
+Se il server MCP `toolkit` e' attivo nel runtime, puoi usare in alternativa alla CLI:
+
+- `toolkit_inspect_paths(config_path)` - verifica path e contract del config
+- `toolkit_blocker_hints(config_path)` - evidenzia mismatch pratici tra output risolti e stato run
+
 Per il dettaglio del run e dei blocker, il riferimento resta:
 
 - [run-candidate.md](./run-candidate.md)
@@ -275,6 +280,7 @@ Prima di considerare l'intake abbastanza sano da aprire una PR o chiedere review
   - `runnable`
   - `scaffolded_with_blocker`
   - `wait`
+- se il server MCP `toolkit` e' disponibile, `toolkit_review_readiness(config_path)` anticipa i check minimi di readiness: config valida, layer presenti, output leggibili, coerenza run record
 
 ## Dove orientarsi
 

--- a/workflows/run-candidate.md
+++ b/workflows/run-candidate.md
@@ -131,6 +131,10 @@ Prima di lanciare tutto, verifica almeno:
 
 Se il contract dei path non e' chiaro, fermati prima del run completo.
 
+Se il server MCP `toolkit` e' attivo nel runtime:
+
+- `toolkit_inspect_paths(config_path)` - alternativa al controllo manuale di path e contract
+
 ### 4. Lancia il run minimo giusto
 
 Il run tipico usa `toolkit` sul config del candidate.
@@ -177,6 +181,10 @@ Segnale minimo di output leggibile:
 - le colonne principali sono coerenti con la domanda o col layer atteso
 - non ci sono rotture evidenti o valori palesemente fuori posto
 
+Se il server MCP `toolkit` e' attivo nel runtime:
+
+- `toolkit_blocker_hints(config_path)` - evidenzia mismatch tra output risolti e run record
+
 ### 6. Se fallisce, isola il primo errore vero
 
 Se il run non regge:
@@ -211,6 +219,8 @@ Il workflow dovrebbe uscire in uno di questi stati:
 - `runnable`
 - `scaffolded_with_blocker`
 - `wait`
+
+Se il server MCP `toolkit` e' attivo, `toolkit_review_readiness(config_path)` esegue i check di readiness prima di passare alla review: config valida, layer presenti, output leggibili, coerenza run record.
 
 `runnable`:
 


### PR DESCRIPTION
## Cosa cambia

Aggiunge i riferimenti agli strumenti MCP `toolkit` nei workflow `intake-candidate` e `run-candidate`, ora disponibili dopo le PR toolkit#103 e toolkit#104.

### `intake-candidate.md`
- Step 5 (run minimo): aggiunto blocco MCP con `toolkit_inspect_paths` e `toolkit_blocker_hints` come alternativa alla CLI
- Sezione "Prima di aprire PR": aggiunto `toolkit_review_readiness` come check di readiness opzionale

### `run-candidate.md`
- Step 3 (controllo path): aggiunto `toolkit_inspect_paths`
- Step 5 (controlla output): aggiunto `toolkit_blocker_hints`
- Step 7 (chiudi con stato): aggiunto `toolkit_review_readiness` prima del passaggio a review

## Note

- Solo documentazione/processo, nessuna modifica al codice
- Tutti i riferimenti MCP sono condizionali ("se il server e' attivo") - nessun requisito aggiunto