### PR TITLE
Aggiunge scaffold candidate da template

### DIFF
--- a/.github/workflows/validate-candidate-structure.yml
+++ b/.github/workflows/validate-candidate-structure.yml
@@ -6,7 +6,10 @@ on:
       - "candidates/**"
       - "support_datasets/**"
       - "registry/archived.md"
+      - "templates/candidate/**"
+      - "scripts/scaffold_candidate.py"
       - "scripts/validate_candidate_structure.py"
+      - "tests/test_scaffold_candidate.py"
       - "README.md"
       - "CONTRIBUTING.md"
 
@@ -25,3 +28,6 @@ jobs:
 
       - name: Validate candidate structure
         run: python scripts/validate_candidate_structure.py
+
+      - name: Test candidate scaffold
+        run: python -m unittest tests/test_scaffold_candidate.py

--- a/.github/workflows/validate-effective-root.yml
+++ b/.github/workflows/validate-effective-root.yml
@@ -3,7 +3,8 @@ name: Validate Effective Root
 on:
   pull_request:
     paths:
-      - "**/dataset.yml"
+      - "candidates/**/dataset.yml"
+      - "support_datasets/**/dataset.yml"
 
 jobs:
   validate-effective-root:
@@ -35,7 +36,9 @@ jobs:
         run: |
           base_sha="${{ github.event.pull_request.base.sha }}"
           head_sha="${{ github.event.pull_request.head.sha }}"
-          git diff --name-only "$base_sha" "$head_sha" -- '**/dataset.yml' > changed_dataset_yml.txt
+          git diff --name-only "$base_sha" "$head_sha" \
+            -- 'candidates/**/dataset.yml' 'support_datasets/**/dataset.yml' \
+            > changed_dataset_yml.txt
           if [ ! -s changed_dataset_yml.txt ]; then
             echo "has_files=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ candidates/caso/
 Il template base e' in `templates/candidate/` e segue il pattern single-source.
 Il notebook `v0` e' opzionale ma consigliato come sanity check del mart prima della promozione.
 
+Per creare lo scaffold da template:
+
+```bash
+python scripts/scaffold_candidate.py \
+  --slug nuovo-candidato \
+  --title "Nuovo candidato" \
+  --discussion-url "https://github.com/dataciviclab/datasets/discussions/..." \
+  --issue-url "https://github.com/dataciviclab/dataset-incubator/issues/..." \
+  --source-url "https://..." \
+  --write
+```
+
 ## Uscita da `dataset-incubator`
 
 Quando un filone matura, puo' uscire in tre modi:

--- a/scripts/scaffold_candidate.py
+++ b/scripts/scaffold_candidate.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+from datetime import date
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TEMPLATE = ROOT / "templates" / "candidate"
+DEFAULT_CANDIDATES = ROOT / "candidates"
+SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def build_replacements(args: argparse.Namespace) -> dict[str, str]:
+    created_date = args.created_date or date.today().isoformat()
+    source_url = args.source_url or "TODO"
+    discussion_url = args.discussion_url or "TODO"
+    issue_url = args.issue_url or "TODO"
+    sql_slug = args.slug.replace("-", "_")
+
+    return {
+        "{slug}": args.slug,
+        "{title}": args.title,
+        "{discussion_url}": discussion_url,
+        "{issue_url}": issue_url,
+        "{source_url}": source_url,
+        "{created_date}": created_date,
+        "{{SLUG}}": args.slug,
+        "{{TITLE}}": args.title,
+        "{{DISCUSSION_URL}}": discussion_url,
+        "{{ISSUE_URL}}": issue_url,
+        "{{SOURCE_URL}}": source_url,
+        "{{CREATED_DATE}}": created_date,
+        "__slug__": args.slug,
+        "__slug_sql__": sql_slug,
+    }
+
+
+def render_text(value: str, replacements: dict[str, str]) -> str:
+    for needle, replacement in replacements.items():
+        value = value.replace(needle, replacement)
+    return value
+
+
+def display_path(path: Path) -> str:
+    if path.is_relative_to(ROOT):
+        return path.relative_to(ROOT).as_posix()
+    return path.as_posix()
+
+
+def iter_template_files(template_dir: Path) -> list[Path]:
+    return sorted(path for path in template_dir.rglob("*") if path.is_file())
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if not SLUG_RE.match(args.slug):
+        raise SystemExit(
+            "Slug non valido: usa solo minuscole, numeri e trattini, es. pensioni-pa-dag."
+        )
+    if not args.title.strip():
+        raise SystemExit("Title obbligatorio.")
+    if not args.template_dir.is_dir():
+        raise SystemExit(f"Template non trovato: {args.template_dir}")
+
+
+def plan_files(
+    template_dir: Path,
+    target_dir: Path,
+    replacements: dict[str, str],
+) -> list[tuple[Path, Path]]:
+    planned: list[tuple[Path, Path]] = []
+    for src in iter_template_files(template_dir):
+        rel = src.relative_to(template_dir)
+        rendered_parts = [render_text(part, replacements) for part in rel.parts]
+        planned.append((src, target_dir.joinpath(*rendered_parts)))
+    return planned
+
+
+def write_file(src: Path, dst: Path, replacements: dict[str, str]) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        text = src.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        shutil.copy2(src, dst)
+        return
+    dst.write_text(render_text(text, replacements), encoding="utf-8")
+
+
+def scaffold(args: argparse.Namespace) -> int:
+    validate_args(args)
+
+    target_dir = args.candidates_dir / args.slug
+    replacements = build_replacements(args)
+    planned = plan_files(args.template_dir, target_dir, replacements)
+
+    existing = [dst for _, dst in planned if dst.exists()]
+    if target_dir.exists() and not args.force:
+        raise SystemExit(f"Candidate gia' esistente: {target_dir}. Usa --force per sovrascrivere.")
+    if existing and not args.force:
+        listed = "\n".join(f"- {display_path(path)}" for path in existing)
+        raise SystemExit(f"File gia' esistenti:\n{listed}\nUsa --force per sovrascrivere.")
+
+    print(f"Candidate: {args.slug}")
+    print(f"Target: {display_path(target_dir)}")
+    print("File:")
+    for _, dst in planned:
+        print(f"- {display_path(dst)}")
+
+    if not args.write:
+        print("\nDry-run: nessun file scritto. Ripeti con --write per creare lo scaffold.")
+        return 0
+
+    for src, dst in planned:
+        write_file(src, dst, replacements)
+
+    print("\nCreato. Prossimi passi:")
+    print(f"- completa {display_path(target_dir / 'dataset.yml')}")
+    print(f"- completa {display_path(target_dir / 'README.md')} e notes.md")
+    print("- esegui: python scripts/validate_candidate_structure.py")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Copia templates/candidate in candidates/{slug} sostituendo placeholder minimi."
+    )
+    parser.add_argument("--slug", required=True)
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--discussion-url")
+    parser.add_argument("--issue-url")
+    parser.add_argument("--source-url")
+    parser.add_argument("--created-date")
+    parser.add_argument("--template-dir", type=Path, default=DEFAULT_TEMPLATE)
+    parser.add_argument("--candidates-dir", type=Path, default=DEFAULT_CANDIDATES)
+    parser.add_argument("--write", action="store_true", help="Scrive i file. Default: dry-run.")
+    parser.add_argument("--force", action="store_true", help="Permette sovrascrittura del target.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    return scaffold(parse_args())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/candidate/README.md
+++ b/templates/candidate/README.md
@@ -1,37 +1,43 @@
-# Template candidato
+---
+lab:
+  topics: []
+  sources: []
+  discussion: "{discussion_url}"
+  issue: "{issue_url}"
+---
 
-Questo e il template operativo canonico della repo.   
+# {title}
 
-Ogni nuovo ingresso in `dataset-incubator` dovrebbe partire da questa cartella, adattando:
+Creato il: {created_date}
 
-- `README.md`
-- `dataset.yml`
-- `notes.md`
-- `sql/clean.sql`
-- `sql/mart.sql`
-- `notebooks/{slug}_v0.ipynb` quando il filone beneficia di un notebook v0 di validazione
+## Link
+
+- Discussion: {discussion_url}
+- Issue: {issue_url}
+- Fonte: {source_url}
 
 ## Domanda
 
--
+- TODO
+
 > Una domanda civica valida ha una tensione ("sta migliorando o peggiorando?", "c'e un divario?"),
 > non e puramente descrittiva ("quanti sono") ed e verificabile con i dati disponibili.
 
 ## Dataset
 
--
+- TODO
 
 ## Perche vale la pena testarlo
 
--
+- TODO
 
 ## Output minimo atteso
 
--
+- TODO
 
 ## Criterio di promozione
 
--
+- TODO
 
 ## Stato
 
@@ -39,4 +45,4 @@ Ogni nuovo ingresso in `dataset-incubator` dovrebbe partire da questa cartella, 
 
 ## Prossimo passo
 
--
+- TODO

--- a/templates/candidate/dataset.yml
+++ b/templates/candidate/dataset.yml
@@ -2,7 +2,7 @@ root: "../../out"
 schema_version: 1
 
 dataset:
-  name: "template_dataset"
+  name: "__slug__"
   years: [2024]
 
 # --- RAW LAYER ---
@@ -15,8 +15,8 @@ raw:
     - name: "fonte_principale_http"
       type: "http_file"
       args:
-        url: "https://example.com/data/dataset_{year}.csv"
-        filename: "dataset_{year}.csv"
+        url: "{source_url}"
+        filename: "{slug}_{year}.csv"
       primary: true
     
     # Esempio local_file (alternativo):
@@ -42,10 +42,10 @@ clean:
 # Tabelle finali pronte per l'analisi o l'explorer.
 mart:
   tables:
-    - name: "mart_template"
+    - name: "mart___slug_sql__"
       sql: "sql/mart.sql"
   required_tables:
-    - "mart_template"
+    - "mart___slug_sql__"
   validate: {}
 
 # --- CROSS YEAR LAYER (Optional) ---

--- a/templates/candidate/notes.md
+++ b/templates/candidate/notes.md
@@ -1,12 +1,17 @@
-# Notes
+# Notes - {title}
+
+- slug: `{slug}`
+- created: {created_date}
+- discussion/issue: {discussion_url}
+- source: {source_url}
 
 ## Tecnico
 
--
+- TODO
 
 ## Analitico
 
--
+- TODO
 
 ## Cautele
 

--- a/tests/test_scaffold_candidate.py
+++ b/tests/test_scaffold_candidate.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from scaffold_candidate import scaffold  # noqa: E402
+
+
+def run_scaffold(args: argparse.Namespace) -> int:
+    with contextlib.redirect_stdout(io.StringIO()):
+        return scaffold(args)
+
+
+class ScaffoldCandidateTest(unittest.TestCase):
+    def make_args(self, tmp_path: Path, *, write: bool = False) -> argparse.Namespace:
+        return argparse.Namespace(
+            slug="test-candidato",
+            title="Test Candidato",
+            discussion_url="https://github.com/dataciviclab/datasets/discussions/1",
+            issue_url="https://github.com/dataciviclab/dataset-incubator/issues/1",
+            source_url="https://example.com/data.csv",
+            created_date="2026-04-17",
+            template_dir=ROOT / "templates" / "candidate",
+            candidates_dir=tmp_path / "candidates",
+            write=write,
+            force=False,
+        )
+
+    def test_dry_run_does_not_write_files(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            self.assertEqual(run_scaffold(self.make_args(tmp_path)), 0)
+
+            self.assertFalse((tmp_path / "candidates" / "test-candidato").exists())
+
+    def test_write_copies_template_and_replaces_placeholders(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            self.assertEqual(run_scaffold(self.make_args(tmp_path, write=True)), 0)
+
+            candidate_dir = tmp_path / "candidates" / "test-candidato"
+            self.assertTrue((candidate_dir / "dataset.yml").exists())
+            self.assertTrue((candidate_dir / "notebooks" / "test-candidato_v0.ipynb").exists())
+
+            readme = (candidate_dir / "README.md").read_text(encoding="utf-8")
+            dataset = (candidate_dir / "dataset.yml").read_text(encoding="utf-8")
+            self.assertIn("# Test Candidato", readme)
+            self.assertIn("https://github.com/dataciviclab/dataset-incubator/issues/1", readme)
+            self.assertIn("https://example.com/data.csv", dataset)
+            self.assertIn('name: "test-candidato"', dataset)
+            self.assertIn('name: "mart_test_candidato"', dataset)
+
+    def test_existing_candidate_requires_force(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = self.make_args(tmp_path, write=True)
+            self.assertEqual(run_scaffold(args), 0)
+
+            with self.assertRaises(SystemExit):
+                run_scaffold(args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workflows/intake-candidate.md
+++ b/workflows/intake-candidate.md
@@ -139,7 +139,13 @@ candidates/caso/
 Il notebook v0 si copia dal template:
 
 ```bash
-cp "templates/candidate/notebooks/{slug}_v0.ipynb" "candidates/{slug}/notebooks/{slug}_v0.ipynb"
+python scripts/scaffold_candidate.py \
+  --slug {slug} \
+  --title "Titolo candidate" \
+  --discussion-url "https://github.com/dataciviclab/datasets/discussions/..." \
+  --issue-url "https://github.com/dataciviclab/dataset-incubator/issues/..." \
+  --source-url "https://..." \
+  --write
 ```
 
 Poi apri il notebook e imposta i due parametri manuali in cima alla cella `setup`:


### PR DESCRIPTION
## Cosa cambia

- aggiunge `scripts/scaffold_candidate.py` per copiare `templates/candidate/` in `candidates/{slug}`
- mantiene dry-run come default e scrive solo con `--write`
- aggiorna il template candidate con placeholder e frontmatter `lab` minimale
- documenta il comando in README e workflow intake

## Perché

Riduce boilerplate ed errori nell’intake senza automatizzare decisioni editoriali: lo script crea lo scaffold, poi il candidate resta da adattare manualmente.

## Verifiche

- `python3 -m pytest -q tests/test_scaffold_candidate.py` -> 3 passed
- `python3 -m ruff check scripts/scaffold_candidate.py tests/test_scaffold_candidate.py`
- `python3 scripts/validate_candidate_structure.py`
- `git diff --check`

Nota: la PR di compattazione docs resta separata.
