### PR TITLE
fix: allinea catalogo clean MUR e auth di push_archive

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
-  "updated_at": "2026-04-14",
+  "updated_at": "2026-04-22",
   "source_repo": "dataciviclab/dataset-incubator",
   "datasets": [
     {
@@ -675,6 +675,62 @@
       "status": "clean_ready",
       "visibility": "public",
       "registry_source": "initial_clean_query_catalog"
+    },
+    {
+      "slug": "mur_contribuzione_universitaria",
+      "name": "MUR - Gettito della contribuzione universitaria",
+      "description": "Gettito della contribuzione studentesca per ateneo e tipologia di entrata (2017-2024).",
+      "source": "MUR / USTAT CKAN",
+      "period": {
+        "start": 2017,
+        "end": 2024
+      },
+      "columns": [
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "dimension",
+          "description": "Anno di riferimento del dato"
+        },
+        {
+          "name": "cod_ateneo",
+          "type": "INTEGER",
+          "role": "dimension",
+          "description": "Codice identificativo dell'ateneo"
+        },
+        {
+          "name": "nome_ateneo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Denominazione dell'ateneo"
+        },
+        {
+          "name": "codice_gettito",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Codice della tipologia di gettito"
+        },
+        {
+          "name": "descrizione_gettito",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Descrizione della tipologia di gettito"
+        },
+        {
+          "name": "euro_contributo",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Importo del gettito in euro"
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/mur_contribuzione_universitaria/*/mur_contribuzione_universitaria_*_clean.parquet",
+        "multi_file": true
+      },
+      "status": "clean_ready",
+      "visibility": "public",
+      "registry_source": "push_archive_auto"
     }
   ]
 }

--- a/scripts/push_archive.py
+++ b/scripts/push_archive.py
@@ -26,12 +26,14 @@ import argparse
 import sys
 import json
 import datetime
+import os
 from pathlib import Path
 
 import pandas as pd
 import pyarrow.parquet as pq
 from google.cloud import bigquery, storage
 from google.api_core.exceptions import Conflict
+from google.oauth2 import credentials as google_oauth2_credentials
 
 # ---------------------------------------------------------------------------
 # Config
@@ -50,6 +52,21 @@ RUNS_ROOT = DI_ROOT / "out" / "data" / "_runs"
 
 SKIP_DIRS = {"_validate", "_run"}
 SKIP_SLUGS = {"malasanita_struttura_mortalita_source_d_test"}  # slug da escludere dal push
+
+
+def load_google_credentials():
+    """Carica credenziali esplicite se GOOGLE_APPLICATION_CREDENTIALS punta a un ADC user file.
+
+    In alcuni ambienti WSL la discovery standard resta appesa sul `gcloud` Windows nel PATH.
+    """
+    adc_path = Path(
+        os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
+    ).expanduser()
+    if adc_path.is_file():
+        return google_oauth2_credentials.Credentials.from_authorized_user_file(
+            str(adc_path)
+        )
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -382,8 +399,13 @@ def main():
                         help="Aggiorna registry/clean_catalog.json con period e location aggiornati")
     args = parser.parse_args()
 
-    gcs_client = storage.Client(project=GCP_PROJECT)
-    bq_client = bigquery.Client(project=GCP_PROJECT) if (not args.no_bq or args.create_bq_table) else None
+    google_credentials = load_google_credentials()
+    gcs_client = storage.Client(project=GCP_PROJECT, credentials=google_credentials)
+    bq_client = (
+        bigquery.Client(project=GCP_PROJECT, credentials=google_credentials)
+        if (not args.no_bq or args.create_bq_table)
+        else None
+    )
 
     if args.layer in ("clean", "all"):
         push_clean(gcs_client, args.slug, args.year, args.dry_run)


### PR DESCRIPTION
## Contesto
Questo PR chiude il publish post-merge di `mur-contribuzione-universitaria` e sistema un blocco reale di ambiente su `push_archive.py`.

## Cosa cambia
- aggiorna `registry/clean_catalog.json` con l'entry completa di `mur_contribuzione_universitaria`
- completa i metadati minimi del dataset (`name`, `description`, `source`, colonne, `status`)
- rende `scripts/push_archive.py` compatibile con l'ambiente WSL/ADC caricando credenziali esplicite da `GOOGLE_APPLICATION_CREDENTIALS`, evitando il blocco su `gcloud` Windows nel PATH

## Verifiche
- publish clean MUR eseguito su GCS
- external table BQ `dataciviclab.mur_contribuzione_universitaria.clean` creata
- `python3 -m py_compile scripts/push_archive.py`
- `push_archive.py --layer clean --slug mur_contribuzione_universitaria --update-catalog --create-bq-table --dry-run`

## Note
- nessuna modifica al boundary del workflow: `push_archive.py` continua ad aggiornare `clean_catalog.json`
- nessun intervento su `pipeline_signals.json`
