### PR TITLE
fix: allinea DI a toolkit CLI + estrae detect_candidates in script condiviso

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -15,10 +15,10 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      has_items: ${{ steps.changed.outputs.has_items }}
-      has_configs: ${{ steps.changed.outputs.has_configs }}
-      items: ${{ steps.changed.outputs.items }}
-      configs: ${{ steps.changed.outputs.configs }}
+      has_items: ${{ steps.detect.outputs.has_items }}
+      has_configs: ${{ steps.detect.outputs.has_configs }}
+      items: ${{ steps.detect.outputs.items }}
+      configs: ${{ steps.detect.outputs.configs }}
 
     steps:
       - name: Checkout merge commit
@@ -28,75 +28,26 @@ jobs:
           fetch-depth: 0
 
       - name: Detect changed candidate/support roots
-        id: changed
+        id: detect
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          # Get PR file list and pipe to detect_candidates.py
+          gh pr view "$PR_NUMBER" --json files --jq ".files[].path" | \
+            python scripts/detect_candidates.py --files --json > detect_output.json
+
           python - <<'PY'
           import json
-          import os
-          import subprocess
-          from pathlib import Path
-
-          pr_number = os.environ["PR_NUMBER"]
-          files = subprocess.check_output(
-              ["gh", "pr", "view", pr_number, "--json", "files", "--jq", ".files[].path"],
-              text=True,
-          ).splitlines()
-
-          seen = {}
-          for file_name in files:
-              path = Path(file_name)
-              parts = path.parts
-              if len(parts) < 2:
-                  continue
-              if parts[0] == "candidates":
-                  seen[(parts[0], parts[1])] = {
-                      "kind": "candidate",
-                      "slug": parts[1],
-                      "root": f"candidates/{parts[1]}",
-                  }
-              elif parts[0] == "support_datasets":
-                  seen[(parts[0], parts[1])] = {
-                      "kind": "support_dataset",
-                      "slug": parts[1],
-                      "root": f"support_datasets/{parts[1]}",
-                  }
-
-          items = sorted(seen.values(), key=lambda item: (item["kind"], item["slug"]))
-          configs = []
-          for item in items:
-              root = Path(item["root"])
-              sources_root = root / "sources"
-              if sources_root.is_dir():
-                  source_dirs = sorted(path for path in sources_root.iterdir() if path.is_dir())
-                  for source_dir in source_dirs:
-                      config_path = source_dir / "dataset.yml"
-                      configs.append({
-                          **item,
-                          "config_path": config_path.as_posix(),
-                          "config_exists": config_path.exists(),
-                          "push_slug": f"{item['slug']}_{source_dir.name}",
-                          "artifact_name": f"{item['slug']}-{source_dir.name}",
-                      })
-              else:
-                  configs.append({
-                      **item,
-                      "config_path": (root / "dataset.yml").as_posix(),
-                      "config_exists": (root / "dataset.yml").exists(),
-                      "push_slug": item["slug"],
-                      "artifact_name": item["slug"],
-                  })
-
+          d = json.load(open("detect_output.json"))
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
-              out.write(f"has_items={'true' if items else 'false'}\n")
-              out.write(f"has_configs={'true' if configs else 'false'}\n")
+              out.write(f"has_items={str(d['has_items']).lower()}\n")
+              out.write(f"has_configs={str(d['has_configs']).lower()}\n")
               out.write("items<<JSON\n")
-              out.write(json.dumps(items, ensure_ascii=False))
+              out.write(json.dumps(d["items"], ensure_ascii=False))
               out.write("\nJSON\n")
               out.write("configs<<JSON\n")
-              out.write(json.dumps(configs, ensure_ascii=False))
+              out.write(json.dumps(d["configs"], ensure_ascii=False))
               out.write("\nJSON\n")
           PY
 

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -38,7 +38,7 @@ jobs:
             python scripts/detect_candidates.py --files --json > detect_output.json
 
           python - <<'PY'
-          import json
+          import json, os
           d = json.load(open("detect_output.json"))
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
               out.write(f"has_items={str(d['has_items']).lower()}\n")

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -101,7 +101,7 @@ jobs:
           echo "is_nested=$IS_NESTED" >> "$GITHUB_OUTPUT"
 
       - name: Install toolkit
-        run: python -m pip install git+https://github.com/dataciviclab/toolkit.git@main
+        run: python -m pip install git+https://github.com/dataciviclab/toolkit.git@v1.3.0
 
       - name: Toolkit inspect paths
         run: |

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -33,6 +33,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -o pipefail
+
           # Get PR file list and pipe to detect_candidates.py
           gh pr view "$PR_NUMBER" --json files --jq ".files[].path" | \
             python scripts/detect_candidates.py --files --json > detect_output.json

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -125,6 +125,9 @@ jobs:
               warnings = d.get('warning_count', 0)
               print('blocker_count=' + str(blockers))
               print('warning_count=' + str(warnings))
+              if blockers > 0:
+                  print('::error::Candidate has ' + str(blockers) + ' blocker(s) — fix before merging')
+                  exit(1)
           except json.JSONDecodeError:
               print('ERROR: failed to parse blocker-hints JSON')
               exit(1)

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -70,7 +70,7 @@ jobs:
           cache: 'pip'
 
       - name: Install toolkit
-        run: pip install git+https://github.com/dataciviclab/toolkit.git@main
+        run: pip install git+https://github.com/dataciviclab/toolkit.git@v1.3.0
 
       - name: Toolkit inspect paths (pre-flight)
         run: |

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -107,22 +107,19 @@ jobs:
           YEAR: ${{ matrix.config.year }}
           DATACIVICLAB_WORKSPACE: ${{ github.workspace }}
         run: |
-          python - <<'PY'
-          import json, sys, subprocess, os
+          RESULT=$(toolkit blocker-hints --config "$CONFIG_PATH" --year "$YEAR" --json 2>&1)
+          echo "blocker_hints_output=$RESULT" >> "$GITHUB_OUTPUT"
 
-          cfg_path = os.environ["CONFIG_PATH"]
-          year = int(os.environ["YEAR"])
+          # Parse blocker_count from JSON
+          BLOCKERS=$(echo "$RESULT" | python -c "import json,sys; d=json.load(sys.stdin); print(d.get('blocker_count',0))")
+          WARNINGS=$(echo "$RESULT" | python -c "import json,sys; d=json.load(sys.stdin); print(d.get('warning_count',0))")
+          echo "blocker_count=$BLOCKERS" >> "$GITHUB_OUTPUT"
+          echo "warning_count=$WARNINGS" >> "$GITHUB_OUTPUT"
 
-          from toolkit.mcp.toolkit_client import blocker_hints
-          bh = blocker_hints(cfg_path, year)
-          blockers = bh.get("blocker_count", 0)
-          warnings = bh.get("warning_count", 0)
-          print(f"blocker_count={blockers}")
-          print(f"warning_count={warnings}")
-          if blockers > 0:
-              print(f"::error::Candidate has {blockers} blocker(s) — fix before merging")
-              sys.exit(1)
-          PY
+          if [ "$BLOCKERS" -gt 0 ]; then
+            echo "::error::Candidate has $BLOCKERS blocker(s) — fix before merging"
+            exit 1
+          fi
 
       - name: Upload artifacts
         if: always()

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -107,19 +107,28 @@ jobs:
           YEAR: ${{ matrix.config.year }}
           DATACIVICLAB_WORKSPACE: ${{ github.workspace }}
         run: |
-          RESULT=$(toolkit blocker-hints --config "$CONFIG_PATH" --year "$YEAR" --json 2>&1)
-          echo "blocker_hints_output=$RESULT" >> "$GITHUB_OUTPUT"
+          RESULT=$(toolkit blocker-hints --config "$CONFIG_PATH" --year "$YEAR" --json 2>/dev/null)
 
-          # Parse blocker_count from JSON
-          BLOCKERS=$(echo "$RESULT" | python -c "import json,sys; d=json.load(sys.stdin); print(d.get('blocker_count',0))")
-          WARNINGS=$(echo "$RESULT" | python -c "import json,sys; d=json.load(sys.stdin); print(d.get('warning_count',0))")
-          echo "blocker_count=$BLOCKERS" >> "$GITHUB_OUTPUT"
-          echo "warning_count=$WARNINGS" >> "$GITHUB_OUTPUT"
-
-          if [ "$BLOCKERS" -gt 0 ]; then
-            echo "::error::Candidate has $BLOCKERS blocker(s) — fix before merging"
+          if [ -z "$RESULT" ]; then
+            echo "::error::blocker-hints failed or returned empty output"
             exit 1
           fi
+
+          echo "$RESULT" > /tmp/blocker_hints.json
+
+          python - <<'PY'
+          import json
+          try:
+              with open('/tmp/blocker_hints.json') as f:
+                  d = json.load(f)
+              blockers = d.get('blocker_count', 0)
+              warnings = d.get('warning_count', 0)
+              print('blocker_count=' + str(blockers))
+              print('warning_count=' + str(warnings))
+          except json.JSONDecodeError:
+              print('ERROR: failed to parse blocker-hints JSON')
+              exit(1)
+          PY
 
       - name: Upload artifacts
         if: always()

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -107,6 +107,7 @@ jobs:
           YEAR: ${{ matrix.config.year }}
           DATACIVICLAB_WORKSPACE: ${{ github.workspace }}
         run: |
+          set -o pipefail
           RESULT=$(toolkit blocker-hints --config "$CONFIG_PATH" --year "$YEAR" --json 2>/dev/null)
 
           if [ -z "$RESULT" ]; then

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -31,7 +31,7 @@ jobs:
             --json > detect_output.json
 
           python - <<'PY'
-          import json
+          import json, os
           d = json.load(open("detect_output.json"))
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
               out.write(f"has_items={str(d['has_items']).lower()}\n")

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -13,8 +13,8 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
-      has_configs: ${{ steps.changed.outputs.has_configs }}
-      configs: ${{ steps.changed.outputs.configs }}
+      has_configs: ${{ steps.detect.outputs.has_configs }}
+      configs: ${{ steps.detect.outputs.configs }}
     steps:
       - name: Checkout PR commit
         uses: actions/checkout@v4
@@ -23,72 +23,24 @@ jobs:
           fetch-depth: 0
 
       - name: Detect changed candidate/support roots
-        id: changed
+        id: detect
         run: |
+          python scripts/detect_candidates.py \
+            --base-sha "${{ github.event.pull_request.base.sha }}" \
+            --head-sha "${{ github.event.pull_request.head.sha }}" \
+            --json > detect_output.json
+
           python - <<'PY'
-          import json, os
-          from pathlib import Path
-
-          base = "${{ github.event.pull_request.base.sha }}"
-          head = "${{ github.event.pull_request.head.sha }}"
-          import subprocess
-          files = subprocess.check_output(
-              ["git", "diff", "--name-only", base, head],
-              text=True
-          ).splitlines()
-
-          seen = {}
-          for f in files:
-              p = Path(f)
-              parts = p.parts
-              if len(parts) < 2:
-                  continue
-              if parts[0] == "candidates":
-                  seen[parts[1]] = ("candidates", parts[1])
-              elif parts[0] == "support_datasets":
-                  seen[parts[1]] = ("support_datasets", parts[1])
-
-          def _resolve_year(cfg):
-              import yaml
-              with open(cfg) as f:
-                  d = yaml.safe_load(f)
-              years = d.get("dataset", {}).get("years", [])
-              return years[-1] if years else 0
-
-          configs = []
-          for kind, slug in sorted(seen.values()):
-              root = Path(kind) / slug
-              sources = root / "sources"
-              if sources.is_dir():
-                  for src in sorted(sources.iterdir()):
-                      cfg = src / "dataset.yml"
-                      if cfg.exists():
-                          year = _resolve_year(cfg)
-                          configs.append({
-                              "kind": kind,
-                              "slug": slug,
-                              "source": src.name,
-                              "config_path": str(cfg),
-                              "year": year,
-                              "artifact_name": f"{slug}-{src.name}",
-                          })
-              else:
-                  cfg = root / "dataset.yml"
-                  if cfg.exists():
-                      year = _resolve_year(cfg)
-                      configs.append({
-                          "kind": kind,
-                          "slug": slug,
-                          "source": None,
-                          "config_path": str(cfg),
-                          "year": year,
-                          "artifact_name": slug,
-                      })
-
-          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
-              out.write(f"has_configs={'true' if configs else 'false'}\n")
+          import json
+          d = json.load(open("detect_output.json"))
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"has_items={str(d['has_items']).lower()}\n")
+              out.write(f"has_configs={str(d['has_configs']).lower()}\n")
+              out.write("items<<JSON\n")
+              out.write(json.dumps(d["items"], ensure_ascii=False))
+              out.write("\nJSON\n")
               out.write("configs<<JSON\n")
-              out.write(json.dumps(configs, ensure_ascii=False))
+              out.write(json.dumps(d["configs"], ensure_ascii=False))
               out.write("\nJSON\n")
           PY
 

--- a/.github/workflows/sample-candidate-run.yml
+++ b/.github/workflows/sample-candidate-run.yml
@@ -109,7 +109,7 @@ jobs:
       # ------------------------------------------------------------------
       - name: Install toolkit
         run: |
-          pip install git+https://github.com/dataciviclab/toolkit.git@main
+          pip install git+https://github.com/dataciviclab/toolkit.git@v1.3.0
 
       # ------------------------------------------------------------------
       # Step 3 — Inspect paths + pre-flight check

--- a/scripts/detect_candidates.py
+++ b/scripts/detect_candidates.py
@@ -70,6 +70,10 @@ def _git_diff_files(base_sha: str | None, head_sha: str) -> list[str]:
             ["git", "diff", "--name-only", "HEAD"],
             capture_output=True, text=True, cwd=ROOT,
         )
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, result.args, result.stdout, result.stderr
+        )
     return [f.strip() for f in result.stdout.splitlines() if f.strip()]
 
 

--- a/scripts/detect_candidates.py
+++ b/scripts/detect_candidates.py
@@ -75,7 +75,6 @@ def _git_diff_files(base_sha: str | None, head_sha: str) -> list[str]:
 
 def _read_stdin_files() -> list[str]:
     """Read newline-separated file paths from stdin."""
-    import sys
     return [line.strip() for line in sys.stdin if line.strip()]
 
 

--- a/scripts/detect_candidates.py
+++ b/scripts/detect_candidates.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Detect changed candidate/support_dataset configs from a git diff.
+
+Replaces the inline Python logic previously duplicated in:
+  - .github/workflows/pr-toolkit-check.yml (detect step)
+  - .github/workflows/post-merge-candidate.yml (detect step)
+
+Usage:
+    # From CI (PR diff):
+    python scripts/detect_candidates.py --base-sha $BASE_SHA --head-sha $HEAD_SHA
+
+    # From local (all candidates):
+    python scripts/detect_candidates.py
+
+    # From local (specific slug):
+    python scripts/detect_candidates.py --slug ispra-ru-costi-kg
+
+Output JSON:
+    {
+      "has_items": true,
+      "has_configs": true,
+      "items": [{"kind": "candidate", "slug": "...", "root": "candidates/..."}],
+      "configs": [
+        {
+          "kind": "candidate",
+          "slug": "...",
+          "config_path": "candidates/.../dataset.yml",
+          "config_exists": true,
+          "artifact_name": "...",
+          "is_nested": false,
+          "push_slug": "..."
+        }
+      ]
+    }
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _resolve_year(cfg_path: Path) -> int:
+    """Resolve the sample year from a dataset.yml — last year in list."""
+    import yaml
+    try:
+        with open(cfg_path, encoding="utf-8") as f:
+            d = yaml.safe_load(f) or {}
+        years = d.get("dataset", {}).get("years", [])
+        return int(years[-1]) if years else 0
+    except Exception:
+        return 0
+
+
+def _git_diff_files(base_sha: str | None, head_sha: str) -> list[str]:
+    """Return list of file paths changed between base and head."""
+    if base_sha:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", base_sha, head_sha],
+            capture_output=True, text=True, cwd=ROOT,
+        )
+    else:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "HEAD"],
+            capture_output=True, text=True, cwd=ROOT,
+        )
+    return [f.strip() for f in result.stdout.splitlines() if f.strip()]
+
+
+def _read_stdin_files() -> list[str]:
+    """Read newline-separated file paths from stdin."""
+    import sys
+    return [line.strip() for line in sys.stdin if line.strip()]
+
+
+def _detect_from_files(files: list[str]) -> tuple[list[dict], list[dict]]:
+    """Detect candidate/support roots and configs from file list."""
+    seen: dict[tuple[str, str], dict] = {}
+    for file_name in files:
+        path = Path(file_name)
+        parts = path.parts
+        if len(parts) < 2:
+            continue
+        if parts[0] == "candidates":
+            seen[("candidates", parts[1])] = {
+                "kind": "candidate",
+                "slug": parts[1],
+                "root": f"candidates/{parts[1]}",
+            }
+        elif parts[0] == "support_datasets":
+            seen[("support_datasets", parts[1])] = {
+                "kind": "support_dataset",
+                "slug": parts[1],
+                "root": f"support_datasets/{parts[1]}",
+            }
+
+    items = sorted(seen.values(), key=lambda item: (item["kind"], item["slug"]))
+    configs: list[dict[str, Any]] = []
+
+    for item in items:
+        root = Path(item["root"])
+        sources_root = root / "sources"
+        if sources_root.is_dir():
+            for source_dir in sorted(sources_root.iterdir()):
+                if not source_dir.is_dir():
+                    continue
+                config_path = source_dir / "dataset.yml"
+                configs.append({
+                    **item,
+                    "config_path": config_path.as_posix(),
+                    "config_exists": config_path.exists(),
+                    "push_slug": f"{item['slug']}_{source_dir.name}",
+                    "artifact_name": f"{item['slug']}-{source_dir.name}",
+                    "year": _resolve_year(config_path) if config_path.exists() else 0,
+                    "is_nested": True,
+                })
+        else:
+            config_path = root / "dataset.yml"
+            configs.append({
+                **item,
+                "config_path": config_path.as_posix(),
+                "config_exists": config_path.exists(),
+                "push_slug": item["slug"],
+                "artifact_name": item["slug"],
+                "year": _resolve_year(config_path) if config_path.exists() else 0,
+                "is_nested": False,
+            })
+
+    return items, configs
+
+
+def detect_candidates(
+    base_sha: str | None = None,
+    head_sha: str | None = None,
+    slug: str | None = None,
+    files: list[str] | None = None,
+) -> dict[str, Any]:
+    """Main detection function. Returns dict with items and configs.
+
+    Supports three modes:
+      - git diff (base_sha + head_sha)
+      - stdin file list (files param, from 'gh pr view --json files')
+      - local slug filter (slug param)
+    """
+    if files is not None:
+        # Called from post-merge with gh pr view files
+        items, configs = _detect_from_files(files)
+    elif slug:
+        # Detect only a specific slug (local use)
+        root_candidates = ROOT / "candidates" / slug
+        root_support = ROOT / "support_datasets" / slug
+        items = []
+        configs = []
+
+        if root_candidates.exists():
+            kind = "candidate"
+            root = f"candidates/{slug}"
+            items.append({"kind": kind, "slug": slug, "root": root})
+            sources_root = root_candidates / "sources"
+            if sources_root.is_dir():
+                for source_dir in sorted(sources_root.iterdir()):
+                    if not source_dir.is_dir():
+                        continue
+                    cfg = source_dir / "dataset.yml"
+                    configs.append({
+                        "kind": kind, "slug": slug, "config_path": cfg.as_posix(),
+                        "config_exists": cfg.exists(),
+                        "push_slug": f"{slug}_{source_dir.name}",
+                        "artifact_name": f"{slug}-{source_dir.name}",
+                        "year": _resolve_year(cfg) if cfg.exists() else 0,
+                        "is_nested": True,
+                    })
+            else:
+                cfg = root_candidates / "dataset.yml"
+                configs.append({
+                    "kind": kind, "slug": slug, "config_path": cfg.as_posix(),
+                    "config_exists": cfg.exists(),
+                    "push_slug": slug, "artifact_name": slug,
+                    "year": _resolve_year(cfg) if cfg.exists() else 0,
+                    "is_nested": False,
+                })
+        elif root_support.exists():
+            kind = "support_dataset"
+            root = f"support_datasets/{slug}"
+            items.append({"kind": kind, "slug": slug, "root": root})
+            cfg = root_support / "dataset.yml"
+            configs.append({
+                "kind": kind, "slug": slug, "config_path": cfg.as_posix(),
+                "config_exists": cfg.exists(),
+                "push_slug": slug, "artifact_name": slug,
+                "year": _resolve_year(cfg) if cfg.exists() else 0,
+                "is_nested": False,
+            })
+    else:
+        # Git diff mode
+        if head_sha is None:
+            head_sha = "HEAD"
+        files = _git_diff_files(base_sha, head_sha)
+        items, configs = _detect_from_files(files)
+
+    return {
+        "has_items": bool(items),
+        "has_configs": bool(configs),
+        "items": items,
+        "configs": configs,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-sha", help="Base commit SHA for git diff")
+    parser.add_argument("--head-sha", help="Head commit SHA for git diff (default: HEAD)")
+    parser.add_argument("--slug", help="Detect only a specific slug (local use)")
+    parser.add_argument("--files", action="store_true", help="Read file list from stdin (gh pr view mode)")
+    parser.add_argument("--json", action="store_true", help="Output JSON (default: text summary)")
+
+    args = parser.parse_args()
+
+    base = args.base_sha or None
+    head = args.head_sha or "HEAD"
+
+    files_input = None
+    if args.files:
+        files_input = _read_stdin_files()
+
+    result = detect_candidates(
+        base_sha=base,
+        head_sha=head,
+        slug=args.slug,
+        files=files_input,
+    )
+
+    if args.json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0
+
+    # Human-readable output
+    print(f"items: {len(result['items'])} | configs: {len(result['configs'])}")
+    for item in result["items"]:
+        print(f"  [{item['kind']}] {item['slug']} @ {item['root']}")
+    for cfg in result["configs"]:
+        nested = " [nested]" if cfg["is_nested"] else ""
+        print(f"  → {cfg['config_path']}{nested} (artifact: {cfg['artifact_name']})")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Questo branch fa tre cose concrete in dataset-incubator:

1. **Sostituisce il modulo interno con CLI pubblica** — `pr-toolkit-check.yml` ora usa `toolkit blocker-hints --json --config X --year Y` invece di `from toolkit.mcp.toolkit_client import blocker_hints`. Più stabile, toolkit può evolvere senza rompere DI.

2. **Pin toolkit a versione** — Tutti i workflow (`pr-toolkit-check.yml`, `post-merge-candidate.yml`, `sample-candidate-run.yml`) ora usano `v1.3.0` invece di `@main`. Elimina il rischio di breaking change silenziose.

3. **Estrae logica detect_candidates in script condiviso** — `scripts/detect_candidates.py` usato da due workflow invece di 90+ righe inline duplicate.

### Correzioni dalla code review

- **Critical**: `import os` mancante nei workflow (causava NameError a runtime)
- **Medium**: step ID mismatch (`steps.changed` → `steps.detect`)
- **Low**: trailing newline mancante, import sys ridondante rimosso

### Test

- `actionlint`: 0 errori ✅
- `pytest`: 17 passed ✅
- YAML syntax: valid ✅