### PR TITLE
fix: valida caratteri sicuri nei path parquet prima di read_parquet

### DIFF
--- a/tools/clean-query-mcp/server.py
+++ b/tools/clean-query-mcp/server.py
@@ -269,7 +269,10 @@ def run_query(
         if year_col:
             sql = _inject_year_filter(sql, year_col, year)
 
-    _validate_parquet_paths(parquet_paths)
+    try:
+        _validate_parquet_paths(parquet_paths)
+    except DuckdbClientError as exc:
+        return {"error": str(exc)}
     escaped_paths = "', '".join(p.replace("'", "''") for p in parquet_paths)
     if len(parquet_paths) == 1:
         source_expr = f"'{escaped_paths}'"

--- a/tools/clean-query-mcp/server.py
+++ b/tools/clean-query-mcp/server.py
@@ -73,6 +73,25 @@ def _validate_select_sql(sql: str) -> str:
     return text
 
 
+# Safe chars for GCS parquet paths: letters, digits, /, _, ., -, :
+_SAFE_PATH_RE = re.compile(r"^[a-zA-Z0-9/_.\-:]+$")
+
+
+def _validate_parquet_paths(paths: list[str]) -> None:
+    """Validate parquet paths before building read_parquet expression.
+
+    DuckDB read_parquet with a string path is sensitive to special characters.
+    This catches non-ASCII, backslash, and other unsafe chars early with a
+    readable error rather than a cryptic DuckDB failure.
+    """
+    for p in paths:
+        if not _SAFE_PATH_RE.match(p):
+            raise DuckdbClientError(
+                f"Path parquet contiene caratteri non sicuri: '{p}'. "
+                f"Caratteri ammessi: lettere, numeri, /, _, ., -, :"
+            )
+
+
 def guard(fn, handled_exceptions: tuple[type[BaseException], ...] = (Exception,)) -> dict[str, Any]:
     try:
         return fn()
@@ -250,6 +269,7 @@ def run_query(
         if year_col:
             sql = _inject_year_filter(sql, year_col, year)
 
+    _validate_parquet_paths(parquet_paths)
     escaped_paths = "', '".join(p.replace("'", "''") for p in parquet_paths)
     if len(parquet_paths) == 1:
         source_expr = f"'{escaped_paths}'"


### PR DESCRIPTION
## Summary

Aggiunge `_validate_parquet_paths()` in `tools/clean-query-mcp/server.py` che valida i path parquet prima di interpolarli nella wrapped SQL per DuckDB.

**Problema** (issue #161): `escaped_paths` faceva solo `replace("'", "''")` sui path. Non gestiva spazi, backslash, caratteri non-ASCII o altri caratteri speciali — causando errori DuckDB oscuri.

**Fix**: regex `^[a-zA-Z0-9/_.\-:]+$` valida ogni path. Se un path contiene caratteri non sicuri, solleva `DuckdbClientError` con messaggio leggibile prima di costruire `source_expr`.

**Esempio errore** ora:
```
Path parquet contiene caratteri non sicuri: 'gs://bucket/path with spaces/file.parquet'.
Caratteri ammessi: lettere, numeri, /, _, ., -, :
```

## Modifiche

- `tools/clean-query-mcp/server.py`: aggiunta funzione `_validate_parquet_paths()` e regex `_SAFE_PATH_RE`, chiamata prima di costruire `escaped_paths`

Fixes #161