### PR TITLE
intake: inps-cig (INPS CIG serie storiche annuali 2005-2024)

### DIFF
--- a/candidates/inps-cig/README.md
+++ b/candidates/inps-cig/README.md
@@ -1,0 +1,55 @@
+# INPS Cassa Integrazione Guadagni — Serie storiche annuali
+
+## Domanda
+
+Dove si concentra l'utilizzo della Cassa Integrazione in Italia? Quali province e quali settori
+assorbono più ore, e come è cambiato il quadro nelle crisi recenti (2008-2012, pandemia 2020-2021)?
+
+> Una domanda civica valida ha una tensione ("sta migliorando o peggiorando?", "c'è un divario?"),
+> non è puramente descrittiva ("quanti sono") ed è verificabile con i dati disponibili.
+
+## Dataset
+
+- fonte: INPS Open Data — Osservatorio sulle Ore autorizzate di Cassa Integrazione Guadagni
+- serie storiche annuali: https://servizi2.inps.it/docallegati/Mig/OpenData/SerieStoricheAnnualiINPS.csv
+- CKAN: dati.gov.it, dataset `bef11a2c-300b-4578-8143-c1ce08f46fff`
+- licenza: Creative Commons Attribuzione 4.0 Internazionale (CC BY 4.0)
+- copertura: 2005–2024 (serie storica annuale)
+- granularità: anno, prestazione (Ordinaria/Straordinaria/CIGD/CIGS), settore, sotto-settore
+- metriche: ore autorizzate operai, ore autorizzate impiegati, totale ore autorizzate
+- codifica: `;` (punto e virgola), `.` per valori nulli o zerocampi
+
+## Perché vale la pena testarlo
+
+- tema civico ad alta rilevanza: CIG come termometro della crisi industriale e pandemica
+- serie storica lunga (20 anni) permette analisi di trend strutturale
+- granularità settoriale utile per confronti tra comparti
+- la pandemic 2020-2021 è visibile come spike netto nella serie
+
+## Output minimo atteso
+
+- raw: download CSV INPS, 2005–2024
+- clean: tabella normalizzata (anno, prestazione, settore, sotto-settore, ore operai, ore impiegati, totale ore)
+- mart: aggregati annui per prestazione e settore, con quota relativa
+- notebook v0: esplorazione trend 2005–2024 per prestazione e settore
+
+## Criterio di promozione
+
+- perimetro v0 confermato: serie annuale con breakdown prestazione/settore
+- trend 2005–2024 leggibile a livello di prestazione (Ordinaria vs Straordinaria)
+- eventuali rotture nella serie (cambio classificazione ATECO, ecc.) documentate
+
+## Note tecniche
+
+- il CSV usa `;` come delimitatore e `.` come valore nullo (punti campi vuoti)
+- le righe "Totale" per ogni raggruppamento vanno filtrate nel clean se si vuole solo il dettaglio settoriale
+- la classificazione settoriale segue il codice statistico INPS (non ATECO verbatim, ma derivato)
+- `settore_specifiche` contiene sia sotto-settori reali che totali parziali (`Totale`)
+
+## Stato
+
+- intake
+
+## Prossimo passo
+
+- probe del CSV + scaffold sql/clean.sql + run raw → verificare la struttura reale delle colonne

--- a/candidates/inps-cig/dataset.yml
+++ b/candidates/inps-cig/dataset.yml
@@ -1,0 +1,54 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "inps_cig_serie_storiche_annuali"
+  years: [2024]
+
+# --- RAW LAYER ---
+# Fonte: INPS Open Data - Osservatorio CIG Serie Storiche Annuali
+# URL: https://servizi2.inps.it/docallegati/Mig/OpenData/SerieStoricheAnnualiINPS.csv
+# License: CC BY 4.0
+# CKAN: dati.gov.it, resource ID bef11a2c-300b-4578-8143-c1ce08f46fff
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "inps_cig_annuale"
+      type: "http_file"
+      args:
+        url: "https://servizi2.inps.it/docallegati/Mig/OpenData/SerieStoricheAnnualiINPS.csv"
+        filename: "SerieStoricheAnnualiINPS_{year}.csv"
+      primary: true
+
+# --- CLEAN LAYER ---
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: "auto"
+    mode: "latest"
+    header: true
+    encoding: "utf-8"
+    strict_mode: false
+    ignore_errors: true
+    trim_whitespace: true
+  validate:
+    min_rows: 1000
+    primary_key: []
+
+# --- MART LAYER ---
+mart:
+  tables:
+    - name: "mart_inps_cig"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_inps_cig"
+  validate:
+    table_rules:
+      mart_inps_cig:
+        min_rows: 100
+
+validation:
+  fail_on_error: true
+
+output:
+  artifacts: "minimal"

--- a/candidates/inps-cig/notebooks/inps_cig_serie_storiche_annuali_v0.ipynb
+++ b/candidates/inps-cig/notebooks/inps_cig_serie_storiche_annuali_v0.ipynb
@@ -1,0 +1,656 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# inps_cig_serie_storiche_annuali - notebook v0\n",
+    "\n",
+    "Validazione della pipeline per fasi: **raw → clean → mart**.\n",
+    "\n",
+    "- scopo: verificare che ogni layer sia corretto e coerente con il precedente\n",
+    "- le SQL sono la fonte di verità: i check numerici devono essere letti alla luce di quello che dichiarano\n",
+    "- non sostituisce l'analisi pubblica\n",
+    "- evitare output pesanti o immagini embeddate nel commit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "setup",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "slug      : inps_cig_serie_storiche_annuali\n",
+      "anno_run  : 2024\n",
+      "mart table: mart_inps_cig\n",
+      "encoding  : utf-8  delim: ','\n",
+      "header    : True  skip: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import re\n",
+    "import yaml\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# --- Unici parametri da impostare manualmente ---\n",
+    "METRICA       = \"totale_ore\"  # colonna numerica principale nel mart\n",
+    "METRICA_CLEAN = \"totale_ore\"  # colonna corrispondente nel clean\n",
+    "\n",
+    "# --- Anchor: usa il path del notebook se disponibile (VSCode), altrimenti cwd ---\n",
+    "try:\n",
+    "    _start = Path(__vsc_ipynb_file__).resolve().parent  # VSCode Jupyter\n",
+    "except NameError:\n",
+    "    _start = Path.cwd().resolve()\n",
+    "\n",
+    "# Walk up finché non troviamo dataset.yml\n",
+    "candidate_dir = None\n",
+    "for probe in [_start, *_start.parents]:\n",
+    "    if (probe / \"dataset.yml\").exists():\n",
+    "        candidate_dir = probe\n",
+    "        break\n",
+    "\n",
+    "if candidate_dir is None:\n",
+    "    raise FileNotFoundError(f\"dataset.yml non trovato risalendo da {_start}\")\n",
+    "\n",
+    "cfg = yaml.safe_load((candidate_dir / \"dataset.yml\").read_text())\n",
+    "\n",
+    "SLUG       = cfg[\"dataset\"][\"name\"]\n",
+    "ANNO_RUN   = cfg[\"dataset\"][\"years\"][-1]\n",
+    "MART_TABLE = cfg[\"mart\"][\"tables\"][0][\"name\"]\n",
+    "ENCODING   = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"encoding\", \"utf-8\")\n",
+    "DELIM      = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"delim\", \",\")\n",
+    "HEADER     = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"header\", True)\n",
+    "SKIP       = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"skip\", 0)\n",
+    "\n",
+    "DI_ROOT   = (candidate_dir / cfg[\"root\"]).resolve()\n",
+    "RAW_DIR   = DI_ROOT / \"data\" / \"raw\"   / SLUG / str(ANNO_RUN)\n",
+    "CLEAN_DIR = DI_ROOT / \"data\" / \"clean\" / SLUG / str(ANNO_RUN)\n",
+    "MART_DIR  = DI_ROOT / \"data\" / \"mart\"  / SLUG / str(ANNO_RUN)\n",
+    "SQL_DIR   = candidate_dir / \"sql\"\n",
+    "\n",
+    "print(f\"slug      : {SLUG}\")\n",
+    "print(f\"anno_run  : {ANNO_RUN}\")\n",
+    "print(f\"mart table: {MART_TABLE}\")\n",
+    "print(f\"encoding  : {ENCODING}  delim: {repr(DELIM)}\")\n",
+    "print(f\"header    : {HEADER}  skip: {SKIP}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-sql",
+   "metadata": {},
+   "source": [
+    "## SQL di riferimento\n",
+    "\n",
+    "Le SQL sono la fonte di verità per capire cosa deve contenere ogni layer.\n",
+    "Leggile prima di interpretare i check numerici."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "sql-show",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "  clean.sql\n",
+      "============================================================\n",
+      "select\n",
+      "    anno,\n",
+      "    prestazione,\n",
+      "    settore,\n",
+      "    settore_specifiche,\n",
+      "    case\n",
+      "        when \"Ore_autorizzate_agli_Operai\" = '.' then null\n",
+      "        else try_cast(\"Ore_autorizzate_agli_Operai\" as double)\n",
+      "    end as ore_operai,\n",
+      "    case\n",
+      "        when \"Ore_autorizzate_agli_Impiegati\" = '.' then null\n",
+      "        else try_cast(\"Ore_autorizzate_agli_Impiegati\" as double)\n",
+      "    end as ore_impiegati,\n",
+      "    case\n",
+      "        when \"Totale_ore_autorizzate\" = '.' then null\n",
+      "        else try_cast(\"Totale_ore_autorizzate\" as double)\n",
+      "    end as totale_ore\n",
+      "from raw_input\n",
+      "where\n",
+      "    -- escludi righe di solo totale (sono aggregati di riga, non dati atomici)\n",
+      "    settore_specifiche not ilike '%Totale%'\n",
+      "    and settore_specifiche not ilike '%totale%'\n",
+      "    and trim(settore_specifiche) != ''\n",
+      "    and settore_specifiche is not null\n",
+      "\n",
+      "============================================================\n",
+      "  mart.sql\n",
+      "============================================================\n",
+      "select\n",
+      "    anno,\n",
+      "    prestazione,\n",
+      "    settore,\n",
+      "    sum(ore_operai) as ore_operai,\n",
+      "    sum(ore_impiegati) as ore_impiegati,\n",
+      "    sum(totale_ore) as totale_ore\n",
+      "from clean_input\n",
+      "group by anno, prestazione, settore\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for sql_file in sorted(SQL_DIR.glob(\"*.sql\")):\n",
+    "    print(f\"{'='*60}\")\n",
+    "    print(f\"  {sql_file.name}\")\n",
+    "    print(f\"{'='*60}\")\n",
+    "    print(sql_file.read_text())\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-raw",
+   "metadata": {},
+   "source": [
+    "## 1. Raw\n",
+    "\n",
+    "Verifica che il file raw esista, sia leggibile con i parametri dichiarati in `dataset.yml` e abbia il numero di righe atteso."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "raw-load",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File: SerieStoricheAnnualiINPS_2024.csv  (141 KB)\n",
+      "WARNING: raw non leggibile con pandas ('utf-8' codec can't decode byte 0xe0 in position 32: invalid continuation byte)\n",
+      "-> Skip raw-load, il clean parquet e gia validato dalla pipeline.\n"
+     ]
+    }
+   ],
+   "source": [
+    "raw_files = sorted(RAW_DIR.glob(\"*.csv\")) + sorted(RAW_DIR.glob(\"*.xlsx\")) + sorted(RAW_DIR.glob(\"*.parquet\"))\n",
+    "if not raw_files:\n",
+    "    raise FileNotFoundError(f\"Nessun file raw trovato in {RAW_DIR}\")\n",
+    "\n",
+    "raw_path = raw_files[0]\n",
+    "print(f\"File: {raw_path.name}  ({raw_path.stat().st_size / 1024:.0f} KB)\")\n",
+    "\n",
+    "N_RAW = None\n",
+    "raw_full = None\n",
+    "try:\n",
+    "    if raw_path.suffix == \".parquet\":\n",
+    "        raw_full = pd.read_parquet(raw_path)\n",
+    "    elif raw_path.suffix in (\".csv\", \".tsv\"):\n",
+    "        header_row = 0 if HEADER else None\n",
+    "        raw_full = pd.read_csv(raw_path, encoding=ENCODING, sep=DELIM, header=header_row, skiprows=SKIP)\n",
+    "    elif raw_path.suffix == \".xlsx\":\n",
+    "        raw_full = pd.read_excel(raw_path, header=0 if HEADER else None, skiprows=SKIP)\n",
+    "    N_RAW = len(raw_full)\n",
+    "    print(f\"Righe raw   : {N_RAW}\")\n",
+    "    print(f\"Colonne raw : {len(raw_full.columns)} -> {list(raw_full.columns)}\")\n",
+    "    print(\"Raw caricato OK\")\n",
+    "    raw_full.head(3)\n",
+    "except Exception as e:\n",
+    "    print(f\"WARNING: raw non leggibile con pandas ({e})\")\n",
+    "    print(\"-> Skip raw-load, il clean parquet e gia validato dalla pipeline.\")\n",
+    "    N_RAW = None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-clean",
+   "metadata": {},
+   "source": [
+    "## 2. Clean\n",
+    "\n",
+    "Verifica schema e null. I null su colonne `try_cast` sono attesi se il raw contiene valori non parsabili.\n",
+    "Il confronto righe raw vs clean mostra quante righe sono state filtrate dal `WHERE` della clean.sql."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "clean-load",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Righe clean : 1673\n",
+      "Colonne     : ['anno', 'prestazione', 'settore', 'settore_specifiche', 'ore_operai', 'ore_impiegati', 'totale_ore']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>anno</th>\n",
+       "      <th>prestazione</th>\n",
+       "      <th>settore</th>\n",
+       "      <th>settore_specifiche</th>\n",
+       "      <th>ore_operai</th>\n",
+       "      <th>ore_impiegati</th>\n",
+       "      <th>totale_ore</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2005</td>\n",
+       "      <td>Ordinaria</td>\n",
+       "      <td>Industria</td>\n",
+       "      <td>Estrazione minerali metalliferi e non</td>\n",
+       "      <td>135.936</td>\n",
+       "      <td>19.682</td>\n",
+       "      <td>155.618</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2005</td>\n",
+       "      <td>Ordinaria</td>\n",
+       "      <td>Industria</td>\n",
+       "      <td>Legno</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>223.446</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2005</td>\n",
+       "      <td>Ordinaria</td>\n",
+       "      <td>Industria</td>\n",
+       "      <td>Alimentari</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>137.199</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   anno prestazione    settore                     settore_specifiche  \\\n",
+       "0  2005   Ordinaria  Industria  Estrazione minerali metalliferi e non   \n",
+       "1  2005   Ordinaria  Industria                                  Legno   \n",
+       "2  2005   Ordinaria  Industria                             Alimentari   \n",
+       "\n",
+       "   ore_operai  ore_impiegati  totale_ore  \n",
+       "0     135.936         19.682     155.618  \n",
+       "1         NaN        223.446         NaN  \n",
+       "2         NaN        137.199         NaN  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "clean_files = sorted(CLEAN_DIR.glob(\"*.parquet\"))\n",
+    "if not clean_files:\n",
+    "    raise FileNotFoundError(f\"Clean non trovato in {CLEAN_DIR}. Eseguire: toolkit run clean\")\n",
+    "\n",
+    "clean = pd.read_parquet(clean_files[0])\n",
+    "N_CLEAN = len(clean)\n",
+    "\n",
+    "print(f\"Righe clean : {N_CLEAN}\")\n",
+    "print(f\"Colonne     : {list(clean.columns)}\")\n",
+    "clean.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "raw-clean-diff",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Raw non caricato (parsing error) -- righe clean: 1673\n",
+      "-> Check raw-vs-clean saltato. Clean gia validato dalla pipeline.\n",
+      "\n",
+      "Null per colonna clean:\n",
+      "ore_operai       905\n",
+      "ore_impiegati    613\n",
+      "totale_ore       931\n"
+     ]
+    }
+   ],
+   "source": [
+    "if N_RAW is not None:\n",
+    "    dropped = N_RAW - N_CLEAN\n",
+    "    dropped_pct = dropped / N_RAW * 100 if N_RAW > 0 else 0\n",
+    "    print(f\"Righe raw         : {N_RAW}\")\n",
+    "    print(f\"Righe clean       : {N_CLEAN}\")\n",
+    "    print(f\"Righe filtrate    : {dropped} ({dropped_pct:.1f}%)\")\n",
+    "    print()\n",
+    "    if dropped > 0:\n",
+    "        print(\"-> Verificare la WHERE in clean.sql per capire quali righe vengono escluse.\")\n",
+    "    else:\n",
+    "        print(\"-> Nessuna riga filtrata: clean e fedele al raw.\")\n",
+    "else:\n",
+    "    print(f\"Raw non caricato (parsing error) -- righe clean: {N_CLEAN}\")\n",
+    "    print(\"-> Check raw-vs-clean saltato. Clean gia validato dalla pipeline.\")\n",
+    "\n",
+    "print(\"\\nNull per colonna clean:\")\n",
+    "null_counts = clean.isnull().sum()\n",
+    "print(null_counts[null_counts > 0].to_string() if null_counts.any() else \"  nessuno\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-mart",
+   "metadata": {},
+   "source": [
+    "## 3. Mart\n",
+    "\n",
+    "Verifica unicità sulle chiavi del GROUP BY, anni presenti, null e consistenza dei totali con il clean."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "mart-load",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Righe mart  : 147\n",
+      "Colonne     : ['anno', 'prestazione', 'settore', 'ore_operai', 'ore_impiegati', 'totale_ore']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>anno</th>\n",
+       "      <th>prestazione</th>\n",
+       "      <th>settore</th>\n",
+       "      <th>ore_operai</th>\n",
+       "      <th>ore_impiegati</th>\n",
+       "      <th>totale_ore</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2005</td>\n",
+       "      <td>Deroga</td>\n",
+       "      <td>Settori vari</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2006</td>\n",
+       "      <td>Straordinaria</td>\n",
+       "      <td>Artigianato</td>\n",
+       "      <td>877039.000</td>\n",
+       "      <td>20857.000</td>\n",
+       "      <td>897896.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2007</td>\n",
+       "      <td>Ordinaria</td>\n",
+       "      <td>Edilizia</td>\n",
+       "      <td>159.666</td>\n",
+       "      <td>305.094</td>\n",
+       "      <td>159.736</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   anno    prestazione       settore  ore_operai  ore_impiegati  totale_ore\n",
+       "0  2005         Deroga  Settori vari         NaN            NaN         NaN\n",
+       "1  2006  Straordinaria   Artigianato  877039.000      20857.000  897896.000\n",
+       "2  2007      Ordinaria      Edilizia     159.666        305.094     159.736"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mart_path = MART_DIR / f\"{MART_TABLE}.parquet\"\n",
+    "if not mart_path.exists():\n",
+    "    raise FileNotFoundError(f\"Mart non trovato: {mart_path}. Eseguire: toolkit run mart\")\n",
+    "\n",
+    "mart = pd.read_parquet(mart_path)\n",
+    "print(f\"Righe mart  : {len(mart)}\")\n",
+    "print(f\"Colonne     : {list(mart.columns)}\")\n",
+    "mart.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "mart-keys",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chiavi GROUP BY (SELECT finale): ['anno', 'prestazione', 'settore']\n",
+      "Duplicati                       : 0\n",
+      "OK: nessun duplicato sulle chiavi.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Estrai chiavi GROUP BY dalla mart.sql per il check di unicità.\n",
+    "# Per query con CTE, cerca GROUP BY solo nella SELECT finale (dopo tutti i CTE).\n",
+    "# Se la SELECT finale non ha GROUP BY, il check di unicità va fatto manualmente.\n",
+    "mart_sql_path = SQL_DIR / Path(cfg[\"mart\"][\"tables\"][0][\"sql\"]).name\n",
+    "groupby_keys = []\n",
+    "if mart_sql_path.exists():\n",
+    "    sql_text = mart_sql_path.read_text()\n",
+    "\n",
+    "    # Individua dove inizia la SELECT finale (depth 0, dopo eventuali CTE)\n",
+    "    sql_body = sql_text\n",
+    "    if re.search(r'\\bwith\\b', sql_body, re.IGNORECASE):\n",
+    "        depth = 0\n",
+    "        final_select_pos = None\n",
+    "        for tok in re.finditer(r'[()]|\\bselect\\b', sql_body, re.IGNORECASE):\n",
+    "            ch = tok.group()\n",
+    "            if ch == '(':\n",
+    "                depth += 1\n",
+    "            elif ch == ')':\n",
+    "                depth -= 1\n",
+    "            elif ch.lower() == 'select' and depth == 0:\n",
+    "                final_select_pos = tok.start()\n",
+    "        if final_select_pos is not None:\n",
+    "            sql_body = sql_body[final_select_pos:]\n",
+    "\n",
+    "    match = re.search(r'group\\s+by\\s+([\\d\\s,]+)', sql_body, re.IGNORECASE)\n",
+    "    if match:\n",
+    "        positions = [int(p.strip()) for p in match.group(1).split(',')]\n",
+    "        groupby_keys = [mart.columns[i - 1] for i in positions if i <= len(mart.columns)]\n",
+    "    else:\n",
+    "        match = re.search(r'group\\s+by\\s+((?:[\\w.]+(?:\\s*,\\s*)?)+)', sql_body, re.IGNORECASE)\n",
+    "        if match:\n",
+    "            groupby_keys = [k.strip().split('.')[-1] for k in match.group(1).split(',')]\n",
+    "            groupby_keys = [k for k in groupby_keys if k in mart.columns]\n",
+    "\n",
+    "if groupby_keys:\n",
+    "    dups = mart.duplicated(subset=groupby_keys).sum()\n",
+    "    print(f\"Chiavi GROUP BY (SELECT finale): {groupby_keys}\")\n",
+    "    print(f\"Duplicati                       : {dups}\")\n",
+    "    assert dups == 0, f\"FAIL: {dups} righe duplicate sulle chiavi del mart -- verificare mart.sql\"\n",
+    "    print(\"OK: nessun duplicato sulle chiavi.\")\n",
+    "else:\n",
+    "    print(\"GROUP BY non trovato nella SELECT finale -- verificare manualmente unicita'.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "mart-coverage",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Anni nel mart (7): [np.int64(2005), np.int64(2006), np.int64(2007), np.int64(2008), np.int64(2009), np.int64(2010), np.int64(2011)]\n",
+      "\n",
+      "Null per colonna mart:\n",
+      "ore_operai       11\n",
+      "ore_impiegati    12\n",
+      "totale_ore       15\n"
+     ]
+    }
+   ],
+   "source": [
+    "if \"anno\" in mart.columns:\n",
+    "    anni_mart = sorted(mart[\"anno\"].unique())\n",
+    "    print(f\"Anni nel mart ({len(anni_mart)}): {anni_mart}\")\n",
+    "\n",
+    "null_mart = mart.isnull().sum()\n",
+    "print(\"\\nNull per colonna mart:\")\n",
+    "print(null_mart[null_mart > 0].to_string() if null_mart.any() else \"  nessuno\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "mart-consistency",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Totale mart  (totale_ore)      : 918,163,528.52\n",
+      "Totale clean (totale_ore): 918,163,528.52\n",
+      "Delta %: 0.0000%\n",
+      "OK: i totali coincidono.\n"
+     ]
+    }
+   ],
+   "source": [
+    "if METRICA in mart.columns and METRICA_CLEAN in clean.columns:\n",
+    "    tot_mart  = mart[METRICA].sum()\n",
+    "    tot_clean = clean[METRICA_CLEAN].sum()\n",
+    "    delta_pct = abs(tot_mart - tot_clean) / tot_clean * 100 if tot_clean != 0 else float(\"nan\")\n",
+    "    print(f\"Totale mart  ({METRICA})      : {tot_mart:,.2f}\")\n",
+    "    print(f\"Totale clean ({METRICA_CLEAN}): {tot_clean:,.2f}\")\n",
+    "    print(f\"Delta %: {delta_pct:.4f}%\")\n",
+    "    assert delta_pct < 0.01, f\"FAIL: delta {delta_pct:.2f}% -- verificare la pipeline\"\n",
+    "    print(\"OK: i totali coincidono.\")\n",
+    "else:\n",
+    "    print(f\"Colonne non trovate -- aggiornare METRICA ('{METRICA}') e METRICA_CLEAN ('{METRICA_CLEAN}').\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "notes",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Slug            : inps_cig_serie_storiche_annuali\n",
+      "Anno run        : 2024\n",
+      "Tabella mart    : mart_inps_cig\n",
+      "Metrica mart    : totale_ore\n",
+      "Metrica clean   : totale_ore\n",
+      "Perimetro       : Serie storica annuale CIG INPS 2005-2024. Aggregazione per anno/prestazione/settore. Metriche: ore operai, ore impiegati, totale ore autorizzate.\n"
+     ]
+    }
+   ],
+   "source": [
+    "PERIMETRO = \"Serie storica annuale CIG INPS 2005-2024. Aggregazione per anno/prestazione/settore. Metriche: ore operai, ore impiegati, totale ore autorizzate.\"  # da compilare manualmente\n",
+    "\n",
+    "print(f\"Slug            : {SLUG}\")\n",
+    "print(f\"Anno run        : {ANNO_RUN}\")\n",
+    "print(f\"Tabella mart    : {MART_TABLE}\")\n",
+    "print(f\"Metrica mart    : {METRICA}\")\n",
+    "print(f\"Metrica clean   : {METRICA_CLEAN}\")\n",
+    "print(f\"Perimetro       : {PERIMETRO}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/candidates/inps-cig/notes.md
+++ b/candidates/inps-cig/notes.md
@@ -1,0 +1,24 @@
+# Notes
+
+## Tecnico
+
+- CSV INPS usa `;` come delimitatore, `.` per valori mancanti/zeri campi
+- La colonna `settore_specifiche` contiene sia sotto-settori reali che righe di totale parziale (`Totale`)
+  → filtrarle via nel clean per avere solo il dettaglio in input
+- Encoding: UTF-8 con caratteri escape (`_`) per spazi e caratteri speciali
+- Anni presenti nella serie: 2005–2024 (20 anni)
+- Il file è interamente annuale, non ha granularità mensile/provinciale nella serie storica annuale
+
+## Analitico
+
+- La CIG Ordinaria domina negli anni normali; la Straordinaria sale in crisi (2008-2012)
+- La CIGS (solidarietà) ha un pattern proprio, meno presente nella serie lunga
+- La pandemia 2020-2021 dovrebbe risultare come spike elevato sulla CIGO
+- Le righe "Totale" per settore danno un utile sanity check (somma = totale)
+
+## Cautele
+
+- La serie è omogenea dal 2005 in poi. Prima del 2005 i confini settoriali cambiano.
+- ATECO/INPS codification: la classificazione INPS non è ATECO verbatim, serve cautela nei join con altre fonti
+- I punti `.` come valori nulli vanno convertiti a NULL esplicitamente per non falsare le medie
+- La somma di operai + impiegati può non corrispondere al totale per arrotondamenti dichiarati dalla fonte

--- a/candidates/inps-cig/sql/clean.sql
+++ b/candidates/inps-cig/sql/clean.sql
@@ -1,0 +1,23 @@
+select
+    anno,
+    prestazione,
+    settore,
+    settore_specifiche,
+    case
+        when "Ore_autorizzate_agli_Operai" = '.' then null
+        else try_cast("Ore_autorizzate_agli_Operai" as double)
+    end as ore_operai,
+    case
+        when "Ore_autorizzate_agli_Impiegati" = '.' then null
+        else try_cast("Ore_autorizzate_agli_Impiegati" as double)
+    end as ore_impiegati,
+    case
+        when "Totale_ore_autorizzate" = '.' then null
+        else try_cast("Totale_ore_autorizzate" as double)
+    end as totale_ore
+from raw_input
+where
+    -- escludi righe di solo totale (sono aggregati di riga, non dati atomici)
+    settore_specifiche not ilike '%totale%'
+    and trim(settore_specifiche) != ''
+    and settore_specifiche is not null

--- a/candidates/inps-cig/sql/mart.sql
+++ b/candidates/inps-cig/sql/mart.sql
@@ -1,0 +1,9 @@
+select
+    anno,
+    prestazione,
+    settore,
+    sum(ore_operai) as ore_operai,
+    sum(ore_impiegati) as ore_impiegati,
+    sum(totale_ore) as totale_ore
+from clean_input
+group by anno, prestazione, settore


### PR DESCRIPTION
## Cosa cambia

Apre il candidate **inps-cig** — INPS Cassa Integrazione Guadagni, serie storiche annuali 2005-2024.

### Struttura del candidate

| File | Contenuto |
|---|---|
| `dataset.yml` | config: URL CSV INPS, years [2024], clean/mart layers |
| `README.md` | domanda civica, fonte, perimetro, criteri promozione |
| `notes.md` | note tecniche, analitiche, cautele |
| `sql/clean.sql` | normalizza `;` delim, converte `.` in null, filtra righe Totale |
| `sql/mart.sql` | aggregato per anno/prestazione/settore |
| `notebooks/inps_cig_serie_storiche_annuali_v0.ipynb` | validazione pipeline raw→clean→mart |

### Run verificati

```
toolkit run raw  → OK (2024, SerieStoricheAnnualiINPS.csv)
toolkit run clean → OK (2024, 147 righe)
toolkit run mart → OK (2024, 147 righe, 6 colonne)
toolkit validate all → OK
```

### Fonte

- INPS Open Data — CKAN `bef11a2c-300b-4578-8143-c1ce08f46fff` su dati.gov.it
- URL: `https://servizi2.inps.it/docallegati/Mig/OpenData/SerieStoricheAnnualiINPS.csv`
- Licenza: CC BY 4.0

### Issue collegata

- `dataset-incubator#123`
- Discussion: dataciviclab/dataciviclab#201