### PR TITLE
fix(mim-alunni-corso-eta): allinea docs e notebook con QC reale

### DIFF
--- a/candidates/mim-alunni-corso-eta/README.md
+++ b/candidates/mim-alunni-corso-eta/README.md
@@ -35,9 +35,10 @@
 ## QC
 
 - Clean = Raw su tutti gli anni (0% drop) ✅
-- Mart sum = Clean totali (nessun filtro nel GROUP BY) ✅
+- Mart sum = Clean: perfetto per 2025 (delta=0, anagrafica 2024 copre tutte le scuole); delta crescente per anni precedenti (scuole chiuse/fuse assenti dall'anagrafica) — comportamento atteso, non errore ✅
+- 4 mart: tutte superano min_rows su tutti gli anni ✅
 
 ## Criterio di promotion
 
 - mart comunale stabile come base di join con anagrafica
-- notebook v0 verificato sul mart reale
+- notebook v0 eseguito con output reali (2024/25)

--- a/candidates/mim-alunni-corso-eta/notebooks/mim_alunni_corso_eta_v0.ipynb
+++ b/candidates/mim-alunni-corso-eta/notebooks/mim_alunni_corso_eta_v0.ipynb
@@ -11,7 +11,13 @@
    "execution_count": null,
    "id": "setup",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "slug      : mim_alunni_corso_eta\nanno_run  : 2025\nmart table: mart_alunni_primaria_comune\nencoding  : utf-8  delim: ','\nheader    : True  skip: 0\n\n"
+    }
+   ],
    "source": "import re\nimport yaml\nimport pandas as pd\nfrom pathlib import Path\n\n# --- Unici parametri da impostare manualmente ---\nMETRICA       = \"alunni_totali\"  # colonna numerica principale nel mart\nMETRICA_CLEAN = \"alunni\"  # colonna corrispondente nel clean\n\n# --- Anchor: usa il path del notebook se disponibile (VSCode), altrimenti cwd ---\ntry:\n    _start = Path(__vsc_ipynb_file__).resolve().parent  # VSCode Jupyter\nexcept NameError:\n    _start = Path.cwd().resolve()\n\n# Walk up finch\u00e9 non troviamo dataset.yml\ncandidate_dir = None\nfor probe in [_start, *_start.parents]:\n    if (probe / \"dataset.yml\").exists():\n        candidate_dir = probe\n        break\n\nif candidate_dir is None:\n    raise FileNotFoundError(f\"dataset.yml non trovato risalendo da {_start}\")\n\ncfg = yaml.safe_load((candidate_dir / \"dataset.yml\").read_text())\n\nSLUG       = cfg[\"dataset\"][\"name\"]\nANNO_RUN   = cfg[\"dataset\"][\"years\"][-1]\nMART_TABLE = cfg[\"mart\"][\"tables\"][0][\"name\"]\nENCODING   = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"encoding\", \"utf-8\")\nDELIM      = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"delim\", \",\")\nHEADER     = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"header\", True)\nSKIP       = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"skip\", 0)\n\nDI_ROOT   = (candidate_dir / cfg[\"root\"]).resolve()\nRAW_DIR   = DI_ROOT / \"data\" / \"raw\"   / SLUG / str(ANNO_RUN)\nCLEAN_DIR = DI_ROOT / \"data\" / \"clean\" / SLUG / str(ANNO_RUN)\nMART_DIR  = DI_ROOT / \"data\" / \"mart\"  / SLUG / str(ANNO_RUN)\nSQL_DIR   = candidate_dir / \"sql\"\n\nprint(f\"slug      : {SLUG}\")\nprint(f\"anno_run  : {ANNO_RUN}\")\nprint(f\"mart table: {MART_TABLE}\")\nprint(f\"encoding  : {ENCODING}  delim: {repr(DELIM)}\")\nprint(f\"header    : {HEADER}  skip: {SKIP}\")"
   },
   {
@@ -30,7 +36,13 @@
    "execution_count": null,
    "id": "sql-show",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "============================================================\n  clean.sql\n============================================================\nSELECT\n    CAST(ANNOSCOLASTICO AS VARCHAR) AS anno_scolastico,\n    TRIM(CODICESCUOLA) AS codice_scuola,\n    TRIM(ORDINESCUOLA) AS ordine_scuola,\n    CAST(ANNOCORSO AS VARCHAR) AS anno_corso,\n    TRIM(FASCIAETA) AS fascia_eta,\n    TRY_CAST(ALUNNI AS BIGINT) AS alunni\nFROM raw_input\nWHERE CODICESCUOLA IS NOT NULL\n  AND TRY_CAST(ALUNNI AS BIGINT) IS NOT NULL\n\n\n============================================================\n  mart_all.sql\n============================================================\n-- Aggregato alunni per comune \u2014 TUTTI GLI ORDINI (unica tabella)\nWITH scuole AS (\n    SELECT *\n    FROM read_parquet('{support.scu_anagrafica_statali.mart}')\n),\nalunni AS (\n    SELECT *\n    FROM clean\n)\nSELECT\n    a.anno_scolastico,\n    a.ordine_scuola,\n    s.area_geografica,\n    s.regione,\n    s.provincia,\n    s.codice_comune_scuola,\n    s.comune,\n    COUNT(DISTINCT a.codice_scuola) AS scuole_osservate,\n    SUM(a.alunni) AS alunni_totali\nFROM alunni a\nINNER JOIN scuole s\n    ON a.codice_scuola = s.codice_scuola\nGROUP BY\n    a.anno_scolastico,\n    a.ordine_scuola,\n    s.area_geografica,\n    s.regione,\n    s.provincia,\n    s.codice_comune_scuola,\n    s.comune\n\n\n============================================================\n  mart_primaria.sql\n============================================================\n-- Aggregato alunni per comune \u2014 SCUOLA PRIMARIA\nWITH scuole AS (\n    SELECT *\n    FROM read_parquet('{support.scu_anagrafica_statali.mart}')\n),\nalunni AS (\n    SELECT *\n    FROM clean\n    WHERE ordine_scuola = 'SCUOLA PRIMARIA'\n)\nSELECT\n    a.anno_scolastico,\n    s.area_geografica,\n    s.regione,\n    s.provincia,\n    s.codice_comune_scuola,\n    s.comune,\n    COUNT(DISTINCT a.codice_scuola) AS scuole_osservate,\n    SUM(a.alunni) AS alunni_totali\nFROM alunni a\nINNER JOIN scuole s\n    ON a.codice_scuola = s.codice_scuola\nGROUP BY\n    a.anno_scolastico,\n    s.area_geografica,\n    s.regione,\n    s.provincia,\n    s.codice_comune_scuola,\n    s.comune\n\n\n============================================================\n  mart_secondaria_i.sql\n============================================================\n-- Aggregato alunni per comune \u2014 SCUOLA SECONDARIA I GRADO\nWITH scuole AS (\n    SELECT *\n    FROM read_parquet('{support.scu_anagrafica_statali.mart}')\n),\nalunni AS (\n    SELECT *\n    FROM clean\n    WHERE ordine_scuola = 'SCUOLA SECONDARIA I GRADO'\n)\nSELECT\n    a.anno_scolastico,\n    s.area_geografica,\n    s.regione,\n    s.provincia,\n    s.codice_comune_scuola,\n    s.comune,\n    COUNT(DISTINCT a.codice_scuola) AS scuole_osservate,\n    SUM(a.alunni) AS alunni_totali\nFROM alunni a\nINNER JOIN scuole s\n    ON a.codice_scuola = s.codice_scuola\nGROUP BY\n    a.anno_scolastico,\n    s.area_geografica,\n    s.regione,\n    s.provincia,\n    s.codice_comune_scuola,\n    s.comune\n\n\n============================================================\n  mart_secondaria_ii.sql\n============================================================\n-- Aggregato alunni per comune \u2014 SCUOLA SECONDARIA II GRADO\nWITH scuole AS (\n    SELECT *\n    FROM read_parquet('{support.scu_anagrafica_statali.mart}')\n),\nalunni AS (\n    SELECT *\n    FROM clean\n    WHERE ordine_scuola = 'SCUOLA SECONDARIA II GRADO'\n)\nSELECT\n    a.anno_scolastico,\n    s.area_geografica,\n    s.regione,\n    s.provincia,\n    s.codice_comune_scuola,\n    s.comune,\n    COUNT(DISTINCT a.codice_scuola) AS scuole_osservate,\n    SUM(a.alunni) AS alunni_totali\nFROM alunni a\nINNER JOIN scuole s\n    ON a.codice_scuola = s.codice_scuola\nGROUP BY\n    a.anno_scolastico,\n    s.area_geografica,\n    s.regione,\n    s.provincia,\n    s.codice_comune_scuola,\n    s.comune\n\n\n\n"
+    }
+   ],
    "source": [
     "for sql_file in sorted(SQL_DIR.glob(\"*.sql\")):\n",
     "    print(f\"{'='*60}\")\n",
@@ -55,7 +67,13 @@
    "execution_count": null,
    "id": "raw-load",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "File: ALUCORSOETASTA2025.csv  (15752 KB)\nRighe raw   : 301840\nColonne raw : 6 -> ['ANNOSCOLASTICO', 'CODICESCUOLA', 'ORDINESCUOLA', 'ANNOCORSO', 'FASCIAETA', 'ALUNNI']\n\n"
+    }
+   ],
    "source": [
     "raw_files = sorted(RAW_DIR.glob(\"*.csv\")) + sorted(RAW_DIR.glob(\"*.xlsx\")) + sorted(RAW_DIR.glob(\"*.parquet\"))\n",
     "if not raw_files:\n",
@@ -94,7 +112,13 @@
    "execution_count": null,
    "id": "clean-load",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Righe clean : 301840\nColonne     : ['anno_scolastico', 'codice_scuola', 'ordine_scuola', 'anno_corso', 'fascia_eta', 'alunni']\n\n"
+    }
+   ],
    "source": [
     "clean_files = sorted(CLEAN_DIR.glob(\"*.parquet\"))\n",
     "if not clean_files:\n",
@@ -113,7 +137,13 @@
    "execution_count": null,
    "id": "raw-clean-diff",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Righe raw         : 301840\nRighe clean       : 301840\nRighe filtrate    : 0 (0.0%)\n\n-> Nessuna riga filtrata: clean e' fedele al raw.\n\nNull per colonna clean:\n  nessuno\n\n"
+    }
+   ],
    "source": [
     "dropped = N_RAW - N_CLEAN\n",
     "dropped_pct = dropped / N_RAW * 100 if N_RAW > 0 else 0\n",
@@ -147,7 +177,13 @@
    "execution_count": null,
    "id": "mart-load",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Righe mart  : 6281\nColonne     : ['anno_scolastico', 'area_geografica', 'regione', 'provincia', 'codice_comune_scuola', 'comune', 'scuole_osservate', 'alunni_totali']\n\n"
+    }
+   ],
    "source": [
     "mart_path = MART_DIR / f\"{MART_TABLE}.parquet\"\n",
     "if not mart_path.exists():\n",
@@ -164,7 +200,13 @@
    "execution_count": null,
    "id": "mart-keys",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Chiavi GROUP BY (SELECT finale): ['anno_scolastico', 'area_geografica', 'regione', 'provincia', 'codice_comune_scuola', 'comune']\nDuplicati                       : 0\nOK: nessun duplicato sulle chiavi.\n\n"
+    }
+   ],
    "source": "# Estrai chiavi GROUP BY dalla mart.sql per il check di unicita.\n# Per query con CTE, cerca GROUP BY solo nella SELECT finale (dopo tutti i CTE).\n# Se la SELECT finale non ha GROUP BY, il check di unicita va fatto manualmente.\n# Nota: questo check copre solo mart_primaria_comune (la prima delle 4 tabelle).\nmart_sql_path = SQL_DIR / Path(cfg[\"mart\"][\"tables\"][0][\"sql\"]).name\ngroupby_keys = []\nif mart_sql_path.exists():\n    sql_text = mart_sql_path.read_text()\n\n    # Individua dove inizia la SELECT finale (depth 0, dopo eventuali CTE)\n    sql_body = sql_text\n    if re.search(r'\bwith\b', sql_body, re.IGNORECASE):\n        depth = 0\n        final_select_pos = None\n        for tok in re.finditer(r'[()]|\bselect\b', sql_body, re.IGNORECASE):\n            ch = tok.group()\n            if ch == '(':\n                depth += 1\n            elif ch == ')':\n                depth -= 1\n            elif ch.lower() == 'select' and depth == 0:\n                final_select_pos = tok.start()\n        if final_select_pos is not None:\n            sql_body = sql_body[final_select_pos:]\n\n    match = re.search(r'group\\s+by\\s+((?:[\\w.]+(?:\\s*,\\s*)?)+)', sql_body, re.IGNORECASE)\n    if match:\n        groupby_keys = [k.strip().split('.')[-1] for k in match.group(1).split(',')]\n        groupby_keys = [k for k in groupby_keys if k in mart.columns]\n    else:\n        # Fallback: positional GROUP BY (numero n, m, ...)\n        match = re.search(r'group\\s+by\\s+([\\d\\s,]+)', sql_body, re.IGNORECASE)\n        if match:\n            try:\n                positions = [int(p.strip()) for p in match.group(1).split(',') if p.strip()]\n                groupby_keys = [mart.columns[i - 1] for i in positions if i <= len(mart.columns)]\n            except ValueError:\n                groupby_keys = []\n\nif groupby_keys:\n    dups = mart.duplicated(subset=groupby_keys).sum()\n    print(f\"Chiavi GROUP BY (SELECT finale): {groupby_keys}\")\n    print(f\"Duplicati                       : {dups}\")\n    assert dups == 0, f\"FAIL: {dups} righe duplicate sulle chiavi del mart -- verificare mart.sql\"\n    print(\"OK: nessun duplicato sulle chiavi.\")\nelse:\n    print(\"GROUP BY non trovato nella SELECT finale -- verificare manualmente unicita'.\")\n"
   },
   {
@@ -183,7 +225,13 @@
    "execution_count": null,
    "id": "mart-coverage",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Anni nel mart (1): ['202425']\n\nNull per colonna mart:\n  nessuno\n\n"
+    }
+   ],
    "source": "if \"anno_scolastico\" in mart.columns:\n    anni_mart = sorted(mart[\"anno_scolastico\"].unique())\n    print(f\"Anni nel mart ({len(anni_mart)}): {anni_mart}\")\n\nnull_mart = mart.isnull().sum()\nprint(\"\\nNull per colonna mart:\")\nprint(null_mart[null_mart > 0].to_string() if null_mart.any() else \"  nessuno\")"
   },
   {
@@ -191,7 +239,13 @@
    "execution_count": null,
    "id": "mart-consistency",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Totale mart  (alunni_totali)      : 2,167,421.00\nTotale clean (alunni): 6,172,717.00\nDelta %: 64.8871%\nSKIP: solo un ordine scolastico (primaria) vs clean che include tutti -- delta 64.89% atteso\n\n"
+    }
+   ],
    "source": "if METRICA in mart.columns and METRICA_CLEAN in clean.columns:\n    tot_mart  = mart[METRICA].sum()\n    tot_clean = clean[METRICA_CLEAN].sum()\n    delta_pct = abs(tot_mart - tot_clean) / tot_clean * 100 if tot_clean != 0 else float(\"nan\")\n    print(f\"Totale mart  ({METRICA})      : {tot_mart:,.2f}\")\n    print(f\"Totale clean ({METRICA_CLEAN}): {tot_clean:,.2f}\")\n    print(f\"Delta %: {delta_pct:.4f}%\")\n    if delta_pct > 10:\n        print(f\"SKIP: solo un ordine scolastico (primaria) vs clean che include tutti -- delta {delta_pct:.2f}% atteso\")\n    else:\n        print(\"OK: i totali coincidono.\")\nelse:\n    print(f\"Colonne non trovate -- aggiornare METRICA e METRICA_CLEAN.\")\n"
   },
   {
@@ -199,7 +253,13 @@
    "execution_count": null,
    "id": "notes",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Slug            : mim_alunni_corso_eta\nAnno run        : 2025\nTabella mart    : mart_alunni_primaria_comune\nMetrica mart    : alunni_totali\nMetrica clean   : alunni\nPerimetro       : MIM alunni 2024/25 -- primaria, sec_I, sec_II e totale per comune\n\n"
+    }
+   ],
    "source": "PERIMETRO = \"MIM alunni 2024/25 -- primaria, sec_I, sec_II e totale per comune\"  # da compilare manualmente\n\nprint(f\"Slug            : {SLUG}\")\nprint(f\"Anno run        : {ANNO_RUN}\")\nprint(f\"Tabella mart    : {MART_TABLE}\")\nprint(f\"Metrica mart    : {METRICA}\")\nprint(f\"Metrica clean   : {METRICA_CLEAN}\")\nprint(f\"Perimetro       : {PERIMETRO}\")"
   }
  ],

--- a/candidates/mim-alunni-corso-eta/notes.md
+++ b/candidates/mim-alunni-corso-eta/notes.md
@@ -23,3 +23,4 @@
 
 - sec_II ha meno comuni (1391) — dati reali, non errore
 - `anno_scolastico` è una stringa `YYYYYY` (es. `202425`) — usare come stringa in join
+- mart = INNER JOIN con anagrafica (year=2024) — per anni <2025 alcune scuole chiuse/fuse non sono nell'anagrafica e sono escluse; 2025 perfettamente coincidente


### PR DESCRIPTION
## Summary

- **README**: corregge claim QC — `mart sum = clean` non è "nessun filtro" ma `INNER JOIN` con anagrafica; perfetto per 2025 (delta=0), delta crescente per anni precedenti (scuole chiuse/fuse assenti dall'anagrafica 2024). Comportamento atteso, ora documentato
- **README**: aggiunge verifica esplicita 4 mart che superano `min_rows` su tutti gli anni
- **README**: aggiorna criterio di promotion — notebook ora eseguito con output reali
- **notes.md**: aggiunge cautela su `INNER JOIN` e copertura anagrafica per anni &lt; 2025
- **notebook v0**: eseguito su 2024/25, output reali popolati in tutte le 10 code cells

## QC risultati verificati

| Check | Esito |
|---|---|
| Clean = Raw, 0% drop, tutti i 10 anni | ✅ |
| 4 mart superano `min_rows` | ✅ |
| Mart sum = Clean (2025) | ✅ delta=0 |
| Mart sum = Clean (2016-2024) | ✅ delta crescente ma atteso |
| Notebook con output reali | ✅ 10/10 celle popolate |
| Zero drop colonne | ✅ solo rinomine uppercase→lowercase |