### PR TITLE
feat: genera pipeline_signals.json per integrazione ACB

### DIFF
--- a/.github/workflows/build-pipeline-signals.yml
+++ b/.github/workflows/build-pipeline-signals.yml
@@ -1,0 +1,40 @@
+name: Build Pipeline Signals
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "candidates/**"
+      - "registry/archived.md"
+      - "scripts/build_pipeline_signals.py"
+      - "scripts/validate_candidate_structure.py"
+
+jobs:
+  build-pipeline-signals:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout dataset-incubator
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Build pipeline_signals.json
+        run: python scripts/build_pipeline_signals.py
+
+      - name: Commit updated pipeline_signals.json
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: aggiorna pipeline_signals.json"
+          file_pattern: registry/pipeline_signals.json
+          commit_user_name: github-actions[bot]
+          commit_user_email: github-actions[bot]@users.noreply.github.com

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,0 +1,128 @@
+{
+  "schema_version": "1",
+  "generated_at": "2026-04-16",
+  "repo": "dataset-incubator",
+  "topic": "pipeline_state",
+  "summary": {
+    "total": 16,
+    "by_status": {
+      "ok": 16,
+      "warn": 0,
+      "error": 0
+    }
+  },
+  "signals": [
+    {
+      "id": "aifa-spesa-consumo",
+      "status": "ok",
+      "label": "aifa-spesa-consumo",
+      "detail": "anni 2022-2024 — multi-source (1 fonte) — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "bdap-entrate-stato",
+      "status": "ok",
+      "label": "bdap-entrate-stato",
+      "detail": "anno 2024 — fonte: openbdap_entrate_csv — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "bdap-lea",
+      "status": "ok",
+      "label": "bdap-lea",
+      "detail": "anno 2024 — fonte: bdap_lea_csv — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "inps-pensioni",
+      "status": "ok",
+      "label": "inps-pensioni",
+      "detail": "anno 2024 — fonte: inps_pensioni_csv — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "ispra-consumo-suolo",
+      "status": "ok",
+      "label": "ispra-consumo-suolo",
+      "detail": "anno 2024 — multi-source (1 fonte) — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "ispra-ru-costi-kg",
+      "status": "ok",
+      "label": "ispra-ru-costi-kg",
+      "detail": "anni 2020-2024 — multi-source (3 fonti) — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "istat-gini-regionale",
+      "status": "ok",
+      "label": "istat-gini-regionale",
+      "detail": "anno 2023 — fonte: istat_sdmx_gini — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "istat-housing-crowding",
+      "status": "ok",
+      "label": "istat-housing-crowding",
+      "detail": "anno 2024 — fonte: istat_sdmx_housing_crowding — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "istat-ipab-aree",
+      "status": "ok",
+      "label": "istat-ipab-aree",
+      "detail": "anno 2024 — fonte: istat_sdmx_ipab_aree — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "mim-alunni-corso-eta",
+      "status": "ok",
+      "label": "mim-alunni-corso-eta",
+      "detail": "anno 2024 — fonte: mim_alunni_corso_eta_csv — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "mit-incidentalita-mensile-2001-2018",
+      "status": "ok",
+      "label": "mit-incidentalita-mensile-2001-2018",
+      "detail": "anno 2001 — fonte: mit_incidentalita_mensile_csv — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "mit-opere-incompiute-2020",
+      "status": "ok",
+      "label": "mit-opere-incompiute-2020",
+      "detail": "anno 2020 — fonte: mit_opere_incompiute_csv — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "opencivitas-fsc-rso",
+      "status": "ok",
+      "label": "opencivitas-fsc-rso",
+      "detail": "anno 2025 — multi-source (2 fonti) — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "opencoesione-pagamenti-ue-2014-2020",
+      "status": "ok",
+      "label": "opencoesione-pagamenti-ue-2014-2020",
+      "detail": "anno 2020 — fonte: opencoesione_progetti_esteso_zip — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "pensioni-pa-dag",
+      "status": "ok",
+      "label": "pensioni-pa-dag",
+      "detail": "anno 2024 — fonte: dag_pensioni_totale_local — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "terna-capacita-rinnovabile",
+      "status": "ok",
+      "label": "terna-capacita-rinnovabile",
+      "detail": "anni 2023-2024 — fonte: terna_capacity_renewable_sources_xlsx — mart: sì",
+      "action": ""
+    }
+  ]
+}

--- a/scripts/build_pipeline_signals.py
+++ b/scripts/build_pipeline_signals.py
@@ -1,0 +1,260 @@
+"""Build registry/pipeline_signals.json for ACB consumption.
+
+Scans active candidates in dataset-incubator and produces a signal file
+following the repo-signals standard (see agent-context-builder/schemas/repo-signals.md).
+
+Status logic:
+  ok   — structure valid + mart SQL present
+  warn — structure valid but no mart SQL yet
+  error — structural issue (missing dataset.yml, clean.sql, or ambiguous layout)
+
+Run:
+  python scripts/build_pipeline_signals.py [--out registry/pipeline_signals.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Import helpers from the existing validation script — no duplication
+sys.path.insert(0, str(ROOT / "scripts"))
+from validate_candidate_structure import has_mart_sql, load_archived_paths  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# dataset.yml reading
+# ---------------------------------------------------------------------------
+
+def _read_yaml(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def _years_label(years: list) -> str:
+    if not years:
+        return "anni: ?"
+    years = sorted(int(y) for y in years)
+    if len(years) == 1:
+        return f"anno {years[0]}"
+    return f"anni {years[0]}-{years[-1]}"
+
+
+def _source_names(sources: list[dict]) -> list[str]:
+    return [s.get("name", "?") for s in sources if isinstance(s, dict)]
+
+
+# ---------------------------------------------------------------------------
+# Candidate introspection
+# ---------------------------------------------------------------------------
+
+def _inspect_single_source(base_dir: Path) -> dict:
+    """Inspect a single-source candidate (root dataset.yml)."""
+    yml_path = base_dir / "dataset.yml"
+    sql_dir = base_dir / "sql"
+
+    failures = []
+    if not yml_path.exists():
+        failures.append("missing dataset.yml")
+    if not sql_dir.is_dir():
+        failures.append("missing sql/")
+    elif not (sql_dir / "clean.sql").exists():
+        failures.append("missing sql/clean.sql")
+
+    mart_ok = sql_dir.is_dir() and has_mart_sql(sql_dir)
+
+    cfg = _read_yaml(yml_path) if yml_path.exists() else {}
+    ds = cfg.get("dataset", {})
+    years = ds.get("years", [])
+    raw_sources = cfg.get("raw", {}).get("sources", [])
+    source_names = _source_names(raw_sources)
+
+    return {
+        "pattern": "single-source",
+        "years": years,
+        "sources": source_names,
+        "mart_ok": mart_ok,
+        "failures": failures,
+    }
+
+
+def _inspect_multi_source(base_dir: Path) -> dict:
+    """Inspect a multi-source candidate (sources/*/dataset.yml)."""
+    sources_dir = base_dir / "sources"
+    source_dirs = sorted(p for p in sources_dir.iterdir() if p.is_dir())
+
+    failures = []
+    all_years: list[int] = []
+    all_sources: list[str] = []
+    mart_ok = False
+
+    for src_dir in source_dirs:
+        yml_path = src_dir / "dataset.yml"
+        sql_dir = src_dir / "sql"
+
+        if not yml_path.exists():
+            failures.append(f"missing {src_dir.name}/dataset.yml")
+            continue
+        if not sql_dir.is_dir():
+            failures.append(f"missing {src_dir.name}/sql/")
+            continue
+        if not (sql_dir / "clean.sql").exists():
+            failures.append(f"missing {src_dir.name}/sql/clean.sql")
+
+        cfg = _read_yaml(yml_path)
+        ds = cfg.get("dataset", {})
+        years = [int(y) for y in ds.get("years", [])]
+        all_years.extend(years)
+        raw_sources = cfg.get("raw", {}).get("sources", [])
+        all_sources.extend(_source_names(raw_sources))
+
+        if has_mart_sql(sql_dir):
+            mart_ok = True
+
+    # compose layer — if present, its mart overrides individual source mart
+    compose_dir = base_dir / "compose"
+    if compose_dir.is_dir():
+        compose_sql = compose_dir / "sql"
+        if compose_sql.is_dir() and has_mart_sql(compose_sql):
+            mart_ok = True
+        elif compose_sql.is_dir() and not has_mart_sql(compose_sql):
+            failures.append("compose/sql/ present but missing mart SQL")
+
+    return {
+        "pattern": "multi-source",
+        "years": sorted(set(all_years)),
+        "sources": list(dict.fromkeys(all_sources)),  # deduplicated, order-preserving
+        "mart_ok": mart_ok,
+        "failures": failures,
+    }
+
+
+def _build_signal(slug: str, base_dir: Path) -> dict:
+    """Build a single signal entry for a candidate."""
+    has_root_dataset = (base_dir / "dataset.yml").exists()
+    has_sources = (base_dir / "sources").is_dir()
+
+    if has_root_dataset and has_sources:
+        info = {
+            "pattern": "ambiguous",
+            "years": [],
+            "sources": [],
+            "mart_ok": False,
+            "failures": ["ambiguous: root dataset.yml and sources/ cannot coexist"],
+        }
+    elif has_root_dataset:
+        info = _inspect_single_source(base_dir)
+    elif has_sources:
+        info = _inspect_multi_source(base_dir)
+    else:
+        info = {
+            "pattern": "unknown",
+            "years": [],
+            "sources": [],
+            "mart_ok": False,
+            "failures": ["no dataset.yml and no sources/ directory"],
+        }
+
+    years_label = _years_label(info["years"])
+    pattern = info["pattern"]
+    sources = info["sources"]
+    mart_label = "mart: sì" if info["mart_ok"] else "mart: no"
+
+    if pattern == "multi-source":
+        n = len(sources)
+        src_label = f"multi-source ({n} {'fonte' if n == 1 else 'fonti'})"
+    elif sources:
+        src_label = f"fonte: {sources[0]}" if len(sources) == 1 else f"fonti: {', '.join(sources[:2])}"
+    else:
+        src_label = "fonte: ?"
+
+    detail_parts = [years_label, src_label, mart_label]
+    if info["failures"]:
+        detail_parts.append("⚠ " + "; ".join(info["failures"]))
+    detail = " — ".join(detail_parts)
+
+    if info["failures"]:
+        status = "error"
+    elif not info["mart_ok"]:
+        status = "warn"
+    else:
+        status = "ok"
+
+    action = ""
+    if status == "warn":
+        action = "aggiungere mart SQL per completare il candidato"
+    elif status == "error":
+        action = "correggere la struttura del candidato"
+
+    return {
+        "id": slug,
+        "status": status,
+        "label": slug,
+        "detail": detail,
+        "action": action,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def build_signals(out_path: Path) -> int:
+    archived_paths = load_archived_paths()
+    signals = []
+
+    candidates_dir = ROOT / "candidates"
+    if not candidates_dir.exists():
+        print("No candidates/ directory found.", file=sys.stderr)
+        return 1
+
+    for entry in sorted(p for p in candidates_dir.iterdir() if p.is_dir()):
+        rel = entry.relative_to(ROOT).as_posix()
+        if rel in archived_paths:
+            continue  # promoted or closed — not operationally active
+        slug = entry.name
+        signals.append(_build_signal(slug, entry))
+
+    by_status: dict[str, int] = {"ok": 0, "warn": 0, "error": 0}
+    for s in signals:
+        by_status[s["status"]] = by_status.get(s["status"], 0) + 1
+
+    payload = {
+        "schema_version": "1",
+        "generated_at": date.today().isoformat(),
+        "repo": "dataset-incubator",
+        "topic": "pipeline_state",
+        "summary": {
+            "total": len(signals),
+            "by_status": by_status,
+        },
+        "signals": signals,
+    }
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"pipeline_signals.json — {len(signals)} candidates ({by_status})")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=ROOT / "registry" / "pipeline_signals.json",
+        help="Output path (default: registry/pipeline_signals.json)",
+    )
+    args = parser.parse_args()
+    return build_signals(args.out)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Aggiunge `scripts/build_pipeline_signals.py`: scansiona `candidates/`, rileva pattern (single-source / multi-source / compose), e produce `registry/pipeline_signals.json` seguendo lo standard `repo-signals v1` (schema definito in `agent-context-builder/schemas/repo-signals.md`)
- Aggiunge `.github/workflows/build-pipeline-signals.yml`: rigenera e committa `pipeline_signals.json` automaticamente ad ogni push su `main` che tocca `candidates/`, `registry/archived.md` o gli script

## Formato segnali

Ogni candidate produce un segnale con:
- `status`: `ok` (struttura valida + mart SQL), `warn` (nessun mart SQL), `error` (problema strutturale)
- `label` / `detail`: fonti, anni, pattern rilevato
- `action`: stringa vuota se ok, suggerimento altrimenti

## Consumatori

`agent-context-builder` legge `registry/pipeline_signals.json` da `main` via GitHub raw e lo mostra nella sezione **Pipeline State** del `session_bootstrap.md` e di `workspace_triage.json`.

## Test plan

- [ ] Verificare che il workflow giri su `workflow_dispatch` dopo il merge
- [ ] Verificare che `pipeline_signals.json` venga aggiornato automaticamente a ogni push su `candidates/`
- [ ] Verificare che ACB mostri Pipeline State correttamente dopo il merge (nessun 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)