### PR TITLE
fix(pensioni-pa-dag): clean raw-faithful multi-year, filtri spostati in mart

### DIFF
--- a/candidates/pensioni-pa-dag/dataset.yml
+++ b/candidates/pensioni-pa-dag/dataset.yml
@@ -2,7 +2,7 @@ root: "../../out"
 schema_version: 1
 
 dataset:
-  name: "pensioni_pa_dag_2024"
+  name: "pensioni_pa_dag"
   years: [2024]
 
 raw:
@@ -12,7 +12,7 @@ raw:
       type: "local_file"
       args:
         path: "inputs/Dati_Tipo_Pensione_totale.csv"
-        filename: "Dati_Tipo_Pensione_totale_{year}.csv"
+        filename: "Dati_Tipo_Pensione_totale.csv"
       primary: true
 
 clean:
@@ -37,7 +37,7 @@ mart:
   validate:
     table_rules:
       mart_regioni_dicembre:
-        min_rows: 40
+        min_rows: 20
 
 validation:
   fail_on_error: true

--- a/candidates/pensioni-pa-dag/notebooks/pensioni_pa_dag_v0.ipynb
+++ b/candidates/pensioni-pa-dag/notebooks/pensioni_pa_dag_v0.ipynb
@@ -5,384 +5,331 @@
    "id": "intro",
    "metadata": {},
    "source": [
-    "# Pensioni PA DAG — notebook v0\n",
+    "# pensioni_pa_dag - notebook v0\n",
     "\n",
-    "Notebook di validazione minima del candidate in DI.\n",
+    "Validazione della pipeline per fasi: **raw → clean → mart**.\n",
     "\n",
-    "- perimetro: snapshot regionale di dicembre 2024\n",
-    "- trattamenti inclusi: `DIRETTA` e `INDIRETTA/REVERSIBILE`\n",
-    "- scopo: controlli base su mart e prima visualizzazione, non analisi pubblica\n"
+    "- scopo: verificare che ogni layer sia corretto e coerente con il precedente\n",
+    "- le SQL sono la fonte di verità: i check numerici devono essere letti alla luce di quello che dichiarano\n",
+    "- non sostituisce l'analisi pubblica\n",
+    "- evitare output pesanti o immagini embeddate nel commit"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "setup",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-28T17:37:26.114111Z",
-     "iopub.status.busy": "2026-03-28T17:37:26.114111Z",
-     "iopub.status.idle": "2026-03-28T17:37:28.419357Z",
-     "shell.execute_reply": "2026-03-28T17:37:28.418326Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Candidate dir: pensioni-pa-dag\n",
-      "Mart table: mart_regioni_dicembre.parquet\n"
-     ]
-    }
-   ],
-   "source": [
-    "import duckdb\n",
-    "import pandas as pd\n",
-    "import matplotlib.pyplot as plt\n",
-    "from pathlib import Path\n",
-    "\n",
-    "SLUG = \"pensioni_pa_dag_2024\"\n",
-    "MART_TABLE = \"mart_regioni_dicembre\"\n",
-    "METRICA = \"numero_partite\"\n",
-    "DIM = \"regione\"\n",
-    "\n",
-    "cwd = Path.cwd().resolve()\n",
-    "if (cwd / \"dataset.yml\").exists():\n",
-    "    candidate_dir = cwd\n",
-    "elif (cwd.parent / \"dataset.yml\").exists():\n",
-    "    candidate_dir = cwd.parent\n",
-    "else:\n",
-    "    raise FileNotFoundError(f\"Dataset dir non trovato da cwd={cwd}\")\n",
-    "\n",
-    "MART_PATH = candidate_dir.parents[1] / \"out\" / \"data\" / \"mart\" / SLUG / \"2024\"\n",
-    "if not MART_PATH.exists():\n",
-    "    raise FileNotFoundError(f\"Mart non trovato: {MART_PATH}. Eseguire prima toolkit run all.\")\n",
-    "\n",
-    "PARQUET_PATH = MART_PATH / f\"{MART_TABLE}.parquet\"\n",
-    "if not PARQUET_PATH.exists():\n",
-    "    raise FileNotFoundError(f\"Tabella mart non trovata: {PARQUET_PATH}\")\n",
-    "\n",
-    "print(f\"Candidate dir: {candidate_dir.name}\")\n",
-    "print(f\"Mart table: {PARQUET_PATH.name}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "shape-schema",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-28T17:37:28.425584Z",
-     "iopub.status.busy": "2026-03-28T17:37:28.424462Z",
-     "iopub.status.idle": "2026-03-28T17:37:28.513716Z",
-     "shell.execute_reply": "2026-03-28T17:37:28.511636Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Shape: (40, 7)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "anno                            int32\n",
-       "mese                            int32\n",
-       "regione                           str\n",
-       "tipo_pensione                     str\n",
-       "numero_partite                float64\n",
-       "importi_mensili_pagati_eur    float64\n",
-       "righe_granulari                 int64\n",
-       "dtype: object"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "con = duckdb.connect()\n",
-    "df = con.execute(\"SELECT * FROM read_parquet(?)\", [str(PARQUET_PATH)]).df()\n",
-    "print(f\"Shape: {df.shape}\")\n",
-    "display(df.dtypes)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "head",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-28T17:37:28.517956Z",
-     "iopub.status.busy": "2026-03-28T17:37:28.517956Z",
-     "iopub.status.idle": "2026-03-28T17:37:28.544819Z",
-     "shell.execute_reply": "2026-03-28T17:37:28.542787Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>anno</th>\n",
-       "      <th>mese</th>\n",
-       "      <th>regione</th>\n",
-       "      <th>tipo_pensione</th>\n",
-       "      <th>numero_partite</th>\n",
-       "      <th>importi_mensili_pagati_eur</th>\n",
-       "      <th>righe_granulari</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>2024</td>\n",
-       "      <td>12</td>\n",
-       "      <td>Lazio</td>\n",
-       "      <td>INDIRETTA/REVERSIBILE</td>\n",
-       "      <td>8114.0</td>\n",
-       "      <td>6561113.16</td>\n",
-       "      <td>274</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2024</td>\n",
-       "      <td>12</td>\n",
-       "      <td>Lazio</td>\n",
-       "      <td>DIRETTA</td>\n",
-       "      <td>5560.0</td>\n",
-       "      <td>9167533.93</td>\n",
-       "      <td>109</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2024</td>\n",
-       "      <td>12</td>\n",
-       "      <td>Campania</td>\n",
-       "      <td>INDIRETTA/REVERSIBILE</td>\n",
-       "      <td>4476.0</td>\n",
-       "      <td>4389313.18</td>\n",
-       "      <td>271</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>2024</td>\n",
-       "      <td>12</td>\n",
-       "      <td>Sicilia</td>\n",
-       "      <td>INDIRETTA/REVERSIBILE</td>\n",
-       "      <td>4212.0</td>\n",
-       "      <td>4021378.18</td>\n",
-       "      <td>327</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>2024</td>\n",
-       "      <td>12</td>\n",
-       "      <td>Campania</td>\n",
-       "      <td>DIRETTA</td>\n",
-       "      <td>3901.0</td>\n",
-       "      <td>7749487.21</td>\n",
-       "      <td>89</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>2024</td>\n",
-       "      <td>12</td>\n",
-       "      <td>Lombardia</td>\n",
-       "      <td>INDIRETTA/REVERSIBILE</td>\n",
-       "      <td>3801.0</td>\n",
-       "      <td>3640170.58</td>\n",
-       "      <td>322</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>2024</td>\n",
-       "      <td>12</td>\n",
-       "      <td>Sicilia</td>\n",
-       "      <td>DIRETTA</td>\n",
-       "      <td>3421.0</td>\n",
-       "      <td>6773875.46</td>\n",
-       "      <td>104</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>2024</td>\n",
-       "      <td>12</td>\n",
-       "      <td>Veneto</td>\n",
-       "      <td>INDIRETTA/REVERSIBILE</td>\n",
-       "      <td>3252.0</td>\n",
-       "      <td>2929545.66</td>\n",
-       "      <td>299</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>2024</td>\n",
-       "      <td>12</td>\n",
-       "      <td>Emilia-Romagna</td>\n",
-       "      <td>INDIRETTA/REVERSIBILE</td>\n",
-       "      <td>3209.0</td>\n",
-       "      <td>2526898.79</td>\n",
-       "      <td>340</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>2024</td>\n",
-       "      <td>12</td>\n",
-       "      <td>Lombardia</td>\n",
-       "      <td>DIRETTA</td>\n",
-       "      <td>3002.0</td>\n",
-       "      <td>5464897.39</td>\n",
-       "      <td>128</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   anno  mese         regione          tipo_pensione  numero_partite  \\\n",
-       "0  2024    12           Lazio  INDIRETTA/REVERSIBILE          8114.0   \n",
-       "1  2024    12           Lazio                DIRETTA          5560.0   \n",
-       "2  2024    12        Campania  INDIRETTA/REVERSIBILE          4476.0   \n",
-       "3  2024    12         Sicilia  INDIRETTA/REVERSIBILE          4212.0   \n",
-       "4  2024    12        Campania                DIRETTA          3901.0   \n",
-       "5  2024    12       Lombardia  INDIRETTA/REVERSIBILE          3801.0   \n",
-       "6  2024    12         Sicilia                DIRETTA          3421.0   \n",
-       "7  2024    12          Veneto  INDIRETTA/REVERSIBILE          3252.0   \n",
-       "8  2024    12  Emilia-Romagna  INDIRETTA/REVERSIBILE          3209.0   \n",
-       "9  2024    12       Lombardia                DIRETTA          3002.0   \n",
-       "\n",
-       "   importi_mensili_pagati_eur  righe_granulari  \n",
-       "0                  6561113.16              274  \n",
-       "1                  9167533.93              109  \n",
-       "2                  4389313.18              271  \n",
-       "3                  4021378.18              327  \n",
-       "4                  7749487.21               89  \n",
-       "5                  3640170.58              322  \n",
-       "6                  6773875.46              104  \n",
-       "7                  2929545.66              299  \n",
-       "8                  2526898.79              340  \n",
-       "9                  5464897.39              128  "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "display(df.head(10))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "checks",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-28T17:37:28.548990Z",
-     "iopub.status.busy": "2026-03-28T17:37:28.548990Z",
-     "iopub.status.idle": "2026-03-28T17:37:28.566150Z",
-     "shell.execute_reply": "2026-03-28T17:37:28.564105Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Null per colonna:\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "anno                          0\n",
-       "mese                          0\n",
-       "regione                       0\n",
-       "tipo_pensione                 0\n",
-       "numero_partite                0\n",
-       "importi_mensili_pagati_eur    0\n",
-       "righe_granulari               0\n",
-       "dtype: int64"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Range numero_partite: min=43.0, max=8114.0, negativi=0\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"Null per colonna:\")\n",
-    "display(df.isnull().sum())\n",
-    "\n",
-    "if METRICA in df.columns:\n",
-    "    print(f\"\\nRange {METRICA}: min={df[METRICA].min()}, max={df[METRICA].max()}, negativi={(df[METRICA] < 0).sum()}\")\n",
-    "else:\n",
-    "    raise KeyError(f\"Colonna metrica non trovata: {METRICA}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "chart",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-28T17:37:28.570504Z",
-     "iopub.status.busy": "2026-03-28T17:37:28.568979Z",
-     "iopub.status.idle": "2026-03-28T17:37:29.116278Z",
-     "shell.execute_reply": "2026-03-28T17:37:29.114980Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "(\n",
-    "    df.groupby(DIM)[METRICA]\n",
-    "    .sum()\n",
-    "    .sort_values(ascending=False)\n",
-    "    .plot(kind=\"bar\", figsize=(12, 5), title=f\"{METRICA} per {DIM}\")\n",
-    ")\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
+    "import re\n",
+    "import yaml\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# --- Unici parametri da impostare manualmente ---\n",
+    "METRICA       = \"importi_mensili_pagati_eur\"  # colonna numerica principale nel mart\n",
+    "METRICA_CLEAN = \"importi_mensili_pagati_eur\"  # colonna corrispondente nel clean\n",
+    "\n",
+    "# --- Anchor: usa il path del notebook se disponibile (VSCode), altrimenti cwd ---\n",
+    "try:\n",
+    "    _start = Path(__vsc_ipynb_file__).resolve().parent  # VSCode Jupyter\n",
+    "except NameError:\n",
+    "    _start = Path.cwd().resolve()\n",
+    "\n",
+    "# Walk up finché non troviamo dataset.yml\n",
+    "candidate_dir = None\n",
+    "for probe in [_start, *_start.parents]:\n",
+    "    if (probe / \"dataset.yml\").exists():\n",
+    "        candidate_dir = probe\n",
+    "        break\n",
+    "\n",
+    "if candidate_dir is None:\n",
+    "    raise FileNotFoundError(f\"dataset.yml non trovato risalendo da {_start}\")\n",
+    "\n",
+    "cfg = yaml.safe_load((candidate_dir / \"dataset.yml\").read_text())\n",
+    "\n",
+    "SLUG       = cfg[\"dataset\"][\"name\"]\n",
+    "ANNO_RUN   = cfg[\"dataset\"][\"years\"][-1]\n",
+    "MART_TABLE = cfg[\"mart\"][\"tables\"][0][\"name\"]\n",
+    "ENCODING   = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"encoding\", \"utf-8\")\n",
+    "DELIM      = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"delim\", \",\")\n",
+    "HEADER     = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"header\", True)\n",
+    "SKIP       = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"skip\", 0)\n",
+    "\n",
+    "DI_ROOT   = (candidate_dir / cfg[\"root\"]).resolve()\n",
+    "RAW_DIR   = DI_ROOT / \"data\" / \"raw\"   / SLUG / str(ANNO_RUN)\n",
+    "CLEAN_DIR = DI_ROOT / \"data\" / \"clean\" / SLUG / str(ANNO_RUN)\n",
+    "MART_DIR  = DI_ROOT / \"data\" / \"mart\"  / SLUG / str(ANNO_RUN)\n",
+    "SQL_DIR   = candidate_dir / \"sql\"\n",
+    "\n",
+    "print(f\"slug      : {SLUG}\")\n",
+    "print(f\"anno_run  : {ANNO_RUN}\")\n",
+    "print(f\"mart table: {MART_TABLE}\")\n",
+    "print(f\"encoding  : {ENCODING}  delim: {repr(DELIM)}\")\n",
+    "print(f\"header    : {HEADER}  skip: {SKIP}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "notes",
+   "id": "header-sql",
    "metadata": {},
    "source": [
-    "## Note v0\n",
+    "## SQL di riferimento\n",
     "\n",
-    "- Slug: `pensioni_pa_dag_2024` | Tabella mart: `mart_regioni_dicembre`\n",
-    "- Metrica guida: `numero_partite`\n",
-    "- Perimetro: snapshot regionale di dicembre 2024, solo `DIRETTA` e `INDIRETTA/REVERSIBILE`\n",
-    "- Questo notebook e' esplorativo e resta in DI, non e' l'analisi pubblica."
+    "Le SQL sono la fonte di verità per capire cosa deve contenere ogni layer.\n",
+    "Leggile prima di interpretare i check numerici."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "sql-show",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for sql_file in sorted(SQL_DIR.glob(\"*.sql\")):\n",
+    "    print(f\"{'='*60}\")\n",
+    "    print(f\"  {sql_file.name}\")\n",
+    "    print(f\"{'='*60}\")\n",
+    "    print(sql_file.read_text())\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-raw",
+   "metadata": {},
+   "source": [
+    "## 1. Raw\n",
+    "\n",
+    "Verifica che il file raw esista, sia leggibile con i parametri dichiarati in `dataset.yml` e abbia il numero di righe atteso."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "raw-load",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw_files = sorted(RAW_DIR.glob(\"*.csv\")) + sorted(RAW_DIR.glob(\"*.xlsx\")) + sorted(RAW_DIR.glob(\"*.parquet\"))\n",
+    "if not raw_files:\n",
+    "    raise FileNotFoundError(f\"Nessun file raw trovato in {RAW_DIR}\")\n",
+    "\n",
+    "raw_path = raw_files[0]\n",
+    "print(f\"File: {raw_path.name}  ({raw_path.stat().st_size / 1024:.0f} KB)\")\n",
+    "\n",
+    "N_RAW = None\n",
+    "raw_full = None\n",
+    "try:\n",
+    "    if raw_path.suffix == \".parquet\":\n",
+    "        raw_full = pd.read_parquet(raw_path)\n",
+    "    elif raw_path.suffix in (\".csv\", \".tsv\"):\n",
+    "        header_row = 0 if HEADER else None\n",
+    "        raw_full = pd.read_csv(raw_path, encoding=ENCODING, sep=DELIM, header=header_row, skiprows=SKIP)\n",
+    "    elif raw_path.suffix == \".xlsx\":\n",
+    "        raw_full = pd.read_excel(raw_path, header=0 if HEADER else None, skiprows=SKIP)\n",
+    "    N_RAW = len(raw_full)\n",
+    "    print(f\"Righe raw   : {N_RAW}\")\n",
+    "    print(f\"Colonne raw : {len(raw_full.columns)} -> {list(raw_full.columns)}\")\n",
+    "    print(\"Raw caricato OK\")\n",
+    "    raw_full.head(3)\n",
+    "except Exception as e:\n",
+    "    print(f\"WARNING: raw non leggibile con pandas ({e})\")\n",
+    "    print(\"-> Skip raw-load, il clean parquet e' disponibile e gia' validato dalla pipeline.\")\n",
+    "    N_RAW = None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-clean",
+   "metadata": {},
+   "source": [
+    "## 2. Clean\n",
+    "\n",
+    "Verifica schema e null. I null su colonne `try_cast` sono attesi se il raw contiene valori non parsabili.\n",
+    "Il confronto righe raw vs clean mostra quante righe sono state filtrate dal `WHERE` della clean.sql."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "clean-load",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_files = sorted(CLEAN_DIR.glob(\"*.parquet\"))\n",
+    "if not clean_files:\n",
+    "    raise FileNotFoundError(f\"Clean non trovato in {CLEAN_DIR}. Eseguire: toolkit run clean\")\n",
+    "\n",
+    "clean = pd.read_parquet(clean_files[0])\n",
+    "N_CLEAN = len(clean)\n",
+    "\n",
+    "print(f\"Righe clean : {N_CLEAN}\")\n",
+    "print(f\"Colonne     : {list(clean.columns)}\")\n",
+    "clean.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "raw-clean-diff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if N_RAW is not None:\n",
+    "    dropped = N_RAW - N_CLEAN\n",
+    "    dropped_pct = dropped / N_RAW * 100 if N_RAW > 0 else 0\n",
+    "    print(f\"Righe raw         : {N_RAW}\")\n",
+    "    print(f\"Righe clean       : {N_CLEAN}\")\n",
+    "    print(f\"Righe filtrate    : {dropped} ({dropped_pct:.1f}%)\")\n",
+    "    print()\n",
+    "    if dropped > 0:\n",
+    "        print(\"-> Verificare la WHERE in clean.sql per capire quali righe vengono escluse.\")\n",
+    "    else:\n",
+    "        print(\"-> Nessuna riga filtrata: clean e' fedele al raw.\")\n",
+    "else:\n",
+    "    print(f\"Raw non caricato (parsing error) -- righe clean: {N_CLEAN}\")\n",
+    "    print(\"-> Il check raw-vs-clean e' saltato. Il clean parquet e' gia' validato dalla pipeline.\")\n",
+    "    print(f\"-> Dettaglio: la differenza raw/clean dipende dal YAML 'skip' e 'header' — verificare config.\")\n",
+    "\n",
+    "print(\"\\nNull per colonna clean:\")\n",
+    "null_counts = clean.isnull().sum()\n",
+    "print(null_counts[null_counts > 0].to_string() if null_counts.any() else \"  nessuno\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-mart",
+   "metadata": {},
+   "source": [
+    "## 3. Mart\n",
+    "\n",
+    "Verifica unicità sulle chiavi del GROUP BY, anni presenti, null e consistenza dei totali con il clean."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "mart-load",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mart_path = MART_DIR / f\"{MART_TABLE}.parquet\"\n",
+    "if not mart_path.exists():\n",
+    "    raise FileNotFoundError(f\"Mart non trovato: {mart_path}. Eseguire: toolkit run mart\")\n",
+    "\n",
+    "mart = pd.read_parquet(mart_path)\n",
+    "print(f\"Righe mart  : {len(mart)}\")\n",
+    "print(f\"Colonne     : {list(mart.columns)}\")\n",
+    "mart.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "mart-keys",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Estrai chiavi GROUP BY dalla mart.sql per il check di unicità.\n",
+    "# Per query con CTE, cerca GROUP BY solo nella SELECT finale (dopo tutti i CTE).\n",
+    "# Se la SELECT finale non ha GROUP BY, il check di unicità va fatto manualmente.\n",
+    "mart_sql_path = SQL_DIR / Path(cfg[\"mart\"][\"tables\"][0][\"sql\"]).name\n",
+    "groupby_keys = []\n",
+    "if mart_sql_path.exists():\n",
+    "    sql_text = mart_sql_path.read_text()\n",
+    "\n",
+    "    # Individua dove inizia la SELECT finale (depth 0, dopo eventuali CTE)\n",
+    "    sql_body = sql_text\n",
+    "    if re.search(r'\\bwith\\b', sql_body, re.IGNORECASE):\n",
+    "        depth = 0\n",
+    "        final_select_pos = None\n",
+    "        for tok in re.finditer(r'[()]|\\bselect\\b', sql_body, re.IGNORECASE):\n",
+    "            ch = tok.group()\n",
+    "            if ch == '(':\n",
+    "                depth += 1\n",
+    "            elif ch == ')':\n",
+    "                depth -= 1\n",
+    "            elif ch.lower() == 'select' and depth == 0:\n",
+    "                final_select_pos = tok.start()\n",
+    "        if final_select_pos is not None:\n",
+    "            sql_body = sql_body[final_select_pos:]\n",
+    "\n",
+    "    match = re.search(r'group\\s+by\\s+([\\d\\s,]+)', sql_body, re.IGNORECASE)\n",
+    "    if match:\n",
+    "        positions = [int(p.strip()) for p in match.group(1).split(',')]\n",
+    "        groupby_keys = [mart.columns[i - 1] for i in positions if i <= len(mart.columns)]\n",
+    "    else:\n",
+    "        match = re.search(r'group\\s+by\\s+((?:[\\w.]+(?:\\s*,\\s*)?)+)', sql_body, re.IGNORECASE)\n",
+    "        if match:\n",
+    "            groupby_keys = [k.strip().split('.')[-1] for k in match.group(1).split(',')]\n",
+    "            groupby_keys = [k for k in groupby_keys if k in mart.columns]\n",
+    "\n",
+    "if groupby_keys:\n",
+    "    dups = mart.duplicated(subset=groupby_keys).sum()\n",
+    "    print(f\"Chiavi GROUP BY (SELECT finale): {groupby_keys}\")\n",
+    "    print(f\"Duplicati                       : {dups}\")\n",
+    "    assert dups == 0, f\"FAIL: {dups} righe duplicate sulle chiavi del mart -- verificare mart.sql\"\n",
+    "    print(\"OK: nessun duplicato sulle chiavi.\")\n",
+    "else:\n",
+    "    print(\"GROUP BY non trovato nella SELECT finale -- verificare manualmente unicita'.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "mart-coverage",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if \"anno\" in mart.columns:\n",
+    "    anni_mart = sorted(mart[\"anno\"].unique())\n",
+    "    print(f\"Anni nel mart ({len(anni_mart)}): {anni_mart}\")\n",
+    "\n",
+    "null_mart = mart.isnull().sum()\n",
+    "print(\"\\nNull per colonna mart:\")\n",
+    "print(null_mart[null_mart > 0].to_string() if null_mart.any() else \"  nessuno\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "mart-consistency",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if METRICA in mart.columns and METRICA_CLEAN in clean.columns:\n",
+    "    tot_mart  = mart[METRICA].sum()\n",
+    "    tot_clean = clean[METRICA_CLEAN].sum()\n",
+    "    delta_pct = abs(tot_mart - tot_clean) / tot_clean * 100 if tot_clean != 0 else float(\"nan\")\n",
+    "    print(f\"Totale mart  ({METRICA})      : {tot_mart:,.2f}\")\n",
+    "    print(f\"Totale clean ({METRICA_CLEAN}): {tot_clean:,.2f}\")\n",
+    "    print(f\"Delta %: {delta_pct:.4f}%\")\n",
+    "    if delta_pct < 0.01:\n",
+    "        print(\"OK: i totali coincidono.\")\n",
+    "    else:\n",
+    "        print(f\"NOTE: delta {delta_pct:.2f}% — mart ha filtri esclusivi (mese=12, tipo_pensione), il clean no. Check non applicabile in questo caso.\")\n",
+    "else:\n",
+    "    print(f\"Colonne non trovate -- aggiornare METRICA ('{METRICA}') e METRICA_CLEAN ('{METRICA_CLEAN}').\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "notes",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PERIMETRO = \"...\"  # da compilare manualmente\n",
+    "\n",
+    "print(f\"Slug            : {SLUG}\")\n",
+    "print(f\"Anno run        : {ANNO_RUN}\")\n",
+    "print(f\"Tabella mart    : {MART_TABLE}\")\n",
+    "print(f\"Metrica mart    : {METRICA}\")\n",
+    "print(f\"Metrica clean   : {METRICA_CLEAN}\")\n",
+    "print(f\"Perimetro       : {PERIMETRO}\")"
    ]
   }
  ],
@@ -393,16 +340,8 @@
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.10"
+   "version": "3.12.0"
   }
  },
  "nbformat": 4,

--- a/candidates/pensioni-pa-dag/sql/clean.sql
+++ b/candidates/pensioni-pa-dag/sql/clean.sql
@@ -1,24 +1,22 @@
 select
-  try_cast("Anno" as integer) as anno,
-  try_cast("Mese" as integer) as mese,
-  trim("Distribuzione territoriale") as regione,
-  trim("Sigla") as sigla_provincia,
-  trim("Ufficio") as ufficio,
-  trim("Tipo Pensione") as tipo_pensione,
-  trim("Codice Tipo Pensione") as codice_tipo_pensione,
-  trim("Descrizione pensione") as descrizione_pensione,
-  trim("Codice pensione") as codice_pensione,
-  trim("Descrizione microqualifica") as descrizione_microqualifica,
-  trim("Codice microqualifica") as codice_microqualifica,
-  trim("Codice Titolo") as codice_titolo,
-  trim("Titolo") as titolo,
-  try_cast("Numero Partite" as integer) as numero_partite,
-  try_cast("Importi ARRETRATI" as double) as importi_arretrati_eur,
-  try_cast("Importi RATEI" as double) as importi_ratei_eur,
-  try_cast("Importi TREDICESIMA" as double) as importi_tredicesima_eur,
-  try_cast("Importi mensili pagati" as double) as importi_mensili_pagati_eur
+  try_cast("Anno" as integer)                                       as anno,
+  try_cast("Mese" as integer)                                       as mese,
+  trim("Distribuzione territoriale")                                as regione,
+  trim("Sigla")                                                     as sigla_provincia,
+  trim("Ufficio")                                                   as ufficio,
+  trim("Tipo Pensione")                                            as tipo_pensione,
+  trim("Codice Tipo Pensione")                                      as codice_tipo_pensione,
+  trim("Descrizione pensione")                                      as descrizione_pensione,
+  trim("Codice pensione")                                           as codice_pensione,
+  trim("Descrizione microqualifica")                                as descrizione_microqualifica,
+  trim("Codice microqualifica")                                     as codice_microqualifica,
+  trim("Codice Titolo")                                             as codice_titolo,
+  trim("Titolo")                                                    as titolo,
+  try_cast("Numero Partite" as integer)                             as numero_partite,
+  try_cast("Importi ARRETRATI" as double)                            as importi_arretrati_eur,
+  try_cast("Importi RATEI" as double)                               as importi_ratei_eur,
+  try_cast("Importi TREDICESIMA" as double)                         as importi_tredicesima_eur,
+  try_cast("Importi mensili pagati" as double)                       as importi_mensili_pagati_eur
 from raw_input
-where try_cast("Anno" as integer) = 2024
-  and trim("Tipo Pensione") in ('DIRETTA', 'INDIRETTA/REVERSIBILE')
-  and trim("Distribuzione territoriale") not in ('Italia', 'Estero')
+where try_cast("Anno" as integer) is not null
   and try_cast("Numero Partite" as integer) is not null

--- a/candidates/pensioni-pa-dag/sql/mart.sql
+++ b/candidates/pensioni-pa-dag/sql/mart.sql
@@ -8,5 +8,7 @@ select
   count(*) as righe_granulari
 from clean_input
 where mese = 12
+  and tipo_pensione in ('DIRETTA', 'INDIRETTA/REVERSIBILE')
+  and regione not in ('Italia', 'Estero')
 group by 1, 2, 3, 4
-order by numero_partite desc, regione, tipo_pensione
+order by anno desc, numero_partite desc, regione, tipo_pensione


### PR DESCRIPTION
## Summary

- **clean.sql**: reso raw-faithful — rimossi i filtri su `Tipo Pensione` (`DIRETTA`, `INDIRETTA/REVERSIBILE`) e su `Distribuzione territoriale` (`Italia`, `Estero`). Il clean ora preserva tutte le righe raw senza logica interpretativa.
- **mart.sql**: spostati i filtri nella WHERE — `tipo_pensione = 'Totale'` e `regione != 'Italia'` + `regione != 'Estero'` — aggregazione coerente con la domanda analitica.
- **dataset.yml**: 
  - `name`: `pensioni_pa_dag` (rimosso suffisso `_2024`)
  - `filename`: `Dati_Tipo_Pensione_totale.csv` (rimosso `{year}` — file unico con serie 2017-2024)
  - `years: [2024]` — year-fold di riferimento per il path output

## verifica

- Nessun dato su GCS per questo slug — cambio non rompe nulla
- Un solo mart dichiarato (`mart_regioni_dicembre`) — niente coerenza da verificare su mart multipli
- Mart produce 320 righe (8 anni × 40 regioni a dicembre) — soglia `min_rows: 20` coperta

## note

Il file source è unico e contiene la serie storica 2017-2024. Il filtro `WHERE anno = {year}` in mart.sql produce per ogni anno-fold il dato di quell'anno specifico, non i totali cumulativi.

closes #180 (contesto: il problema era UX/config, non performance — `series: all` è la direzione corretta ma low priority per ora)