### PR TITLE
chore(aifa-spesa-consumo): clean_catalog — ruoli, description, column description

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -6,6 +6,128 @@
   "source_repo": "dataciviclab/dataset-incubator",
   "datasets": [
     {
+      "slug": "aifa_spesa_consumo",
+      "name": "AIFA Spesa Farmaceutica Convenzionata",
+      "description": "Spesa e consumo farmaceutico convenzionato SSN per regione, mese, categoria ATC — AIFA 2018-2024",
+      "source": "AIFA — Open Data Spesa e Consumo Farmaceutico",
+      "period": {
+        "start": 2018,
+        "end": 2024
+      },
+      "columns": [
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "dimension",
+          "description": "Anno di riferimento"
+        },
+        {
+          "name": "mese",
+          "type": "INTEGER",
+          "role": "dimension",
+          "description": "Mese di riferimento (1-12)"
+        },
+        {
+          "name": "codreg",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Codice regione"
+        },
+        {
+          "name": "regione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Denominazione regione"
+        },
+        {
+          "name": "classe",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Classe farmaceutica"
+        },
+        {
+          "name": "atc1",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Codice ATC livello 1"
+        },
+        {
+          "name": "descrizione_atc1",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Descrizione ATC livello 1"
+        },
+        {
+          "name": "atc2",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Codice ATC livello 2"
+        },
+        {
+          "name": "descrizione_atc2",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Descrizione ATC livello 2"
+        },
+        {
+          "name": "atc3",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Codice ATC livello 3"
+        },
+        {
+          "name": "descrizione_atc3",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Descrizione ATC livello 3"
+        },
+        {
+          "name": "atc4",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Codice ATC livello 4"
+        },
+        {
+          "name": "descrizione_atc4",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Descrizione ATC livello 4"
+        },
+        {
+          "name": "numero_confezioni_traccia",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Numero confezioni tracciabilità"
+        },
+        {
+          "name": "spesa_flusso_tracciabilita",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Spesa flusso tracciabilità (euro)"
+        },
+        {
+          "name": "numero_confezioni_convenzionata",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Numero confezioni convenzionate"
+        },
+        {
+          "name": "spesa_convenzionata",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Spesa convenzionata SSN (euro)"
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/aifa_spesa_consumo/*/aifa_spesa_consumo_*_clean.parquet",
+        "multi_file": true
+      },
+      "status": "candidate",
+      "visibility": "public",
+      "registry_source": "push_archive_auto"
+    },
+    {
       "slug": "bdap_entrate_stato",
       "name": "BDAP Entrate Stato - Serie Storica",
       "description": "Entrate statali da BDAP, aggregate per titolo, natura, tipologia, provento",


### PR DESCRIPTION
## Cosa fa

Compila `registry/clean_catalog.json` per `aifa_spesa_consumo` (post-merge #194):

- `name`: AIFA Spesa Farmaceutica Convenzionata
- `description`: Spesa e consumo farmaceutico convenzionato SSN per regione, mese, categoria ATC
- `source`: AIFA — Open Data Spesa e Consumo Farmaceutico
- `role`: dimension per chiavi descrittive (anno, mese, regione, ATC), metric per numerici
- `column description` per tutte le 16 colonne

## Post-merge gia completato

- GCS push: 7 anni (2018-2024) → `gs://dataciviclab-clean/aifa_spesa_consumo/*/`
- BQ table: `dataciviclab.aifa_spesa_consumo.clean`