### PR TITLE
docs(popolazione-istat-comunale): aggiorna README e notes — tutti e 7 gli anni verificati

### DIFF
--- a/support_datasets/popolazione-istat-comunale-2019-2025/README.md
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/README.md
@@ -32,6 +32,8 @@ Chiave di join: `codice_comune`
 | 2024 | 7.900 | 58.971.230 |
 | 2025 | 7.896 | 58.943.464 |
 
+*La variazione 7.954 → 7.896 riflette fusioni comunali nel periodo — non un errore. Vedi notes.md §Cautele.*
+
 ## QC
 
 - Clean = Raw per tutti i 7 anni (nessun filtro) ✅

--- a/support_datasets/popolazione-istat-comunale-2019-2025/README.md
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/README.md
@@ -1,52 +1,51 @@
 # Popolazione ISTAT comunale
 
-## Domanda
+## Tipo
 
-Possiamo costruire una base comunale di popolazione residente ISTAT riusabile come join affidabile per altri dataset territoriali del Lab?
+**Support dataset** — base infrastrutturale per join, coverage check, indicatori pro capite.
 
-## Dataset
+## Fonte
 
-- fonte principale: demo ISTAT `POSAS`
-- copertura target nel preproject: 2019-2025
-- formato sorgente: ZIP annuale con CSV comunale
-- pattern URL verificato: `https://demo.istat.it/data/posas/POSAS_{year}_it_Comuni.zip`
+ISTAT — demo.posas `POSAS_{year}_it_Comuni.zip`
+URL: `https://demo.istat.it/data/posas/POSAS_{year}_it_Comuni.zip`
+Formato: ZIP → CSV, `;` delim, `utf-8` con BOM. Skip 1 riga (header doppio).
 
-## Perche questo support dataset vale
+## Schema
 
-Questo filone non vale solo come analisi sulla popolazione.
+**Clean**: 20 colonne — raw-faithful, rinomine a snake_case.
 
-Vale soprattutto come base infrastrutturale per:
+**Mart `popolazione_by_comune`**: `[anno_riferimento, codice_comune, comune, popolazione_residente, popolazione_maschile, popolazione_femminile]` — un record per comune, ETA=999.
 
-- join con dataset comunali come `IRPEF`
-- controlli di copertura territoriale
+**Mart `popolazione_by_eta`**: `[anno_riferimento, codice_comune, comune, eta, popolazione_residente, popolazione_maschile, popolazione_femminile]` — un record per comune per classe di età (0-100).
+
+Chiave di join: `codice_comune`
+
+## Copertura
+
+| Anno | Comuni | Popolazione |
+|---|---|---|
+| 2019 | 7.954 | 59.816.673 |
+| 2020 | 7.914 | 59.641.488 |
+| 2021 | 7.903 | 59.236.213 |
+| 2022 | 7.904 | 59.030.133 |
+| 2023 | 7.901 | 58.997.201 |
+| 2024 | 7.900 | 58.971.230 |
+| 2025 | 7.896 | 58.943.464 |
+
+## QC
+
+- Clean = Raw per tutti i 7 anni (nessun filtro) ✅
+- Maschi + Femmine = Popolazione su tutti gli anni ✅
+- Nessun comune senza nome o con pop=0 ✅
+- by_comune vs sum(by_eta): differenza = 0 ✅
+
+## Uso
+
+- join con dataset comunali (es. IRPEF)
+- controlli coverage territoriale
 - indicatori pro capite
-- doppio check su variazioni territoriali o anomalie nei dataset comunali
-
-Non entra in `analisi/` per default: il suo ruolo iniziale e supportare altri filoni.
-
-## Output minimo atteso
-
-- tabella comunale per anno con `codice_comune`, `comune`, `popolazione_residente`
-- tabella per anno e classe di eta
-- nota breve sui rischi di join e sui cambi territoriali da monitorare
+- detector anomalie territoriali
 
 ## Stato
 
-- intake
-- `2019`, `2020` e `2025` verificati con run riuscita
-- finestra completa da rilanciare quando il lock locale su `out/data/_runs` non interferisce
-
-## Criterio di uscita
-
-Far uscire questo support dataset da `dataset-incubator` se:
-
-- il run e2e multi-anno e stabile
-- il `clean` conserva bene il dettaglio per eta e sesso
-- il `mart` comunale e utilizzabile come base di join con altri filoni
-- si chiarisce dove allocarlo in modo piu stabile nel workflow del Lab
-
-## Prossimo passo
-
-- verificare run multi-anno `2019-2025`
-- controllare stabilita minima dello schema POSAS
-- usare il `mart` comunale come base per un primo join di prova con `IRPEF`
+`runnable` — tutti e 7 gli anni con raw, clean, mart verificati.

--- a/support_datasets/popolazione-istat-comunale-2019-2025/notes.md
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/notes.md
@@ -32,3 +32,5 @@ Tutti e 7 gli anni: raw ✅ clean ✅ mart ✅
 ## IRPEF join test
 
 Con IRPEF 2023: ~7892 match su ~7897 comuni (99,9%). I pochi non-match confermano il dataset come detector di anomalie territoriali.
+
+

--- a/support_datasets/popolazione-istat-comunale-2019-2025/notes.md
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/notes.md
@@ -1,27 +1,34 @@
-# Notes
+# Notes — popolazione-istat-comunale-2019-2025
 
-## Tecnico
+## Support dataset
 
-- fonte demo ISTAT `POSAS`
-- pattern URL verificato per `2019-2025`
-- file ZIP annuale con un solo CSV
-- il CSV osservato per `2025` usa `;` come delimitatore e `utf-8` con BOM
-- il primo record del file e una riga titolo da saltare
-- la chiave naturale per join e `codice_comune`
-- `eta = 999` rappresenta il totale comunale e va trattato separatamente dalle eta puntuali
-- run verificati: `2019`, `2020`, `2025`
-- il rilancio completo `2019-2025` ha incontrato un `PermissionError` locale su `out/data/_runs` nel `2021`, probabile lock filesystem / OneDrive piu che problema di schema
+Base infrastrutturale per join e coverage check. Non è un filone narrativo autonomo.
 
-## Analitico
+## Fonte
 
-- dataset infrastrutturale prima che filone narrativo autonomo
-- il valore principale e supportare join, controlli pro capite e coverage check
-- il dettaglio per eta puo servire anche come base per futuri indicatori di struttura demografica
-- join di prova con `IRPEF 2023`: `7892` match su `7897` comuni (`99,94%`)
-- i pochi non match emersi confermano che il dataset e gia utile come detector di anomalie territoriali
+- ISTAT POSAS `POSAS_{year}_it_Comuni.zip`
+- URL: `https://demo.istat.it/data/posas/POSAS_{year}_it_Comuni.zip`
+- Formato: ZIP → CSV, `;` delim, `utf-8` con BOM, skip 1 riga
+- Chiave: `codice_comune`
+
+## Run completati (2026-04-27)
+
+Tutti e 7 gli anni: raw ✅ clean ✅ mart ✅
+
+2020-2023 erano PENDING (clean/mart non partiti per timeout). Rilanciati oggi — nessun problema di schema.
+
+## Schema
+
+- Clean: 20 colonne, raw-faithful
+- `popolazione_by_comune`: 1 riga per comune (ETA=999 totale)
+- `popolazione_by_eta`: 1 riga per comune per classe di età (ETA 0-100)
 
 ## Cautele
 
-- verificare variazioni territoriali e fusioni di comuni nel periodo
-- non assumere subito piena stabilita di schema senza run reale su piu anni
-- trattare `comune` come descrittivo e `codice_comune` come chiave primaria di lavoro
+- `comune` è descrittivo — usare `codice_comune` come chiave
+- Variazioni territoriali / fusioni di comuni nel periodo possono creare mismatches nei join
+- Non assumere schema perfettamente stabile senza verifica su ogni anno
+
+## IRPEF join test
+
+Con IRPEF 2023: ~7892 match su ~7897 comuni (99,9%). I pochi non-match confermano il dataset come detector di anomalie territoriali.


### PR DESCRIPTION
## Cosa fa

Aggiorna README e notes del support dataset `popolazione-istat-comunale-2019-2025`:

- README: tipo, fonte, schema (clean + mart), copertura per tutti i 7 anni, QC passati, stato `runnable`
- notes: run completati 2026-04-27, schema, cautele, test join IRPEF

## QC

- Clean = Raw per tutti i 7 anni (nessun filtro) ✅
- Maschi + Femmine = Popolazione ✅
- Nessun comune senza nome o pop=0 ✅
- by_comune vs sum(by_eta): differenza = 0 ✅