### PR TITLE
feat(clean-query-mcp): aggiungi search_datasets, auto-inject WHERE year, e helper aggregate

### DIFF
--- a/tools/clean-query-mcp/catalog.py
+++ b/tools/clean-query-mcp/catalog.py
@@ -78,6 +78,27 @@ def list_datasets() -> list[dict[str, Any]]:
     ]
 
 
+def search_datasets(query: str) -> list[dict[str, Any]]:
+    """Cerca nei dataset per nome, descrizione e fonte."""
+    q = query.lower()
+    catalog = _load_catalog()
+    matches = []
+    for ds in catalog:
+        name = ds.get("name", "").lower()
+        desc = ds.get("description", "").lower()
+        source = ds.get("source", "").lower()
+        if q in name or q in desc or q in source:
+            matches.append({
+                "slug": ds["slug"],
+                "name": ds["name"],
+                "description": ds["description"],
+                "source": ds.get("source"),
+                "period_start": ds["period"]["start"],
+                "period_end": ds["period"]["end"],
+            })
+    return matches
+
+
 def describe_dataset(slug: str) -> dict[str, Any]:
     catalog = _load_catalog()
     ds = next((d for d in catalog if d["slug"] == slug), None)
@@ -96,6 +117,25 @@ def describe_dataset(slug: str) -> dict[str, Any]:
         "location_type": ds["location"]["type"],
         "location_path": ds["location"]["path"],
     }
+
+
+_ANNUAL_COLUMMS = {"anno", "anno_di_imposta", "anno_estrazione", "year", "annual_year"}
+
+
+def get_year_column(slug: str) -> str | None:
+    """Restituisce il nome della colonna anno per un dataset, se presente."""
+    catalog = _load_catalog()
+    ds = next((d for d in catalog if d["slug"] == slug), None)
+    if ds is None:
+        return None
+    columns = ds.get("columns", [])
+    for col in columns:
+        if col.get("type") not in ("INTEGER", "BIGINT"):
+            continue
+        name_lower = col["name"].lower()
+        if name_lower in _ANNUAL_COLUMMS or name_lower.startswith("anno"):
+            return col["name"]
+    return None
 
 
 def resolve_parquet_path(slug: str, year: int | None = None) -> list[str]:

--- a/tools/clean-query-mcp/catalog.py
+++ b/tools/clean-query-mcp/catalog.py
@@ -119,7 +119,7 @@ def describe_dataset(slug: str) -> dict[str, Any]:
     }
 
 
-_ANNUAL_COLUMMS = {"anno", "anno_di_imposta", "anno_estrazione", "year", "annual_year"}
+_ANNUAL_COLUMNS = {"anno", "anno_di_imposta", "anno_estrazione", "year", "annual_year"}
 
 
 def get_year_column(slug: str) -> str | None:
@@ -133,7 +133,7 @@ def get_year_column(slug: str) -> str | None:
         if col.get("type") not in ("INTEGER", "BIGINT"):
             continue
         name_lower = col["name"].lower()
-        if name_lower in _ANNUAL_COLUMMS or name_lower.startswith("anno"):
+        if name_lower in _ANNUAL_COLUMNS or name_lower.startswith("anno"):
             return col["name"]
     return None
 

--- a/tools/clean-query-mcp/server.py
+++ b/tools/clean-query-mcp/server.py
@@ -188,9 +188,6 @@ def _inject_year_filter(sql: str, year_col: str | None, year: int) -> str:
     s = sql.strip()
     low = s.lower()
 
-    if "where" in low:
-        return s
-
     from_match = list(re.finditer(r'\bfrom\s+clean_input\b', low))
     if not from_match:
         return s
@@ -337,8 +334,6 @@ def aggregate(
     filters: str | None = None,
     year: int | None = None,
 ) -> dict[str, Any]:
-    from catalog import get_year_column
-
     if not metric:
         return {"error": "metric non può essere vuota"}
     if not group_by:

--- a/tools/clean-query-mcp/server.py
+++ b/tools/clean-query-mcp/server.py
@@ -6,8 +6,10 @@ from typing import Any
 from mcp.server.fastmcp import FastMCP
 
 from catalog import describe_dataset as describe_impl  # noqa: E402
+from catalog import get_year_column  # noqa: E402
 from catalog import list_datasets as list_impl  # noqa: E402
 from catalog import resolve_parquet_path  # noqa: E402
+from catalog import search_datasets as search_impl  # noqa: E402
 
 ALLOWED_FROM = {"clean_input"}
 MAX_ROWS_HARD_CAP = 500
@@ -159,6 +161,17 @@ def list_datasets() -> list[dict[str, Any]]:
 
 
 @mcp.tool(
+    description="Cerca nei dataset per nome, descrizione o fonte.",
+    structured_output=True,
+)
+@mcp_telemetry("clean-query")
+def search_datasets(query: str) -> list[dict[str, Any]]:
+    if not (query or "").strip():
+        raise DuckdbClientError("query non può essere vuota")
+    return search_impl(query.strip())
+
+
+@mcp.tool(
     description="Descrive lo schema di un dataset: colonne, tipi, ruolo (dimension/metric), periodo.",
     structured_output=True,
 )
@@ -167,13 +180,52 @@ def describe_dataset(slug: str) -> dict[str, Any]:
     return describe_impl(slug)
 
 
+def _inject_year_filter(sql: str, year_col: str | None, year: int) -> str:
+    """Inietta WHERE {year_col}={year} subito dopo FROM clean_input, prima di GROUP BY/ORDER BY/LIMIT."""
+    if not year_col or year is None:
+        return sql
+    filter_sql = f"WHERE {year_col} = {year}"
+    s = sql.strip()
+    low = s.lower()
+
+    if "where" in low:
+        return s
+
+    from_match = list(re.finditer(r'\bfrom\s+clean_input\b', low))
+    if not from_match:
+        return s
+
+    last_from = from_match[-1].end()
+    tail = s[last_from:].strip()
+
+    if tail.lower().startswith("where"):
+        return s
+
+    tail_low = tail.lower()
+    for keyword in ["group by", "order by", "limit"]:
+        idx = tail_low.find(keyword)
+        if idx != -1:
+            before = tail[:idx].strip()
+            after = tail[idx:]
+            base = s[:last_from].rstrip()
+            if before:
+                return f"{base} {before} {filter_sql} {after}".strip()
+            return f"{base} {filter_sql} {after}".strip()
+
+    base = s[:last_from].rstrip()
+    tail_clean = tail.strip()
+    if tail_clean:
+        return f"{base} {tail_clean} {filter_sql}".strip()
+    return f"{base} {filter_sql}".strip()
+
+
 @mcp.tool(
     description=(
         "Esegue una query SQL read-only su un dataset clean tramite DuckDB. "
         "Solo SELECT/WITH. Il SQL deve riferire SOLO 'FROM clean_input' o CTE locali. "
         "I path ai parquet sono risolti automaticamente dal catalogo. "
         "Hard cap: max 500 righe, timeout 60s. "
-        "Per dataset multi-anno, usare year per filtrare (opzionale)."
+        "Se year è specificato e il dataset ha una colonna anno, la WHERE viene iniettata automaticamente."
     ),
     structured_output=True,
 )
@@ -186,20 +238,21 @@ def run_query(
     except (ValueError, FileNotFoundError) as exc:
         return {"error": str(exc)}
 
-    # Scope enforcement: only clean_input and local CTEs in FROM/JOIN clauses.
     try:
         _validate_scope(sql)
     except DuckdbClientError as exc:
         return {"error": str(exc)}
 
-    # Hygiene checks: no DDL/DML, blocked keywords.
     try:
         _validate_select_sql(sql)
     except DuckdbClientError as exc:
         return {"error": str(exc)}
 
-    # Build the SQL wrapping user query.
-    # For multi-file datasets, DuckDB reads a list of URLs directly.
+    if year is not None:
+        year_col = get_year_column(dataset)
+        if year_col:
+            sql = _inject_year_filter(sql, year_col, year)
+
     escaped_paths = "', '".join(p.replace("'", "''") for p in parquet_paths)
     if len(parquet_paths) == 1:
         source_expr = f"'{escaped_paths}'"
@@ -263,6 +316,69 @@ def cache_stats() -> dict[str, Any]:
     from catalog import gcs_cache_stats
 
     return gcs_cache_stats()
+
+
+
+@mcp.tool(
+    description=(
+        "Helper per aggregazioni pre-scritte: somma una metrica raggruppando per una o più dimensioni. "
+        "Restituisce SQL che può essere passato a run_query(). "
+        "metric: colonna numerica da sommare (es. 'numero_pensioni'). "
+        "group_by: lista di dimensioni (es. ['anno','regione']). "
+        "filters:WHERE aggiuntivo opzionale (es. \"anno = 2023 AND regione = 'Lombardia'\")."
+    ),
+    structured_output=True,
+)
+@mcp_telemetry("clean-query")
+def aggregate(
+    dataset: str,
+    metric: str,
+    group_by: list[str],
+    filters: str | None = None,
+    year: int | None = None,
+) -> dict[str, Any]:
+    from catalog import get_year_column
+
+    if not metric:
+        return {"error": "metric non può essere vuota"}
+    if not group_by:
+        return {"error": "group_by deve avere almeno una dimensione"}
+
+    schema = describe_impl(dataset)
+    if "error" in schema:
+        return schema
+    col_names = {c["name"] for c in schema.get("columns", [])}
+    for col in group_by:
+        if col not in col_names:
+            return {"error": f"Colonna group_by '{col}' non trovata. Disponibili: {', '.join(sorted(col_names))}"}
+    if metric not in col_names:
+        return {"error": f"Metrica '{metric}' non trovata. Disponibili: {', '.join(sorted(col_names))}"}
+
+    year_col = get_year_column(dataset)
+    where_parts = []
+    if year is not None and year_col:
+        where_parts.append(f"{year_col} = {year}")
+    if filters:
+        where_parts.append(f"({filters})")
+    where_clause = ""
+    if where_parts:
+        where_clause = "WHERE " + " AND ".join(where_parts)
+
+    group_cols = ", ".join(group_by)
+    sql = (
+        f"SELECT {group_cols}, SUM({metric}) AS total "
+        f"FROM clean_input {where_clause} "
+        f"GROUP BY {group_cols} "
+        f"ORDER BY {group_by[0]}, total DESC"
+    )
+    return {
+        "sql": sql,
+        "dataset": dataset,
+        "metric": metric,
+        "group_by": group_by,
+        "year": year,
+        "note": "Passa questo sql a run_query(). Non include LIMIT; aggiungilo in run_query.",
+    }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Tre migliorie al MCP `clean-query`:

- **`search_datasets(query)`** — cerca nei dataset per nome, descrizione o fonte; ritorna slug e metadata.
- **Auto-inject `WHERE anno=year`** — quando si passa `year` a `run_query()`, se il dataset ha una colonna temporale (`anno`, `anno_di_imposta`, ecc.) il filtro viene iniettato automaticamente nella SQL, prima di `GROUP BY`/`ORDER BY`/`LIMIT`. Non richiede più `WHERE` manuale.
- **`aggregate(dataset, metric, group_by, filters, year)`** — helper che genera SQL pre-scritto per aggregazioni comuni (somma di una metrica raggruppata per dimensioni), con validazione colonne e supporto per `year` e filtri custom.

## Changes

- `tools/clean-query-mcp/catalog.py`: aggiunte `search_datasets()`, `get_year_column()`
- `tools/clean-query-mcp/server.py`: aggiunte `search_datasets` tool, `aggregate` tool, `_inject_year_filter()` con fix per posizionamento corretto della WHERE prima di GROUP BY/ORDER BY/LIMIT

## Test

- Smoke test: 14/14 dataset OK
- `_inject_year_filter`: testato su 7 casi (GROUP BY, ORDER BY, LIMIT, WHERE esistente, coda, CTE con alias)
