### PR TITLE
feat(post-merge): mim_alunni_corso_eta — clean catalog entry, GCS push, BQ external table

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -757,6 +757,62 @@
       "registry_source": "initial_clean_query_catalog"
     },
     {
+      "slug": "mim_alunni_corso_eta",
+      "name": "Alunni per corso ed età — MIM",
+      "description": "Alunni delle scuole statali italiane per ordine scolastico, anno di corso e fascia di età. Dato MI-MIM a livello di singola scuola (CODICESCUOLA), aggregato opzionale per comune tramite anagrafica scuole statali.",
+      "source": "https://dati.istruzione.it/opendata/ — Ministero dell'Istruzione e del Merito (MIM)",
+      "period": {
+        "start": 2024,
+        "end": 2024
+      },
+      "columns": [
+        {
+          "name": "anno_scolastico",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Anno scolastico di riferimento (es. 2024/25)"
+        },
+        {
+          "name": "codice_scuola",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Codice ministeriale della scuola"
+        },
+        {
+          "name": "ordine_scuola",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Ordine scolastico: Primaria, Secondaria di I grado, Secondaria di II grado"
+        },
+        {
+          "name": "anno_corso",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Anno di corso all'interno dell'ordine"
+        },
+        {
+          "name": "fascia_eta",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Fascia di età dell'alunno"
+        },
+        {
+          "name": "alunni",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": "Numero di alunni"
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/mim_alunni_corso_eta/*/mim_alunni_corso_eta_*_clean.parquet",
+        "multi_file": true
+      },
+      "status": "candidate",
+      "visibility": "public",
+      "registry_source": "push_archive_auto"
+    },
+    {
       "slug": "mur_contribuzione_universitaria",
       "name": "MUR - Gettito della contribuzione universitaria",
       "description": "Gettito della contribuzione studentesca per ateneo e tipologia di entrata (2017-2024).",


### PR DESCRIPTION
## Summary

Post-merge work per `mim-alunni-corso-eta` (PR #163 merged 2026-04-24):

- ✅ GCS push: `gs://dataciviclab-clean/mim_alunni_corso_eta/2024/` (clean parquet + pipeline_run.json)
- ✅ BQ external table: `dataciviclab.mim_alunni_corso_eta.clean`
- ✅ Mart parquet pushed: 4 tabelle (primaria 6281, secondaria_i 5053, secondaria_ii 1391, all 12725 righe)
- ✅ BQ mart tables: `dataciviclab.mim_alunni_corso_eta.mart_alunni_*`
- ✅ `pipeline_signals.json` gia' aggiornato dall'auto-build (contiene gia' `mim-alunni-corso-eta`)

## Changed files

| File | Cambio |
|---|---|
| `registry/clean_catalog.json` | Entry `mim_alunni_corso_eta` con metadata complete, status `candidate` |

## Status checks

- [ ] `validate-candidate-structure`
- [ ] `validate-clean-catalog`

## Note

Periodo: `2024-2024` — il dataset riguarda l'anno scolastico 2024/25. Nessun riferimento a 2025 da aggiornare (diverso da `civile-flussi`).