### PR TITLE
ci: registra sample-run nel pipeline state

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -11,6 +11,9 @@ jobs:
   detect:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       has_items: ${{ steps.changed.outputs.has_items }}
       has_configs: ${{ steps.changed.outputs.has_configs }}
@@ -27,8 +30,8 @@ jobs:
       - name: Detect changed candidate/support roots
         id: changed
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           python - <<'PY'
           import json
@@ -36,10 +39,9 @@ jobs:
           import subprocess
           from pathlib import Path
 
-          base = os.environ["BASE_SHA"]
-          merge = os.environ["MERGE_SHA"]
+          pr_number = os.environ["PR_NUMBER"]
           files = subprocess.check_output(
-              ["git", "diff", "--name-only", base, merge],
+              ["gh", "pr", "view", pr_number, "--json", "files", "--jq", ".files[].path"],
               text=True,
           ).splitlines()
 
@@ -74,6 +76,7 @@ jobs:
                       configs.append({
                           **item,
                           "config_path": config_path.as_posix(),
+                          "config_exists": config_path.exists(),
                           "push_slug": f"{item['slug']}_{source_dir.name}",
                           "artifact_name": f"{item['slug']}-{source_dir.name}",
                       })
@@ -81,6 +84,7 @@ jobs:
                   configs.append({
                       **item,
                       "config_path": (root / "dataset.yml").as_posix(),
+                      "config_exists": (root / "dataset.yml").exists(),
                       "push_slug": item["slug"],
                       "artifact_name": item["slug"],
                   })
@@ -109,7 +113,6 @@ jobs:
         shell: bash
     env:
       CONFIG_PATH: ${{ matrix.config_path }}
-      STRICT_FLAG: ""
 
     steps:
       - name: Checkout merge commit
@@ -139,12 +142,10 @@ jobs:
 
           SLUG=$(python -c "import json; d=json.load(open('sample_params.json')); print(d['slug'])")
           FINAL_YEAR=$(python -c "import json; d=json.load(open('sample_params.json')); print(d['sample_year'])")
-          ALL_YEARS=$(python -c "import json; d=json.load(open('sample_params.json')); print(','.join(str(y) for y in d['all_years']))")
           IS_NESTED=$(python -c "import json; d=json.load(open('sample_params.json')); print(str(d['is_nested']).lower())")
 
           echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
           echo "final_year=$FINAL_YEAR" >> "$GITHUB_OUTPUT"
-          echo "all_years=$ALL_YEARS" >> "$GITHUB_OUTPUT"
           echo "is_nested=$IS_NESTED" >> "$GITHUB_OUTPUT"
 
       - name: Install toolkit
@@ -155,23 +156,22 @@ jobs:
           toolkit inspect paths \
             --config "$CONFIG_PATH" \
             --json \
-            $STRICT_FLAG \
             2>&1 | tee inspect_paths.json || true
 
       - name: Toolkit run all
+        id: run_all
         run: |
           toolkit run all \
             --config "$CONFIG_PATH" \
             --years "${{ steps.resolve.outputs.final_year }}" \
-            $STRICT_FLAG \
             2>&1 | tee run_all.log
 
       - name: Toolkit validate all
+        id: validate_all
         run: |
           toolkit validate all \
             --config "$CONFIG_PATH" \
             --years "${{ steps.resolve.outputs.final_year }}" \
-            $STRICT_FLAG \
             2>&1 | tee validate_all.json
 
       - name: Toolkit status latest
@@ -182,8 +182,46 @@ jobs:
             --year "${{ steps.resolve.outputs.final_year }}" \
             --latest \
             --config "$CONFIG_PATH" \
-            $STRICT_FLAG \
             2>&1 | tee status.log || true
+
+      - name: Write sample-run result
+        if: always()
+        env:
+          RESOLVE_OUTCOME: ${{ steps.resolve.outcome }}
+          RUN_OUTCOME: ${{ steps.run_all.outcome }}
+          VALIDATE_OUTCOME: ${{ steps.validate_all.outcome }}
+          SIGNAL_ID: ${{ matrix.slug }}
+          CONFIG_PATH: ${{ matrix.config_path }}
+          CONFIG_EXISTS: ${{ matrix.config_exists }}
+          FINAL_YEAR: ${{ steps.resolve.outputs.final_year }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+
+          critical_outcomes = [
+              os.environ.get("RESOLVE_OUTCOME"),
+              os.environ.get("RUN_OUTCOME"),
+              os.environ.get("VALIDATE_OUTCOME"),
+          ]
+          year = os.environ.get("FINAL_YEAR") or None
+          payload = {
+              "id": os.environ["SIGNAL_ID"],
+              "status": "passed" if all(outcome == "success" for outcome in critical_outcomes) else "failed",
+              "year": int(year) if year else None,
+              "config_path": os.environ["CONFIG_PATH"],
+              "config_exists": os.environ["CONFIG_EXISTS"] == "true",
+              "run_id": os.environ["RUN_ID"],
+              "run_url": os.environ["RUN_URL"],
+              "checked_at": datetime.now(timezone.utc).date().isoformat(),
+          }
+          with open("sample_run_result.json", "w", encoding="utf-8") as f:
+              json.dump(payload, f, ensure_ascii=False, indent=2)
+              f.write("\n")
+          PY
 
       - name: Upload sample-run artifacts
         uses: actions/upload-artifact@v4
@@ -196,6 +234,7 @@ jobs:
             run_all.log
             validate_all.json
             status.log
+            sample_run_result.json
           if-no-files-found: warn
           retention-days: 14
 
@@ -226,6 +265,17 @@ jobs:
 
       - name: Build pipeline_signals.json
         run: python scripts/build_pipeline_signals.py
+
+      - name: Download sample-run artifacts
+        if: needs.detect.outputs.has_configs == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: sample-run-*
+          path: sample_run_artifacts
+
+      - name: Apply sample-run results to pipeline_signals.json
+        if: needs.detect.outputs.has_configs == 'true'
+        run: python scripts/update_pipeline_sample_runs.py --samples-dir sample_run_artifacts
 
       - name: Check registry diff
         id: diff

--- a/scripts/build_pipeline_signals.py
+++ b/scripts/build_pipeline_signals.py
@@ -219,6 +219,7 @@ def _build_signal(slug: str, base_dir: Path) -> dict:
 # ---------------------------------------------------------------------------
 
 def build_signals(out_path: Path) -> int:
+    previous_sample_runs = load_previous_sample_runs(out_path)
     signals = []
 
     candidates_dir = ROOT / "candidates"
@@ -228,14 +229,20 @@ def build_signals(out_path: Path) -> int:
 
     for entry in sorted(p for p in candidates_dir.iterdir() if p.is_dir()):
         slug = entry.name
-        signals.append(_build_signal(slug, entry))
+        signal = _build_signal(slug, entry)
+        if slug in previous_sample_runs:
+            signal["sample_run"] = previous_sample_runs[slug]
+        signals.append(signal)
 
     # support_datasets also use detect_candidate_layout and need to appear in signals
     support_dir = ROOT / "support_datasets"
     if support_dir.exists():
         for entry in sorted(p for p in support_dir.iterdir() if p.is_dir()):
             slug = entry.name
-            signals.append(_build_signal(slug, entry))
+            signal = _build_signal(slug, entry)
+            if slug in previous_sample_runs:
+                signal["sample_run"] = previous_sample_runs[slug]
+            signals.append(signal)
 
     by_status: dict[str, int] = {"ok": 0, "warn": 0, "error": 0}
     for s in signals:
@@ -257,6 +264,24 @@ def build_signals(out_path: Path) -> int:
     out_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
     print(f"pipeline_signals.json — {len(signals)} candidates ({by_status})")
     return 0
+
+
+def load_previous_sample_runs(path: Path) -> dict[str, dict]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    sample_runs = {}
+    for signal in payload.get("signals", []):
+        if not isinstance(signal, dict):
+            continue
+        signal_id = signal.get("id")
+        sample_run = signal.get("sample_run")
+        if signal_id and isinstance(sample_run, dict):
+            sample_runs[signal_id] = sample_run
+    return sample_runs
 
 
 def main() -> int:

--- a/scripts/update_pipeline_sample_runs.py
+++ b/scripts/update_pipeline_sample_runs.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CATALOG = ROOT / "registry" / "pipeline_signals.json"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Attach post-merge sample-run results to pipeline_signals.json."
+    )
+    parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
+    parser.add_argument(
+        "--samples-dir",
+        type=Path,
+        required=True,
+        help="Directory containing sample_run_result.json artifacts.",
+    )
+    args = parser.parse_args()
+
+    catalog = json.loads(args.catalog.read_text(encoding="utf-8"))
+    results = read_sample_results(args.samples_dir)
+    if not results:
+        print(f"no sample_run_result.json files found in {args.samples_dir}", file=sys.stderr)
+        return 1
+
+    errors = apply_sample_results(catalog, results)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    args.catalog.write_text(
+        json.dumps(catalog, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"updated {args.catalog} with {len(results)} sample-run result(s)")
+    return 0
+
+
+def read_sample_results(samples_dir: Path) -> list[dict[str, Any]]:
+    results = []
+    for path in sorted(samples_dir.rglob("sample_run_result.json")):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["_artifact_path"] = str(path)
+        results.append(payload)
+    return results
+
+
+def apply_sample_results(
+    catalog: dict[str, Any],
+    results: list[dict[str, Any]],
+) -> list[str]:
+    signals = catalog.get("signals", [])
+    by_id = {signal.get("id"): signal for signal in signals if isinstance(signal, dict)}
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    errors = []
+
+    for result in results:
+        signal_id = result.get("id")
+        if not signal_id:
+            errors.append(f"{result.get('_artifact_path', '<unknown>')}: missing id")
+            continue
+        if signal_id not in by_id:
+            errors.append(f"{signal_id}: no matching signal in catalog")
+            continue
+        grouped.setdefault(signal_id, []).append(result)
+
+    if errors:
+        return errors
+
+    for signal_id, signal_results in grouped.items():
+        by_id[signal_id]["sample_run"] = summarize_sample_results(signal_results)
+    return []
+
+
+def summarize_sample_results(results: list[dict[str, Any]]) -> dict[str, Any]:
+    ordered = sorted(results, key=lambda item: item.get("config_path", ""))
+    failed = any(item.get("status") != "passed" for item in ordered)
+    latest = ordered[-1]
+
+    summary: dict[str, Any] = {
+        "status": "failed" if failed else "passed",
+        "run_id": str(latest.get("run_id", "")),
+        "run_url": latest.get("run_url", ""),
+        "checked_at": latest.get("checked_at", ""),
+    }
+
+    if len(ordered) == 1:
+        only = ordered[0]
+        summary["year"] = only.get("year")
+        summary["config_path"] = only.get("config_path", "")
+        if only.get("config_exists") is False:
+            summary["config_exists"] = False
+        return summary
+
+    configs = []
+    years = set()
+    for item in ordered:
+        year = item.get("year")
+        if year is not None:
+            years.add(int(year))
+        config = {
+            "status": item.get("status", "failed"),
+            "year": year,
+            "config_path": item.get("config_path", ""),
+        }
+        if item.get("config_exists") is False:
+            config["config_exists"] = False
+        configs.append(config)
+
+    summary["years"] = sorted(years)
+    summary["configs"] = configs
+    return summary
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pipeline_sample_runs.py
+++ b/tests/test_pipeline_sample_runs.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from update_pipeline_sample_runs import apply_sample_results, summarize_sample_results  # noqa: E402
+
+
+class PipelineSampleRunTest(unittest.TestCase):
+    def test_single_sample_result_uses_flat_shape(self) -> None:
+        summary = summarize_sample_results(
+            [
+                {
+                    "id": "istat-housing-crowding",
+                    "status": "passed",
+                    "year": 2024,
+                    "config_path": "candidates/istat-housing-crowding/dataset.yml",
+                    "run_id": "123",
+                    "run_url": "https://example.test/runs/123",
+                    "checked_at": "2026-04-29",
+                }
+            ]
+        )
+
+        self.assertEqual(summary["status"], "passed")
+        self.assertEqual(summary["year"], 2024)
+        self.assertEqual(
+            summary["config_path"],
+            "candidates/istat-housing-crowding/dataset.yml",
+        )
+        self.assertNotIn("configs", summary)
+
+    def test_multiple_sample_results_are_aggregated(self) -> None:
+        summary = summarize_sample_results(
+            [
+                {
+                    "id": "multi",
+                    "status": "passed",
+                    "year": 2023,
+                    "config_path": "candidates/multi/sources/a/dataset.yml",
+                    "run_id": "123",
+                    "run_url": "https://example.test/runs/123",
+                    "checked_at": "2026-04-29",
+                },
+                {
+                    "id": "multi",
+                    "status": "failed",
+                    "year": 2024,
+                    "config_path": "candidates/multi/sources/b/dataset.yml",
+                    "run_id": "123",
+                    "run_url": "https://example.test/runs/123",
+                    "checked_at": "2026-04-29",
+                },
+            ]
+        )
+
+        self.assertEqual(summary["status"], "failed")
+        self.assertEqual(summary["years"], [2023, 2024])
+        self.assertEqual(len(summary["configs"]), 2)
+
+    def test_apply_sample_results_updates_matching_signal(self) -> None:
+        catalog = {
+            "signals": [
+                {
+                    "id": "bdap-anagrafe-enti",
+                    "status": "ok",
+                    "label": "bdap-anagrafe-enti",
+                    "detail": "",
+                    "action": "",
+                }
+            ]
+        }
+
+        errors = apply_sample_results(
+            catalog,
+            [
+                {
+                    "id": "bdap-anagrafe-enti",
+                    "status": "passed",
+                    "year": 2024,
+                    "config_path": "support_datasets/bdap-anagrafe-enti/dataset.yml",
+                    "run_id": "123",
+                    "run_url": "https://example.test/runs/123",
+                    "checked_at": "2026-04-29",
+                }
+            ],
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(catalog["signals"][0]["sample_run"]["status"], "passed")
+
+    def test_apply_sample_results_rejects_unknown_signal(self) -> None:
+        catalog = {"signals": []}
+
+        errors = apply_sample_results(catalog, [{"id": "missing"}])
+
+        self.assertEqual(errors, ["missing: no matching signal in catalog"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workflows/post-merge-candidate.md
+++ b/workflows/post-merge-candidate.md
@@ -16,8 +16,9 @@ Richiede accesso in scrittura a GCS (`dataciviclab-clean`).
 Il workflow GitHub `Post-Merge Candidate Registry` apre una draft PR di handoff
 quando viene mergiata una PR che modifica `candidates/**` o `support_datasets/**`.
 La draft PR aggiorna automaticamente `registry/pipeline_signals.json`, esegue un
-sample-run CI sui config path modificati e contiene la checklist per completare
-run, push GCS/BQ e aggiornamento del clean catalog.
+sample-run CI sui config path modificati, salva l'esito in `sample_run` dentro il
+signal corrispondente e contiene la checklist per completare run, push GCS/BQ e
+aggiornamento del clean catalog.
 Se la rigenerazione di `pipeline_signals.json` non produce differenze, il workflow
 apre comunque la draft PR con un commit vuoto di handoff.
 
@@ -36,7 +37,8 @@ Controlla la draft PR aperta dal workflow `Post-Merge Candidate Registry`.
 Quella PR sostituisce la vecchia follow-up issue e resta draft finché il push
 GCS/BQ e il catalog sono verificati.
 
-La PR riporta l'esito del sample-run CI e linka gli artifact `sample-run-*`.
+La PR riporta l'esito del sample-run CI, linka gli artifact `sample-run-*` e
+aggiorna il campo `sample_run` nel relativo signal di `pipeline_signals.json`.
 Se il sample-run fallisce, usa gli artifact per diagnosticare prima di procedere
 con il run completo.
 
@@ -122,5 +124,6 @@ for review.
 - Il `pipeline_signals.json` si aggiorna automaticamente nella draft PR post-merge.
 - Se `pipeline_signals.json` resta invariato, la draft PR viene comunque aperta come contenitore operativo.
 - Il sample-run CI è una verifica rapida: non sostituisce il run completo del maintainer e non pubblica nulla.
+- Il campo `sample_run` registra solo l'esito CI del sample-run; la pubblicazione GCS resta tracciata dal clean catalog.
 - `clean_catalog.json` va completato solo dopo il push GCS/BQ: prima del push non può dichiarare path pubblici affidabili.
 - `--update-catalog` nel `push_archive.py` esegue un upsert del catalog — usalo insieme a `build_clean_catalog.py --write` e `--check-gcs`.


### PR DESCRIPTION
## Cosa cambia

Follow-up del nuovo workflow post-merge candidate.

Questa PR:
- corregge la detection dei root modificati usando i file reali della PR (`gh pr view --json files`) invece del diff tra base SHA e merge SHA;
- evita quindi il caso visto nel test di #199/#230, dove una PR vecchia includeva candidate non correlati;
- scrive un artifact `sample_run_result.json` per ogni sample-run matrix;
- applica questi risultati a `registry/pipeline_signals.json` nel campo `sample_run`;
- preserva `sample_run` quando `build_pipeline_signals.py` rigenera lo stato strutturale;
- aggiunge test unitari per l'aggregazione dei sample-run.

Formato atteso per un signal single-config:

```json
"sample_run": {
  "status": "passed",
  "run_id": "25119585145",
  "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25119585145",
  "checked_at": "2026-04-29",
  "year": 2024,
  "config_path": "support_datasets/bdap-anagrafe-enti/dataset.yml"
}
```

Per multi-source, `sample_run.configs` contiene una voce per config path.

## Perché

Il primo test reale del workflow ha confermato che l'automazione gira, ma ha anche esposto una detection troppo ampia per PR aperte da molto tempo: usare `github.event.pull_request.base.sha` può includere modifiche entrate in `main` dopo l'apertura della PR. Usare la lista file della PR risolve il problema alla fonte.

## Verifiche

```bash
actionlint .github/workflows/post-merge-candidate.yml
python -m unittest discover -s tests
python scripts/build_pipeline_signals.py --out /tmp/pipeline_signals_test.json
git diff --check origin/main..HEAD
```

Ho anche simulato localmente la detection su PR #199: ora rileva solo `support_datasets/bdap-anagrafe-enti`.
