### PR TITLE
feat: workflow consumer diff_summary SO -> triage candidate DI

### DIFF
--- a/.github/workflows/monitor-triage.yml
+++ b/.github/workflows/monitor-triage.yml
@@ -1,0 +1,74 @@
+name: monitor-triage
+
+on:
+  workflow_dispatch:
+    inputs:
+      diff_url:
+        description: 'URL del diff_summary.json prodotto da source-observatory'
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install PyYAML pytest
+
+      - name: Run tests
+        run: pytest tests/test_triage_monitor_diff.py -q
+
+      - name: Download diff_summary.json
+        env:
+          TRIAGE_WORK: ${{ runner.temp }}/monitor-triage
+        run: |
+          mkdir -p "$TRIAGE_WORK"
+          curl -fsSL "${{ github.event.inputs.diff_url }}" -o "$TRIAGE_WORK/diff_summary.json"
+
+      - name: Run triage
+        env:
+          TRIAGE_WORK: ${{ runner.temp }}/monitor-triage
+        run: |
+          python scripts/triage_monitor_diff.py \
+            --diff "$TRIAGE_WORK/diff_summary.json" \
+            --map config/monitor/source_candidate_map.yml \
+            --output-dir "$TRIAGE_WORK/output"
+
+      - name: Verify checkout remains clean
+        run: git diff --quiet --exit-code
+
+      - name: Publish summary
+        env:
+          TRIAGE_WORK: ${{ runner.temp }}/monitor-triage
+        run: |
+          report="$TRIAGE_WORK/output/triage_report.md"
+          if [[ -f "$report" ]]; then
+            cat "$report" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: monitor-triage
+          path: |
+            ${{ runner.temp }}/monitor-triage/output/triage_report.md
+            ${{ runner.temp }}/monitor-triage/output/triage_result.json
+          if-no-files-found: error

--- a/config/monitor/source_candidate_map.yml
+++ b/config/monitor/source_candidate_map.yml
@@ -1,0 +1,29 @@
+# Mapping source_id (SO monitor) -> candidate slug (DI)
+#
+# source_id: identificativo della fonte in resource_monitor.sources.yml di source-observatory
+# candidates: lista di slug candidate in DI che dipendono da quella fonte
+# active: se false, la fonte viene ignorata dal workflow di triage
+#
+# Aggiornare quando si aggiunge una nuova fonte monitorata in SO
+# o un nuovo candidate in DI collegato a una fonte gia' monitorata.
+
+mappings:
+  - source_id: ispra-consumo-suolo
+    candidates:
+      - ispra-consumo-suolo
+    active: true
+
+  - source_id: civile-flussi
+    candidates:
+      - civile-flussi
+    active: true
+
+  - source_id: opencoesione-pagamenti
+    candidates:
+      - opencoesione-pagamenti-ue-2014-2020
+    active: true
+
+  - source_id: terna-electricity-by-source
+    candidates:
+      - terna-electricity-by-source
+    active: true

--- a/scripts/triage_monitor_diff.py
+++ b/scripts/triage_monitor_diff.py
@@ -18,8 +18,12 @@ import yaml
 def load_map(map_path: Path) -> dict[str, list[str]]:
     """Carica il mapping source_id -> candidates. Restituisce solo le entry active."""
     data = yaml.safe_load(map_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"source_candidate_map.yml non valido: atteso dict, trovato {type(data).__name__}")
     result: dict[str, list[str]] = {}
-    for entry in data.get("mappings", []):
+    for i, entry in enumerate(data.get("mappings", [])):
+        if not isinstance(entry, dict) or "source_id" not in entry:
+            raise ValueError(f"mappings[{i}]: entry non valida, 'source_id' richiesto")
         if entry.get("active", True):
             result[entry["source_id"]] = entry.get("candidates", [])
     return result
@@ -32,13 +36,13 @@ def triage(diff: dict, source_map: dict[str, list[str]]) -> dict:
         candidates = source_map.get(source_id, [])
         if not candidates:
             continue
-        source_diff = diff["per_source"][source_id]
+        source_diff = diff.get("per_source", {}).get(source_id, {})
         impacted.append({
             "source_id": source_id,
             "candidates": candidates,
-            "new": source_diff["new"],
-            "changed": source_diff["changed"],
-            "removed": source_diff["removed"],
+            "new": source_diff.get("new", 0),
+            "changed": source_diff.get("changed", 0),
+            "removed": source_diff.get("removed", 0),
         })
 
     errors_in_map: list[str] = [

--- a/scripts/triage_monitor_diff.py
+++ b/scripts/triage_monitor_diff.py
@@ -1,0 +1,129 @@
+"""Triage candidate DI impattati da diff monitor source-observatory.
+
+Legge un diff_summary.json prodotto da SO resource_monitor e un mapping
+source_id -> candidate slug, e produce un report di triage (Markdown + JSON).
+
+Nessun side effect: non apre issue, non avvia pipeline, non scrive nel repo.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def load_map(map_path: Path) -> dict[str, list[str]]:
+    """Carica il mapping source_id -> candidates. Restituisce solo le entry active."""
+    data = yaml.safe_load(map_path.read_text(encoding="utf-8"))
+    result: dict[str, list[str]] = {}
+    for entry in data.get("mappings", []):
+        if entry.get("active", True):
+            result[entry["source_id"]] = entry.get("candidates", [])
+    return result
+
+
+def triage(diff: dict, source_map: dict[str, list[str]]) -> dict:
+    """Calcola candidate impattati a partire dal diff_summary."""
+    impacted: list[dict] = []
+    for source_id in diff.get("sources_with_changes", []):
+        candidates = source_map.get(source_id, [])
+        if not candidates:
+            continue
+        source_diff = diff["per_source"][source_id]
+        impacted.append({
+            "source_id": source_id,
+            "candidates": candidates,
+            "new": source_diff["new"],
+            "changed": source_diff["changed"],
+            "removed": source_diff["removed"],
+        })
+
+    errors_in_map: list[str] = [
+        source_id
+        for source_id in diff.get("sources_with_errors", [])
+        if source_id in source_map
+    ]
+
+    return {
+        "generated_at": diff.get("generated_at_utc", diff.get("generated_at", "")),
+        "impacted_count": len(impacted),
+        "impacted": impacted,
+        "sources_with_errors_in_map": errors_in_map,
+    }
+
+
+def render_report(result: dict) -> str:
+    lines = ["# Monitor diff triage - candidate impattati", ""]
+    lines.append(f"Diff generato: {result['generated_at']}")
+    lines.append("")
+
+    if result["impacted_count"] == 0:
+        lines.append(
+            "**Nessuna azione richiesta.** "
+            "Nessun candidate DI impattato da cambi nelle fonti monitorate."
+        )
+    else:
+        lines.append(
+            f"**{result['impacted_count']} fonte/i con cambi che impattano candidate DI:**"
+        )
+        lines.append("")
+        for item in result["impacted"]:
+            cand_list = ", ".join(f"`{c}`" for c in item["candidates"])
+            lines.append(f"- **{item['source_id']}** -> {cand_list}")
+            lines.append(
+                f"  new: {item['new']}, changed: {item['changed']}, removed: {item['removed']}"
+            )
+
+    if result["sources_with_errors_in_map"]:
+        lines.append("")
+        lines.append("**Fonti con errori (monitor) presenti nel mapping DI:**")
+        for s in result["sources_with_errors_in_map"]:
+            lines.append(f"- {s}")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Triage candidate DI impattati da diff monitor SO."
+    )
+    parser.add_argument(
+        "--diff", required=True, type=Path, help="Path al diff_summary.json di SO"
+    )
+    parser.add_argument(
+        "--map", required=True, type=Path, help="Path al source_candidate_map.yml"
+    )
+    parser.add_argument(
+        "--output-dir", type=Path, default=Path("."), help="Directory di output"
+    )
+    args = parser.parse_args()
+
+    if not args.diff.exists():
+        print(f"Errore: file diff non trovato: {args.diff}", file=sys.stderr)
+        return 1
+    if not args.map.exists():
+        print(f"Errore: file map non trovato: {args.map}", file=sys.stderr)
+        return 1
+
+    diff = json.loads(args.diff.read_text(encoding="utf-8"))
+    source_map = load_map(args.map)
+    result = triage(diff, source_map)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = args.output_dir / "triage_report.md"
+    result_path = args.output_dir / "triage_result.json"
+
+    report_path.write_text(render_report(result), encoding="utf-8")
+    result_path.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    print(f"Report:              {report_path}")
+    print(f"Result:              {result_path}")
+    print(f"Candidate impattati: {result['impacted_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))

--- a/tests/test_triage_monitor_diff.py
+++ b/tests/test_triage_monitor_diff.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from triage_monitor_diff import load_map, render_report, triage
+
+
+# --- load_map ---
+
+def test_load_map_returns_active_entries(tmp_path: Path) -> None:
+    map_data = {
+        "mappings": [
+            {"source_id": "s1", "candidates": ["c1"], "active": True},
+            {"source_id": "s2", "candidates": ["c2"], "active": False},
+        ]
+    }
+    map_file = tmp_path / "map.yml"
+    map_file.write_text(yaml.dump(map_data), encoding="utf-8")
+
+    result = load_map(map_file)
+
+    assert "s1" in result
+    assert result["s1"] == ["c1"]
+    assert "s2" not in result
+
+
+def test_load_map_active_defaults_to_true(tmp_path: Path) -> None:
+    map_data = {"mappings": [{"source_id": "s1", "candidates": ["c1"]}]}
+    map_file = tmp_path / "map.yml"
+    map_file.write_text(yaml.dump(map_data), encoding="utf-8")
+
+    result = load_map(map_file)
+
+    assert "s1" in result
+
+
+def test_load_map_empty_mappings(tmp_path: Path) -> None:
+    map_file = tmp_path / "map.yml"
+    map_file.write_text(yaml.dump({"mappings": []}), encoding="utf-8")
+
+    assert load_map(map_file) == {}
+
+
+# --- triage ---
+
+def _make_diff(
+    sources_with_changes: list[str] | None = None,
+    sources_with_errors: list[str] | None = None,
+    per_source: dict | None = None,
+) -> dict:
+    return {
+        "generated_at_utc": "2026-04-12T10:00:00Z",
+        "sources_with_changes": sources_with_changes or [],
+        "sources_with_errors": sources_with_errors or [],
+        "per_source": per_source or {},
+    }
+
+
+def test_triage_no_changes() -> None:
+    result = triage(_make_diff(), source_map={"s1": ["c1"]})
+
+    assert result["impacted_count"] == 0
+    assert result["impacted"] == []
+
+
+def test_triage_source_in_map_with_changes() -> None:
+    diff = _make_diff(
+        sources_with_changes=["s1"],
+        per_source={"s1": {"new": 0, "changed": 2, "removed": 0}},
+    )
+    result = triage(diff, source_map={"s1": ["c1", "c2"]})
+
+    assert result["impacted_count"] == 1
+    item = result["impacted"][0]
+    assert item["source_id"] == "s1"
+    assert item["candidates"] == ["c1", "c2"]
+    assert item["changed"] == 2
+
+
+def test_triage_unknown_source_ignored() -> None:
+    diff = _make_diff(
+        sources_with_changes=["unknown"],
+        per_source={"unknown": {"new": 1, "changed": 0, "removed": 0}},
+    )
+    result = triage(diff, source_map={"s1": ["c1"]})
+
+    assert result["impacted_count"] == 0
+
+
+def test_triage_errors_in_map_reported() -> None:
+    diff = _make_diff(sources_with_errors=["s1"])
+    result = triage(diff, source_map={"s1": ["c1"]})
+
+    assert "s1" in result["sources_with_errors_in_map"]
+
+
+def test_triage_errors_not_in_map_ignored() -> None:
+    diff = _make_diff(sources_with_errors=["other-source"])
+    result = triage(diff, source_map={"s1": ["c1"]})
+
+    assert result["sources_with_errors_in_map"] == []
+
+
+# --- render_report ---
+
+def test_render_report_no_action() -> None:
+    result = {
+        "generated_at": "2026-04-12T10:00:00Z",
+        "impacted_count": 0,
+        "impacted": [],
+        "sources_with_errors_in_map": [],
+    }
+    report = render_report(result)
+
+    assert "Nessuna azione" in report
+
+
+def test_render_report_shows_impacted() -> None:
+    result = {
+        "generated_at": "2026-04-12T10:00:00Z",
+        "impacted_count": 1,
+        "impacted": [
+            {"source_id": "s1", "candidates": ["c1"], "new": 0, "changed": 1, "removed": 0}
+        ],
+        "sources_with_errors_in_map": [],
+    }
+    report = render_report(result)
+
+    assert "s1" in report
+    assert "c1" in report
+    assert "changed: 1" in report
+
+
+def test_render_report_shows_errors() -> None:
+    result = {
+        "generated_at": "2026-04-12T10:00:00Z",
+        "impacted_count": 0,
+        "impacted": [],
+        "sources_with_errors_in_map": ["s1"],
+    }
+    report = render_report(result)
+
+    assert "s1" in report
+    assert "errori" in report.lower()

--- a/tests/test_triage_monitor_diff.py
+++ b/tests/test_triage_monitor_diff.py
@@ -45,6 +45,23 @@ def test_load_map_empty_mappings(tmp_path: Path) -> None:
     assert load_map(map_file) == {}
 
 
+def test_load_map_invalid_root_type(tmp_path: Path) -> None:
+    map_file = tmp_path / "map.yml"
+    map_file.write_text("- just a list\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="non valido"):
+        load_map(map_file)
+
+
+def test_load_map_entry_missing_source_id(tmp_path: Path) -> None:
+    map_data = {"mappings": [{"candidates": ["c1"], "active": True}]}
+    map_file = tmp_path / "map.yml"
+    map_file.write_text(yaml.dump(map_data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="source_id"):
+        load_map(map_file)
+
+
 # --- triage ---
 
 def _make_diff(
@@ -79,6 +96,32 @@ def test_triage_source_in_map_with_changes() -> None:
     assert item["source_id"] == "s1"
     assert item["candidates"] == ["c1", "c2"]
     assert item["changed"] == 2
+
+
+def test_triage_missing_per_source_entry_degrades() -> None:
+    """Se sources_with_changes elenca una fonte ma per_source e' incompleto, non crasha."""
+    diff = _make_diff(
+        sources_with_changes=["s1"],
+        per_source={},  # chiave mancante
+    )
+    result = triage(diff, source_map={"s1": ["c1"]})
+
+    assert result["impacted_count"] == 1
+    item = result["impacted"][0]
+    assert item["new"] == 0
+    assert item["changed"] == 0
+    assert item["removed"] == 0
+
+
+def test_triage_missing_count_keys_degrades() -> None:
+    """Se per_source ha la entry ma mancano le chiavi di conteggio, usa 0 come default."""
+    diff = _make_diff(
+        sources_with_changes=["s1"],
+        per_source={"s1": {}},  # entry presente ma senza new/changed/removed
+    )
+    result = triage(diff, source_map={"s1": ["c1"]})
+
+    assert result["impacted"][0]["changed"] == 0
 
 
 def test_triage_unknown_source_ignored() -> None:


### PR DESCRIPTION
## Summary

- Aggiunge `config/monitor/source_candidate_map.yml`: mapping versionato `source_id` (SO) -> slug candidate (DI), welfare-first, 4 fonti attive
- Aggiunge `scripts/triage_monitor_diff.py`: legge `diff_summary.json` + map, produce `triage_report.md` e `triage_result.json` senza side effect
- Aggiunge `tests/` con `conftest.py` e 11 test per `load_map`, `triage`, `render_report`
- Aggiunge `.github/workflows/monitor-triage.yml`: `workflow_dispatch` con input `diff_url`, test in-workflow, isolamento `$RUNNER_TEMP`, `git diff --quiet` check, artifact upload

Il workflow v1 e' solo `workflow_dispatch` (nessun `schedule`). Il `cron` verra' aggiunto in follow-up dopo 1-2 run reali di validazione.

## Closes

Closes #130
Closes #131

## Test plan

- [ ] 11 test locali verdi (`pytest tests/test_triage_monitor_diff.py -q`)
- [ ] Eseguire `monitor-triage` via Actions con un `diff_url` reale da SO per validare il flusso end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)