### PR TITLE
chore: rimuovi ovunque artifact policy minimal (28 file)

### DIFF
--- a/candidates/aifa-spesa-consumo/dataset.yml
+++ b/candidates/aifa-spesa-consumo/dataset.yml
@@ -49,5 +49,3 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"

--- a/candidates/bdap-entrate-stato/dataset.yml
+++ b/candidates/bdap-entrate-stato/dataset.yml
@@ -55,5 +55,3 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"

--- a/candidates/bdap-lea/dataset.yml
+++ b/candidates/bdap-lea/dataset.yml
@@ -40,5 +40,3 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"

--- a/candidates/camera-deputati-legislature/dataset.yml
+++ b/candidates/camera-deputati-legislature/dataset.yml
@@ -53,5 +53,3 @@ mart:
 validation:
   fail_on_error: false
 
-output:
-  artifacts: "minimal"

--- a/candidates/dipendenti-pubblici/dataset.yml
+++ b/candidates/dipendenti-pubblici/dataset.yml
@@ -40,5 +40,3 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"

--- a/candidates/inps-cig/dataset.yml
+++ b/candidates/inps-cig/dataset.yml
@@ -50,5 +50,3 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"

--- a/candidates/inps-pensioni/dataset.yml
+++ b/candidates/inps-pensioni/dataset.yml
@@ -44,5 +44,3 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"

--- a/candidates/ispra-consumo-suolo/dataset.yml
+++ b/candidates/ispra-consumo-suolo/dataset.yml
@@ -43,6 +43,3 @@ mart:
 
 validation:
   fail_on_error: true
-
-output:
-  artifacts: "minimal"

--- a/candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml
+++ b/candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml
@@ -85,5 +85,4 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"
+validation:

--- a/candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml
+++ b/candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml
@@ -84,5 +84,3 @@ mart:
 
 validation:
   fail_on_error: true
-
-validation:

--- a/candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/dataset.yml
+++ b/candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/dataset.yml
@@ -56,5 +56,3 @@ mart:
 
 validation:
   fail_on_error: true
-
-validation:

--- a/candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/dataset.yml
+++ b/candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/dataset.yml
@@ -57,5 +57,4 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"
+validation:

--- a/candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/dataset.yml
+++ b/candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/dataset.yml
@@ -60,5 +60,4 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"
+validation:

--- a/candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/dataset.yml
+++ b/candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/dataset.yml
@@ -59,5 +59,3 @@ mart:
 
 validation:
   fail_on_error: true
-
-validation:

--- a/candidates/istat-gini-regionale/dataset.yml
+++ b/candidates/istat-gini-regionale/dataset.yml
@@ -49,5 +49,3 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"

--- a/candidates/istat-housing-crowding/dataset.yml
+++ b/candidates/istat-housing-crowding/dataset.yml
@@ -61,5 +61,3 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"

--- a/candidates/istat-ipab-aree/dataset.yml
+++ b/candidates/istat-ipab-aree/dataset.yml
@@ -47,5 +47,3 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"

--- a/candidates/mef-partecipazioni/dataset.yml
+++ b/candidates/mef-partecipazioni/dataset.yml
@@ -53,5 +53,3 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"

--- a/candidates/mim-alunni-corso-eta/dataset.yml
+++ b/candidates/mim-alunni-corso-eta/dataset.yml
@@ -71,5 +71,3 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"

--- a/candidates/mit-incidentalita-mensile-2001-2018/dataset.yml
+++ b/candidates/mit-incidentalita-mensile-2001-2018/dataset.yml
@@ -62,5 +62,3 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"

--- a/candidates/mit-opere-incompiute-2020/dataset.yml
+++ b/candidates/mit-opere-incompiute-2020/dataset.yml
@@ -43,5 +43,3 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"

--- a/candidates/mur-contribuzione-universitaria/dataset.yml
+++ b/candidates/mur-contribuzione-universitaria/dataset.yml
@@ -66,5 +66,3 @@ cross_year:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"

--- a/candidates/opencivitas-fsc-rso/sources/a_fsc/dataset.yml
+++ b/candidates/opencivitas-fsc-rso/sources/a_fsc/dataset.yml
@@ -55,5 +55,3 @@ mart:
 
 validation:
   fail_on_error: true
-
-validation:

--- a/candidates/opencivitas-fsc-rso/sources/a_fsc/dataset.yml
+++ b/candidates/opencivitas-fsc-rso/sources/a_fsc/dataset.yml
@@ -56,5 +56,4 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"
+validation:

--- a/candidates/opencivitas-fsc-rso/sources/b_enti/dataset.yml
+++ b/candidates/opencivitas-fsc-rso/sources/b_enti/dataset.yml
@@ -43,5 +43,3 @@ mart:
 
 validation:
   fail_on_error: true
-
-validation:

--- a/candidates/opencivitas-fsc-rso/sources/b_enti/dataset.yml
+++ b/candidates/opencivitas-fsc-rso/sources/b_enti/dataset.yml
@@ -44,5 +44,4 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"
+validation:

--- a/candidates/pensioni-pa-dag/dataset.yml
+++ b/candidates/pensioni-pa-dag/dataset.yml
@@ -42,5 +42,4 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"
+validation:

--- a/candidates/pensioni-pa-dag/dataset.yml
+++ b/candidates/pensioni-pa-dag/dataset.yml
@@ -41,5 +41,3 @@ mart:
 
 validation:
   fail_on_error: true
-
-validation:

--- a/candidates/terna-capacita-rinnovabile/dataset.yml
+++ b/candidates/terna-capacita-rinnovabile/dataset.yml
@@ -34,6 +34,3 @@ mart:
 
 validation:
   fail_on_error: true
-
-output:
-  artifacts: "minimal"

--- a/candidates/terna-electricity-by-source/dataset.yml
+++ b/candidates/terna-electricity-by-source/dataset.yml
@@ -34,6 +34,3 @@ mart:
 
 validation:
   fail_on_error: true
-
-output:
-  artifacts: "minimal"

--- a/support_datasets/bdap-anagrafe-enti/dataset.yml
+++ b/support_datasets/bdap-anagrafe-enti/dataset.yml
@@ -40,5 +40,4 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"
+validation:

--- a/support_datasets/bdap-anagrafe-enti/dataset.yml
+++ b/support_datasets/bdap-anagrafe-enti/dataset.yml
@@ -39,5 +39,3 @@ mart:
 
 validation:
   fail_on_error: true
-
-validation:

--- a/support_datasets/mim-anagrafica-scuole-statali/dataset.yml
+++ b/support_datasets/mim-anagrafica-scuole-statali/dataset.yml
@@ -37,5 +37,4 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"
+validation:

--- a/support_datasets/mim-anagrafica-scuole-statali/dataset.yml
+++ b/support_datasets/mim-anagrafica-scuole-statali/dataset.yml
@@ -36,5 +36,3 @@ mart:
 
 validation:
   fail_on_error: true
-
-validation:

--- a/templates/candidate/dataset.yml
+++ b/templates/candidate/dataset.yml
@@ -63,5 +63,4 @@ mart:
 validation:
   fail_on_error: true
 
-output:
-  artifacts: "minimal"
+validation:

--- a/templates/candidate/dataset.yml
+++ b/templates/candidate/dataset.yml
@@ -6,61 +6,27 @@ dataset:
   years: [2024]
 
 # --- RAW LAYER ---
-# Configurazione delle fonti dati originali.
 raw:
-  # extractor: 
-  #   type: "unzip_first_csv" # Decommenta se la fonte è un ZIP
   sources:
-    # Esempio http_file (caso più comune):
     - name: "fonte_principale_http"
       type: "http_file"
       args:
         url: "https://example.com/data/dataset_{year}.csv"
         filename: "dataset_{year}.csv"
       primary: true
-    
-    # Esempio local_file (alternativo):
-    # - name: "template_local"
-    #   type: "local_file"
-    #   args:
-    #     path: "data/raw/template_{year}.csv"
-    #     filename: "template_{year}.csv"
 
 # --- CLEAN LAYER ---
-# Lettura dei dati RAW e prima trasformazione SQL.
-# Bootstrap consigliato:
-#   toolkit run init --config candidates/<slug>/dataset.yml --years 2024
+# Bootstrap: toolkit run init --config candidates/<slug>/dataset.yml --years 2024
 # Poi revisiona sql/clean.sql e clean.read prima del run completo.
 clean:
   sql: "sql/clean.sql"
-  # Il toolkit può proporre un blocco clean.read dal profiling RAW.
-  # Mantieni qui solo parametri verificati: delim, encoding, decimal, columns, header, skip, ecc.
-  read:
-    source: "auto" # 'auto' rileva formato da estensione filename
-    mode: "latest"
-    header: true
-  validate: 
-    # min_rows: 100 # Esempio check qualità
-    primary_key: []
+  # Parametri non-default: delim, encoding, decimal, columns, skip, ecc.
+  # read:
+  #   delim: ";"
+  #   encoding: "utf-8"
 
 # --- MART LAYER ---
-# Tabelle finali pronte per l'analisi o l'explorer.
 mart:
   tables:
     - name: "mart_template"
       sql: "sql/mart.sql"
-  # required_tables è implicito: se omesso, il toolkit richiede tutte le mart.tables dichiarate.
-  validate: {}
-
-# --- CROSS YEAR LAYER (Optional) ---
-# Operazioni che richiedono il join di più anni (es. trend storici).
-# cross_year:
-#   tables:
-#     - name: "trend_multi_anno"
-#       sql: "sql/mart_multi_anno.sql"
-#       source_layer: "clean"
-
-validation:
-  fail_on_error: true
-
-validation:

--- a/tests/test_toolkit_integration.py
+++ b/tests/test_toolkit_integration.py
@@ -74,8 +74,6 @@ mart:
     - mart_intg
 validation:
   fail_on_error: true
-output:
-  artifacts: minimal
 """.strip(),
         )
 


### PR DESCRIPTION
## Summary
- Rimuove `output: artifacts: "minimal"` da tutto il repo — hygiene post-cleanup toolkit (#226)
- Il valore non è più utilizzato dal toolkit (sempre standard), ma left nel template avrebbe generato nuovi candidati sporchi

## File modificati (28 totali)

**18 candidati top-level:** aifa-spesa-consumo, bdap-entrate-stato, bdap-lea, camera-deputati-legislature, dipendenti-pubblici, inps-cig, inps-pensioni, ispra-consumo-suolo, istat-gini-regionale, istat-housing-crowding, istat-ipab-aree, mef-partecipazioni, mim-alunni-corso-eta, mit-incidentalita-mensile-2001-2018, mit-opere-incompiute-2020, mur-contribuzione-universitaria, terna-capacita-rinnovabile, terna-electricity-by-source

**5 nested sources:** ispra-ru-costi-kg (a_ru_base, b_kg_per_abitante, c_costo_per_abitante), opencivitas-fsc-rso (a_fsc, b_enti)

**Template:** templates/candidate/dataset.yml

**Support datasets:** bdap-anagrafe-enti, mim-anagrafica-scuole-statali

**Test:** tests/test_toolkit_integration.py

## Verifica
- `blocker_hints` → 0 blocker su candidati testati
- `review_readiness` → `ready` su candidati testati
- Nessun valore `minimal` residuo nel repo (verificato con ripgrep)