### PR TITLE
fix: set GH_TOKEN env var for gh pr create in workflow

### DIFF
--- a/.github/workflows/build-pipeline-signals.yml
+++ b/.github/workflows/build-pipeline-signals.yml
@@ -43,6 +43,8 @@ jobs:
           git push -u origin "build-pipeline-signals-auto/${{ github.sha }}"
 
       - name: Create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh pr create \
             --base main \


### PR DESCRIPTION
## Summary

Fix #2 del workflow `Build Pipeline Signals`:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
```

Il step `gh pr create` falliva perché `GH_TOKEN` non era impostato nel runner. Il git push era andato a buon fine (branch creato su origin), ma la PR non veniva generata.

## Fix

Aggiunto `env: GH_TOKEN: ${{ github.token }}` nel step `Create PR`.

## Test

Il workflow genera una PR automatica verso `main` con il branch `build-pipeline-signals-auto/<sha>`. Verificare che la PR venga creata e che il merge sia pulito.