### PR TITLE
feat: two-phase support_prep per workflow post-merge e sample-run

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -106,6 +106,9 @@ jobs:
           echo "has_support=$HAS_SUPPORT" >> "$GITHUB_OUTPUT"
           echo "support_configs=$SUPPORT_JSON" >> "$GITHUB_OUTPUT"
 
+      - name: Install toolkit
+        run: python -m pip install git+https://github.com/dataciviclab/toolkit.git@v1.3.0
+
       - name: Run support datasets first (if has_support)
         if: steps.resolve.outputs.has_support == 'true'
         run: |
@@ -120,9 +123,6 @@ jobs:
             toolkit run all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_run_${SUPPORT//\//_}.log"
             toolkit validate all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_validate_${SUPPORT//\//_}.log"
           done
-
-      - name: Install toolkit
-        run: python -m pip install git+https://github.com/dataciviclab/toolkit.git@v1.3.0
 
       - name: Toolkit inspect paths
         run: |

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -97,10 +97,29 @@ jobs:
           SLUG=$(python -c "import json; d=json.load(open('sample_params.json')); print(d['slug'])")
           FINAL_YEAR=$(python -c "import json; d=json.load(open('sample_params.json')); print(d['sample_year'])")
           IS_NESTED=$(python -c "import json; d=json.load(open('sample_params.json')); print(str(d['is_nested']).lower())")
+          HAS_SUPPORT=$(python -c "import json; d=json.load(open('sample_params.json')); print(str(d.get('has_support', False)).lower())")
+          SUPPORT_JSON=$(python -c "import json; d=json.load(open('sample_params.json')); print(json.dumps(d.get('support', [])))")
 
           echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
           echo "final_year=$FINAL_YEAR" >> "$GITHUB_OUTPUT"
           echo "is_nested=$IS_NESTED" >> "$GITHUB_OUTPUT"
+          echo "has_support=$HAS_SUPPORT" >> "$GITHUB_OUTPUT"
+          echo "support_configs=$SUPPORT_JSON" >> "$GITHUB_OUTPUT"
+
+      - name: Run support datasets first (if has_support)
+        if: steps.resolve.outputs.has_support == 'true'
+        run: |
+          echo "::notice::This candidate has support dependencies. Running support datasets first."
+          echo "support_configs=${{ steps.resolve.outputs.support_configs }}"
+
+          SUPPORT_JSON='${{ steps.resolve.outputs.support_configs }}'
+          for SUPPORT in $(echo "$SUPPORT_JSON" | python -c "import json,sys; support=json.load(sys.stdin); [print(s['config']) for s in support]"); do
+            echo "::notice::Running support dataset: $SUPPORT"
+            SUPPORT_YEAR=$(python scripts/resolve_sample_run.py "$SUPPORT" 2>/dev/null | python -c "import json,sys; d=json.load(sys.stdin); print(d.get('sample_year',''))")
+            echo "::notice::Support year: $SUPPORT_YEAR"
+            toolkit run all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_run_${SUPPORT//\//_}.log"
+            toolkit validate all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_validate_${SUPPORT//\//_}.log"
+          done
 
       - name: Install toolkit
         run: python -m pip install git+https://github.com/dataciviclab/toolkit.git@v1.3.0

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -116,7 +116,7 @@ jobs:
           echo "support_configs=${{ steps.resolve.outputs.support_configs }}"
 
           SUPPORT_JSON='${{ steps.resolve.outputs.support_configs }}'
-          echo "$SUPPORT_JSON" | python -c "import json,sys; support=json.load(sys.stdin); [print(s['config']) for s in support]" | while IFS= read -r SUPPORT; do
+          while IFS= read -r SUPPORT; do
             echo "::notice::Running support dataset: $SUPPORT"
             SUPPORT_YEAR=$(python scripts/resolve_sample_run.py "$SUPPORT" 2>/dev/null | python -c "import json,sys; d=json.load(sys.stdin); print(d.get('sample_year',''))")
             if [ -z "$SUPPORT_YEAR" ]; then
@@ -126,7 +126,7 @@ jobs:
             echo "::notice::Support year: $SUPPORT_YEAR"
             toolkit run all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_run_${SUPPORT//\//_}.log"
             toolkit validate all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_validate_${SUPPORT//\//_}.log"
-          done
+          done < <(echo "$SUPPORT_JSON" | python -c "import json,sys; support=json.load(sys.stdin); [print(s['config']) for s in support]")
 
       - name: Toolkit inspect paths
         run: |

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -116,9 +116,13 @@ jobs:
           echo "support_configs=${{ steps.resolve.outputs.support_configs }}"
 
           SUPPORT_JSON='${{ steps.resolve.outputs.support_configs }}'
-          for SUPPORT in $(echo "$SUPPORT_JSON" | python -c "import json,sys; support=json.load(sys.stdin); [print(s['config']) for s in support]"); do
+          echo "$SUPPORT_JSON" | python -c "import json,sys; support=json.load(sys.stdin); [print(s['config']) for s in support]" | while IFS= read -r SUPPORT; do
             echo "::notice::Running support dataset: $SUPPORT"
             SUPPORT_YEAR=$(python scripts/resolve_sample_run.py "$SUPPORT" 2>/dev/null | python -c "import json,sys; d=json.load(sys.stdin); print(d.get('sample_year',''))")
+            if [ -z "$SUPPORT_YEAR" ]; then
+              echo "::error::Failed to resolve support year for $SUPPORT"
+              exit 1
+            fi
             echo "::notice::Support year: $SUPPORT_YEAR"
             toolkit run all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_run_${SUPPORT//\//_}.log"
             toolkit validate all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_validate_${SUPPORT//\//_}.log"

--- a/.github/workflows/sample-candidate-run.yml
+++ b/.github/workflows/sample-candidate-run.yml
@@ -109,6 +109,13 @@ jobs:
           echo "support_configs=$SUPPORT_JSON" >> $GITHUB_OUTPUT
 
       # ------------------------------------------------------------------
+      # Step 2 — Install toolkit
+      # ------------------------------------------------------------------
+      - name: Install toolkit
+        run: |
+          pip install git+https://github.com/dataciviclab/toolkit.git@v1.3.0
+
+      # ------------------------------------------------------------------
       # Step 1b — Run support datasets first (if has_support)
       # ------------------------------------------------------------------
       - name: Run support datasets first (if has_support)
@@ -125,13 +132,6 @@ jobs:
             toolkit run all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_run_${SUPPORT//\//_}.log"
             toolkit validate all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_validate_${SUPPORT//\//_}.log"
           done
-
-      # ------------------------------------------------------------------
-      # Step 2 — Install toolkit
-      # ------------------------------------------------------------------
-      - name: Install toolkit
-        run: |
-          pip install git+https://github.com/dataciviclab/toolkit.git@v1.3.0
 
       # ------------------------------------------------------------------
       # Step 3 — Inspect paths + pre-flight check

--- a/.github/workflows/sample-candidate-run.yml
+++ b/.github/workflows/sample-candidate-run.yml
@@ -91,6 +91,8 @@ jobs:
           RESOLVED_YEAR=$(echo "$RESULT" | python -c "import sys,json; d=json.load(sys.stdin); print(d['sample_year'])")
           ALL_YEARS=$(echo "$RESULT" | python -c "import sys,json; d=json.load(sys.stdin); print(','.join(str(y) for y in d['all_years']))")
           IS_NESTED=$(echo "$RESULT" | python -c "import sys,json; d=json.load(sys.stdin); print(str(d['is_nested']).lower())")
+          HAS_SUPPORT=$(echo "$RESULT" | python -c "import sys,json; d=json.load(sys.stdin); print(str(d.get('has_support', False)).lower())")
+          SUPPORT_JSON=$(echo "$RESULT" | python -c "import sys,json; d=json.load(sys.stdin); print(json.dumps(d.get('support', [])))")
 
           # Override with user input if provided, otherwise use resolved
           FINAL_YEAR="$INPUT_SAMPLE_YEAR"
@@ -103,6 +105,26 @@ jobs:
           echo "final_year=$FINAL_YEAR" >> $GITHUB_OUTPUT
           echo "all_years=$ALL_YEARS" >> $GITHUB_OUTPUT
           echo "is_nested=$IS_NESTED" >> $GITHUB_OUTPUT
+          echo "has_support=$HAS_SUPPORT" >> $GITHUB_OUTPUT
+          echo "support_configs=$SUPPORT_JSON" >> $GITHUB_OUTPUT
+
+      # ------------------------------------------------------------------
+      # Step 1b — Run support datasets first (if has_support)
+      # ------------------------------------------------------------------
+      - name: Run support datasets first (if has_support)
+        if: steps.resolve.outputs.has_support == 'true'
+        run: |
+          echo "::notice::This candidate has support dependencies. Running support datasets first."
+          echo "support_configs=${{ steps.resolve.outputs.support_configs }}"
+
+          SUPPORT_JSON='${{ steps.resolve.outputs.support_configs }}'
+          for SUPPORT in $(echo "$SUPPORT_JSON" | python -c "import json,sys; support=json.load(sys.stdin); [print(s['config']) for s in support]"); do
+            echo "::notice::Running support dataset: $SUPPORT"
+            SUPPORT_YEAR=$(python scripts/resolve_sample_run.py "$SUPPORT" 2>/dev/null | python -c "import json,sys; d=json.load(sys.stdin); print(d.get('sample_year',''))")
+            echo "::notice::Support year: $SUPPORT_YEAR"
+            toolkit run all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_run_${SUPPORT//\//_}.log"
+            toolkit validate all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_validate_${SUPPORT//\//_}.log"
+          done
 
       # ------------------------------------------------------------------
       # Step 2 — Install toolkit

--- a/.github/workflows/sample-candidate-run.yml
+++ b/.github/workflows/sample-candidate-run.yml
@@ -125,7 +125,7 @@ jobs:
           echo "support_configs=${{ steps.resolve.outputs.support_configs }}"
 
           SUPPORT_JSON='${{ steps.resolve.outputs.support_configs }}'
-          echo "$SUPPORT_JSON" | python -c "import json,sys; support=json.load(sys.stdin); [print(s['config']) for s in support]" | while IFS= read -r SUPPORT; do
+          while IFS= read -r SUPPORT; do
             echo "::notice::Running support dataset: $SUPPORT"
             SUPPORT_YEAR=$(python scripts/resolve_sample_run.py "$SUPPORT" 2>/dev/null | python -c "import json,sys; d=json.load(sys.stdin); print(d.get('sample_year',''))")
             if [ -z "$SUPPORT_YEAR" ]; then
@@ -135,7 +135,7 @@ jobs:
             echo "::notice::Support year: $SUPPORT_YEAR"
             toolkit run all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_run_${SUPPORT//\//_}.log"
             toolkit validate all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_validate_${SUPPORT//\//_}.log"
-          done
+          done < <(echo "$SUPPORT_JSON" | python -c "import json,sys; support=json.load(sys.stdin); [print(s['config']) for s in support]")
 
       # ------------------------------------------------------------------
       # Step 3 — Inspect paths + pre-flight check

--- a/.github/workflows/sample-candidate-run.yml
+++ b/.github/workflows/sample-candidate-run.yml
@@ -125,9 +125,13 @@ jobs:
           echo "support_configs=${{ steps.resolve.outputs.support_configs }}"
 
           SUPPORT_JSON='${{ steps.resolve.outputs.support_configs }}'
-          for SUPPORT in $(echo "$SUPPORT_JSON" | python -c "import json,sys; support=json.load(sys.stdin); [print(s['config']) for s in support]"); do
+          echo "$SUPPORT_JSON" | python -c "import json,sys; support=json.load(sys.stdin); [print(s['config']) for s in support]" | while IFS= read -r SUPPORT; do
             echo "::notice::Running support dataset: $SUPPORT"
             SUPPORT_YEAR=$(python scripts/resolve_sample_run.py "$SUPPORT" 2>/dev/null | python -c "import json,sys; d=json.load(sys.stdin); print(d.get('sample_year',''))")
+            if [ -z "$SUPPORT_YEAR" ]; then
+              echo "::error::Failed to resolve support year for $SUPPORT"
+              exit 1
+            fi
             echo "::notice::Support year: $SUPPORT_YEAR"
             toolkit run all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_run_${SUPPORT//\//_}.log"
             toolkit validate all --config "$SUPPORT" --years "$SUPPORT_YEAR" 2>&1 | tee "support_validate_${SUPPORT//\//_}.log"

--- a/scripts/resolve_sample_run.py
+++ b/scripts/resolve_sample_run.py
@@ -1,6 +1,6 @@
 """Resolve sample run parameters from a dataset.yml.
 
-Responsabilità (per issue #154):
+Responsabilita (per issue #154):
   - leggere dataset.yml
   - determinare sample_year (ultimo anno in dataset.years)
   - validare gli input minimi
@@ -63,7 +63,7 @@ def resolve(config_path: str) -> dict:
     years = dataset.get("years", [])
     if not years:
         return {
-            "error": f"No 'dataset.years' in {config_path} — cannot determine sample year",
+            "error": f"No 'dataset.years' in {config_path} -- cannot determine sample year",
             "config_path": str(path),
             "slug": None,
         }
@@ -79,8 +79,8 @@ def resolve(config_path: str) -> dict:
     # Compute slug from config path, NOT from YAML dataset.name
     # This avoids mismatch with pipeline_signals which uses directory names
     parts = path.parts
-<<<<<<< HEAD
-=======
+
+    # Nested config detection
     is_nested = "sources" in parts or "compose" in parts
 
     # Collect support[] entries from dataset config.
@@ -91,40 +91,9 @@ def resolve(config_path: str) -> dict:
     #     - name: b
     #       config: ../b_kg_per_abitante/dataset.yml
     #       years: [2020, 2021, 2022, 2023, 2024]
+    # Note: support[] can be at root level OR inside dataset (both patterns in use)
     support_entries = []
-    for entry in dataset.get("support", []) or []:
-        cfg_path = entry.get("config", "")
-        # config is a relative path from the dataset.yml to the support dataset.yml
-        if cfg_path:
-            # Resolve relative to the current config's directory
-            support_cfg_path = str((path.parent / cfg_path).resolve())
-            # Compute relative to ROOT for canonical output
-            try:
-                support_rel = Path(support_cfg_path).relative_to(ROOT)
-            except ValueError:
-                support_rel = Path(support_cfg_path)
-            support_entries.append({
-                "name": entry.get("name", ""),
-                "config": str(support_rel),
-                "years": entry.get("years", []),
-            })
-
-    has_support = len(support_entries) > 0
-
-    # Compute slug from config path relative to ROOT
->>>>>>> 15768df (enhance(resolve-sample-run): aggiunge support[] detection per workflow two-phase)
-    is_nested = "sources" in parts or "compose" in parts
-
-    # Collect support[] entries from dataset config.
-    # These reference OTHER datasets (support_datasets/ or other candidates/)
-    # that must be prepared before this config can run.
-    # Example from ispra-ru-costi-kg:
-    #   support:
-    #     - name: b
-    #       config: ../b_kg_per_abitante/dataset.yml
-    #       years: [2020, 2021, 2022, 2023, 2024]
-    support_entries = []
-    for entry in dataset.get("support", []) or []:
+    for entry in cfg.get("support", []) or []:
         cfg_path = entry.get("config", "")
         # config is a relative path from the dataset.yml to the support dataset.yml
         if cfg_path:
@@ -171,7 +140,7 @@ def resolve(config_path: str) -> dict:
         "has_support": has_support,
         "support": support_entries,
         "note": (
-            "nested config — run via source layer"
+            "nested config -- run via source layer"
             if is_nested
             else ""
         ),

--- a/scripts/resolve_sample_run.py
+++ b/scripts/resolve_sample_run.py
@@ -84,22 +84,13 @@ def resolve(config_path: str) -> dict:
     is_nested = "sources" in parts or "compose" in parts
 
     # Collect support[] entries from dataset config.
-    # These reference OTHER datasets (support_datasets/ or other candidates/)
-    # that must be prepared before this config can run.
-    # Example from ispra-ru-costi-kg:
-    #   support:
-    #     - name: b
-    #       config: ../b_kg_per_abitante/dataset.yml
-    #       years: [2020, 2021, 2022, 2023, 2024]
-    # Note: support[] can be at root level OR inside dataset (both patterns in use)
+    # Currently only root-level support[] is in use (es. mim-alunni-corso-eta).
+    # The support structure is at root level: {name, config, years}
     support_entries = []
     for entry in cfg.get("support", []) or []:
         cfg_path = entry.get("config", "")
-        # config is a relative path from the dataset.yml to the support dataset.yml
         if cfg_path:
-            # Resolve relative to the current config's directory
             support_cfg_path = str((path.parent / cfg_path).resolve())
-            # Compute relative to ROOT for canonical output
             try:
                 support_rel = Path(support_cfg_path).relative_to(ROOT)
             except ValueError:

--- a/scripts/resolve_sample_run.py
+++ b/scripts/resolve_sample_run.py
@@ -79,6 +79,71 @@ def resolve(config_path: str) -> dict:
     # Compute slug from config path, NOT from YAML dataset.name
     # This avoids mismatch with pipeline_signals which uses directory names
     parts = path.parts
+<<<<<<< HEAD
+=======
+    is_nested = "sources" in parts or "compose" in parts
+
+    # Collect support[] entries from dataset config.
+    # These reference OTHER datasets (support_datasets/ or other candidates/)
+    # that must be prepared before this config can run.
+    # Example from ispra-ru-costi-kg:
+    #   support:
+    #     - name: b
+    #       config: ../b_kg_per_abitante/dataset.yml
+    #       years: [2020, 2021, 2022, 2023, 2024]
+    support_entries = []
+    for entry in dataset.get("support", []) or []:
+        cfg_path = entry.get("config", "")
+        # config is a relative path from the dataset.yml to the support dataset.yml
+        if cfg_path:
+            # Resolve relative to the current config's directory
+            support_cfg_path = str((path.parent / cfg_path).resolve())
+            # Compute relative to ROOT for canonical output
+            try:
+                support_rel = Path(support_cfg_path).relative_to(ROOT)
+            except ValueError:
+                support_rel = Path(support_cfg_path)
+            support_entries.append({
+                "name": entry.get("name", ""),
+                "config": str(support_rel),
+                "years": entry.get("years", []),
+            })
+
+    has_support = len(support_entries) > 0
+
+    # Compute slug from config path relative to ROOT
+>>>>>>> 15768df (enhance(resolve-sample-run): aggiunge support[] detection per workflow two-phase)
+    is_nested = "sources" in parts or "compose" in parts
+
+    # Collect support[] entries from dataset config.
+    # These reference OTHER datasets (support_datasets/ or other candidates/)
+    # that must be prepared before this config can run.
+    # Example from ispra-ru-costi-kg:
+    #   support:
+    #     - name: b
+    #       config: ../b_kg_per_abitante/dataset.yml
+    #       years: [2020, 2021, 2022, 2023, 2024]
+    support_entries = []
+    for entry in dataset.get("support", []) or []:
+        cfg_path = entry.get("config", "")
+        # config is a relative path from the dataset.yml to the support dataset.yml
+        if cfg_path:
+            # Resolve relative to the current config's directory
+            support_cfg_path = str((path.parent / cfg_path).resolve())
+            # Compute relative to ROOT for canonical output
+            try:
+                support_rel = Path(support_cfg_path).relative_to(ROOT)
+            except ValueError:
+                support_rel = Path(support_cfg_path)
+            support_entries.append({
+                "name": entry.get("name", ""),
+                "config": str(support_rel),
+                "years": entry.get("years", []),
+            })
+
+    has_support = len(support_entries) > 0
+
+    # Compute slug from config path relative to ROOT
     try:
         rel = path.relative_to(ROOT)
     except ValueError:
@@ -97,15 +162,14 @@ def resolve(config_path: str) -> dict:
     if slug is None:
         slug = path.parts[-2] if len(path.parts) >= 2 else None
 
-    # Nested config detection
-    is_nested = "sources" in parts or "compose" in parts
-
     return {
         "config_path": str(rel),
         "slug": slug,
         "sample_year": sample_year,
         "all_years": years_int,
         "is_nested": is_nested,
+        "has_support": has_support,
+        "support": support_entries,
         "note": (
             "nested config — run via source layer"
             if is_nested

--- a/scripts/resolve_sample_run.py
+++ b/scripts/resolve_sample_run.py
@@ -84,10 +84,14 @@ def resolve(config_path: str) -> dict:
     is_nested = "sources" in parts or "compose" in parts
 
     # Collect support[] entries from dataset config.
-    # Currently only root-level support[] is in use (es. mim-alunni-corso-eta).
-    # The support structure is at root level: {name, config, years}
+    # Two patterns in use:
+    #   - root level: support: [{name, config, years}]  (es. mim-alunni-corso-eta)
+    #   - inside dataset: dataset.support: [{name, config, years}]  (es. ispra-ru-costi-kg, malasanita, opencivitas)
+    # Try root level first, then dataset.support
     support_entries = []
-    for entry in cfg.get("support", []) or []:
+    raw_support = cfg.get("support", []) or []
+    dataset_support = cfg.get("dataset", {}).get("support", []) or []
+    for entry in raw_support + dataset_support:
         cfg_path = entry.get("config", "")
         if cfg_path:
             support_cfg_path = str((path.parent / cfg_path).resolve())


### PR DESCRIPTION
## Summary

Il flusso two-phase per candidates con `support[]` ora funziona. Quando un candidato ha dipendenze (es. `mim-alunni-corso-eta`), il workflow esegue prima i support dataset prima del candidate principale.

## Changes (3 commit)

### `scripts/resolve_sample_run.py`
- Estrae `support[]` dal root level del dataset.yml (non piu dentro `dataset`)
- Restituisce `has_support: bool` + `support[]` array con `{name, config, years}`

### `.github/workflows/post-merge-candidate.yml`
- Step **Run support datasets first** quando `has_support: true`
- Per ogni support in `support_configs`: run + validate prima del candidate
- Poi prosegue normalmente con `toolkit run all`

### `.github/workflows/sample-candidate-run.yml`
- Stessa logica two-phase: run support prima del candidate
- Step 1b: Run support datasets first (if has_support)

## Flusso

```
resolve_sample_run.py -> has_support=true + support_configs=[...]
  -> Run support dataset (toolkit run all --config <support>)
  -> Validate support dataset
  -> Run candidate principale (toolkit run all --config <candidate>)
```

## Candidates gestiti

- `mim-alunni-corso-eta` — support: `support_datasets/mim-anagrafica-scuole-statali`
- Qualsiasi candidate futuro con `support[]` al root level del dataset.yml

## Tests

```bash
python scripts/resolve_sample_run.py candidates/mim-alunni-corso-eta/dataset.yml
# -> has_support: true, support: [{name, config, years}]

python scripts/resolve_sample_run.py candidates/terna-capacita-rinnovabile/dataset.yml
# -> has_support: false, support: []
```

## Related

- Fix: `support[]` era cercato in `dataset.support` (main) invece che al root level
- Per il two-phase era gia documentato in `post-merge-candidate.yml` commenti come Option B