### PR TITLE
docs(skills): allinea bootstrap candidate a run init

### DIFF
--- a/skills/intake-candidate.md
+++ b/skills/intake-candidate.md
@@ -3,7 +3,7 @@ name: intake-candidate
 description: Skill canonico di dataset-incubator per portare un caso da issue intake a PR pronta per merge.
 license: MIT
 metadata:
-  version: "0.3"
+  version: "0.4"
   owner: "DataCivicLab"
   tags: [dataset-incubator, intake, candidate, support-dataset]
 ---
@@ -11,7 +11,7 @@ metadata:
 # Skill: intake-candidate
 
 Skill canonico di `dataset-incubator`.
-Versione: 0.3 - 2026-05-03
+Versione: 0.4 - 2026-05-06
 
 ## Obiettivo
 
@@ -47,6 +47,12 @@ candidates/<slug>/
   sql/clean.sql, mart.sql
 ```
 
+Nota scaffold toolkit:
+
+- `sql/clean.sql` può partire dal placeholder del template (`SELECT * FROM raw_input`) oppure essere generato da `toolkit run init`.
+- Non scrivere parsing CSV dentro `clean.sql`: il parsing sta in `clean.read`, mentre `clean.sql` legge sempre da `raw_input`.
+- Dopo il bootstrap, revisiona sempre `clean.sql` e la proposta `clean.read` prima di considerare runnable il candidate.
+
 Copia il notebook da `templates/candidate/notebooks/` e imposta `METRICA` / `METRICA_CLEAN` in cima alla cella setup.
 
 ### 3. Two-phase se c'è support
@@ -55,7 +61,7 @@ Se `dataset.yml` dichiara `support`, i support girano prima del main.
 
 Verifica che siano necessari e non sostituibili con un join a mart esistente.
 
-### 4. Run e valida
+### 4. Bootstrap, run e valida
 
 Check rapido pre-flight:
 
@@ -65,7 +71,19 @@ toolkit inspect paths --config candidates/{slug}/dataset.yml --json
 
 Oppure MCP: `toolkit_inspect_paths(config_path)` → path contract verificato.
 
-Run + valida:
+Primo bootstrap su candidate nuovo o su source appena aggiunta:
+
+```bash
+toolkit run init --config candidates/{slug}/dataset.yml --years 2024
+```
+
+`run init` esegue RAW, profiling e scaffold assistito. Se genera o aggiorna indicazioni per `clean.read`, incorpora nel `dataset.yml` solo la parte verificata. Poi revisiona:
+
+- `sql/clean.sql` generato/placeholder: deve leggere da `raw_input`
+- `clean.read`: deve contenere parsing RAW esplicito quando serve
+- boundary clean/mart: clean raw-faithful, mart analitico
+
+Run completo solo dopo revisione dello scaffold:
 
 ```bash
 toolkit run all --config candidates/{slug}/dataset.yml --years 2024
@@ -77,6 +95,8 @@ Usa `--strict-config` per intercettare campi legacy o deprecati:
 ```bash
 toolkit run all --config candidates/{slug}/dataset.yml --years 2024 --strict-config
 ```
+
+Non usare `run all` come bootstrap da zero: se manca `clean.sql`, il comando deve fallire prima di RAW. Usa `run init`.
 
 Se fallisce → MCP `toolkit_blocker_hints(config_path)` per isolare il primo errore. Blocker specifico documentato, non formulaico.
 

--- a/skills/run-candidate.md
+++ b/skills/run-candidate.md
@@ -3,7 +3,7 @@ name: run-candidate
 description: Skill canonico di dataset-incubator per eseguire un candidate, verificare gli output e chiudere con uno stato tecnico chiaro.
 license: MIT
 metadata:
-  version: "0.3"
+  version: "0.4"
   owner: "DataCivicLab"
   tags: [dataset-incubator, run, candidate, validation]
 ---
@@ -11,7 +11,7 @@ metadata:
 # Skill: run-candidate
 
 Skill canonico di `dataset-incubator`.
-Versione: 0.3 - 2026-05-03
+Versione: 0.4 - 2026-05-06
 
 ## Obiettivo
 
@@ -37,9 +37,27 @@ Oppure MCP: `toolkit_inspect_paths(config_path)` → `run_file_count >= 1`, `lat
 
 ### 2. Run
 
+Se il candidate è nuovo, manca `sql/clean.sql`, oppure lo scaffold non è ancora stato revisionato, non partire da `run all`.
+
+Bootstrap:
+
+```bash
+toolkit run init --config candidates/{slug}/dataset.yml --years 2024
+```
+
+Poi revisiona prima di proseguire:
+
+- `sql/clean.sql` deve leggere da `raw_input`, non da `read_csv(...)`
+- `clean.read` deve descrivere il parsing RAW quando serve
+- eventuale proposta `clean.read`/profiling va incorporata nel `dataset.yml` solo dopo verifica
+
+Run completo, quando `clean.sql` e mart SQL sono presenti e revisionati:
+
 ```bash
 toolkit run all --config candidates/{slug}/dataset.yml --years 2024
 ```
+
+`run all` è una verifica finale della pipeline completa, non il comando di bootstrap da zero.
 
 **Two-phase**: se `dataset.yml` ha `support`, i support girano prima del main — in locale e in CI.
 

--- a/templates/candidate/README.md
+++ b/templates/candidate/README.md
@@ -1,6 +1,6 @@
 # Template candidato
 
-Questo e il template operativo canonico della repo.   
+Questo è il template operativo canonico della repo.   
 
 Ogni nuovo ingresso in `dataset-incubator` dovrebbe partire da questa cartella, adattando:
 
@@ -11,11 +11,34 @@ Ogni nuovo ingresso in `dataset-incubator` dovrebbe partire da questa cartella, 
 - `sql/mart.sql`
 - `notebooks/{slug}_v0.ipynb` quando il filone beneficia di un notebook v0 di validazione
 
+## Bootstrap toolkit
+
+Per un candidate nuovo, usa il bootstrap prima del run completo:
+
+```bash
+toolkit run init --config candidates/<slug>/dataset.yml --years 2024
+```
+
+Questo scarica RAW, produce profiling e può scaffoldare/aiutare `sql/clean.sql` e `clean.read`.
+
+Prima di lanciare `run all`, revisiona:
+
+- `sql/clean.sql`: deve leggere da `raw_input`
+- `clean.read`: deve contenere solo parsing RAW verificato
+- `sql/mart.sql`: deve contenere trasformazioni analitiche, non pulizia raw
+
+Poi verifica la pipeline completa:
+
+```bash
+toolkit run all --config candidates/<slug>/dataset.yml --years 2024
+toolkit validate all --config candidates/<slug>/dataset.yml --years 2024
+```
+
 ## Domanda
 
 -
-> Una domanda civica valida ha una tensione ("sta migliorando o peggiorando?", "c'e un divario?"),
-> non e puramente descrittiva ("quanti sono") ed e verificabile con i dati disponibili.
+> Una domanda civica valida ha una tensione ("sta migliorando o peggiorando?", "c'è un divario?"),
+> non è puramente descrittiva ("quanti sono") ed è verificabile con i dati disponibili.
 
 ## Dataset
 

--- a/templates/candidate/dataset.yml
+++ b/templates/candidate/dataset.yml
@@ -9,9 +9,9 @@ dataset:
 # Configurazione delle fonti dati originali.
 raw:
   # extractor: 
-  #   type: "unzip_first_csv" # Decommenta se la fonte e un ZIP
+  #   type: "unzip_first_csv" # Decommenta se la fonte è un ZIP
   sources:
-    # Esempio http_file (caso piu comune):
+    # Esempio http_file (caso più comune):
     - name: "fonte_principale_http"
       type: "http_file"
       args:
@@ -28,14 +28,19 @@ raw:
 
 # --- CLEAN LAYER ---
 # Lettura dei dati RAW e prima trasformazione SQL.
+# Bootstrap consigliato:
+#   toolkit run init --config candidates/<slug>/dataset.yml --years 2024
+# Poi revisiona sql/clean.sql e clean.read prima del run completo.
 clean:
   sql: "sql/clean.sql"
+  # Il toolkit può proporre un blocco clean.read dal profiling RAW.
+  # Mantieni qui solo parametri verificati: delim, encoding, decimal, columns, header, skip, ecc.
   read:
     source: "auto" # 'auto' rileva formato da estensione filename
     mode: "latest"
     header: true
   validate: 
-    # min_rows: 100 # Esempio check qualita
+    # min_rows: 100 # Esempio check qualità
     primary_key: []
 
 # --- MART LAYER ---
@@ -44,12 +49,11 @@ mart:
   tables:
     - name: "mart_template"
       sql: "sql/mart.sql"
-  required_tables:
-    - "mart_template"
+  # required_tables è implicito: se omesso, il toolkit richiede tutte le mart.tables dichiarate.
   validate: {}
 
 # --- CROSS YEAR LAYER (Optional) ---
-# Operazioni che richiedono il join di piu anni (es. trend storici).
+# Operazioni che richiedono il join di più anni (es. trend storici).
 # cross_year:
 #   tables:
 #     - name: "trend_multi_anno"


### PR DESCRIPTION
## Summary
- documenta `toolkit run init` come bootstrap per candidate nuovi
- chiarisce che `toolkit run all` e' verifica finale, non bootstrap da zero
- allinea il template candidate al flusso `raw_input` / `clean.read`
- rimuove `mart.required_tables` esplicito dal template, ora implicito dal toolkit

## Tests
- parsing YAML di `templates/candidate/dataset.yml`
