### PR TITLE
feat: implementa sample-candidate-run workflow (#154)

### DIFF
--- a/.github/workflows/post-merge-reminder.yml
+++ b/.github/workflows/post-merge-reminder.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout merge commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
@@ -74,17 +74,21 @@ jobs:
             const body = [
               `## Candidate mergiati: ${slugs.join(', ')}`,
               '',
-              'Eseguire localmente i seguenti passi per completare il post-merge:',
+              'Eseguire i seguenti passi per completare il post-merge:',
               '',
               list,
               '',
-              '**Step da eseguire** (vedi [`workflows/post-merge-candidate.md`](workflows/post-merge-candidate.md)):',
+              '**Step** (vedi [`workflows/post-merge-candidate.md`](workflows/post-merge-candidate.md)):',
               '',
               '```bash',
               ...cmds.flat(),
               '```',
               '',
-              'Chiudi questa issue dopo aver completato il push.',
+              '**3. Sample run in CI** — verifica che il candidate parta anche in CI:',
+              '   In GitHub Actions → "Sample Candidate Run" → Run workflow → dispatch con:',
+              '   - `config_path`: `candidates/{slug}/dataset.yml`',
+              '',
+              'Chiudi questa issue dopo aver completato il push e verificato il sample run.',
             ].join('\n');
 
             await github.rest.issues.create({

--- a/.github/workflows/sample-candidate-run.yml
+++ b/.github/workflows/sample-candidate-run.yml
@@ -1,0 +1,173 @@
+name: Sample Candidate Run
+
+# Issue #154 — Sample run GitHub per candidate usando il toolkit.
+#
+# Scope iniziale:
+#   - trigger manuale (workflow_dispatch)
+#   - un candidate/config alla volta
+#   - sample year = ultimo anno in dataset.years (override opzionale via input)
+#   - niente publish GCS/BQ
+#   - niente logica duplicata di pipeline
+#
+# Output:
+#   - artifact con run record, metadata, validation JSON
+#   - nessuna modifica al repo
+
+on:
+  workflow_dispatch:
+    inputs:
+      config_path:
+        description: >
+          Path al dataset.yml del candidate.
+          Esempio: candidates/istat-housing-crowding/dataset.yml
+          Per nested: candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml
+        required: true
+        type: string
+      sample_year:
+        description: >
+          Anno di sample run (default: ultimo anno in dataset.years).
+          Passa questo per forzare un anno specifico.
+        required: false
+        type: string
+      strict_config:
+        description: "Tratta forme config deprecate come errori"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  sample-run:
+    runs-on: ubuntu-latest
+    # Non usa contents:write perché non modifica il repo
+
+    steps:
+      - name: Checkout dataset-incubator
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      # ------------------------------------------------------------------
+      # Step 1 — Resolve sample year
+      # ------------------------------------------------------------------
+      - name: Resolve sample run parameters
+        id: resolve
+        run: |
+          RESULT=$(python scripts/resolve_sample_run.py "${{ inputs.config_path }}" 2>&1)
+          echo "resolve_raw=$RESULT"
+          echo "$RESULT" > ${{ github.run_id }}_params.json
+
+          # Check for error from resolve
+          ERROR=$(echo "$RESULT" | python -c "import sys,json; d=json.load(sys.stdin); print(d.get('error',''))" 2>/dev/null)
+          if [ -n "$ERROR" ]; then
+            echo "resolve_error=$ERROR"
+            exit 1
+          fi
+
+          # Extract resolved values
+          SLUG=$(echo "$RESULT" | python -c "import sys,json; d=json.load(sys.stdin); print(d['slug'])")
+          RESOLVED_YEAR=$(echo "$RESULT" | python -c "import sys,json; d=json.load(sys.stdin); print(d['sample_year'])")
+          ALL_YEARS=$(echo "$RESULT" | python -c "import sys,json; d=json.load(sys.stdin); print(','.join(str(y) for y in d['all_years'])))")
+          IS_NESTED=$(echo "$RESULT" | python -c "import sys,json; d=json.load(sys.stdin); print(str(d['is_nested']).lower())")
+
+          # Override with user input if provided, otherwise use resolved
+          FINAL_YEAR="${{ inputs.sample_year }}"
+          if [ -z "$FINAL_YEAR" ]; then
+            FINAL_YEAR="$RESOLVED_YEAR"
+          fi
+
+          echo "slug=$SLUG" >> $GITHUB_OUTPUT
+          echo "resolved_year=$RESOLVED_YEAR" >> $GITHUB_OUTPUT
+          echo "final_year=$FINAL_YEAR" >> $GITHUB_OUTPUT
+          echo "all_years=$ALL_YEARS" >> $GITHUB_OUTPUT
+          echo "is_nested=$IS_NESTED" >> $GITHUB_OUTPUT
+
+      # ------------------------------------------------------------------
+      # Step 2 — Install toolkit
+      # ------------------------------------------------------------------
+      - name: Install toolkit
+        run: |
+          pip install git+https://github.com/dataciviclab/toolkit.git@main
+
+      # ------------------------------------------------------------------
+      # Step 3 — Inspect paths
+      # ------------------------------------------------------------------
+      - name: Toolkit inspect paths
+        run: |
+          STRICT_FLAG=""
+          if [ "${{ inputs.strict_config }}" = "true" ]; then
+            STRICT_FLAG="--strict-config"
+          fi
+          toolkit inspect paths \
+            --config "${{ inputs.config_path }}" \
+            --json \
+            $STRICT_FLAG \
+            2>&1 | tee inspect_paths.json || true
+
+      # ------------------------------------------------------------------
+      # Step 4 — Run all layers
+      # ------------------------------------------------------------------
+      - name: Toolkit run all
+        run: |
+          STRICT_FLAG=""
+          if [ "${{ inputs.strict_config }}" = "true" ]; then
+            STRICT_FLAG="--strict-config"
+          fi
+          toolkit run all \
+            --config "${{ inputs.config_path }}" \
+            --years "${{ steps.resolve.outputs.final_year }}" \
+            $STRICT_FLAG \
+            2>&1 | tee run_all.log
+
+      # ------------------------------------------------------------------
+      # Step 5 — Validate all layers
+      # ------------------------------------------------------------------
+      - name: Toolkit validate all
+        run: |
+          STRICT_FLAG=""
+          if [ "${{ inputs.strict_config }}" = "true" ]; then
+            STRICT_FLAG="--strict-config"
+          fi
+          toolkit validate all \
+            --config "${{ inputs.config_path }}" \
+            --years "${{ steps.resolve.outputs.final_year }}" \
+            $STRICT_FLAG \
+            2>&1 | tee validate_all.json
+
+      # ------------------------------------------------------------------
+      # Step 6 — Status (latest run)
+      # ------------------------------------------------------------------
+      - name: Toolkit status latest
+        run: |
+          STRICT_FLAG=""
+          if [ "${{ inputs.strict_config }}" = "true" ]; then
+            STRICT_FLAG="--strict-config"
+          fi
+          toolkit status \
+            --dataset "${{ steps.resolve.outputs.slug }}" \
+            --year "${{ steps.resolve.outputs.final_year }}" \
+            --latest \
+            --config "${{ inputs.config_path }}" \
+            $STRICT_FLAG \
+            2>&1 | tee status.log || true
+
+      # ------------------------------------------------------------------
+      # Step 7 — Upload artifacts
+      # ------------------------------------------------------------------
+      - name: Upload run artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: sample-run-${{ github.run_id }}
+          path: |
+            ${{ github.run_id }}_params.json
+            inspect_paths.json
+            run_all.log
+            validate_all.json
+            status.log
+          retention-days: 14

--- a/.github/workflows/sample-candidate-run.yml
+++ b/.github/workflows/sample-candidate-run.yml
@@ -38,10 +38,13 @@ on:
 jobs:
   sample-run:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     # Non usa contents:write perché non modifica il repo
     env:
       CONFIG_PATH: ${{ inputs.config_path }}
-      STRICT_FLAG: ${{ inputs.strict_config == 'true' && '--strict-config' || '' }}
+      STRICT_FLAG: ${{ inputs.strict_config && '--strict-config' || '' }}
 
     steps:
       - name: Checkout dataset-incubator

--- a/.github/workflows/sample-candidate-run.yml
+++ b/.github/workflows/sample-candidate-run.yml
@@ -39,13 +39,16 @@ jobs:
   sample-run:
     runs-on: ubuntu-latest
     # Non usa contents:write perché non modifica il repo
+    env:
+      CONFIG_PATH: ${{ inputs.config_path }}
+      STRICT_FLAG: ${{ inputs.strict_config == 'true' && '--strict-config' || '' }}
 
     steps:
       - name: Checkout dataset-incubator
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -57,8 +60,10 @@ jobs:
       # ------------------------------------------------------------------
       - name: Resolve sample run parameters
         id: resolve
+        env:
+          INPUT_SAMPLE_YEAR: ${{ inputs.sample_year }}
         run: |
-          RESULT=$(python scripts/resolve_sample_run.py "${{ inputs.config_path }}" 2>&1)
+          RESULT=$(python scripts/resolve_sample_run.py "$CONFIG_PATH" 2>&1)
           echo "resolve_raw=$RESULT"
           echo "$RESULT" > ${{ github.run_id }}_params.json
 
@@ -72,11 +77,11 @@ jobs:
           # Extract resolved values
           SLUG=$(echo "$RESULT" | python -c "import sys,json; d=json.load(sys.stdin); print(d['slug'])")
           RESOLVED_YEAR=$(echo "$RESULT" | python -c "import sys,json; d=json.load(sys.stdin); print(d['sample_year'])")
-          ALL_YEARS=$(echo "$RESULT" | python -c "import sys,json; d=json.load(sys.stdin); print(','.join(str(y) for y in d['all_years'])))")
+          ALL_YEARS=$(echo "$RESULT" | python -c "import sys,json; d=json.load(sys.stdin); print(','.join(str(y) for y in d['all_years']))")
           IS_NESTED=$(echo "$RESULT" | python -c "import sys,json; d=json.load(sys.stdin); print(str(d['is_nested']).lower())")
 
           # Override with user input if provided, otherwise use resolved
-          FINAL_YEAR="${{ inputs.sample_year }}"
+          FINAL_YEAR="$INPUT_SAMPLE_YEAR"
           if [ -z "$FINAL_YEAR" ]; then
             FINAL_YEAR="$RESOLVED_YEAR"
           fi
@@ -99,12 +104,8 @@ jobs:
       # ------------------------------------------------------------------
       - name: Toolkit inspect paths
         run: |
-          STRICT_FLAG=""
-          if [ "${{ inputs.strict_config }}" = "true" ]; then
-            STRICT_FLAG="--strict-config"
-          fi
           toolkit inspect paths \
-            --config "${{ inputs.config_path }}" \
+            --config "$CONFIG_PATH" \
             --json \
             $STRICT_FLAG \
             2>&1 | tee inspect_paths.json || true
@@ -114,12 +115,8 @@ jobs:
       # ------------------------------------------------------------------
       - name: Toolkit run all
         run: |
-          STRICT_FLAG=""
-          if [ "${{ inputs.strict_config }}" = "true" ]; then
-            STRICT_FLAG="--strict-config"
-          fi
           toolkit run all \
-            --config "${{ inputs.config_path }}" \
+            --config "$CONFIG_PATH" \
             --years "${{ steps.resolve.outputs.final_year }}" \
             $STRICT_FLAG \
             2>&1 | tee run_all.log
@@ -129,12 +126,8 @@ jobs:
       # ------------------------------------------------------------------
       - name: Toolkit validate all
         run: |
-          STRICT_FLAG=""
-          if [ "${{ inputs.strict_config }}" = "true" ]; then
-            STRICT_FLAG="--strict-config"
-          fi
           toolkit validate all \
-            --config "${{ inputs.config_path }}" \
+            --config "$CONFIG_PATH" \
             --years "${{ steps.resolve.outputs.final_year }}" \
             $STRICT_FLAG \
             2>&1 | tee validate_all.json
@@ -144,15 +137,11 @@ jobs:
       # ------------------------------------------------------------------
       - name: Toolkit status latest
         run: |
-          STRICT_FLAG=""
-          if [ "${{ inputs.strict_config }}" = "true" ]; then
-            STRICT_FLAG="--strict-config"
-          fi
           toolkit status \
             --dataset "${{ steps.resolve.outputs.slug }}" \
             --year "${{ steps.resolve.outputs.final_year }}" \
             --latest \
-            --config "${{ inputs.config_path }}" \
+            --config "$CONFIG_PATH" \
             $STRICT_FLAG \
             2>&1 | tee status.log || true
 

--- a/scripts/resolve_sample_run.py
+++ b/scripts/resolve_sample_run.py
@@ -1,0 +1,124 @@
+"""Resolve sample run parameters from a dataset.yml.
+
+Responsabilità (per issue #154):
+  - leggere dataset.yml
+  - determinare sample_year (ultimo anno in dataset.years)
+  - validare gli input minimi
+  - restituire JSON usabile dal workflow
+
+Non deve:
+  - eseguire la pipeline
+  - duplicare logica di pipeline
+  - supportare euristiche complesse per source/config
+
+Usage:
+  python scripts/resolve_sample_run.py candidates/istat-housing-crowding/dataset.yml
+  python scripts/resolve_sample_run.py candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml
+
+Output JSON:
+  {
+    "config_path": "candidates/istat-housing-crowding/dataset.yml",
+    "slug": "istat-housing-crowding",
+    "sample_year": 2024,
+    "is_nested": false,
+    "note": ""
+  }
+
+Errors exit with code 1 and JSON on stderr:
+  {"error": "message"}
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def resolve(config_path: str) -> dict:
+    """Resolve sample run parameters for a dataset config."""
+    path = Path(config_path)
+    if not path.exists():
+        return {"error": f"File not found: {config_path}"}
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+    except yaml.YAMLError as e:
+        return {"error": f"Invalid YAML: {e}"}
+
+    # Validate it's a dataset.yml with required fields
+    dataset = cfg.get("dataset", {})
+    if not dataset:
+        return {"error": f"No 'dataset' section in {config_path}"}
+
+    name = dataset.get("name", "")
+    if not name:
+        return {"error": f"No 'dataset.name' in {config_path}"}
+
+    years = dataset.get("years", [])
+    if not years:
+        return {
+            "error": f"No 'dataset.years' in {config_path} — cannot determine sample year",
+            "config_path": str(path),
+            "slug": name,
+        }
+
+    # Sample year = last year in the list (most recent)
+    try:
+        years_int = sorted(int(y) for y in years)
+    except (TypeError, ValueError):
+        return {"error": f"Invalid years value in {config_path}: {years}"}
+
+    sample_year = years_int[-1]
+
+    # Determine if nested (config is inside a sources/ or compose/ directory)
+    parts = path.parts
+    is_nested = "sources" in parts or "compose" in parts
+
+    # Compute slug from config path relative to ROOT
+    try:
+        rel = path.relative_to(ROOT)
+    except ValueError:
+        # path is absolute or outside ROOT — use as-is
+        rel = path
+
+    return {
+        "config_path": str(rel),
+        "slug": name,
+        "sample_year": sample_year,
+        "all_years": years_int,
+        "is_nested": is_nested,
+        "note": (
+            "nested config — run via source layer"
+            if is_nested
+            else ""
+        ),
+    }
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(
+            json.dumps({"error": "Usage: python resolve_sample_run.py <dataset.yml path>"}),
+            file=sys.stderr,
+        )
+        return 1
+
+    config_path = sys.argv[1]
+    result = resolve(config_path)
+
+    if "error" in result:
+        print(json.dumps(result), file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Aggiunge il layer sottile di orchestrazione per sample run in CI usando il toolkit esistente — senza duplicare logica di pipeline.

**Files:**

- `scripts/resolve_sample_run.py`: Legge `dataset.yml`, determina `sample_year` come ultimo anno in `dataset.years`, restituisce JSON con `slug`, `is_nested`, `all_years`. Errori gestiti con JSON su stderr + exit 1.
- `.github/workflows/sample-candidate-run.yml`: Trigger manuale (`workflow_dispatch`) con input `config_path` (required), `sample_year` (override opzionale), `strict_config`. Sequenza: resolve → install toolkit → inspect paths → run all → validate all → status → upload artifact. Artifact retention 14 giorni.
- `.github/workflows/post-merge-reminder.yml` (fix incluso): `checkout@v6` → `@v4` + aggiunto step sample-run in CI al template della reminder issue.

## Fix da review

- `checkout@v6` → `@v4`, `setup-python@v6` → `@v5`
- SyntaxError in `ALL_YEARS` python one-liner (extra `)` removed)
- Config path via env var `CONFIG_PATH` (previene injection)
- `STRICT_FLAG` consolidato a livello job env
- `defaults.run.shell: bash` per garantire pipefail su tutti i step
- `inputs.strict_config` è boolean — expressions syntax corretta
- `checkout@v6` → `@v4` anche in `post-merge-reminder.yml`

## Scope iniziale (fuori scope per ora)

- Trigger on-merge automatico del sample-run
- Publish GCS/BQ
- Multi-year run

## QA

- `python scripts/resolve_sample_run.py candidates/istat-housing-crowding/dataset.yml` → ✅
- `python scripts/resolve_sample_run.py candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml` → ✅
- `python scripts/resolve_sample_run.py candidates/ispra-ru-costi-kg/dataset.yml` → errore atteso ✅
- YAML workflow syntax validato ✅