### PR TITLE
chore(popolazione): clean_catalog — ruoli, description, status candidate

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -1252,9 +1252,9 @@
     },
     {
       "slug": "popolazione_istat_comunale_2019_2025",
-      "name": "Popolazione Istat Comunale 2019 2025",
-      "description": "",
-      "source": "",
+      "name": "Popolazione ISTAT Comunale",
+      "description": "Popolazione residente italiana per comune, sesso, classe di età — POSAS ISTAT 2019-2025",
+      "source": "ISTAT - demo.posas (Popolazione residente per sesso, età e comune)",
       "period": {
         "start": 2019,
         "end": 2025
@@ -1264,121 +1264,121 @@
           "name": "codice_comune",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice comune ISTAT (codice numerico)"
         },
         {
           "name": "comune",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione del comune"
         },
         {
           "name": "eta",
           "type": "INTEGER",
           "role": "dimension",
-          "description": ""
+          "description": "Classe di età (0-100, 999 = totale comunale)"
         },
         {
           "name": "celibi",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Celibi (maschi nubili mai sposati)"
         },
         {
           "name": "coniugati",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Coniugati (maschi sposati)"
         },
         {
           "name": "divorziati",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Divorziati (maschi separati legalmente)"
         },
         {
           "name": "vedovi",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Vedovi (maschi con coniuge deceduto)"
         },
         {
           "name": "uniti_civilmente_maschi",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Uniti civilmente (maschi)"
         },
         {
           "name": "maschi_gia_unione_civile_scioglimento",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Ex uniti civilmente — scioglimento (maschi)"
         },
         {
           "name": "maschi_gia_unione_civile_decesso",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Ex uniti civilmente — decesso coniuge (maschi)"
         },
         {
           "name": "totale_maschi",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Totale popolazione maschile"
         },
         {
           "name": "nubili",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Nubili (femmine nubili mai sposate)"
         },
         {
           "name": "coniugate",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Coniugate (femmine sposate)"
         },
         {
           "name": "divorziate",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Divorziate (femmine separate legalmente)"
         },
         {
           "name": "vedove",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Vedove (femmine con coniuge deceduto)"
         },
         {
           "name": "unite_civilmente_femmine",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Unite civilmente (femmine)"
         },
         {
           "name": "femmine_gia_unione_civile_scioglimento",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Ex unite civilmente — scioglimento (femmine)"
         },
         {
           "name": "femmine_gia_unione_civile_decesso",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Ex unite civilmente — decesso coniuge (femmine)"
         },
         {
           "name": "totale_femmine",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Totale popolazione femminile"
         },
         {
           "name": "popolazione_residente",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Popolazione residente totale"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
-  "updated_at": "2026-04-26",
+  "updated_at": "2026-04-27",
   "source_repo": "dataciviclab/dataset-incubator",
   "datasets": [
     {
@@ -1249,6 +1249,146 @@
       "visibility": "public",
       "registry_source": "push_archive_auto",
       "multi_file": false
+    },
+    {
+      "slug": "popolazione_istat_comunale_2019_2025",
+      "name": "Popolazione Istat Comunale 2019 2025",
+      "description": "",
+      "source": "",
+      "period": {
+        "start": 2019,
+        "end": 2025
+      },
+      "columns": [
+        {
+          "name": "codice_comune",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "comune",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "eta",
+          "type": "INTEGER",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "celibi",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "coniugati",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "divorziati",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "vedovi",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "uniti_civilmente_maschi",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "maschi_gia_unione_civile_scioglimento",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "maschi_gia_unione_civile_decesso",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "totale_maschi",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "nubili",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "coniugate",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "divorziate",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "vedove",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "unite_civilmente_femmine",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "femmine_gia_unione_civile_scioglimento",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "femmine_gia_unione_civile_decesso",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "totale_femmine",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "popolazione_residente",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/popolazione_istat_comunale_2019_2025/*/popolazione_istat_comunale_2019_2025_*_clean.parquet",
+        "multi_file": true
+      },
+      "status": "candidate",
+      "visibility": "public",
+      "registry_source": "push_archive_auto"
     }
   ]
 }


### PR DESCRIPTION
## Cosa fa

Aggiorna `registry/clean_catalog.json` per `popolazione_istat_comunale_2019_2025`:

- `role`: `dimension` per `codice_comune`, `comune`, `eta`; `metric` per tutti i campi numerici
- `description`: vuoto (da completare in fase di pubblicazione)
- `status`: `candidate` (già impostato da push_archive)

## Perché

Il push_archive aveva aggiunto l'entry con role vuoto — schema non validato. Ora l entry è coerente e passa `build_clean_catalog.py --check-gcs`.