### PR TITLE
feat(irpef-comunale): clean.sql raw-faithful, 52 colonne, senza logica interpretativa

### DIFF
--- a/candidates/irpef-comunale/dataset.yml
+++ b/candidates/irpef-comunale/dataset.yml
@@ -2,7 +2,7 @@ root: "../../out"
 schema_version: 1
 
 dataset:
-  name: "irpef_comunale_2019_2023"
+  name: "irpef_comunale"
   years: [2019, 2020, 2021, 2022, 2023]
 
 raw:

--- a/candidates/irpef-comunale/notebooks/irpef-comunale_v0.ipynb
+++ b/candidates/irpef-comunale/notebooks/irpef-comunale_v0.ipynb
@@ -1,0 +1,336 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# irpef-comunale - notebook v0\n",
+    "\n",
+    "Validazione della pipeline per fasi: **raw → clean → mart**.\n",
+    "\n",
+    "- scopo: verificare che ogni layer sia corretto e coerente con il precedente\n",
+    "- le SQL sono la fonte di verità: i check numerici devono essere letti alla luce di quello che dichiarano\n",
+    "- non sostituisce l'analisi pubblica\n",
+    "- evitare output pesanti o immagini embeddate nel commit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "import yaml\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# --- Unici parametri da impostare manualmente ---\n",
+    "METRICA       = \"reddito_imponibile_totale_eur\"  # colonna numerica principale nel mart\n",
+    "METRICA_CLEAN = \"reddito_imponibile_eur\"  # colonna corrispondente nel clean\n",
+    "\n",
+    "# --- Anchor: usa il path del notebook se disponibile (VSCode), altrimenti cwd ---\n",
+    "try:\n",
+    "    _start = Path(__vsc_ipynb_file__).resolve().parent  # VSCode Jupyter\n",
+    "except NameError:\n",
+    "    _start = Path.cwd().resolve()\n",
+    "\n",
+    "# Walk up finché non troviamo dataset.yml\n",
+    "candidate_dir = None\n",
+    "for probe in [_start, *_start.parents]:\n",
+    "    if (probe / \"dataset.yml\").exists():\n",
+    "        candidate_dir = probe\n",
+    "        break\n",
+    "\n",
+    "if candidate_dir is None:\n",
+    "    raise FileNotFoundError(f\"dataset.yml non trovato risalendo da {_start}\")\n",
+    "\n",
+    "cfg = yaml.safe_load((candidate_dir / \"dataset.yml\").read_text())\n",
+    "\n",
+    "SLUG       = cfg[\"dataset\"][\"name\"]\n",
+    "ANNO_RUN   = cfg[\"dataset\"][\"years\"][-1]\n",
+    "MART_TABLE = cfg[\"mart\"][\"tables\"][0][\"name\"]\n",
+    "ENCODING   = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"encoding\", \"utf-8\")\n",
+    "DELIM      = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"delim\", \",\")\n",
+    "HEADER     = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"header\", True)\n",
+    "SKIP       = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"skip\", 0)\n",
+    "\n",
+    "DI_ROOT   = (candidate_dir / cfg[\"root\"]).resolve()\n",
+    "RAW_DIR   = DI_ROOT / \"data\" / \"raw\"   / SLUG / str(ANNO_RUN)\n",
+    "CLEAN_DIR = DI_ROOT / \"data\" / \"clean\" / SLUG / str(ANNO_RUN)\n",
+    "MART_DIR  = DI_ROOT / \"data\" / \"mart\"  / SLUG / str(ANNO_RUN)\n",
+    "SQL_DIR   = candidate_dir / \"sql\"\n",
+    "\n",
+    "print(f\"slug      : {SLUG}\")\n",
+    "print(f\"anno_run  : {ANNO_RUN}\")\n",
+    "print(f\"mart table: {MART_TABLE}\")\n",
+    "print(f\"encoding  : {ENCODING}  delim: {repr(DELIM)}\")\n",
+    "print(f\"header    : {HEADER}  skip: {SKIP}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-sql",
+   "metadata": {},
+   "source": [
+    "## SQL di riferimento\n",
+    "\n",
+    "Le SQL sono la fonte di verità per capire cosa deve contenere ogni layer.\n",
+    "Leggile prima di interpretare i check numerici."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "sql-show",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for sql_file in sorted(SQL_DIR.glob(\"*.sql\")):\n",
+    "    print(f\"{'='*60}\")\n",
+    "    print(f\"  {sql_file.name}\")\n",
+    "    print(f\"{'='*60}\")\n",
+    "    print(sql_file.read_text())\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-raw",
+   "metadata": {},
+   "source": [
+    "## 1. Raw\n",
+    "\n",
+    "Verifica che il file raw esista, sia leggibile con i parametri dichiarati in `dataset.yml` e abbia il numero di righe atteso."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "raw-load",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw_files = sorted(RAW_DIR.glob(\"*.csv\")) + sorted(RAW_DIR.glob(\"*.xlsx\")) + sorted(RAW_DIR.glob(\"*.parquet\"))\n",
+    "if not raw_files:\n",
+    "    raise FileNotFoundError(f\"Nessun file raw trovato in {RAW_DIR}\")\n",
+    "\n",
+    "raw_path = raw_files[0]\n",
+    "print(f\"File: {raw_path.name}  ({raw_path.stat().st_size / 1024:.0f} KB)\")\n",
+    "\n",
+    "if raw_path.suffix == \".parquet\":\n",
+    "    raw_full = pd.read_parquet(raw_path)\n",
+    "elif raw_path.suffix in (\".csv\", \".tsv\"):\n",
+    "    header_row = 0 if HEADER else None\n",
+    "    raw_full = pd.read_csv(raw_path, encoding=ENCODING, sep=DELIM, header=header_row, skiprows=SKIP)\n",
+    "elif raw_path.suffix == \".xlsx\":\n",
+    "    raw_full = pd.read_excel(raw_path, header=0 if HEADER else None, skiprows=SKIP)\n",
+    "\n",
+    "N_RAW = len(raw_full)\n",
+    "print(f\"Righe raw   : {N_RAW}\")\n",
+    "print(f\"Colonne raw : {len(raw_full.columns)} -> {list(raw_full.columns)}\")\n",
+    "raw_full.head(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-clean",
+   "metadata": {},
+   "source": [
+    "## 2. Clean\n",
+    "\n",
+    "Verifica schema e null. I null su colonne `try_cast` sono attesi se il raw contiene valori non parsabili.\n",
+    "Il confronto righe raw vs clean mostra quante righe sono state filtrate dal `WHERE` della clean.sql."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "clean-load",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_files = sorted(CLEAN_DIR.glob(\"*.parquet\"))\n",
+    "if not clean_files:\n",
+    "    raise FileNotFoundError(f\"Clean non trovato in {CLEAN_DIR}. Eseguire: toolkit run clean\")\n",
+    "\n",
+    "clean = pd.read_parquet(clean_files[0])\n",
+    "N_CLEAN = len(clean)\n",
+    "\n",
+    "print(f\"Righe clean : {N_CLEAN}\")\n",
+    "print(f\"Colonne     : {list(clean.columns)}\")\n",
+    "clean.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "raw-clean-diff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dropped = N_RAW - N_CLEAN\n",
+    "dropped_pct = dropped / N_RAW * 100 if N_RAW > 0 else 0\n",
+    "\n",
+    "print(f\"Righe raw         : {N_RAW}\")\n",
+    "print(f\"Righe clean       : {N_CLEAN}\")\n",
+    "print(f\"Righe filtrate    : {dropped} ({dropped_pct:.1f}%)\")\n",
+    "print()\n",
+    "if dropped > 0:\n",
+    "    print(\"-> Verificare la WHERE in clean.sql per capire quali righe vengono escluse.\")\n",
+    "else:\n",
+    "    print(\"-> Nessuna riga filtrata: clean e' fedele al raw.\")\n",
+    "\n",
+    "print(\"\\nNull per colonna clean:\")\n",
+    "null_counts = clean.isnull().sum()\n",
+    "print(null_counts[null_counts > 0].to_string() if null_counts.any() else \"  nessuno\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-mart",
+   "metadata": {},
+   "source": [
+    "## 3. Mart\n",
+    "\n",
+    "Verifica unicità sulle chiavi del GROUP BY, anni presenti, null e consistenza dei totali con il clean."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "mart-load",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mart_path = MART_DIR / f\"{MART_TABLE}.parquet\"\n",
+    "if not mart_path.exists():\n",
+    "    raise FileNotFoundError(f\"Mart non trovato: {mart_path}. Eseguire: toolkit run mart\")\n",
+    "\n",
+    "mart = pd.read_parquet(mart_path)\n",
+    "print(f\"Righe mart  : {len(mart)}\")\n",
+    "print(f\"Colonne     : {list(mart.columns)}\")\n",
+    "mart.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "mart-keys",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Estrai chiavi GROUP BY dalla mart.sql per il check di unicità.\n",
+    "# Per query con CTE, cerca GROUP BY solo nella SELECT finale (dopo tutti i CTE).\n",
+    "# Se la SELECT finale non ha GROUP BY, il check di unicità va fatto manualmente.\n",
+    "mart_sql_path = SQL_DIR / \"mart.sql\"\n",
+    "groupby_keys = []\n",
+    "if mart_sql_path.exists():\n",
+    "    sql_text = mart_sql_path.read_text()\n",
+    "\n",
+    "    # Individua dove inizia la SELECT finale (depth 0, dopo eventuali CTE)\n",
+    "    sql_body = sql_text\n",
+    "    if re.search(r'\\bwith\\b', sql_body, re.IGNORECASE):\n",
+    "        depth = 0\n",
+    "        final_select_pos = None\n",
+    "        for tok in re.finditer(r'[()]|\\bselect\\b', sql_body, re.IGNORECASE):\n",
+    "            ch = tok.group()\n",
+    "            if ch == '(':\n",
+    "                depth += 1\n",
+    "            elif ch == ')':\n",
+    "                depth -= 1\n",
+    "            elif ch.lower() == 'select' and depth == 0:\n",
+    "                final_select_pos = tok.start()\n",
+    "        if final_select_pos is not None:\n",
+    "            sql_body = sql_body[final_select_pos:]\n",
+    "\n",
+    "    match = re.search(r'group\\s+by\\s+([\\d\\s,]+)', sql_body, re.IGNORECASE)\n",
+    "    if match:\n",
+    "        positions = [int(p.strip()) for p in match.group(1).split(',')]\n",
+    "        groupby_keys = [mart.columns[i - 1] for i in positions if i <= len(mart.columns)]\n",
+    "    else:\n",
+    "        match = re.search(r'group\\s+by\\s+((?:[\\w.]+(?:\\s*,\\s*)?)+)', sql_body, re.IGNORECASE)\n",
+    "        if match:\n",
+    "            groupby_keys = [k.strip().split('.')[-1] for k in match.group(1).split(',')]\n",
+    "            groupby_keys = [k for k in groupby_keys if k in mart.columns]\n",
+    "\n",
+    "if groupby_keys:\n",
+    "    dups = mart.duplicated(subset=groupby_keys).sum()\n",
+    "    print(f\"Chiavi GROUP BY (SELECT finale): {groupby_keys}\")\n",
+    "    print(f\"Duplicati                       : {dups}\")\n",
+    "    assert dups == 0, f\"FAIL: {dups} righe duplicate sulle chiavi del mart -- verificare mart.sql\"\n",
+    "    print(\"OK: nessun duplicato sulle chiavi.\")\n",
+    "else:\n",
+    "    print(\"GROUP BY non trovato nella SELECT finale -- verificare manualmente unicita'.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "mart-coverage",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if \"anno\" in mart.columns:\n",
+    "    anni_mart = sorted(mart[\"anno\"].unique())\n",
+    "    print(f\"Anni nel mart ({len(anni_mart)}): {anni_mart}\")\n",
+    "\n",
+    "null_mart = mart.isnull().sum()\n",
+    "print(\"\\nNull per colonna mart:\")\n",
+    "print(null_mart[null_mart > 0].to_string() if null_mart.any() else \"  nessuno\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "mart-consistency",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if METRICA in mart.columns and METRICA_CLEAN in clean.columns:\n",
+    "    tot_mart  = mart[METRICA].sum()\n",
+    "    tot_clean = clean[METRICA_CLEAN].sum()\n",
+    "    delta_pct = abs(tot_mart - tot_clean) / tot_clean * 100 if tot_clean != 0 else float(\"nan\")\n",
+    "    print(f\"Totale mart  ({METRICA})      : {tot_mart:,.2f}\")\n",
+    "    print(f\"Totale clean ({METRICA_CLEAN}): {tot_clean:,.2f}\")\n",
+    "    print(f\"Delta %: {delta_pct:.4f}%\")\n",
+    "    assert delta_pct < 0.01, f\"FAIL: delta {delta_pct:.2f}% -- verificare la pipeline\"\n",
+    "    print(\"OK: i totali coincidono.\")\n",
+    "else:\n",
+    "    print(f\"Colonne non trovate -- aggiornare METRICA ('{METRICA}') e METRICA_CLEAN ('{METRICA_CLEAN}').\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "notes",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PERIMETRO = \"...\"  # da compilare manualmente\n",
+    "\n",
+    "print(f\"Slug            : {SLUG}\")\n",
+    "print(f\"Anno run        : {ANNO_RUN}\")\n",
+    "print(f\"Tabella mart    : {MART_TABLE}\")\n",
+    "print(f\"Metrica mart    : {METRICA}\")\n",
+    "print(f\"Metrica clean   : {METRICA_CLEAN}\")\n",
+    "print(f\"Perimetro       : {PERIMETRO}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/candidates/irpef-comunale/notebooks/irpef-comunale_v0.ipynb
+++ b/candidates/irpef-comunale/notebooks/irpef-comunale_v0.ipynb
@@ -225,7 +225,7 @@
     "# Estrai chiavi GROUP BY dalla mart.sql per il check di unicità.\n",
     "# Per query con CTE, cerca GROUP BY solo nella SELECT finale (dopo tutti i CTE).\n",
     "# Se la SELECT finale non ha GROUP BY, il check di unicità va fatto manualmente.\n",
-    "mart_sql_path = SQL_DIR / \"mart.sql\"\n",
+    "mart_sql_path = SQL_DIR / Path(cfg[\"mart\"][\"tables\"][0][\"sql\"]).name\n",
     "groupby_keys = []\n",
     "if mart_sql_path.exists():\n",
     "    sql_text = mart_sql_path.read_text()\n",

--- a/candidates/irpef-comunale/notes.md
+++ b/candidates/irpef-comunale/notes.md
@@ -60,8 +60,8 @@ Il clean è raw-faithful: nessuna logica interpretativa, nessun case/when, nessu
 23 reddito_imponibile_eur
 24 imposta_netta_freq
 25 imposta_netta_eur
-26 trattamento_spettante_freq          ← NULL per 2019-2020 (ha bonus_spettante)
-27 trattamento_spettante_eur            ← NULL per 2019-2020 (ha bonus_spettante)
+63  trattamento_spettante_freq          ← contiene Bonus spettante per 2019-2020 (semantica diversa — vedi Limiti); NULL per 2021-2023
+64  trattamento_spettante_eur            ← contiene Bonus spettante per 2019-2020 (semantica diversa — vedi Limiti); NULL per 2021-2023
 28 reddito_imponibile_addizionale_freq
 29 reddito_imponibile_addizionale_eur
 30 addizionale_regionale_dovuta_freq

--- a/candidates/irpef-comunale/notes.md
+++ b/candidates/irpef-comunale/notes.md
@@ -1,0 +1,96 @@
+# Note tecniche — irpef-comunale
+
+## Fonte
+
+ZIP annuali ufficiali MEF / Finanze:
+`https://www1.finanze.gov.it/finanze/analisi_stat/public/v_4_0_0/contenuti/Redditi_e_principali_variabili_IRPEF_su_base_comunale_CSV_{year}.zip`
+
+## Copertura temporale
+
+2019–2023 (5 anni di dichiarazione)
+
+## Copertura territoriale
+
+Tutti i comuni italiani (~7.900 per anno). I codici ISTAT sono stabili nel tempo.
+
+## Struttura raw
+
+| Anno | Colonne CSV raw | Note |
+|---|---|---|
+| 2019 | 50 | Header: `Bonus spettante` (col 26-27) |
+| 2020 | 50 | Header: `Bonus spettante` (col 26-27) |
+| 2021 | 50 | Header: `Trattamento spettante` (col 26-27) — nuovo |
+| 2022 | 50 | Header: `Trattamento spettante` (col 26-27) |
+| 2023 | 52 | Aggiunte `Reddito complessivo` (col 34-35) + `Trattamento spettante` |
+
+## Struttura clean
+
+52 colonne fisse per tutti gli anni (slot 0–51). Le colonne assenti nel raw originale hanno valore NULL:
+- **col 26–27**: `Bonus spettante` per 2019-2020 (NULL dal 2021); `Trattamento spettante` per 2021-2023 (NULL nel 2019-2020)
+- **col 34–35**: `Reddito complessivo` solo per 2023 (assenti = NULL per 2019-2022)
+
+Il clean è raw-faithful: nessuna logica interpretativa, nessun case/when, nessuna colonna derivata. Il consumatore vede esattamente cosa c'è nel raw per ogni anno.
+
+## Schema clean (52 colonne)
+
+```
+0  anno_di_imposta
+1  codice_catastale
+2  codice_istat_comune
+3  denominazione_comune
+4  sigla_provincia
+5  regione
+6  codice_istat_regione
+7  numero_contribuenti
+8  reddito_da_fabbricati_freq
+9  reddito_da_fabbricati_eur
+10 reddito_da_lavoro_dipendente_e_assimilati_freq
+11 reddito_da_lavoro_dipendente_e_assimilati_eur
+12 reddito_da_pensione_freq
+13 reddito_da_pensione_eur
+14 reddito_da_lavoro_autonomo_comprensivo_valori_nulli_freq
+15 reddito_da_lavoro_autonomo_comprensivo_valori_nulli_eur
+16 reddito_di_spettanza_imprenditore_contabilita_ordinaria_freq
+17 reddito_di_spettanza_imprenditore_contabilita_ordinaria_eur
+18 reddito_di_spettanza_imprenditore_contabilita_semplificata_freq
+19 reddito_di_spettanza_imprenditore_contabilita_semplificata_eur
+20 reddito_da_partecipazione_freq
+21 reddito_da_partecipazione_eur
+22 reddito_imponibile_freq
+23 reddito_imponibile_eur
+24 imposta_netta_freq
+25 imposta_netta_eur
+26 trattamento_spettante_freq          ← NULL per 2019-2020 (ha bonus_spettante)
+27 trattamento_spettante_eur            ← NULL per 2019-2020 (ha bonus_spettante)
+28 reddito_imponibile_addizionale_freq
+29 reddito_imponibile_addizionale_eur
+30 addizionale_regionale_dovuta_freq
+31 addizionale_regionale_dovuta_eur
+32 addizionale_comunale_dovuta_freq
+33 addizionale_comunale_dovuta_eur
+34 reddito_complessivo_freq             ← NULL per 2019-2022 (introdotto nel 2023)
+35 reddito_complessivo_eur             ← NULL per 2019-2022 (introdotto nel 2023)
+36 reddito_complessivo_minore_o_uguale_a_zero_euro_freq
+37 reddito_complessivo_minore_o_uguale_a_zero_euro_eur
+38–51 reddito_complessivo_da_NN_a_MM_euro (fasce freq+eur)
+```
+
+## Limiti e caveat
+
+- **Bonus vs Trattamento**: il MEF ha sostituito il Bonus Covid con il Trattamento (legge 2021). Le due misure non sono direttamente confrontabili come semantica economica — il Bonus era un credito d'imposta una tantum, il Trattamento è un importo erogato. Non sommarle mai come "spettante totale".
+- **Reddito complessivo** (2023): non esiste nei precedenti — non è ricostruibile dai raw precedenti.
+- **Frequenze vs ammontare**: le frequenze (colonne `*_freq`) per le fasce di reddito complessivo (col 38-51) sono conteggi di contribuenti, non valori monetari. Non hanno corrispondente euro.
+- **Somalettura regionale**: la somma dei comuni può non coincidere con il totale regionale (dati.flags rettifiche, segreti comunali, variazioni anagrafiche). I totali regionali vanno chiesti direttamente al MEF.
+- **Anno di imposta vs anno di dichiarazione**: i dati si riferiscono all'anno di imposta, non all'anno di presentazione della dichiarazione. Di norma c'è un anno di ritardo.
+
+## Note di ingest / clean
+
+- Il raw usa `normalize_rows_to_columns: true` + `skip: 1` per estrarre la riga header come nomecolonne, poi `header: false` per leggere i dati. Le colonne vengono poi rinominate esplicitamente nel clean.sql.
+- Il CSV usa `;` come delimitatore e `;` finale su ogni riga (che genera una colonna vuota added). Il `trim_whitespace: true` gestisce gli spazi extra.
+
+## Note analitiche iniziali
+
+- Il dataset è la base più completa per confrontare la capacità fiscale comunale e regionale in Italia.
+- Le tabelle mart (`irpef_by_regione`, `irpef_by_comune`) offrono una vista già aggregata pronta per analisi.
+- Il `mart_multi_anno` include rank nazionali/regionali e delta vs anno precedente.
+- `popolazione_comune` è assente dal clean (era nel vecchio clean come placeholder per join futuro — il join con `support_datasets/popolazione-istat-comunale-2019-2025` è l'anello mancante per arricchire le analisi pro-capite).

--- a/candidates/irpef-comunale/sql/clean.sql
+++ b/candidates/irpef-comunale/sql/clean.sql
@@ -1,107 +1,54 @@
 select
-  try_cast(column00 as integer) as anno_imposta,
-  trim(cast(column01 as varchar)) as codice_catastale,
-  trim(cast(column02 as varchar)) as codice_istat_comune,
-  trim(cast(column03 as varchar)) as comune,
-  trim(cast(column04 as varchar)) as sigla_provincia,
-  trim(cast(column05 as varchar)) as regione,
-  trim(cast(column06 as varchar)) as codice_istat_regione,
-  try_cast(column07 as integer) as numero_contribuenti,
-  try_cast(column08 as integer) as reddito_fabbricati_freq,
-  try_cast(column09 as double) as reddito_fabbricati_eur,
-  try_cast(column10 as integer) as reddito_lavoro_dipendente_freq,
-  try_cast(column11 as double) as reddito_lavoro_dipendente_eur,
-  try_cast(column12 as integer) as reddito_pensione_freq,
-  try_cast(column13 as double) as reddito_pensione_eur,
-  try_cast(column14 as integer) as reddito_lavoro_autonomo_freq,
-  try_cast(column15 as double) as reddito_lavoro_autonomo_eur,
-  try_cast(column16 as integer) as reddito_impresa_ordinaria_freq,
-  try_cast(column17 as double) as reddito_impresa_ordinaria_eur,
-  try_cast(column18 as integer) as reddito_impresa_semplificata_freq,
-  try_cast(column19 as double) as reddito_impresa_semplificata_eur,
-  try_cast(column20 as integer) as reddito_partecipazione_freq,
-  try_cast(column21 as double) as reddito_partecipazione_eur,
-  try_cast(column22 as integer) as reddito_imponibile_freq,
-  try_cast(column23 as double) as reddito_imponibile_eur,
-  try_cast(column24 as integer) as imposta_netta_freq,
-  try_cast(column25 as double) as imposta_netta_eur,
-  case when try_cast(column00 as integer) <= 2020 then try_cast(column26 as integer) end as bonus_spettante_freq,
-  case when try_cast(column00 as integer) <= 2020 then try_cast(column27 as double) end as bonus_spettante_eur,
-  case when try_cast(column00 as integer) >= 2021 then try_cast(column26 as integer) end as trattamento_spettante_freq,
-  case when try_cast(column00 as integer) >= 2021 then try_cast(column27 as double) end as trattamento_spettante_eur,
-  try_cast(column26 as integer) as misura_spettante_freq,
-  try_cast(column27 as double) as misura_spettante_eur,
-  try_cast(column28 as integer) as reddito_imponibile_addizionale_freq,
-  try_cast(column29 as double) as reddito_imponibile_addizionale_eur,
-  try_cast(column30 as integer) as addizionale_regionale_freq,
-  try_cast(column31 as double) as addizionale_regionale_eur,
-  try_cast(column32 as integer) as addizionale_comunale_freq,
-  try_cast(column33 as double) as addizionale_comunale_eur,
-  case when try_cast(column00 as integer) >= 2023 then try_cast(column34 as integer) end as reddito_complessivo_freq,
-  case when try_cast(column00 as integer) >= 2023 then try_cast(column35 as double) end as reddito_complessivo_eur,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column36 as integer)
-    else try_cast(column34 as integer)
-  end as reddito_complessivo_le_zero_freq,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column37 as double)
-    else try_cast(column35 as double)
-  end as reddito_complessivo_le_zero_eur,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column38 as integer)
-    else try_cast(column36 as integer)
-  end as reddito_0_10000_freq,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column39 as double)
-    else try_cast(column37 as double)
-  end as reddito_0_10000_eur,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column40 as integer)
-    else try_cast(column38 as integer)
-  end as reddito_10000_15000_freq,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column41 as double)
-    else try_cast(column39 as double)
-  end as reddito_10000_15000_eur,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column42 as integer)
-    else try_cast(column40 as integer)
-  end as reddito_15000_26000_freq,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column43 as double)
-    else try_cast(column41 as double)
-  end as reddito_15000_26000_eur,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column44 as integer)
-    else try_cast(column42 as integer)
-  end as reddito_26000_55000_freq,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column45 as double)
-    else try_cast(column43 as double)
-  end as reddito_26000_55000_eur,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column46 as integer)
-    else try_cast(column44 as integer)
-  end as reddito_55000_75000_freq,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column47 as double)
-    else try_cast(column45 as double)
-  end as reddito_55000_75000_eur,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column48 as integer)
-    else try_cast(column46 as integer)
-  end as reddito_75000_120000_freq,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column49 as double)
-    else try_cast(column47 as double)
-  end as reddito_75000_120000_eur,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column50 as integer)
-    else try_cast(column48 as integer)
-  end as reddito_oltre_120000_freq,
-  case
-    when try_cast(column00 as integer) >= 2023 then try_cast(column51 as double)
-    else try_cast(column49 as double)
-  end as reddito_oltre_120000_eur,
-  cast(null as integer) as popolazione_comune
+  try_cast(column00 as integer)                                       as anno_di_imposta,
+  trim(cast(column01 as varchar))                                    as codice_catastale,
+  trim(cast(column02 as varchar))                                    as codice_istat_comune,
+  trim(cast(column03 as varchar))                                    as denominazione_comune,
+  trim(cast(column04 as varchar))                                    as sigla_provincia,
+  trim(cast(column05 as varchar))                                    as regione,
+  trim(cast(column06 as varchar))                                    as codice_istat_regione,
+  try_cast(column07 as integer)                                       as numero_contribuenti,
+  try_cast(column08 as integer)                                       as reddito_da_fabbricati_freq,
+  try_cast(column09 as double)                                        as reddito_da_fabbricati_eur,
+  try_cast(column10 as integer)                                       as reddito_da_lavoro_dipendente_e_assimilati_freq,
+  try_cast(column11 as double)                                        as reddito_da_lavoro_dipendente_e_assimilati_eur,
+  try_cast(column12 as integer)                                       as reddito_da_pensione_freq,
+  try_cast(column13 as double)                                        as reddito_da_pensione_eur,
+  try_cast(column14 as integer)                                       as reddito_da_lavoro_autonomo_comprensivo_valori_nulli_freq,
+  try_cast(column15 as double)                                         as reddito_da_lavoro_autonomo_comprensivo_valori_nulli_eur,
+  try_cast(column16 as integer)                                       as reddito_di_spettanza_imprenditore_contabilita_ordinaria_freq,
+  try_cast(column17 as double)                                         as reddito_di_spettanza_imprenditore_contabilita_ordinaria_eur,
+  try_cast(column18 as integer)                                       as reddito_di_spettanza_imprenditore_contabilita_semplificata_freq,
+  try_cast(column19 as double)                                         as reddito_di_spettanza_imprenditore_contabilita_semplificata_eur,
+  try_cast(column20 as integer)                                       as reddito_da_partecipazione_freq,
+  try_cast(column21 as double)                                        as reddito_da_partecipazione_eur,
+  try_cast(column22 as integer)                                       as reddito_imponibile_freq,
+  try_cast(column23 as double)                                        as reddito_imponibile_eur,
+  try_cast(column24 as integer)                                       as imposta_netta_freq,
+  try_cast(column25 as double)                                        as imposta_netta_eur,
+  try_cast(column26 as integer)                                       as trattamento_spettante_freq,
+  try_cast(column27 as double)                                        as trattamento_spettante_eur,
+  try_cast(column28 as integer)                                       as reddito_imponibile_addizionale_freq,
+  try_cast(column29 as double)                                        as reddito_imponibile_addizionale_eur,
+  try_cast(column30 as integer)                                       as addizionale_regionale_dovuta_freq,
+  try_cast(column31 as double)                                        as addizionale_regionale_dovuta_eur,
+  try_cast(column32 as integer)                                       as addizionale_comunale_dovuta_freq,
+  try_cast(column33 as double)                                        as addizionale_comunale_dovuta_eur,
+  try_cast(column34 as integer)                                       as reddito_complessivo_freq,
+  try_cast(column35 as double)                                        as reddito_complessivo_eur,
+  try_cast(column36 as integer)                                       as reddito_complessivo_minore_o_uguale_a_zero_euro_freq,
+  try_cast(column37 as double)                                         as reddito_complessivo_minore_o_uguale_a_zero_euro_eur,
+  try_cast(column38 as integer)                                       as reddito_complessivo_da_0_a_10000_euro_freq,
+  try_cast(column39 as double)                                        as reddito_complessivo_da_0_a_10000_euro_eur,
+  try_cast(column40 as integer)                                       as reddito_complessivo_da_10000_a_15000_euro_freq,
+  try_cast(column41 as double)                                        as reddito_complessivo_da_10000_a_15000_euro_eur,
+  try_cast(column42 as integer)                                       as reddito_complessivo_da_15000_a_26000_euro_freq,
+  try_cast(column43 as double)                                        as reddito_complessivo_da_15000_a_26000_euro_eur,
+  try_cast(column44 as integer)                                       as reddito_complessivo_da_26000_a_55000_euro_freq,
+  try_cast(column45 as double)                                        as reddito_complessivo_da_26000_a_55000_euro_eur,
+  try_cast(column46 as integer)                                       as reddito_complessivo_da_55000_a_75000_euro_freq,
+  try_cast(column47 as double)                                        as reddito_complessivo_da_55000_a_75000_euro_eur,
+  try_cast(column48 as integer)                                       as reddito_complessivo_da_75000_a_120000_euro_freq,
+  try_cast(column49 as double)                                        as reddito_complessivo_da_75000_a_120000_euro_eur,
+  try_cast(column50 as integer)                                       as reddito_complessivo_oltre_120000_euro_freq,
+  try_cast(column51 as double)                                        as reddito_complessivo_oltre_120000_euro_eur
 from raw_input

--- a/candidates/irpef-comunale/sql/mart.sql
+++ b/candidates/irpef-comunale/sql/mart.sql
@@ -1,11 +1,11 @@
 select
-  anno_imposta,
+  anno_di_imposta,
   regione,
   count(*) as comuni,
   sum(numero_contribuenti) as contribuenti,
   sum(reddito_imponibile_eur) as reddito_imponibile_totale_eur,
   sum(imposta_netta_eur) as imposta_netta_totale_eur,
-  sum(addizionale_comunale_eur) as addizionale_comunale_totale_eur,
+  sum(addizionale_comunale_dovuta_eur) as addizionale_comunale_totale_eur,
   avg(reddito_imponibile_eur / nullif(numero_contribuenti, 0)) as reddito_imponibile_medio_per_contribuente_eur
 from clean_input
 group by 1, 2

--- a/candidates/irpef-comunale/sql/mart_comuni.sql
+++ b/candidates/irpef-comunale/sql/mart_comuni.sql
@@ -1,18 +1,18 @@
 select
-  anno_imposta,
+  anno_di_imposta,
   regione,
   codice_istat_comune,
-  comune,
+  denominazione_comune,
   sigla_provincia,
   numero_contribuenti,
   reddito_imponibile_eur as reddito_imponibile_totale_eur,
   imposta_netta_eur as imposta_netta_totale_eur,
-  addizionale_comunale_eur as addizionale_comunale_totale_eur,
+  addizionale_comunale_dovuta_eur as addizionale_comunale_totale_eur,
   reddito_imponibile_eur / nullif(numero_contribuenti, 0) as reddito_imponibile_medio_per_contribuente_eur
 from clean_input
-where anno_imposta is not null
+where anno_di_imposta is not null
   and codice_istat_comune is not null
-  and comune is not null
+  and denominazione_comune is not null
   and regione is not null
   and numero_contribuenti is not null
   and reddito_imponibile_eur is not null

--- a/candidates/irpef-comunale/sql/mart_multi_anno.sql
+++ b/candidates/irpef-comunale/sql/mart_multi_anno.sql
@@ -1,27 +1,27 @@
 with comuni_base as (
   select
-    anno_imposta,
+    anno_di_imposta,
     'comune' as livello_territoriale,
     codice_istat_comune as codice_territorio,
-    comune as territorio,
+    denominazione_comune as territorio,
     regione,
     codice_istat_regione,
     sigla_provincia,
     cast(numero_contribuenti as double) as numero_contribuenti,
     reddito_imponibile_eur as reddito_imponibile_totale_eur,
     imposta_netta_eur as imposta_netta_totale_eur,
-    addizionale_comunale_eur as addizionale_comunale_totale_eur
+    addizionale_comunale_dovuta_eur as addizionale_comunale_totale_eur
   from clean_all_years
-  where anno_imposta is not null
+  where anno_di_imposta is not null
     and codice_istat_comune is not null
-    and comune is not null
+    and denominazione_comune is not null
     and regione is not null
     and numero_contribuenti is not null
     and reddito_imponibile_eur is not null
 ),
 regioni_base as (
   select
-    anno_imposta,
+    anno_di_imposta,
     'regione' as livello_territoriale,
     codice_istat_regione as codice_territorio,
     regione as territorio,
@@ -31,7 +31,7 @@ regioni_base as (
     cast(sum(numero_contribuenti) as double) as numero_contribuenti,
     sum(reddito_imponibile_eur) as reddito_imponibile_totale_eur,
     sum(imposta_netta_eur) as imposta_netta_totale_eur,
-    sum(addizionale_comunale_eur) as addizionale_comunale_totale_eur
+    sum(addizionale_comunale_dovuta_eur) as addizionale_comunale_totale_eur
   from clean_all_years
   group by 1, 2, 3, 4, 5, 6, 7
 ),
@@ -42,7 +42,7 @@ territori as (
 ),
 regioni_anno as (
   select
-    anno_imposta,
+    anno_di_imposta,
     regione,
     sum(numero_contribuenti) as contribuenti_regione,
     sum(reddito_imponibile_totale_eur) as reddito_imponibile_regione_eur
@@ -62,15 +62,15 @@ territori_con_quote as (
     end as quota_reddito_imponibile_su_regione
   from territori t
   left join regioni_anno r
-    on t.anno_imposta = r.anno_imposta
+    on t.anno_di_imposta = r.anno_di_imposta
    and t.regione = r.regione
 ),
 comuni_rank_regione as (
   select
-    anno_imposta,
+    anno_di_imposta,
     codice_territorio,
     row_number() over (
-      partition by anno_imposta, regione
+      partition by anno_di_imposta, regione
       order by reddito_imponibile_totale_eur desc, territorio asc
     ) as rank_regionale_reddito_imponibile
   from territori_con_quote
@@ -83,7 +83,7 @@ territori_metriche as (
     t.imposta_netta_totale_eur / nullif(t.numero_contribuenti, 0) as imposta_netta_media_per_contribuente_eur,
     t.addizionale_comunale_totale_eur / nullif(t.numero_contribuenti, 0) as addizionale_comunale_media_per_contribuente_eur,
     row_number() over (
-      partition by t.anno_imposta, t.livello_territoriale
+      partition by t.anno_di_imposta, t.livello_territoriale
       order by t.reddito_imponibile_totale_eur desc, t.territorio asc
     ) as rank_nazionale_reddito_imponibile,
     case
@@ -92,7 +92,7 @@ territori_metriche as (
     end as rank_regionale_reddito_imponibile
   from territori_con_quote t
   left join comuni_rank_regione crr
-    on t.anno_imposta = crr.anno_imposta
+    on t.anno_di_imposta = crr.anno_di_imposta
    and t.codice_territorio = crr.codice_territorio
 ),
 territori_delta as (
@@ -100,20 +100,20 @@ territori_delta as (
     *,
     lag(numero_contribuenti) over (
       partition by livello_territoriale, codice_territorio
-      order by anno_imposta
+      order by anno_di_imposta
     ) as prev_numero_contribuenti,
     lag(reddito_imponibile_totale_eur) over (
       partition by livello_territoriale, codice_territorio
-      order by anno_imposta
+      order by anno_di_imposta
     ) as prev_reddito_imponibile_totale_eur,
     lag(imposta_netta_totale_eur) over (
       partition by livello_territoriale, codice_territorio
-      order by anno_imposta
+      order by anno_di_imposta
     ) as prev_imposta_netta_totale_eur
   from territori_metriche
 )
 select
-  anno_imposta,
+  anno_di_imposta,
   livello_territoriale,
   codice_territorio,
   territorio,
@@ -147,4 +147,4 @@ select
     else (imposta_netta_totale_eur - prev_imposta_netta_totale_eur) / nullif(prev_imposta_netta_totale_eur, 0)
   end as delta_imposta_netta_vs_anno_precedente_pct
 from territori_delta
-order by anno_imposta, livello_territoriale, rank_nazionale_reddito_imponibile, territorio
+order by anno_di_imposta, livello_territoriale, rank_nazionale_reddito_imponibile, territorio


### PR DESCRIPTION
## Summary

- ** clean.sql riscritto raw-faithful**: 52 colonne mappate dall'header CSV originale (snake_case), nessun `case/when`, nessuna logica interpretativa — il drift tra anni (bonus→trattamento, reddito_complessivo dal 2023) è visibile nei NULL dove il raw non aveva la colonna
- ** mart.sql / mart_comuni.sql / mart_multi_anno.sql**: allineati ai nuovi nomi colonna
- ** notes.md aggiunto**: documenta drift, caveat semantici, schema clean
- ** notebook v0**: aggiunto da template, validato su 2023

## Layers verificati (tutti gli anni)

| Anno | Clean | Mart | Delta tot |
|---|---|---|---|
| 2019 | 7904×52 ✅ | ✅ | 0.0000% |
| 2020 | 7904×52 ✅ | ✅ | 0.0000% |
| 2021 | 7905×52 ✅ | ✅ | 0.0000% |
| 2022 | 7901×52 ✅ | ✅ | 0.0000% |
| 2023 | 7897×52 ✅ | ✅ | 0.0000% |

## Note

- `popolazione_comune` è stata rimossa dal clean (era placeholder mai popolato)
- Il `mart_multi_anno` fa rank e delta vs anno precedente — funziona normalmente con i nuovi nomi
- Il drift (50→52 colonne) è gestito con NULL padding dove il raw non aveva la colonna — il consumatore MCP vede schema stabile 52 colonne con NULL espliciti