### PR TITLE
chore(ispra-consumo-suolo): compila entry clean catalog — 40 cols

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
-  "updated_at": "2026-04-27",
+  "updated_at": "2026-04-28",
   "source_repo": "dataciviclab/dataset-incubator",
   "datasets": [
     {
@@ -927,31 +927,230 @@
           "description": "Regione"
         },
         {
+          "name": "incremento_netto_ha_2006_2012",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento netto consumo suolo 2006-2012 [ha]"
+        },
+        {
+          "name": "incremento_lordo_ha_2006_2012",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento lordo consumo suolo 2006-2012 [ha]"
+        },
+        {
+          "name": "ripristino_ha_2006_2012",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Aree ripristinate 2006-2012 [ha]"
+        },
+        {
+          "name": "incremento_netto_ha_2012_2015",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento netto consumo suolo 2012-2015 [ha]"
+        },
+        {
+          "name": "incremento_lordo_ha_2012_2015",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento lordo consumo suolo 2012-2015 [ha]"
+        },
+        {
+          "name": "ripristino_ha_2012_2015",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Aree ripristinate 2012-2015 [ha]"
+        },
+        {
+          "name": "incremento_netto_ha_2015_2016",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento netto consumo suolo 2015-2016 [ha]"
+        },
+        {
+          "name": "incremento_lordo_ha_2015_2016",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento lordo consumo suolo 2015-2016 [ha]"
+        },
+        {
+          "name": "ripristino_ha_2015_2016",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Aree ripristinate 2015-2016 [ha]"
+        },
+        {
+          "name": "incremento_netto_ha_2016_2017",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento netto consumo suolo 2016-2017 [ha]"
+        },
+        {
+          "name": "incremento_lordo_ha_2016_2017",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento lordo consumo suolo 2016-2017 [ha]"
+        },
+        {
+          "name": "ripristino_ha_2016_2017",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Aree ripristinate 2016-2017 [ha]"
+        },
+        {
+          "name": "incremento_netto_ha_2017_2018",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento netto consumo suolo 2017-2018 [ha]"
+        },
+        {
+          "name": "incremento_lordo_ha_2017_2018",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento lordo consumo suolo 2017-2018 [ha]"
+        },
+        {
+          "name": "ripristino_ha_2017_2018",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Aree ripristinate 2017-2018 [ha]"
+        },
+        {
+          "name": "incremento_netto_ha_2018_2019",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento netto consumo suolo 2018-2019 [ha]"
+        },
+        {
+          "name": "incremento_lordo_ha_2018_2019",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento lordo consumo suolo 2018-2019 [ha]"
+        },
+        {
+          "name": "ripristino_ha_2018_2019",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Aree ripristinate 2018-2019 [ha]"
+        },
+        {
+          "name": "incremento_netto_ha_2019_2020",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento netto consumo suolo 2019-2020 [ha]"
+        },
+        {
+          "name": "incremento_lordo_ha_2019_2020",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento lordo consumo suolo 2019-2020 [ha]"
+        },
+        {
+          "name": "ripristino_ha_2019_2020",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Aree ripristinate 2019-2020 [ha]"
+        },
+        {
+          "name": "incremento_netto_ha_2020_2021",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento netto consumo suolo 2020-2021 [ha]"
+        },
+        {
+          "name": "incremento_lordo_ha_2020_2021",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento lordo consumo suolo 2020-2021 [ha]"
+        },
+        {
+          "name": "ripristino_ha_2020_2021",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Aree ripristinate 2020-2021 [ha]"
+        },
+        {
+          "name": "incremento_netto_ha_2021_2022",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento netto consumo suolo 2021-2022 [ha]"
+        },
+        {
+          "name": "incremento_lordo_ha_2021_2022",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento lordo consumo suolo 2021-2022 [ha]"
+        },
+        {
+          "name": "ripristino_ha_2021_2022",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Aree ripristinate 2021-2022 [ha]"
+        },
+        {
+          "name": "incremento_netto_ha_2022_2023",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento netto consumo suolo 2022-2023 [ha]"
+        },
+        {
+          "name": "incremento_lordo_ha_2022_2023",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento lordo consumo suolo 2022-2023 [ha]"
+        },
+        {
+          "name": "ripristino_ha_2022_2023",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Aree ripristinate 2022-2023 [ha]"
+        },
+        {
           "name": "incremento_ha_2023_2024",
           "type": "DOUBLE",
           "role": "metric",
-          "description": "Incremento consumo suolo (ettari) 2023-2024"
+          "description": "Incremento netto consumo suolo 2023-2024 [ha]"
+        },
+        {
+          "name": "incremento_netto_ha_2023_2024",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento netto consumo suolo 2023-2024 [ha]"
+        },
+        {
+          "name": "incremento_lordo_ha_2023_2024",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Incremento lordo consumo suolo 2023-2024 [ha]"
+        },
+        {
+          "name": "ripristino_ha_2023_2024",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": "Aree ripristinate 2023-2024 [ha]"
         },
         {
           "name": "stock_ha_2024",
           "type": "DOUBLE",
           "role": "metric",
-          "description": "Stock consumo suolo 2024 (ettari)"
+          "description": "Stock consumo suolo 2024 [ha]"
         },
         {
           "name": "stock_pct_2024",
           "type": "DOUBLE",
           "role": "metric",
-          "description": "Stock consumo suolo 2024 (% territorio comunale)"
+          "description": "Stock consumo suolo 2024 [% territorio comunale]"
         }
       ],
       "location": {
         "type": "gcs",
-        "path": "gs://dataciviclab-clean/ispra_consumo_suolo/2024/ispra_consumo_suolo_2024_clean.parquet"
+        "path": "gs://dataciviclab-clean/ispra_consumo_suolo/2024/ispra_consumo_suolo_2024_clean.parquet",
+        "multi_file": false
       },
-      "status": "clean_ready",
+      "status": "candidate",
       "visibility": "public",
-      "registry_source": "initial_clean_query_catalog"
+      "registry_source": "push_archive_manual"
     },
     {
       "slug": "ispra_ru_base",


### PR DESCRIPTION
## Summary

- Entry `ispra_consumo_suolo` compilata con 40 colonne (era 7)
- Path: `gs://dataciviclab-clean/ispra_consumo_suolo/2024/ispra_consumo_suolo_2024_clean.parquet`
- `multi_file: false`
- `status: candidate`

## Columns

4 dimension (pro_com, comune, provincia, regione) + 36 metric (11 periodi × 3 serie: netto/lordo/ripristino + stock)

## GCS check

```bash
$ python scripts/build_clean_catalog.py --check-gcs
ok (14 datasets)
```
