### PR TITLE
fix: estrai layout detection condivisa tra validate_candidate_structure e build_pipeline_signals

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,14 +1,14 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-04-25",
+  "generated_at": "2026-04-28",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 17,
+    "total": 27,
     "by_status": {
-      "ok": 17,
+      "ok": 26,
       "warn": 0,
-      "error": 0
+      "error": 1
     }
   },
   "signals": [
@@ -16,7 +16,7 @@
       "id": "aifa-spesa-consumo",
       "status": "ok",
       "label": "aifa-spesa-consumo",
-      "detail": "anni 2022-2024 — multi-source (1 fonte) — mart: sì",
+      "detail": "anni 2018-2024 — fonte: aifa_spesa_consumo_csv — mart: sì",
       "action": ""
     },
     {
@@ -34,6 +34,27 @@
       "action": ""
     },
     {
+      "id": "camera-deputati-legislature",
+      "status": "ok",
+      "label": "camera-deputati-legislature",
+      "detail": "anno 2024 — fonte: camera_deputati_sparql — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "civile-flussi",
+      "status": "ok",
+      "label": "civile-flussi",
+      "detail": "anno 2025 — fonte: ministero_giustizia_xlsx — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "dipendenti-pubblici",
+      "status": "ok",
+      "label": "dipendenti-pubblici",
+      "detail": "anni 2010-2023 — fonte: bdap_csv — mart: sì",
+      "action": ""
+    },
+    {
       "id": "inps-pensioni",
       "status": "ok",
       "label": "inps-pensioni",
@@ -41,10 +62,17 @@
       "action": ""
     },
     {
+      "id": "irpef-comunale",
+      "status": "ok",
+      "label": "irpef-comunale",
+      "detail": "anni 2019-2023 — fonte: finanze_http_zip — mart: sì",
+      "action": ""
+    },
+    {
       "id": "ispra-consumo-suolo",
       "status": "ok",
       "label": "ispra-consumo-suolo",
-      "detail": "anno 2024 — multi-source (1 fonte) — mart: sì",
+      "detail": "anno 2024 — fonte: ispra_consumo_suolo_xlsx — mart: sì",
       "action": ""
     },
     {
@@ -53,6 +81,13 @@
       "label": "ispra-ru-costi-kg",
       "detail": "anni 2020-2024 — multi-source (3 fonti) — mart: sì",
       "action": ""
+    },
+    {
+      "id": "istat-ciclo-acqua-prelievo-distribuzione",
+      "status": "error",
+      "label": "istat-ciclo-acqua-prelievo-distribuzione",
+      "detail": "anni: ? — fonte: ? — mart: no — ⚠ no dataset.yml and no sources/ directory",
+      "action": "correggere la struttura del candidato"
     },
     {
       "id": "istat-gini-regionale",
@@ -76,10 +111,17 @@
       "action": ""
     },
     {
+      "id": "malasanita-struttura-mortalita",
+      "status": "ok",
+      "label": "malasanita-struttura-mortalita",
+      "detail": "anno 2022 — multi-source (4 fonti) — mart: sì",
+      "action": ""
+    },
+    {
       "id": "mim-alunni-corso-eta",
       "status": "ok",
       "label": "mim-alunni-corso-eta",
-      "detail": "anno 2024 — fonte: mim_alunni_corso_eta_csv — mart: sì",
+      "detail": "anni 2016-2025 — fonte: mim_alunni_corso_eta_csv — mart: sì",
       "action": ""
     },
     {
@@ -129,6 +171,34 @@
       "status": "ok",
       "label": "terna-capacita-rinnovabile",
       "detail": "anni 2023-2024 — fonte: terna_capacity_renewable_sources_xlsx — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "terna-electricity-by-source",
+      "status": "ok",
+      "label": "terna-electricity-by-source",
+      "detail": "anni 2023-2024 — fonte: terna_electricity_by_source_xlsx — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "bdap-anagrafe-enti",
+      "status": "ok",
+      "label": "bdap-anagrafe-enti",
+      "detail": "anni: ? — fonte: ? — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "mim-anagrafica-scuole-statali",
+      "status": "ok",
+      "label": "mim-anagrafica-scuole-statali",
+      "detail": "anni: ? — fonte: ? — mart: sì",
+      "action": ""
+    },
+    {
+      "id": "popolazione-istat-comunale-2019-2025",
+      "status": "ok",
+      "label": "popolazione-istat-comunale-2019-2025",
+      "detail": "anni: ? — fonte: ? — mart: sì",
       "action": ""
     }
   ]

--- a/scripts/build_pipeline_signals.py
+++ b/scripts/build_pipeline_signals.py
@@ -26,7 +26,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 # Import helpers from the existing validation script — no duplication
 sys.path.insert(0, str(ROOT / "scripts"))
-from validate_candidate_structure import has_mart_sql  # noqa: E402
+from validate_candidate_structure import has_mart_sql, detect_candidate_layout  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -138,10 +138,19 @@ def _inspect_multi_source(base_dir: Path) -> dict:
 
 def _build_signal(slug: str, base_dir: Path) -> dict:
     """Build a single signal entry for a candidate."""
-    has_root_dataset = (base_dir / "dataset.yml").exists()
-    has_sources = (base_dir / "sources").is_dir()
+    layout_info = detect_candidate_layout(base_dir)
+    layout = layout_info["layout"]
 
-    if has_root_dataset and has_sources:
+    if layout == "support-dataset":
+        # support_datasets follow single-source validation but are tracked separately
+        info = {
+            "pattern": "support-dataset",
+            "years": [],
+            "sources": [],
+            "mart_ok": (base_dir / "sql").is_dir() and has_mart_sql(base_dir / "sql"),
+            "failures": [],
+        }
+    elif layout == "ambiguous":
         info = {
             "pattern": "ambiguous",
             "years": [],
@@ -149,9 +158,9 @@ def _build_signal(slug: str, base_dir: Path) -> dict:
             "mart_ok": False,
             "failures": ["ambiguous: root dataset.yml and sources/ cannot coexist"],
         }
-    elif has_root_dataset:
+    elif layout == "single-source":
         info = _inspect_single_source(base_dir)
-    elif has_sources:
+    elif layout == "multi-source":
         info = _inspect_multi_source(base_dir)
     else:
         info = {
@@ -191,7 +200,6 @@ def _build_signal(slug: str, base_dir: Path) -> dict:
     if status == "warn":
         action = "aggiungere mart SQL per completare il candidato"
     elif status == "error":
-        pattern = info.get("pattern", "")
         if pattern == "ambiguous":
             action = "scegliere un layout: sources/ (multi-source) oppure solo dataset.yml root (single-source) — mai entrambi"
         else:
@@ -221,6 +229,13 @@ def build_signals(out_path: Path) -> int:
     for entry in sorted(p for p in candidates_dir.iterdir() if p.is_dir()):
         slug = entry.name
         signals.append(_build_signal(slug, entry))
+
+    # support_datasets also use detect_candidate_layout and need to appear in signals
+    support_dir = ROOT / "support_datasets"
+    if support_dir.exists():
+        for entry in sorted(p for p in support_dir.iterdir() if p.is_dir()):
+            slug = entry.name
+            signals.append(_build_signal(slug, entry))
 
     by_status: dict[str, int] = {"ok": 0, "warn": 0, "error": 0}
     for s in signals:

--- a/scripts/validate_candidate_structure.py
+++ b/scripts/validate_candidate_structure.py
@@ -2,9 +2,39 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-
+from typing import Literal
 
 ROOT = Path(__file__).resolve().parents[1]
+
+LayoutType = Literal["single-source", "multi-source", "ambiguous", "unknown", "support-dataset"]
+
+
+def detect_candidate_layout(base_dir: Path) -> dict:
+    """Shared layout detection for candidate and support_dataset structures.
+
+    Returns a dict with:
+      layout: LayoutType — one of the five literal values
+      has_root_dataset: bool
+      has_sources: bool
+    """
+    if base_dir.parts[-2] == "support_datasets":
+        return {
+            "layout": "support-dataset",
+            "has_root_dataset": (base_dir / "dataset.yml").exists(),
+            "has_sources": False,
+        }
+
+    has_root_dataset = (base_dir / "dataset.yml").exists()
+    has_sources = (base_dir / "sources").is_dir()
+
+    if has_root_dataset and has_sources:
+        return {"layout": "ambiguous", "has_root_dataset": True, "has_sources": True}
+    elif has_root_dataset:
+        return {"layout": "single-source", "has_root_dataset": True, "has_sources": False}
+    elif has_sources:
+        return {"layout": "multi-source", "has_root_dataset": False, "has_sources": True}
+    else:
+        return {"layout": "unknown", "has_root_dataset": False, "has_sources": False}
 
 
 def has_mart_sql(sql_dir: Path) -> bool:
@@ -84,24 +114,24 @@ def validate_entry(base_dir: Path, failures: list[str]) -> None:
 
     validate_root_docs(base_dir, failures)
 
-    if base_dir.parts[-2] == "support_datasets":
+    info = detect_candidate_layout(base_dir)
+    layout = info["layout"]
+
+    if layout == "support-dataset":
         validate_single_source(base_dir, failures)
         return
 
-    has_root_dataset = (base_dir / "dataset.yml").exists()
-    has_sources = (base_dir / "sources").is_dir()
-
-    if has_root_dataset and has_sources:
+    if layout == "ambiguous":
         failures.append(
             f"{rel_str} has ambiguous structure: root dataset.yml and sources/ cannot coexist"
         )
         return
 
-    if has_root_dataset:
+    if layout == "single-source":
         validate_single_source(base_dir, failures)
         return
 
-    if has_sources:
+    if layout == "multi-source":
         validate_multi_source(base_dir, failures)
         return
 


### PR DESCRIPTION
## Summary

- Aggiunge `detect_candidate_layout()` in `validate_candidate_structure.py` come helper centralizzato per layout detection (single-source, multi-source, ambiguous, unknown, support-dataset)
- Aggiorna `validate_entry()` a usare `detect_candidate_layout()` invece di logica inline duplicata
- Aggiorna `_build_signal()` in `build_pipeline_signals.py` a usare lo stesso helper
- Aggiunge `support_datasets` allo scan di `build_signals()` — prima era completamente assente e tutti i support_datasets risultavano `unknown`

## Corregge

Issue #162: support_datasets in `build_pipeline_signals` ricevevano `pattern=unknown` anche quando la struttura era valida.

## Dettagli tecnici

La logica di layout detection era duplicata in due posti con una differenza critica:
- `validate_candidate_structure.py` aveva un check esplicito per `support_datasets`
- `build_pipeline_signals.py` non aveva nessun check per `support_datasets`

Estraendo in un helper condiviso entrambi gli script usano ora la stessa logica.

## QA

- `python scripts/validate_candidate_structure.py` → pass
- `python scripts/build_pipeline_signals.py` → 27 candidates (26 ok, 1 error preesistente), `bdap-anagrafe-enti` ora compare con status `ok`