### PR TITLE
fix: toolkit MCP steps in run-candidate, workflow consolidation, new PR gate

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -158,6 +158,32 @@ jobs:
             --json \
             2>&1 | tee inspect_paths.json || true
 
+      - name: Pre-flight check
+        run: |
+          python - <<'PY'
+          import json, sys
+
+          try:
+              d = json.load(open("inspect_paths.json"))
+          except Exception:
+              print("::warning::Could not parse inspect_paths.json — skipping pre-flight checks")
+              sys.exit(0)
+
+          run_count = d.get("run_file_count", 0)
+          latest = d.get("latest_run") or {}
+          latest_status = latest.get("status", "N/A")
+          latest_run_id = latest.get("run_id", "N/A")
+
+          print(f"::notice::run_file_count={run_count}, latest_run={latest_run_id} ({latest_status})")
+
+          if run_count == 0:
+              print("::warning::No previous runs found for this candidate — this will be a first run")
+          elif latest_status == "FAILED":
+              print(f"::warning::Latest run was FAILED ({latest_run_id})")
+          elif latest_status == "SUCCESS":
+              print(f"::notice::Latest run was SUCCESS ({latest_run_id})")
+          PY
+
       - name: Toolkit run all
         id: run_all
         run: |
@@ -167,22 +193,13 @@ jobs:
             2>&1 | tee run_all.log
 
       - name: Toolkit validate all
+        if: success()
         id: validate_all
         run: |
           toolkit validate all \
             --config "$CONFIG_PATH" \
             --years "${{ steps.resolve.outputs.final_year }}" \
             2>&1 | tee validate_all.json
-
-      - name: Toolkit status latest
-        if: always() && steps.resolve.outputs.slug != ''
-        run: |
-          toolkit status \
-            --dataset "${{ steps.resolve.outputs.slug }}" \
-            --year "${{ steps.resolve.outputs.final_year }}" \
-            --latest \
-            --config "$CONFIG_PATH" \
-            2>&1 | tee status.log || true
 
       - name: Write sample-run result
         if: always()
@@ -233,7 +250,6 @@ jobs:
             inspect_paths.json
             run_all.log
             validate_all.json
-            status.log
             sample_run_result.json
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -1,0 +1,202 @@
+name: Toolkit Pipeline Check
+
+# Esegue la pipeline toolkit su candidate modificati in PR.
+# Fallisce la PR se run o validate falliscono, o se blocker_hints trova blocker.
+
+on:
+  pull_request:
+    paths:
+      - "candidates/**"
+      - "support_datasets/**"
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      has_configs: ${{ steps.changed.outputs.has_configs }}
+      configs: ${{ steps.changed.outputs.configs }}
+    steps:
+      - name: Checkout PR commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Detect changed candidate/support roots
+        id: changed
+        run: |
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+
+          base = "${{ github.event.pull_request.base.sha }}"
+          head = "${{ github.event.pull_request.head.sha }}"
+          import subprocess
+          files = subprocess.check_output(
+              ["git", "diff", "--name-only", base, head],
+              text=True
+          ).splitlines()
+
+          seen = {}
+          for f in files:
+              p = Path(f)
+              parts = p.parts
+              if len(parts) < 2:
+                  continue
+              if parts[0] == "candidates":
+                  seen[parts[1]] = ("candidates", parts[1])
+              elif parts[0] == "support_datasets":
+                  seen[parts[1]] = ("support_datasets", parts[1])
+
+          configs = []
+          for kind, slug in sorted(seen.values()):
+              root = Path(kind) / slug
+              sources = root / "sources"
+              if sources.is_dir():
+                  for src in sorted(sources.iterdir()):
+                      cfg = src / "dataset.yml"
+                      if cfg.exists():
+                          year = _resolve_year(cfg)
+                          configs.append({
+                              "kind": kind,
+                              "slug": slug,
+                              "source": src.name,
+                              "config_path": str(cfg),
+                              "year": year,
+                              "artifact_name": f"{slug}-{src.name}",
+                          })
+              else:
+                  cfg = root / "dataset.yml"
+                  if cfg.exists():
+                      year = _resolve_year(cfg)
+                      configs.append({
+                          "kind": kind,
+                          "slug": slug,
+                          "source": None,
+                          "config_path": str(cfg),
+                          "year": year,
+                          "artifact_name": slug,
+                      })
+
+          def _resolve_year(cfg):
+              import yaml
+              with open(cfg) as f:
+                  d = yaml.safe_load(f)
+              years = d.get("dataset", {}).get("years", [])
+              return years[-1] if years else 0
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+              out.write(f"has_configs={'true' if configs else 'false'}\n")
+              out.write("configs<<JSON\n")
+              out.write(json.dumps(configs, ensure_ascii=False))
+              out.write("\nJSON\n")
+          PY
+
+  toolkit-check:
+    needs: detect
+    if: needs.detect.outputs.has_configs == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJSON(needs.detect.outputs.configs) }}
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout PR commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install toolkit
+        run: pip install git+https://github.com/dataciviclab/toolkit.git@main
+
+      - name: Toolkit inspect paths (pre-flight)
+        run: |
+          echo "=== inspect paths ==="
+          toolkit inspect paths \
+            --config "${{ matrix.config.config_path }}" \
+            --json \
+            2>&1 | python -c "import sys,json; d=json.load(sys.stdin); print(f'run_file_count={d.get(\"run_file_count\",0)} latest_run={d.get(\"latest_run\",{}).get(\"status\",\"N/A\")}')"
+
+      - name: Toolkit run all
+        id: run_all
+        run: |
+          toolkit run all \
+            --config "${{ matrix.config.config_path }}" \
+            --years "${{ matrix.config.year }}" \
+            2>&1 | tee run_all.log
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Toolkit validate all
+        if: success()
+        id: validate_all
+        run: |
+          toolkit validate all \
+            --config "${{ matrix.config.config_path }}" \
+            --years "${{ matrix.config.year }}" \
+            2>&1 | tee validate_all.log
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Check blockers via Python
+        if: success()
+        run: |
+          python - <<'PY'
+          import json, sys, subprocess
+
+          # Run blocker_hints
+          result = subprocess.run(
+              ["toolkit", "inspect", "paths", "--config", "${{ matrix.config.config_path }}", "--json"],
+              capture_output=True, text=True, timeout=60
+          )
+          if result.returncode == 0:
+              try:
+                  d = json.loads(result.stdout)
+                  # blocker_hints not in CLI output, compute via summary
+                  from toolkit.mcp.toolkit_client import blocker_hints
+                  bh = blocker_hints("${{ matrix.config.config_path }}", ${{ matrix.config.year }})
+                  blockers = bh.get("blocker_count", 0)
+                  warnings = bh.get("warning_count", 0)
+                  print(f"blocker_count={blockers}")
+                  print(f"warning_count={warnings}")
+                  if blockers > 0:
+                      print(f"::error::Candidate has {blockers} blocker(s) — fix before merging")
+                      sys.exit(1)
+              except Exception as e:
+                  print(f"warning::Could not compute blocker_hints: {e}")
+          PY
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-toolkit-${{ matrix.config.artifact_name }}
+          path: |
+            run_all.log
+            validate_all.log
+          retention-days: 7
+
+  report:
+    needs: [detect, toolkit-check]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set summary
+        run: |
+          echo "## Toolkit Pipeline Check" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Configs changed: ${{ needs.detect.outputs.configs }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ needs.toolkit-check.result }}" = "success" ]; then
+            echo "✅ All candidates passed toolkit run + validate" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "❌ Some candidates failed — see job details" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -48,6 +48,13 @@ jobs:
               elif parts[0] == "support_datasets":
                   seen[parts[1]] = ("support_datasets", parts[1])
 
+          def _resolve_year(cfg):
+              import yaml
+              with open(cfg) as f:
+                  d = yaml.safe_load(f)
+              years = d.get("dataset", {}).get("years", [])
+              return years[-1] if years else 0
+
           configs = []
           for kind, slug in sorted(seen.values()):
               root = Path(kind) / slug
@@ -77,13 +84,6 @@ jobs:
                           "year": year,
                           "artifact_name": slug,
                       })
-
-          def _resolve_year(cfg):
-              import yaml
-              with open(cfg) as f:
-                  d = yaml.safe_load(f)
-              years = d.get("dataset", {}).get("years", [])
-              return years[-1] if years else 0
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as out:
               out.write(f"has_configs={'true' if configs else 'false'}\n")
@@ -148,30 +148,25 @@ jobs:
 
       - name: Check blockers via Python
         if: success()
+        env:
+          CONFIG_PATH: ${{ matrix.config.config_path }}
+          YEAR: ${{ matrix.config.year }}
         run: |
           python - <<'PY'
-          import json, sys, subprocess
+          import json, sys, subprocess, os
 
-          # Run blocker_hints
-          result = subprocess.run(
-              ["toolkit", "inspect", "paths", "--config", "${{ matrix.config.config_path }}", "--json"],
-              capture_output=True, text=True, timeout=60
-          )
-          if result.returncode == 0:
-              try:
-                  d = json.loads(result.stdout)
-                  # blocker_hints not in CLI output, compute via summary
-                  from toolkit.mcp.toolkit_client import blocker_hints
-                  bh = blocker_hints("${{ matrix.config.config_path }}", ${{ matrix.config.year }})
-                  blockers = bh.get("blocker_count", 0)
-                  warnings = bh.get("warning_count", 0)
-                  print(f"blocker_count={blockers}")
-                  print(f"warning_count={warnings}")
-                  if blockers > 0:
-                      print(f"::error::Candidate has {blockers} blocker(s) — fix before merging")
-                      sys.exit(1)
-              except Exception as e:
-                  print(f"warning::Could not compute blocker_hints: {e}")
+          cfg_path = os.environ["CONFIG_PATH"]
+          year = int(os.environ["YEAR"])
+
+          from toolkit.mcp.toolkit_client import blocker_hints
+          bh = blocker_hints(cfg_path, year)
+          blockers = bh.get("blocker_count", 0)
+          warnings = bh.get("warning_count", 0)
+          print(f"blocker_count={blockers}")
+          print(f"warning_count={warnings}")
+          if blockers > 0:
+              print(f"::error::Candidate has {blockers} blocker(s) — fix before merging")
+              sys.exit(1)
           PY
 
       - name: Upload artifacts

--- a/.github/workflows/sample-candidate-run.yml
+++ b/.github/workflows/sample-candidate-run.yml
@@ -12,6 +12,14 @@ name: Sample Candidate Run
 # Output:
 #   - artifact con run record, metadata, validation JSON
 #   - nessuna modifica al repo
+#
+# Steps:
+#   1. Resolve sample year from config
+#   2. Install toolkit
+#   3. Inspect paths + pre-flight check (run_file_count, latest_run status)
+#   4. Run all layers
+#   5. Validate all layers (only if run succeeded)
+#   6. Upload artifacts
 
 on:
   workflow_dispatch:
@@ -103,7 +111,7 @@ jobs:
           pip install git+https://github.com/dataciviclab/toolkit.git@main
 
       # ------------------------------------------------------------------
-      # Step 3 — Inspect paths
+      # Step 3 — Inspect paths + pre-flight check
       # ------------------------------------------------------------------
       - name: Toolkit inspect paths
         run: |
@@ -113,10 +121,39 @@ jobs:
             $STRICT_FLAG \
             2>&1 | tee inspect_paths.json || true
 
+      - name: Pre-flight check
+        env:
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python - <<'PY'
+          import json, sys
+
+          try:
+              d = json.load(open("inspect_paths.json"))
+          except Exception:
+              print("::warning::Could not parse inspect_paths.json — skipping pre-flight checks")
+              sys.exit(0)
+
+          run_count = d.get("run_file_count", 0)
+          latest = d.get("latest_run") or {}
+          latest_status = latest.get("status", "N/A")
+          latest_run_id = latest.get("run_id", "N/A")
+
+          print(f"::notice::run_file_count={run_count}, latest_run={latest_run_id} ({latest_status})")
+
+          if run_count == 0:
+              print("::warning::No previous runs found for this candidate — this will be a first run")
+          elif latest_status == "FAILED":
+              print(f"::warning::Latest run was FAILED ({latest_run_id}) — check artifact from previous run before proceeding")
+          elif latest_status == "SUCCESS":
+              print(f"::notice::Latest run was SUCCESS ({latest_run_id}) — proceeding with sample run")
+          PY
+
       # ------------------------------------------------------------------
       # Step 4 — Run all layers
       # ------------------------------------------------------------------
       - name: Toolkit run all
+        id: run_all
         run: |
           toolkit run all \
             --config "$CONFIG_PATH" \
@@ -125,9 +162,10 @@ jobs:
             2>&1 | tee run_all.log
 
       # ------------------------------------------------------------------
-      # Step 5 — Validate all layers
+      # Step 5 — Validate all layers (only if run succeeded)
       # ------------------------------------------------------------------
       - name: Toolkit validate all
+        if: success()
         run: |
           toolkit validate all \
             --config "$CONFIG_PATH" \
@@ -135,21 +173,8 @@ jobs:
             $STRICT_FLAG \
             2>&1 | tee validate_all.json
 
-      # ------------------------------------------------------------------
-      # Step 6 — Status (latest run)
-      # ------------------------------------------------------------------
-      - name: Toolkit status latest
-        run: |
-          toolkit status \
-            --dataset "${{ steps.resolve.outputs.slug }}" \
-            --year "${{ steps.resolve.outputs.final_year }}" \
-            --latest \
-            --config "$CONFIG_PATH" \
-            $STRICT_FLAG \
-            2>&1 | tee status.log || true
-
-      # ------------------------------------------------------------------
-      # Step 7 — Upload artifacts
+# ------------------------------------------------------------------
+      # Step 5/6 — Upload artifacts
       # ------------------------------------------------------------------
       - name: Upload run artifacts
         uses: actions/upload-artifact@v4
@@ -161,5 +186,4 @@ jobs:
             inspect_paths.json
             run_all.log
             validate_all.json
-            status.log
           retention-days: 14

--- a/workflows/run-candidate.md
+++ b/workflows/run-candidate.md
@@ -131,9 +131,20 @@ Prima di lanciare tutto, verifica almeno:
 
 Se il contract dei path non e' chiaro, fermati prima del run completo.
 
-Se il server MCP `toolkit` e' attivo nel runtime:
+Step pre-flight (equivalente al controllo manuale di cui sopra):
 
-- `toolkit_inspect_paths(config_path)` - alternativa al controllo manuale di path e contract
+```bash
+cd toolkit
+python -m toolkit.cli.app inspect paths --config ../dataset-incubator/candidates/{slug}/dataset.yml --json
+```
+
+Se il server MCP `toolkit` e' attivo nel runtime, puoi usare in alternativa:
+
+```
+toolkit_inspect_paths(config_path) → run_file_count, years_seen, latest_run, path contract verificato
+```
+
+Verifica che nell'output `run_file_count` sia >= 1 e `latest_run.status` sia coerente col run atteso.
 
 ### 4. Lancia il run minimo giusto
 
@@ -181,9 +192,21 @@ Segnale minimo di output leggibile:
 - le colonne principali sono coerenti con la domanda o col layer atteso
 - non ci sono rotture evidenti o valori palesemente fuori posto
 
+Step post-run (diagnostica compatta):
+
+```bash
+cd toolkit
+python -m toolkit.cli.app inspect paths --config ../dataset-incubator/candidates/{slug}/dataset.yml --json
+```
+
 Se il server MCP `toolkit` e' attivo nel runtime:
 
-- `toolkit_blocker_hints(config_path)` - evidenzia mismatch tra output risolti e run record
+```
+toolkit_inspect_paths(config_path)   → path contract + run metadata (run_file_count, years_seen, latest_run)
+toolkit_blocker_hints(config_path)  → mismatch tra output risolti e run record
+```
+
+Se `toolkit_blocker_hints` restituisce blocker, fermati e risolvili prima di procedere.
 
 ### 6. Se fallisce, isola il primo errore vero
 
@@ -205,6 +228,16 @@ Se utile, chiudi il blocker con una formula semplice:
 - `blocco parsing`
 - `blocco SQL`
 - `blocco validazione`
+
+Diagnostica failure con MCP (se il server toolkit e' attivo):
+
+```
+toolkit_list_runs(config_path, status="FAILED", limit=5)
+    → ultimi 5 run falliti: run_id, started_at, error dal record
+
+toolkit_run_summary(config_path)
+    → run_rate, failed_count, avg_duration; utile per capire se il fallimento e' isolato o ricorrente
+```
 
 Non usare questo workflow per:
 


### PR DESCRIPTION
## Summary

- **`run-candidate.md`**: aggiunti step CLI e MCP espliciti (`inspect paths`, `blocker_hints`, `list_runs`) nel loop canonico
- **`sample-candidate-run.yml`**: pre-flight check, validate conditional on run success, rimosso `toolkit status --latest` (ridondante con inspect paths)
- **`post-merge-candidate.yml`**: stessi miglioramenti, validate conditional
- **`pr-toolkit-check.yml`**: nuovo workflow — esegue `run all` + `validate all` + `blocker_hints` su candidate modificati in PR come gate pre-merge

## Changed files

- `workflows/run-candidate.md` — step pre/post run espansiti
- `.github/workflows/sample-candidate-run.yml` — pre-flight + conditional validate
- `.github/workflows/post-merge-candidate.yml` — pre-flight + conditional validate
- `.github/workflows/pr-toolkit-check.yml` — nuovo workflow (202 linee)

## Motivation

Prima non esisteva nessun check in PR che eseguisse effettivamente la pipeline. Il maintainer scopriva se il candidate gira davvero solo post-merge. Ora:

- **PR**: `pr-toolkit-check` fail-fast se pipeline è rotta
- **Post-merge**: conferma + publish GCS/BQ + aggiornamento `pipeline_signals.json`

Double check intenzionale — PR fail-fast vs post-merge publish + ACB update.