### PR TITLE
chore(bdap-entrate-stato): aggiorna clean_catalog post-push GCS

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -84,7 +84,8 @@
       ],
       "location": {
         "type": "gcs",
-        "path": "gs://dataciviclab-clean/bdap_entrate_stato/2024/bdap_entrate_stato_2024_clean.parquet"
+        "path": "gs://dataciviclab-clean/bdap_entrate_stato/*/bdap_entrate_stato_*_clean.parquet",
+        "multi_file": true
       },
       "status": "clean_ready",
       "visibility": "public",


### PR DESCRIPTION
## Post-merge: bdap-entrate-stato (#177)

### Azioni post-merge

- ✅ GCS push: `gs://dataciviclab-clean/bdap_entrate_stato/2024/bdap_entrate_stato_2024_clean.parquet`
- ✅ BQ external table: `dataciviclab.bdap_entrate_stato.clean`
- ✅ Catalog locale aggiornato

### Catalogo

- **Periodo**: 2008–2024 (17 anni, 1320 righe)
- **GCS path**: `gs://dataciviclab-clean/bdap_entrate_stato/*/bdap_entrate_stato_*_clean.parquet` (multi-year)
- **Schema**: 12 colonne