### PR TITLE
feat(camera-deputati-legislature): candidate runnable — SPARQL fix, clean raw-faithful

### DIFF
--- a/candidates/camera-deputati-legislature/README.md
+++ b/candidates/camera-deputati-legislature/README.md
@@ -1,0 +1,43 @@
+# Camera Deputati — Legislature
+
+## Domanda
+
+Quanti deputati hanno fatto parte di ciascuna legislature della Camera?
+
+## Fonte
+
+[dati.camera.it/sparql](https://dati.camera.it/sparql) — endpoint SPARQL del Catalogo linked-data Camera dei deputati.
+
+## Perimetro
+
+Tutti i deputati di tutte le legislature della Repubblica Italiana (fino alla XIX). Ogni deputato può comparire in più legislature — la chiave è `(deputato, legislature)`.
+
+## Schema
+
+| Colonna | Tipo | Descrizione |
+|---|---|---|
+| `deputato` | string | URI RDF del deputato |
+| `cogn` | string | Cognome |
+| `nome` | string | Nome |
+| `legislatura` | string | Numero della legislature (es. "17", "18", "19") |
+| `gender` | string | Sesso |
+
+## Output atteso
+
+- **Raw**: CSV da SPARQL con 10k+ righe
+- **Clean**: raw-faithful, nessun filtro
+- **Mart**: `mart_deputati.parquet` — un record per `(deputato, legislature)`, unico per deputato per legislature
+
+## Note tecniche
+
+- L'estrazione della legislature avviene dall'URI `?leg` (`repubblica_N`) tramite `REPLACE(STR(?leg), 'http://dati.camera.it/ocd/legislatura.rdf/repubblica_', '')`
+- `dct:title` non è disponibile su quel endpoint — la legislature è solo nell'URI
+- L'endpoint SPARQL Camera può restituire 503 in modo intermittente
+
+## Run
+
+```bash
+cd toolkit
+python -m toolkit.cli.app run all \
+  --config ../dataset-incubator/candidates/camera-deputati-legislature/dataset.yml
+```

--- a/candidates/camera-deputati-legislature/dataset.yml
+++ b/candidates/camera-deputati-legislature/dataset.yml
@@ -1,0 +1,57 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "camera_deputati_legislature"
+  years: [2024]
+
+raw:
+  sources:
+    - name: "camera_deputati_sparql"
+      type: "sparql"
+      primary: true
+      args:
+        endpoint: "https://dati.camera.it/sparql"
+        query: |
+          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+          PREFIX ocd: <http://dati.camera.it/ocd/>
+          SELECT DISTINCT ?deputato ?cogn ?nome ?legislatura ?gender
+          WHERE {
+            ?deputato a ocd:deputato .
+            OPTIONAL { ?deputato foaf:surname ?cogn . }
+            OPTIONAL { ?deputato foaf:firstName ?nome . }
+            OPTIONAL { ?deputato ocd:rif_leg ?leg .
+                       BIND(REPLACE(STR(?leg), 'http://dati.camera.it/ocd/legislatura.rdf/repubblica_', '') AS ?legislatura) . }
+            OPTIONAL { ?deputato foaf:gender ?gender . }
+          }
+          LIMIT 50000
+        accept_format: "csv"
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: auto
+    mode: latest
+    header: true
+    encoding: "utf-8"
+    strict_mode: false
+    ignore_errors: true
+    trim_whitespace: true
+  validate: {}
+
+mart:
+  tables:
+    - name: "mart_deputati"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_deputati"
+  validate:
+    table_rules:
+      mart_deputati:
+        min_rows: 1000
+
+validation:
+  fail_on_error: false
+
+output:
+  artifacts: "minimal"

--- a/candidates/camera-deputati-legislature/notebooks/camera_deputati_legislature_v0.ipynb
+++ b/candidates/camera-deputati-legislature/notebooks/camera_deputati_legislature_v0.ipynb
@@ -1,0 +1,345 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "intro",
+      "metadata": {},
+      "source": [
+        "# Camera Deputati Legislature - notebook v0\n",
+        "\n",
+        "Validazione della pipeline per fasi: **raw → clean → mart**.\n",
+        "\n",
+        "- scopo: verificare che ogni layer sia corretto e coerente con il precedente\n",
+        "- le SQL sono la fonte di verità: i check numerici devono essere letti alla luce di quello che dichiarano\n",
+        "- non sostituisce l'analisi pubblica\n",
+        "- evitare output pesanti o immagini embeddate nel commit"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "setup",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import re\n",
+        "import yaml\n",
+        "import pandas as pd\n",
+        "from pathlib import Path\n",
+        "\n",
+        "# --- Unici parametri da impostare manualmente ---\n",
+        "METRICA       = \"deputato\"  # n/a per dataset personale, check conteggio\n",
+        "METRICA_CLEAN = \"deputato\"  # corrispondente nel clean\n",
+        "\n",
+        "# --- Anchor: usa il path del notebook se disponibile (VSCode), altrimenti cwd ---\n",
+        "try:\n",
+        "    _start = Path(__vsc_ipynb_file__).resolve().parent  # VSCode Jupyter\n",
+        "except NameError:\n",
+        "    _start = Path.cwd().resolve()\n",
+        "\n",
+        "# Walk up finché non troviamo dataset.yml\n",
+        "candidate_dir = None\n",
+        "for probe in [_start, *_start.parents]:\n",
+        "    if (probe / \"dataset.yml\").exists():\n",
+        "        candidate_dir = probe\n",
+        "        break\n",
+        "\n",
+        "if candidate_dir is None:\n",
+        "    raise FileNotFoundError(f\"dataset.yml non trovato risalendo da {_start}\")\n",
+        "\n",
+        "cfg = yaml.safe_load((candidate_dir / \"dataset.yml\").read_text())\n",
+        "\n",
+        "SLUG       = cfg[\"dataset\"][\"name\"]\n",
+        "ANNO_RUN   = cfg[\"dataset\"][\"years\"][-1]\n",
+        "MART_TABLE = cfg[\"mart\"][\"tables\"][0][\"name\"]\n",
+        "ENCODING   = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"encoding\", \"utf-8\")\n",
+        "DELIM      = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"delim\", \",\")\n",
+        "HEADER     = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"header\", True)\n",
+        "SKIP       = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"skip\", 0)\n",
+        "\n",
+        "DI_ROOT   = (candidate_dir / cfg[\"root\"]).resolve()\n",
+        "RAW_DIR   = DI_ROOT / \"data\" / \"raw\"   / SLUG / str(ANNO_RUN)\n",
+        "CLEAN_DIR = DI_ROOT / \"data\" / \"clean\" / SLUG / str(ANNO_RUN)\n",
+        "MART_DIR  = DI_ROOT / \"data\" / \"mart\"  / SLUG / str(ANNO_RUN)\n",
+        "SQL_DIR   = candidate_dir / \"sql\"\n",
+        "\n",
+        "print(f\"slug      : {SLUG}\")\n",
+        "print(f\"anno_run  : {ANNO_RUN}\")\n",
+        "print(f\"mart table: {MART_TABLE}\")\n",
+        "print(f\"encoding  : {ENCODING}  delim: {repr(DELIM)}\")\n",
+        "print(f\"header    : {HEADER}  skip: {SKIP}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "header-sql",
+      "metadata": {},
+      "source": [
+        "## SQL di riferimento\n",
+        "\n",
+        "Le SQL sono la fonte di verità per capire cosa deve contenere ogni layer.\n",
+        "Leggile prima di interpretare i check numerici."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "sql-show",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "for sql_file in sorted(SQL_DIR.glob(\"*.sql\")):\n",
+        "    print(f\"{'='*60}\")\n",
+        "    print(f\"  {sql_file.name}\")\n",
+        "    print(f\"{'='*60}\")\n",
+        "    print(sql_file.read_text())\n",
+        "    print()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "header-raw",
+      "metadata": {},
+      "source": [
+        "## 1. Raw\n",
+        "\n",
+        "Verifica che il file raw esista, sia leggibile con i parametri dichiarati in `dataset.yml` e abbia il numero di righe atteso."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "raw-load",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "raw_files = sorted(RAW_DIR.glob(\"*.csv\")) + sorted(RAW_DIR.glob(\"*.xlsx\")) + sorted(RAW_DIR.glob(\"*.parquet\"))\n",
+        "if not raw_files:\n",
+        "    raise FileNotFoundError(f\"Nessun file raw trovato in {RAW_DIR}\")\n",
+        "\n",
+        "raw_path = raw_files[0]\n",
+        "print(f\"File: {raw_path.name}  ({raw_path.stat().st_size / 1024:.0f} KB)\")\n",
+        "\n",
+        "if raw_path.suffix == \".parquet\":\n",
+        "    raw_full = pd.read_parquet(raw_path)\n",
+        "elif raw_path.suffix in (\".csv\", \".tsv\"):\n",
+        "    header_row = 0 if HEADER else None\n",
+        "    raw_full = pd.read_csv(raw_path, encoding=ENCODING, sep=DELIM, header=header_row, skiprows=SKIP)\n",
+        "elif raw_path.suffix == \".xlsx\":\n",
+        "    raw_full = pd.read_excel(raw_path, header=0 if HEADER else None, skiprows=SKIP)\n",
+        "\n",
+        "N_RAW = len(raw_full)\n",
+        "print(f\"Righe raw   : {N_RAW}\")\n",
+        "print(f\"Colonne raw : {len(raw_full.columns)} -> {list(raw_full.columns)}\")\n",
+        "raw_full.head(3)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "header-clean",
+      "metadata": {},
+      "source": [
+        "## 2. Clean\n",
+        "\n",
+        "Verifica schema e null. I null su colonne `try_cast` sono attesi se il raw contiene valori non parsabili.\n",
+        "Il confronto righe raw vs clean mostra quante righe sono state filtrate dal `WHERE` della clean.sql."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "clean-load",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "clean_files = sorted(CLEAN_DIR.glob(\"*.parquet\"))\n",
+        "if not clean_files:\n",
+        "    raise FileNotFoundError(f\"Clean non trovato in {CLEAN_DIR}. Eseguire: toolkit run clean\")\n",
+        "\n",
+        "clean = pd.read_parquet(clean_files[0])\n",
+        "N_CLEAN = len(clean)\n",
+        "\n",
+        "print(f\"Righe clean : {N_CLEAN}\")\n",
+        "print(f\"Colonne     : {list(clean.columns)}\")\n",
+        "clean.head(3)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "raw-clean-diff",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "dropped = N_RAW - N_CLEAN\n",
+        "dropped_pct = dropped / N_RAW * 100 if N_RAW > 0 else 0\n",
+        "\n",
+        "print(f\"Righe raw         : {N_RAW}\")\n",
+        "print(f\"Righe clean       : {N_CLEAN}\")\n",
+        "print(f\"Righe filtrate    : {dropped} ({dropped_pct:.1f}%)\")\n",
+        "print()\n",
+        "if dropped > 0:\n",
+        "    print(\"-> Verificare la WHERE in clean.sql per capire quali righe vengono escluse.\")\n",
+        "else:\n",
+        "    print(\"-> Nessuna riga filtrata: clean e' fedele al raw.\")\n",
+        "\n",
+        "print(\"\\nNull per colonna clean:\")\n",
+        "null_counts = clean.isnull().sum()\n",
+        "print(null_counts[null_counts > 0].to_string() if null_counts.any() else \"  nessuno\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "header-mart",
+      "metadata": {},
+      "source": [
+        "## 3. Mart\n",
+        "\n",
+        "Verifica unicità sulle chiavi del GROUP BY, anni presenti, null e consistenza dei totali con il clean."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "mart-load",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "mart_path = MART_DIR / f\"{MART_TABLE}.parquet\"\n",
+        "if not mart_path.exists():\n",
+        "    raise FileNotFoundError(f\"Mart non trovato: {mart_path}. Eseguire: toolkit run mart\")\n",
+        "\n",
+        "mart = pd.read_parquet(mart_path)\n",
+        "print(f\"Righe mart  : {len(mart)}\")\n",
+        "print(f\"Colonne     : {list(mart.columns)}\")\n",
+        "mart.head(3)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "mart-keys",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Estrai chiavi GROUP BY dalla mart.sql per il check di unicità.\n",
+        "# Per query con CTE, cerca GROUP BY solo nella SELECT finale (dopo tutti i CTE).\n",
+        "# Se la SELECT finale non ha GROUP BY, il check di unicità va fatto manualmente.\n",
+        "mart_sql_path = SQL_DIR / \"mart.sql\"\n",
+        "groupby_keys = []\n",
+        "if mart_sql_path.exists():\n",
+        "    sql_text = mart_sql_path.read_text()\n",
+        "\n",
+        "    # Individua dove inizia la SELECT finale (depth 0, dopo eventuali CTE)\n",
+        "    sql_body = sql_text\n",
+        "    if re.search(r'\\bwith\\b', sql_body, re.IGNORECASE):\n",
+        "        depth = 0\n",
+        "        final_select_pos = None\n",
+        "        for tok in re.finditer(r'[()]|\\bselect\\b', sql_body, re.IGNORECASE):\n",
+        "            ch = tok.group()\n",
+        "            if ch == '(':\n",
+        "                depth += 1\n",
+        "            elif ch == ')':\n",
+        "                depth -= 1\n",
+        "            elif ch.lower() == 'select' and depth == 0:\n",
+        "                final_select_pos = tok.start()\n",
+        "        if final_select_pos is not None:\n",
+        "            sql_body = sql_body[final_select_pos:]\n",
+        "\n",
+        "    match = re.search(r'group\\s+by\\s+([\\d\\s,]+)', sql_body, re.IGNORECASE)\n",
+        "    if match:\n",
+        "        positions = [int(p.strip()) for p in match.group(1).split(',')]\n",
+        "        groupby_keys = [mart.columns[i - 1] for i in positions if i <= len(mart.columns)]\n",
+        "    else:\n",
+        "        match = re.search(r'group\\s+by\\s+((?:[\\w.]+(?:\\s*,\\s*)?)+)', sql_body, re.IGNORECASE)\n",
+        "        if match:\n",
+        "            groupby_keys = [k.strip().split('.')[-1] for k in match.group(1).split(',')]\n",
+        "            groupby_keys = [k for k in groupby_keys if k in mart.columns]\n",
+        "\n",
+        "if groupby_keys:\n",
+        "    dups = mart.duplicated(subset=groupby_keys).sum()\n",
+        "    print(f\"Chiavi GROUP BY (SELECT finale): {groupby_keys}\")\n",
+        "    print(f\"Duplicati                       : {dups}\")\n",
+        "    assert dups == 0, f\"FAIL: {dups} righe duplicate sulle chiavi del mart -- verificare mart.sql\"\n",
+        "    print(\"OK: nessun duplicato sulle chiavi.\")\n",
+        "else:\n",
+        "    print(\"GROUP BY non trovato nella SELECT finale -- verificare manualmente unicita'.\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "mart-coverage",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "if \"anno\" in mart.columns:\n",
+        "    anni_mart = sorted(mart[\"anno\"].unique())\n",
+        "    print(f\"Anni nel mart ({len(anni_mart)}): {anni_mart}\")\n",
+        "\n",
+        "null_mart = mart.isnull().sum()\n",
+        "print(\"\\nNull per colonna mart:\")\n",
+        "print(null_mart[null_mart > 0].to_string() if null_mart.any() else \"  nessuno\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "mart-consistency",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Per dataset a livello persona (no aggregazione numerica):\n",
+        "# confronta conteggio righe clean vs mart\n",
+        "tot_clean = len(clean)\n",
+        "tot_mart = len(mart)\n",
+        "delta = abs(tot_mart - tot_clean)\n",
+        "print(f\"Totale clean: {tot_clean}\")\n",
+        "print(f\"Totale mart : {tot_mart}\")\n",
+        "print(f\"Delta righe : {delta}\")\n",
+        "if delta == 0:\n",
+        "    print(\"OK: clean e mart hanno lo stesso numero di righe (dataset a livello persona).\")\n",
+        "else:\n",
+        "    print(f\"-> {delta} righe filtrate da WHERE in mart.sql\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "notes",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "PERIMETRO = \"...\"  # da compilare manualmente\n",
+        "\n",
+        "print(f\"Slug            : {SLUG}\")\n",
+        "print(f\"Anno run        : {ANNO_RUN}\")\n",
+        "print(f\"Tabella mart    : {MART_TABLE}\")\n",
+        "print(f\"Metrica mart    : {METRICA}\")\n",
+        "print(f\"Metrica clean   : {METRICA_CLEAN}\")\n",
+        "print(f\"Perimetro       : {PERIMETRO}\")"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/candidates/camera-deputati-legislature/notes.md
+++ b/candidates/camera-deputati-legislature/notes.md
@@ -1,0 +1,41 @@
+# Notes — camera-deputati-legislature
+
+## 2026-04-26 — Runnable
+
+- Pipeline completata: raw ✅ clean ✅ mart ✅
+- Struttura flatten da nested a single-source
+- Query SPARQL fixata: `dct:title` non esiste → `REPLACE` su URI
+- Raw rifatto con 10k righe (LIMIT 50000)
+- Tutti i layer validano OK
+
+## Source
+
+- Endpoint: `https://dati.camera.it/sparql` — RD93 / OpenData Camera
+- Probe: ~55k deputati totali, 10k nel campione (LIMIT 50000)
+- Nota: endpoint può dare 503 intermittenti — raw scaricato via fetch diretto
+
+## Blocker risolti
+
+1. **Bug `_format_args` toolkit**: `.format(year=year)` su ogni stringa → `KeyError` su SPARQL con `{`. Fix: `"{year}" in v` prima di formattare.
+2. **Query SPARQL**: `?leg dct:title ?legislatura` restituiva sempre null. Fix: estrazione da URI con `REPLACE(STR(?leg), ..., '')`.
+3. **Typo colonna**: `legislature` vs `legislatura` in mart.sql.
+
+## Dato
+
+- Ogni deputato può apparire in più legislature → la chiave è `(deputato, legislature)`
+- Nessuna aggregazione numerica — è un dataset a livello persona
+- `legislatura` è un intero roman/arabico in stringa ("17", "18"...)
+
+## Struttura
+
+```
+camera-deputati-legislature/
+├── dataset.yml          # entrypoint
+├── README.md
+├── notes.md
+├── sql/
+│   ├── clean.sql       # raw-faithful (5 cols)
+│   └── mart.sql        # deduplicazione + ORDER BY
+└── notebooks/
+    └── camera_deputati_legislature_v0.ipynb
+```

--- a/candidates/camera-deputati-legislature/sql/clean.sql
+++ b/candidates/camera-deputati-legislature/sql/clean.sql
@@ -1,0 +1,10 @@
+-- Clean: camera_deputati_legislature
+-- raw-faithful: nessun filtro
+
+SELECT
+  deputato,
+  cogn,
+  nome,
+  legislatura,
+  gender
+FROM raw_input

--- a/candidates/camera-deputati-legislature/sql/mart.sql
+++ b/candidates/camera-deputati-legislature/sql/mart.sql
@@ -1,0 +1,13 @@
+-- Mart: camera_deputati_legislature
+-- aggregato finale dei deputati
+
+SELECT
+  deputato,
+  cogn,
+  nome,
+  legislatura,
+  gender
+FROM clean_input
+WHERE deputato IS NOT NULL
+ORDER BY cogn, nome
+;


### PR DESCRIPTION
## Summary

- **Struttura**: flatten da nested a single-source (`dataset.yml` + `sql/` al root)
- **Fix query SPARQL**: estrazione `legislatura` da URI (`dct:title` non disponibile sul endpoint Camera)
- **Fix typo colonna**: `legislature` → `legislatura` in `mart.sql`
- **Raw**: 10k deputati (campione LIMIT 50000)
- **Clean**: raw-faithful, 5 colonne
- **Mart**: deduplicato su `(deputato, legislature)`, 10k righe
- **Notebook v0**: creato
- **README + notes**: aggiornati

## Layer prodotti

| Layer | Output | Righe |
|---|---|---|
| raw | `camera_deputati_sparql.csv` | 10.000 |
| clean | `camera_deputati_legislature_2024_clean.parquet` | 10.000 |
| mart | `mart_deputati.parquet` | 10.000 |

## Blocker risolti

1. Bug `_format_args` toolkit: `.format(year=year)` su ogni stringa → `KeyError` su SPARQL con `{`
2. Query SPARQL: `dct:title` non esiste → estrazione da URI con `REPLACE(STR(?leg), ..., '')`

## Schema mart

`[deputato, cogn, nome, legislature, gender]`

## Note

L'endpoint SPARQL Camera può restituire 503 intermittenti — raw scaricato via fetch diretto.