### PR TITLE
feat(clean-query): upgrade MCP con preview, count, time_series e altri 4 tool

### DIFF
--- a/scripts/push_archive.py
+++ b/scripts/push_archive.py
@@ -329,17 +329,17 @@ def push_clean(gcs_client, slug_filter=None, year_filter=None, dry_run=False):
                     rows = None
                 else:
                     try:
-                        rows = len(pd.read_parquet(pq))
+                        rows = len(pd.read_parquet(parq))
                     except Exception:
                         rows = None
                 manifest["items"].append(
                     {
                         "slug": slug,
                         "year": int(year),
-                        "file": pq.name,
+                        "file": parq.name,
                         "gcs_path": gcs_path,
                         "gcs_url": f"gs://{GCS_CLEAN_BUCKET}/{gcs_path}",
-                        "updated_at": pd.Timestamp(pq.stat().st_mtime, unit="s").isoformat(),
+                        "updated_at": pd.Timestamp(parq.stat().st_mtime, unit="s").isoformat(),
                         "rows": rows,
                     }
                 )

--- a/skills/run-candidate.md
+++ b/skills/run-candidate.md
@@ -75,7 +75,13 @@ toolkit_show_schema(config_path, layer="clean") → schema parquet prima di scri
 toolkit_raw_profile(config_path)      → encoding/delimiter dopo raw fallito
 toolkit_list_runs(config_path, status="FAILED", limit=5) → pattern di fallimento
 toolkit_run_summary(config_path)      → isolato o ricorrente?
+toolkit_schema_diff(config_path)      → confronto schema raw cross-year (colonne, encoding)
 ```
+
+**Quando usare `schema_diff`**:
+- Dopo fallimento raw parsing — per vedere se encoding o colonne sono cambiate tra anni
+- Prima di lanciare run su tutti gli anni — verifica consistenza schema source
+- Durante review di candidate — segnala drift strutturale tra annualità
 
 ### 6. Chiudi con stato
 

--- a/tools/clean-query-mcp/README.md
+++ b/tools/clean-query-mcp/README.md
@@ -12,12 +12,38 @@ Il file locale `datasets.yml` non è più fonte di verità. Il catalogo MCP deve
 
 ## Tool
 
+### Scoperta e catalogo
+
 | Tool | Scopo |
 |---|---|
-| `list_datasets()` | Lista slug disponibili |
+| `list_datasets()` | Lista slug disponibili con nome, descrizione, periodo |
+| `search_datasets(query)` | Cerca per nome, descrizione o fonte |
 | `describe_dataset(slug)` | Schema completo: colonne, tipi, ruolo, periodo |
-| `run_query(sql, dataset, max_rows, year)` | Query DuckDB read-only sul parquet clean |
-| `cache_stats()` | Stato della cache di risoluzione GCS |
+| `find_metric_datasets(query, metric_name)` | Cerca dataset che abbiano colonne role=metric |
+| `column_search(query)` | Cerca sia in meta dataset che in nome/descrizione colonne |
+
+### Esplorazione senza SQL
+
+| Tool | Scopo |
+|---|---|
+| `preview(dataset, limit, year)` | Prime N righe — no SQL, veloce per capire la struttura |
+| `count(dataset, year)` | Conteggio righe totale, con filtro anno opzionale |
+| `distinct_values(dataset, column, limit)` | Valori unici di una colonna — utile per UI filter |
+
+### Analisi pre-costruita
+
+| Tool | Scopo |
+|---|---|
+| `aggregate(dataset, metric, group_by, filters, year)` | Helper: SQL di aggregazione pre-scritto, passa a `run_query()` |
+| `time_series(dataset, metric, group_by, year, limit)` | Serie storica metric×dimension nel tempo |
+
+### Query e debug
+
+| Tool | Scopo |
+|---|---|
+| `run_query(sql, dataset, max_rows, year)` | Query DuckDB read-only — solo SELECT/WITH, hard cap 500 righe |
+| `explain_query(sql, dataset)` | Valida SQL senza eseguirla — stima validità e risolve parquet |
+| `cache_stats()` | Stato della cache GCS — utile per debug
 
 ## Runtime
 
@@ -74,6 +100,57 @@ gs://dataciviclab-clean/catalog/clean_catalog.json
 - Accesso diretto a `read_parquet()` / `read_csv()` bloccato nel SQL utente
 - GCS pubblico anonimo di default; usa `CLEAN_QUERY_GCS_AUTH=1` solo se serve autenticazione esplicita
 
+## Output workflow — tool per stage
+
+Pipeline: `source → raw → clean → mart → output`
+
+### Post-clean (verifica qualità)
+
+Dopo `toolkit run --config candidates/{slug}/dataset.yml` e push GCS:
+
+```python
+# 1. Verifica struttura e righe
+preview(slug, limit=5)          # prime righe — ok se non vuoto
+count(slug, year=2024)          # conteggio — confronta con atteso
+
+# 2. Verifica schema
+describe_dataset(slug)          # colonne, tipi, role — per conferma contract
+
+# 3. Verifica valori chiave
+distinct_values(slug, 'regione')  # valori distinti — outlier visibility
+```
+
+### Post-mart (analisi readiness)
+
+Dopo mart SQL e output parquet disponibili:
+
+```python
+# 1. Serie storica disponibile?
+time_series(dataset, metric='spesa_convenzionata', group_by='regione')
+
+# 2. metriche aggregate
+aggregate(dataset, metric='totale_ru_tonnellate', group_by=['regione'], year=2024)
+
+# 3. Query esplorativa
+run_query("SELECT regione, SUM(...) FROM clean_input GROUP BY regione", dataset)
+```
+
+### Pre-publication (validazione)
+
+Prima di aprire Discussion opromuovere su data-explorer:
+
+```python
+# 1. Quali dataset hanno metriche simili?
+find_metric_datasets(metric_name='spesa')          # per cross-reference
+column_search('regione')                            # per capire coverage
+
+# 2. Valida query complessa prima di esporla
+explain_query(sql, dataset)                         # senza eseguirla
+
+# 3. Verifica copertura temporale
+time_series(dataset, metric='...', group_by='regione', year=None)
+```
+
 ## Smoke test
 
 ```bash
@@ -89,5 +166,23 @@ python tools/clean-query-mcp/scripts/smoke.py --dataset ispra_ru_base
 ## Limiti noti
 
 - Il tool interroga un dataset alla volta.
-- Le analisi cross-dataset richiedono una preparazione a monte o un’estensione esplicita del contratto.
+- Le analisi cross-dataset richiedono una preparazione a monte o un'estensione esplicita del contratto.
 - Il catalogo semantico resta manuale finché non verrà generato direttamente dai `dataset.yml` e dai run record DI.
+
+## Aggiornare il catalogo locale
+
+Dopo push GCS via `push_archive.py`, il catalogo locale `registry/clean_catalog.json` viene aggiornato automaticamente. Per sincronizzarlo:
+
+```bash
+python scripts/build_clean_catalog.py --write --check-gcs
+```
+
+## Output artifact (publication)
+
+Il clean parquet pubblico è raggiungibile come:
+
+```text
+gs://dataciviclab-clean/{slug}/*/{slug}_*_clean.parquet
+```
+
+L'MCP risolve automaticamente i blob GCS pubblici senza necessitare di autenticazione.

--- a/tools/clean-query-mcp/catalog.py
+++ b/tools/clean-query-mcp/catalog.py
@@ -63,6 +63,11 @@ def _load_catalog() -> list[dict[str, Any]]:
         return _cache
 
 
+def load_catalog() -> list[dict[str, Any]]:
+    """Public wrapper around _load_catalog — exposes the cached catalog read."""
+    return _load_catalog()
+
+
 def list_datasets() -> list[dict[str, Any]]:
     catalog = _load_catalog()
     return [

--- a/tools/clean-query-mcp/server.py
+++ b/tools/clean-query-mcp/server.py
@@ -530,6 +530,10 @@ def count(dataset: str, year: int | None = None) -> dict[str, Any]:
         try:
             future = pool.submit(_run)
             total = future.result(timeout=60)
+        except concurrent.futures.TimeoutError:
+            conn.close()
+            pool.shutdown(wait=False)
+            return {"error": "Query timeout (60s). Riduci la complessita o aggiungi filtri."}
         finally:
             conn.close()
             pool.shutdown(wait=False)
@@ -620,6 +624,10 @@ def time_series(
         try:
             future = pool.submit(_run)
             columns, rows = future.result(timeout=60)
+        except concurrent.futures.TimeoutError:
+            conn.close()
+            pool.shutdown(wait=False)
+            return {"error": "Query timeout (60s). Riduci la complessita o aggiungi filtri."}
         finally:
             conn.close()
             pool.shutdown(wait=False)
@@ -694,6 +702,10 @@ def distinct_values(dataset: str, column: str, limit: int = 100) -> dict[str, An
         try:
             future = pool.submit(_run)
             columns, rows = future.result(timeout=60)
+        except concurrent.futures.TimeoutError:
+            conn.close()
+            pool.shutdown(wait=False)
+            return {"error": "Query timeout (60s). Riduci la complessita o aggiungi filtri."}
         finally:
             conn.close()
             pool.shutdown(wait=False)
@@ -818,9 +830,9 @@ def column_search(query: str, limit: int = 15) -> dict[str, Any]:
 
 @mcp.tool(
     description=(
-        "Spiega cosa farebbe una query SQL senza eseguirla. "
-        "Valida sintassi e risolve i riferimenti a clean_input. "
-        "Non stima il numero di righe — usa preview() per un campione reale."
+        "Pre-check di una query SQL: valida scope, sintassi e riferimenti a clean_input. "
+        "Non esegue la query — usa EXPLAIN di DuckDB per validazione semantica base. "
+        "Usa preview() per un campione reale dei dati."
     ),
     structured_output=True,
 )
@@ -834,21 +846,54 @@ def explain_query(sql: str, dataset: str) -> dict[str, Any]:
     try:
         _validate_scope(sql)
     except DuckdbClientError as exc:
-        return {"validation_error": str(exc)}
+        return {"validation_error": str(exc), "valid": False}
 
     try:
         _validate_select_sql(sql)
     except DuckdbClientError as exc:
-        return {"validation_error": str(exc)}
+        return {"validation_error": str(exc), "valid": False}
 
-    return {
-        "valid": True,
-        "dataset": dataset,
-        "sql": sql,
-        "source_parquets": parquet_paths,
-        "note": "Query sintatticamente valida. L'esecuzione effettiva potrebbe fallire per timeout, memoria o dati mancanti.",
-        "tip": "Usa preview() per verificare i dati prima di run_query().",
-    }
+    # Validate with actual DuckDB EXPLAIN on the wrapped query
+    escaped_paths = "', '".join(p.replace("'", "''") for p in parquet_paths)
+    if len(parquet_paths) == 1:
+        source_expr = f"'{escaped_paths}'"
+    else:
+        source_expr = f"['{escaped_paths}']"
+    wrapped_sql = f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) {sql}"
+
+    try:
+        import duckdb
+        import concurrent.futures
+
+        conn = duckdb.connect(database=":memory:")
+        conn.execute("PRAGMA disable_progress_bar")
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            future = pool.submit(lambda: conn.execute(f"EXPLAIN {wrapped_sql}"))
+            explain_result = future.result(timeout=30)
+            # EXPLAIN returns a single row with "plan" column
+            plan_text = explain_result.fetchone()[0] if explain_result else None
+        finally:
+            conn.close()
+            pool.shutdown(wait=False)
+
+        return {
+            "valid": True,
+            "dataset": dataset,
+            "sql": sql,
+            "source_parquets": parquet_paths,
+            "plan_excerpt": plan_text[:200] if plan_text else None,
+            "note": "EXPLAIN eseguito con successo — query sintatticamente e semanticamente valida.",
+            "tip": "Usa preview() per verificare i dati reali prima di run_query().",
+        }
+    except Exception as exc:
+        return {
+            "valid": False,
+            "validation_error": f"EXPLAIN fallito: {exc}",
+            "dataset": dataset,
+            "sql": sql,
+            "tip": "Correggi la query oppure usa preview() per verificare lo schema.",
+        }
 
 
 if __name__ == "__main__":

--- a/tools/clean-query-mcp/server.py
+++ b/tools/clean-query-mcp/server.py
@@ -399,5 +399,213 @@ def aggregate(
     }
 
 
+@mcp.tool(
+    description=(
+        "Anteprima: prime N righe di un dataset senza SQL. "
+        "Utile per esplorare la struttura prima di scrivere una query. "
+        "Non usa SQL, ritorna righe raw dal parquet."
+    ),
+    structured_output=True,
+)
+@mcp_telemetry("clean-query")
+def preview(dataset: str, limit: int = 10, year: int | None = None) -> dict[str, Any]:
+    try:
+        parquet_paths = resolve_parquet_path(dataset, year=year)
+    except (ValueError, FileNotFoundError) as exc:
+        return {"error": str(exc)}
+
+    try:
+        _validate_parquet_paths(parquet_paths)
+    except DuckdbClientError as exc:
+        return {"error": str(exc)}
+
+    escaped_paths = "', '".join(p.replace("'", "''") for p in parquet_paths)
+    if len(parquet_paths) == 1:
+        source_expr = f"'{escaped_paths}'"
+    else:
+        source_expr = f"['{escaped_paths}']"
+
+    wrapped_sql = f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) SELECT * FROM clean_input LIMIT {limit}"
+
+    def _exec() -> dict[str, Any]:
+        import duckdb
+        import concurrent.futures
+
+        _guard_max_rows(limit)
+        conn = duckdb.connect(database=":memory:")
+        conn.execute("PRAGMA disable_progress_bar")
+        conn.execute("SET memory_limit='2GB'")
+
+        def _run():
+            result = conn.execute(wrapped_sql)
+            return [item[0] for item in (result.description or [])], result.fetchall()
+
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            columns, rows = _run()
+        finally:
+            conn.close()
+            pool.shutdown(wait=False)
+
+        return {
+            "columns": columns,
+            "rows": [list(row) for row in rows],
+            "row_count": len(rows),
+            "dataset": dataset,
+            "limit_applied": limit,
+        }
+
+    return guard(_exec, handled_exceptions=(DuckdbClientError, Exception))
+
+
+@mcp.tool(
+    description=(
+        "Conteggio righe: numero totale di record in un dataset, opzionalmente filtrato per anno. "
+        "Utile per verificare copertura e dimensionalità prima di query complesse."
+    ),
+    structured_output=True,
+)
+@mcp_telemetry("clean-query")
+def count(dataset: str, year: int | None = None) -> dict[str, Any]:
+    try:
+        parquet_paths = resolve_parquet_path(dataset, year=year)
+    except (ValueError, FileNotFoundError) as exc:
+        return {"error": str(exc)}
+
+    try:
+        _validate_parquet_paths(parquet_paths)
+    except DuckdbClientError as exc:
+        return {"error": str(exc)}
+
+    escaped_paths = "', '".join(p.replace("'", "''") for p in parquet_paths)
+    if len(parquet_paths) == 1:
+        source_expr = f"'{escaped_paths}'"
+    else:
+        source_expr = f"['{escaped_paths}']"
+
+    wrapped_sql = f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) SELECT COUNT(*) AS total FROM clean_input"
+
+    def _exec() -> dict[str, Any]:
+        import duckdb
+        import concurrent.futures
+
+        conn = duckdb.connect(database=":memory:")
+        conn.execute("PRAGMA disable_progress_bar")
+        conn.execute("SET memory_limit='2GB'")
+
+        def _run():
+            result = conn.execute(wrapped_sql)
+            return result.fetchone()[0]
+
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            total = _run()
+        finally:
+            conn.close()
+            pool.shutdown(wait=False)
+
+        return {
+            "dataset": dataset,
+            "total_rows": total,
+            "year_filter": year,
+            "files_count": len(parquet_paths),
+        }
+
+    return guard(_exec, handled_exceptions=(DuckdbClientError, Exception))
+
+
+@mcp.tool(
+    description=(
+        "Serie storica: valori di una metrica nel tempo, raggruppati per una dimensione (es. regione). "
+        "Se year è specificato, ritorna una singola annualità. "
+        "Se year è None, ritorna tutti gli anni disponibili con la metrica aggregata per la dimensione scelta."
+    ),
+    structured_output=True,
+)
+@mcp_telemetry("clean-query")
+def time_series(
+    dataset: str,
+    metric: str,
+    group_by: str,
+    year: int | None = None,
+    limit: int = 200,
+) -> dict[str, Any]:
+    schema = describe_impl(dataset)
+    if "error" in schema:
+        return schema
+
+    col_names = {c["name"] for c in schema.get("columns", [])}
+    if metric not in col_names:
+        return {"error": f"Metrica '{metric}' non trovata. Disponibili: {', '.join(sorted(col_names))}"}
+    if group_by not in col_names:
+        return {"error": f"Dimensione group_by '{group_by}' non trovata. Disponibili: {', '.join(sorted(col_names))}"}
+
+    try:
+        parquet_paths = resolve_parquet_path(dataset, year=year)
+    except (ValueError, FileNotFoundError) as exc:
+        return {"error": str(exc)}
+
+    try:
+        _validate_parquet_paths(parquet_paths)
+    except DuckdbClientError as exc:
+        return {"error": str(exc)}
+
+    escaped_paths = "', '".join(p.replace("'", "''") for p in parquet_paths)
+    if len(parquet_paths) == 1:
+        source_expr = f"'{escaped_paths}'"
+    else:
+        source_expr = f"['{escaped_paths}']"
+
+    year_col = get_year_column(dataset)
+    if year_col is None:
+        return {"error": f"Dataset '{dataset}' non ha una colonna anno riconosciuta. Impossibile costruire serie storica."}
+
+    select_cols = f"{year_col}, {group_by}"
+    group_cols = f"{year_col}, {group_by}"
+    order_clause = f"{year_col}, {group_by}"
+
+    wrapped_sql = (
+        f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) "
+        f"SELECT {select_cols}, SUM({metric}) AS value "
+        f"FROM clean_input "
+        f"GROUP BY {group_cols} "
+        f"ORDER BY {order_clause} "
+        f"LIMIT {limit + 1}"
+    )
+
+    def _exec() -> dict[str, Any]:
+        import duckdb
+        import concurrent.futures
+
+        conn = duckdb.connect(database=":memory:")
+        conn.execute("PRAGMA disable_progress_bar")
+        conn.execute("SET memory_limit='2GB'")
+
+        def _run():
+            result = conn.execute(wrapped_sql)
+            return [item[0] for item in (result.description or [])], result.fetchall()
+
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            columns, rows = _run()
+        finally:
+            conn.close()
+            pool.shutdown(wait=False)
+
+        truncated = len(rows) > limit
+        return {
+            "columns": columns,
+            "rows": [list(row) for row in rows[:limit]],
+            "row_count": len(rows),
+            "truncated": truncated,
+            "dataset": dataset,
+            "metric": metric,
+            "group_by": group_by,
+            "year_filter": year,
+        }
+
+    return guard(_exec, handled_exceptions=(DuckdbClientError, Exception))
+
+
 if __name__ == "__main__":
     mcp.run()

--- a/tools/clean-query-mcp/server.py
+++ b/tools/clean-query-mcp/server.py
@@ -10,7 +10,7 @@ from catalog import get_year_column  # noqa: E402
 from catalog import list_datasets as list_impl  # noqa: E402
 from catalog import resolve_parquet_path  # noqa: E402
 from catalog import search_datasets as search_impl  # noqa: E402
-from catalog import _load_catalog  # noqa: E402
+from catalog import load_catalog  # noqa: E402
 
 ALLOWED_FROM = {"clean_input"}
 MAX_ROWS_HARD_CAP = 500
@@ -470,7 +470,8 @@ def aggregate(
 )
 @mcp_telemetry("clean-query")
 def preview(dataset: str, limit: int = 10, year: int | None = None) -> dict[str, Any]:
-    _guard_max_rows(limit)
+    if limit <= 0 or limit > MAX_ROWS_HARD_CAP:
+        return {"error": f"limit deve essere tra 1 e {MAX_ROWS_HARD_CAP}"}
     wrapped_sql = (
         f"WITH clean_input AS (SELECT * FROM read_parquet({{SOURCE_EXPR}})) "
         f"SELECT * FROM clean_input LIMIT {limit}"
@@ -564,7 +565,8 @@ def time_series(
     year: int | None = None,
     limit: int = 200,
 ) -> dict[str, Any]:
-    _guard_max_rows(limit)
+    if limit <= 0 or limit > MAX_ROWS_HARD_CAP:
+        return {"error": f"limit deve essere tra 1 e {MAX_ROWS_HARD_CAP}"}
     schema = describe_impl(dataset)
     if "error" in schema:
         return schema
@@ -656,7 +658,8 @@ def time_series(
 )
 @mcp_telemetry("clean-query")
 def distinct_values(dataset: str, column: str, limit: int = 100) -> dict[str, Any]:
-    _guard_max_rows(limit)
+    if limit <= 0 or limit > MAX_ROWS_HARD_CAP:
+        return {"error": f"limit deve essere tra 1 e {MAX_ROWS_HARD_CAP}"}
     schema = describe_impl(dataset)
     if "error" in schema:
         return schema
@@ -732,7 +735,7 @@ def distinct_values(dataset: str, column: str, limit: int = 100) -> dict[str, An
 @mcp_telemetry("clean-query")
 def find_metric_datasets(query: str = "", metric_name: str = "", limit: int = 20) -> dict[str, Any]:
     def _exec() -> dict[str, Any]:
-        catalog = _load_catalog()
+        catalog = load_catalog()
         results = []
         for ds in catalog:
             cols = ds.get("columns", [])
@@ -788,7 +791,7 @@ def find_metric_datasets(query: str = "", metric_name: str = "", limit: int = 20
 @mcp_telemetry("clean-query")
 def column_search(query: str, limit: int = 15) -> dict[str, Any]:
     def _exec() -> dict[str, Any]:
-        catalog = _load_catalog()
+        catalog = load_catalog()
         q = query.lower()
         results = []
         for ds in catalog:
@@ -871,8 +874,10 @@ def explain_query(sql: str, dataset: str) -> dict[str, Any]:
         try:
             future = pool.submit(lambda: conn.execute(f"EXPLAIN {wrapped_sql}"))
             explain_result = future.result(timeout=30)
-            # EXPLAIN returns a single row with "plan" column
-            plan_text = explain_result.fetchone()[0] if explain_result else None
+            # EXPLAIN returns rows: each row is (key, value) like ("physical_plan", "...")
+            # Take the value from the first row (physical_plan summary)
+            row = explain_result.fetchone() if explain_result else None
+            plan_text = row[1] if row and len(row) > 1 else (row[0] if row else None)
         finally:
             conn.close()
             pool.shutdown(wait=False)

--- a/tools/clean-query-mcp/server.py
+++ b/tools/clean-query-mcp/server.py
@@ -100,6 +100,66 @@ def guard(fn, handled_exceptions: tuple[type[BaseException], ...] = (Exception,)
         return {"error": str(exc)}
 
 
+def _duckdb_read(
+    dataset: str,
+    year: int | None,
+    wrapped_sql: str,
+    timeout: int = 60,
+) -> dict[str, Any]:
+    """Helper per esecuzione DuckDB read-only su parquet GCS.
+
+    Estrae e condivide il pattern comune a preview/count/time_series/distinct_values:
+    - risoluzione path parquet
+    - costruzione source_expr
+    - connessione DuckDB in-memory
+    - esecuzione con timeout
+    - ritorno {columns, rows} o errore
+    """
+    try:
+        parquet_paths = resolve_parquet_path(dataset, year=year)
+    except (ValueError, FileNotFoundError) as exc:
+        return {"error": str(exc)}
+
+    try:
+        _validate_parquet_paths(parquet_paths)
+    except DuckdbClientError as exc:
+        return {"error": str(exc)}
+
+    escaped_paths = "', '".join(p.replace("'", "''") for p in parquet_paths)
+    if len(parquet_paths) == 1:
+        source_expr = f"'{escaped_paths}'"
+    else:
+        source_expr = f"['{escaped_paths}']"
+
+    # Replace the placeholder in wrapped_sql if present
+    sql = wrapped_sql.replace("{SOURCE_EXPR}", source_expr)
+
+    import duckdb
+    import concurrent.futures
+
+    conn = duckdb.connect(database=":memory:")
+    conn.execute("PRAGMA disable_progress_bar")
+    conn.execute("SET memory_limit='2GB'")
+
+    def _run():
+        result = conn.execute(sql)
+        return [item[0] for item in (result.description or [])], result.fetchall()
+
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        future = pool.submit(_run)
+        columns, rows = future.result(timeout=timeout)
+    except concurrent.futures.TimeoutError:
+        conn.close()
+        pool.shutdown(wait=False)
+        return {"error": f"Query timeout ({timeout}s). Riduci la complessita o aggiungi filtri."}
+    finally:
+        conn.close()
+        pool.shutdown(wait=False)
+
+    return {"columns": columns, "rows": rows}
+
+
 def mcp_telemetry(_server: str):
     def decorator(fn):
         return fn
@@ -410,53 +470,21 @@ def aggregate(
 )
 @mcp_telemetry("clean-query")
 def preview(dataset: str, limit: int = 10, year: int | None = None) -> dict[str, Any]:
-    try:
-        parquet_paths = resolve_parquet_path(dataset, year=year)
-    except (ValueError, FileNotFoundError) as exc:
-        return {"error": str(exc)}
-
-    try:
-        _validate_parquet_paths(parquet_paths)
-    except DuckdbClientError as exc:
-        return {"error": str(exc)}
-
-    escaped_paths = "', '".join(p.replace("'", "''") for p in parquet_paths)
-    if len(parquet_paths) == 1:
-        source_expr = f"'{escaped_paths}'"
-    else:
-        source_expr = f"['{escaped_paths}']"
-
-    wrapped_sql = f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) SELECT * FROM clean_input LIMIT {limit}"
-
-    def _exec() -> dict[str, Any]:
-        import duckdb
-        import concurrent.futures
-
-        _guard_max_rows(limit)
-        conn = duckdb.connect(database=":memory:")
-        conn.execute("PRAGMA disable_progress_bar")
-        conn.execute("SET memory_limit='2GB'")
-
-        def _run():
-            result = conn.execute(wrapped_sql)
-            return [item[0] for item in (result.description or [])], result.fetchall()
-
-        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        try:
-            columns, rows = _run()
-        finally:
-            conn.close()
-            pool.shutdown(wait=False)
-
-        return {
-            "columns": columns,
-            "rows": [list(row) for row in rows],
-            "row_count": len(rows),
-            "dataset": dataset,
-            "limit_applied": limit,
-        }
-
-    return guard(_exec, handled_exceptions=(DuckdbClientError, Exception))
+    _guard_max_rows(limit)
+    wrapped_sql = (
+        f"WITH clean_input AS (SELECT * FROM read_parquet({{SOURCE_EXPR}})) "
+        f"SELECT * FROM clean_input LIMIT {limit}"
+    )
+    result = _duckdb_read(dataset, year, wrapped_sql)
+    if "error" in result:
+        return result
+    return {
+        "columns": result["columns"],
+        "rows": [list(row) for row in result["rows"]],
+        "row_count": len(result["rows"]),
+        "dataset": dataset,
+        "limit_applied": limit,
+    }
 
 
 @mcp.tool(
@@ -500,7 +528,8 @@ def count(dataset: str, year: int | None = None) -> dict[str, Any]:
 
         pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         try:
-            total = _run()
+            future = pool.submit(_run)
+            total = future.result(timeout=60)
         finally:
             conn.close()
             pool.shutdown(wait=False)
@@ -531,6 +560,7 @@ def time_series(
     year: int | None = None,
     limit: int = 200,
 ) -> dict[str, Any]:
+    _guard_max_rows(limit)
     schema = describe_impl(dataset)
     if "error" in schema:
         return schema
@@ -588,7 +618,8 @@ def time_series(
 
         pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         try:
-            columns, rows = _run()
+            future = pool.submit(_run)
+            columns, rows = future.result(timeout=60)
         finally:
             conn.close()
             pool.shutdown(wait=False)
@@ -617,6 +648,7 @@ def time_series(
 )
 @mcp_telemetry("clean-query")
 def distinct_values(dataset: str, column: str, limit: int = 100) -> dict[str, Any]:
+    _guard_max_rows(limit)
     schema = describe_impl(dataset)
     if "error" in schema:
         return schema
@@ -660,7 +692,8 @@ def distinct_values(dataset: str, column: str, limit: int = 100) -> dict[str, An
 
         pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         try:
-            columns, rows = _run()
+            future = pool.submit(_run)
+            columns, rows = future.result(timeout=60)
         finally:
             conn.close()
             pool.shutdown(wait=False)
@@ -686,48 +719,51 @@ def distinct_values(dataset: str, column: str, limit: int = 100) -> dict[str, An
 )
 @mcp_telemetry("clean-query")
 def find_metric_datasets(query: str = "", metric_name: str = "", limit: int = 20) -> dict[str, Any]:
-    catalog = _load_catalog()
-    results = []
-    for ds in catalog:
-        cols = ds.get("columns", [])
-        metric_cols = [
-            {"name": c["name"], "type": c.get("type"), "description": c.get("description")}
-            for c in cols
-            if c.get("role") == "metric"
-        ]
-        if not metric_cols:
-            continue
-
-        # Filter by query (search in name/description/source)
-        q_lower = query.lower()
-        if q_lower and q_lower not in ds.get("name", "").lower() and q_lower not in ds.get("description", "").lower() and q_lower not in ds.get("source", "").lower():
-            continue
-
-        # Filter by metric name
-        if metric_name:
-            mn_lower = metric_name.lower()
-            if not any(mn_lower in mc["name"].lower() for mc in metric_cols):
+    def _exec() -> dict[str, Any]:
+        catalog = _load_catalog()
+        results = []
+        for ds in catalog:
+            cols = ds.get("columns", [])
+            metric_cols = [
+                {"name": c["name"], "type": c.get("type"), "description": c.get("description")}
+                for c in cols
+                if c.get("role") == "metric"
+            ]
+            if not metric_cols:
                 continue
 
-        results.append({
-            "slug": ds["slug"],
-            "name": ds["name"],
-            "source": ds.get("source"),
-            "period": ds.get("period"),
-            "metric_columns": metric_cols,
-            "match_hint": metric_name or query,
-        })
+            # Filter by query (search in name/description/source)
+            q_lower = query.lower()
+            if q_lower and q_lower not in ds.get("name", "").lower() and q_lower not in ds.get("description", "").lower() and q_lower not in ds.get("source", "").lower():
+                continue
 
-        if len(results) >= limit:
-            break
+            # Filter by metric name
+            if metric_name:
+                mn_lower = metric_name.lower()
+                if not any(mn_lower in mc["name"].lower() for mc in metric_cols):
+                    continue
 
-    return {
-        "datasets": results,
-        "count": len(results),
-        "query": query,
-        "metric_name": metric_name,
-        "note": "Ritorna dataset che hanno colonne role=metric. Usa describe_dataset per lo schema completo.",
-    }
+            results.append({
+                "slug": ds["slug"],
+                "name": ds["name"],
+                "source": ds.get("source"),
+                "period": ds.get("period"),
+                "metric_columns": metric_cols,
+                "match_hint": metric_name or query,
+            })
+
+            if len(results) >= limit:
+                break
+
+        return {
+            "datasets": results,
+            "count": len(results),
+            "query": query,
+            "metric_name": metric_name,
+            "note": "Ritorna dataset che hanno colonne role=metric. Usa describe_dataset per lo schema completo.",
+        }
+
+    return guard(_exec, handled_exceptions=(Exception,))
 
 
 @mcp.tool(
@@ -739,48 +775,52 @@ def find_metric_datasets(query: str = "", metric_name: str = "", limit: int = 20
 )
 @mcp_telemetry("clean-query")
 def column_search(query: str, limit: int = 15) -> dict[str, Any]:
-    catalog = _load_catalog()
-    q = query.lower()
-    results = []
-    for ds in catalog:
-        matched_cols = []
-        for col in ds.get("columns", []):
-            if q in col.get("name", "").lower() or q in col.get("description", "").lower():
-                matched_cols.append({
-                    "name": col["name"],
-                    "type": col.get("type"),
-                    "role": col.get("role"),
-                    "description": col.get("description"),
+    def _exec() -> dict[str, Any]:
+        catalog = _load_catalog()
+        q = query.lower()
+        results = []
+        for ds in catalog:
+            matched_cols = []
+            for col in ds.get("columns", []):
+                if q in col.get("name", "").lower() or q in col.get("description", "").lower():
+                    matched_cols.append({
+                        "name": col["name"],
+                        "type": col.get("type"),
+                        "role": col.get("role"),
+                        "description": col.get("description"),
+                    })
+
+            # Match in dataset metadata or in column names/descriptions
+            meta_match = q in ds.get("name", "").lower() or q in ds.get("description", "").lower()
+
+            if matched_cols or meta_match:
+                results.append({
+                    "slug": ds["slug"],
+                    "name": ds["name"],
+                    "source": ds.get("source"),
+                    "period": ds.get("period"),
+                    "matched_columns": matched_cols,
+                    "meta_match": meta_match,
                 })
 
-        # Match in dataset metadata or in column names/descriptions
-        meta_match = q in ds.get("name", "").lower() or q in ds.get("description", "").lower()
+            if len(results) >= limit:
+                break
 
-        if matched_cols or meta_match:
-            results.append({
-                "slug": ds["slug"],
-                "name": ds["name"],
-                "source": ds.get("source"),
-                "period": ds.get("period"),
-                "matched_columns": matched_cols,
-                "meta_match": meta_match,
-            })
+        return {
+            "datasets": results,
+            "count": len(results),
+            "query": query,
+            "note": "Meta_match=True indica match su nome/descrizione dataset; matched_columns indica match su colonna.",
+        }
 
-        if len(results) >= limit:
-            break
-
-    return {
-        "datasets": results,
-        "count": len(results),
-        "query": query,
-        "note": "Meta_match=True indica match su nome/descrizione dataset; matched_columns indica match su colonna.",
-    }
+    return guard(_exec, handled_exceptions=(Exception,))
 
 
 @mcp.tool(
     description=(
         "Spiega cosa farebbe una query SQL senza eseguirla. "
-        "Valida sintassi, risolve i riferimenti a clean_input, stima il numero di righe previste (se stimabile)."
+        "Valida sintassi e risolve i riferimenti a clean_input. "
+        "Non stima il numero di righe — usa preview() per un campione reale."
     ),
     structured_output=True,
 )
@@ -809,3 +849,7 @@ def explain_query(sql: str, dataset: str) -> dict[str, Any]:
         "note": "Query sintatticamente valida. L'esecuzione effettiva potrebbe fallire per timeout, memoria o dati mancanti.",
         "tip": "Usa preview() per verificare i dati prima di run_query().",
     }
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tools/clean-query-mcp/server.py
+++ b/tools/clean-query-mcp/server.py
@@ -10,6 +10,7 @@ from catalog import get_year_column  # noqa: E402
 from catalog import list_datasets as list_impl  # noqa: E402
 from catalog import resolve_parquet_path  # noqa: E402
 from catalog import search_datasets as search_impl  # noqa: E402
+from catalog import _load_catalog  # noqa: E402
 
 ALLOWED_FROM = {"clean_input"}
 MAX_ROWS_HARD_CAP = 500
@@ -607,5 +608,204 @@ def time_series(
     return guard(_exec, handled_exceptions=(DuckdbClientError, Exception))
 
 
-if __name__ == "__main__":
-    mcp.run()
+@mcp.tool(
+    description=(
+        "Valori distinti di una colonna. "
+        "Utile per popolare dropdown/filter nelle UI, o per verificare i valori disponibili prima di query."
+    ),
+    structured_output=True,
+)
+@mcp_telemetry("clean-query")
+def distinct_values(dataset: str, column: str, limit: int = 100) -> dict[str, Any]:
+    schema = describe_impl(dataset)
+    if "error" in schema:
+        return schema
+
+    col_names = {c["name"] for c in schema.get("columns", [])}
+    if column not in col_names:
+        return {"error": f"Colonna '{column}' non trovata. Disponibili: {', '.join(sorted(col_names))}"}
+
+    try:
+        parquet_paths = resolve_parquet_path(dataset, year=None)
+    except (ValueError, FileNotFoundError) as exc:
+        return {"error": str(exc)}
+
+    try:
+        _validate_parquet_paths(parquet_paths)
+    except DuckdbClientError as exc:
+        return {"error": str(exc)}
+
+    escaped_paths = "', '".join(p.replace("'", "''") for p in parquet_paths)
+    if len(parquet_paths) == 1:
+        source_expr = f"'{escaped_paths}'"
+    else:
+        source_expr = f"['{escaped_paths}']"
+
+    wrapped_sql = (
+        f"WITH clean_input AS (SELECT {column} FROM read_parquet({source_expr})) "
+        f"SELECT DISTINCT {column} FROM clean_input WHERE {column} IS NOT NULL LIMIT {limit + 1}"
+    )
+
+    def _exec() -> dict[str, Any]:
+        import duckdb
+        import concurrent.futures
+
+        conn = duckdb.connect(database=":memory:")
+        conn.execute("PRAGMA disable_progress_bar")
+        conn.execute("SET memory_limit='2GB'")
+
+        def _run():
+            result = conn.execute(wrapped_sql)
+            return [item[0] for item in (result.description or [])], result.fetchall()
+
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            columns, rows = _run()
+        finally:
+            conn.close()
+            pool.shutdown(wait=False)
+
+        truncated = len(rows) > limit
+        return {
+            "column": column,
+            "values": [row[0] for row in rows[:limit]],
+            "count": len(rows),
+            "truncated": truncated,
+            "dataset": dataset,
+        }
+
+    return guard(_exec, handled_exceptions=(DuckdbClientError, Exception))
+
+
+@mcp.tool(
+    description=(
+        "Cerca dataset che abbiano una colonna di tipo 'metric' (numerica). "
+        "Filtra per nome colonna o pattern, e ritorna il catalogo dei match con schema resumí."
+    ),
+    structured_output=True,
+)
+@mcp_telemetry("clean-query")
+def find_metric_datasets(query: str = "", metric_name: str = "", limit: int = 20) -> dict[str, Any]:
+    catalog = _load_catalog()
+    results = []
+    for ds in catalog:
+        cols = ds.get("columns", [])
+        metric_cols = [
+            {"name": c["name"], "type": c.get("type"), "description": c.get("description")}
+            for c in cols
+            if c.get("role") == "metric"
+        ]
+        if not metric_cols:
+            continue
+
+        # Filter by query (search in name/description/source)
+        q_lower = query.lower()
+        if q_lower and q_lower not in ds.get("name", "").lower() and q_lower not in ds.get("description", "").lower() and q_lower not in ds.get("source", "").lower():
+            continue
+
+        # Filter by metric name
+        if metric_name:
+            mn_lower = metric_name.lower()
+            if not any(mn_lower in mc["name"].lower() for mc in metric_cols):
+                continue
+
+        results.append({
+            "slug": ds["slug"],
+            "name": ds["name"],
+            "source": ds.get("source"),
+            "period": ds.get("period"),
+            "metric_columns": metric_cols,
+            "match_hint": metric_name or query,
+        })
+
+        if len(results) >= limit:
+            break
+
+    return {
+        "datasets": results,
+        "count": len(results),
+        "query": query,
+        "metric_name": metric_name,
+        "note": "Ritorna dataset che hanno colonne role=metric. Usa describe_dataset per lo schema completo.",
+    }
+
+
+@mcp.tool(
+    description=(
+        "Cerca dataset per nome o descrizione di colonna. "
+        "Cerca sia nelle meta dataset (nome, descrizione, source) che nei nomi colonna."
+    ),
+    structured_output=True,
+)
+@mcp_telemetry("clean-query")
+def column_search(query: str, limit: int = 15) -> dict[str, Any]:
+    catalog = _load_catalog()
+    q = query.lower()
+    results = []
+    for ds in catalog:
+        matched_cols = []
+        for col in ds.get("columns", []):
+            if q in col.get("name", "").lower() or q in col.get("description", "").lower():
+                matched_cols.append({
+                    "name": col["name"],
+                    "type": col.get("type"),
+                    "role": col.get("role"),
+                    "description": col.get("description"),
+                })
+
+        # Match in dataset metadata or in column names/descriptions
+        meta_match = q in ds.get("name", "").lower() or q in ds.get("description", "").lower()
+
+        if matched_cols or meta_match:
+            results.append({
+                "slug": ds["slug"],
+                "name": ds["name"],
+                "source": ds.get("source"),
+                "period": ds.get("period"),
+                "matched_columns": matched_cols,
+                "meta_match": meta_match,
+            })
+
+        if len(results) >= limit:
+            break
+
+    return {
+        "datasets": results,
+        "count": len(results),
+        "query": query,
+        "note": "Meta_match=True indica match su nome/descrizione dataset; matched_columns indica match su colonna.",
+    }
+
+
+@mcp.tool(
+    description=(
+        "Spiega cosa farebbe una query SQL senza eseguirla. "
+        "Valida sintassi, risolve i riferimenti a clean_input, stima il numero di righe previste (se stimabile)."
+    ),
+    structured_output=True,
+)
+@mcp_telemetry("clean-query")
+def explain_query(sql: str, dataset: str) -> dict[str, Any]:
+    try:
+        parquet_paths = resolve_parquet_path(dataset, year=None)
+    except (ValueError, FileNotFoundError) as exc:
+        return {"error": str(exc)}
+
+    try:
+        _validate_scope(sql)
+    except DuckdbClientError as exc:
+        return {"validation_error": str(exc)}
+
+    try:
+        _validate_select_sql(sql)
+    except DuckdbClientError as exc:
+        return {"validation_error": str(exc)}
+
+    return {
+        "valid": True,
+        "dataset": dataset,
+        "sql": sql,
+        "source_parquets": parquet_paths,
+        "note": "Query sintatticamente valida. L'esecuzione effettiva potrebbe fallire per timeout, memoria o dati mancanti.",
+        "tip": "Usa preview() per verificare i dati prima di run_query().",
+    }


### PR DESCRIPTION
## Summary

- Aggiunge 7 nuovi tool al clean-query MCP:
  - `preview` — prime N righe senza SQL
  - `count` — conteggio righe per dataset/anno
  - `time_series` — serie storica metric×dimension
  - `distinct_values` — valori unici di colonna
  - `find_metric_datasets` — cerca per colonna role=metric
  - `column_search` — cerca in meta e nomi colonna
  - `explain_query` — valida SQL senza eseguirlo
- Aggiorna README con tutti i tool e output workflow (post-clean → post-mart → pre-publication)
- Corregge bug `pq`→`parq` in `push_archive.py`
- Aggiunge `toolkit_schema_diff` a skill e reference post-merge PR #203 toolkit

## Tool aggiunti

| Tool | Priority | Note |
|---|---|---|
| `preview` | alta | no SQL, veloce |
| `count` | alta | filtro anno opzionale |
| `time_series` | alta | richiede colonna anno |
| `distinct_values` | media | UI filter |
| `find_metric_datasets` | media | role=metric |
| `column_search` | media | meta+colonna |
| `explain_query` | bassa | debug |

## Testati

```python
preview('ispra_ru_base', limit=3)     → 3 righe OK
count('ispra_ru_base', year=2024)     → 7671 righe OK
time_series('aifa_spesa_consumo', ...) → OK (anno presente)
distinct_values('aifa', 'regione')   → 6 valori OK
find_metric_datasets(metric_name='spesa') → 1 dataset OK
column_search('regione')             → 9 dataset OK
explain_query(...)                   → valid=True OK
```

## Skills aggiornate

- `skills/run-candidate.md` — aggiunto `toolkit_schema_diff` alla diagnostica con use case