### PR TITLE
fix(inps-pensioni): quote+escape per CSV INPS con apostrofi (issue #213)

### DIFF
--- a/candidates/inps-pensioni/dataset.yml
+++ b/candidates/inps-pensioni/dataset.yml
@@ -25,6 +25,8 @@ clean:
     strict_mode: false
     ignore_errors: true
     trim_whitespace: true
+    quote: '"'
+    escape: '"'
   validate:
     min_rows: 100000
 


### PR DESCRIPTION
## Summary

Fix CSV parsing per INPS con `quote: '"'` + `escape: '"'`.

## Problema (issue #213)

CSV INPS (`dataset_6002.csv`) contiene apostrofi dentro quoted fields, es. `"3.000,00 e piu'"`. DuckDB con `ignore_errors=true` produce righe concatenate shiftate:
- `area_geografica` riceveva valori di `classe_eta`
- ~37k righe malformate

## Fix

```yaml
clean:
  read:
    quote: '"'
    escape: '"'
```

## Risultato

| | Prima | Dopo |
|---|---|---|
| Clean rows | ~124k | **161,561** (+36,700) |
| Bad area_geografica | 3,597 | **0** |

## GCS push

Gia pushato su GCS con pipeline run `20260428T101317Z`.

## Issue

Closes #213