### PR TITLE
fix: rimuovi colonne mart dal clean di dipendenti_pubblici nel catalog

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -439,30 +439,6 @@
           "type": "DOUBLE",
           "role": "metric",
           "description": "Numero dipendenti uomini cessati"
-        },
-        {
-          "name": "donne_totali",
-          "type": "DOUBLE",
-          "role": "metric",
-          "description": "Totale dipendenti donne"
-        },
-        {
-          "name": "uomini_totali",
-          "type": "DOUBLE",
-          "role": "metric",
-          "description": "Totale dipendenti uomini"
-        },
-        {
-          "name": "assunti_totali",
-          "type": "DOUBLE",
-          "role": "metric",
-          "description": "Totale assunti"
-        },
-        {
-          "name": "cessati_totali",
-          "type": "DOUBLE",
-          "role": "metric",
-          "description": "Totale cessati"
         }
       ],
       "location": {
@@ -470,9 +446,8 @@
         "path": "gs://dataciviclab-clean/dipendenti_pubblici/*/dipendenti_pubblici_*_clean.parquet",
         "multi_file": true
       },
-      "status": "clean_ready",
-      "visibility": "public",
-      "registry_source": "initial_clean_query_catalog"
+      "status": "candidate",
+      "visibility": "public"
     },
     {
       "slug": "inps_pensioni_2017_2024",


### PR DESCRIPTION
## Summary

- Rimosse `donne_totali`, `uomini_totali`, `assunti_totali`, `cessati_totali` — sono colonne del mart, non del clean
- Corretto `status`: `clean_ready` → `candidate`
- Rimosso campo non standard `registry_source`

## Dataset

- `dipendenti_pubblici`: 23 colonne clean (era 27, 4 erano mart)

