### PR TITLE
chore(post-merge): aggiorna registry per PR #261

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-05",
+  "generated_at": "2026-05-07",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -20,9 +20,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25384102122",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25384102122",
-        "checked_at": "2026-05-05",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
         "year": 2024,
         "config_path": "candidates/aifa-spesa-consumo/dataset.yml"
       }
@@ -32,21 +32,45 @@
       "status": "ok",
       "label": "bdap-entrate-stato",
       "detail": "anno 2024 — fonte: openbdap_entrate_csv — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2024,
+        "config_path": "candidates/bdap-entrate-stato/dataset.yml"
+      }
     },
     {
       "id": "bdap-lea",
       "status": "ok",
       "label": "bdap-lea",
       "detail": "anno 2024 — fonte: bdap_lea_csv — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2024,
+        "config_path": "candidates/bdap-lea/dataset.yml"
+      }
     },
     {
       "id": "camera-deputati-legislature",
       "status": "ok",
       "label": "camera-deputati-legislature",
       "detail": "anno 2024 — fonte: camera_deputati_sparql — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "failed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2024,
+        "config_path": "candidates/camera-deputati-legislature/dataset.yml"
+      }
     },
     {
       "id": "civile-flussi",
@@ -60,7 +84,15 @@
       "status": "ok",
       "label": "dipendenti-pubblici",
       "detail": "anni 2010-2023 — fonte: bdap_csv — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2023,
+        "config_path": "candidates/dipendenti-pubblici/dataset.yml"
+      }
     },
     {
       "id": "inps-cig",
@@ -70,9 +102,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25276463099",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25276463099",
-        "checked_at": "2026-05-03",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
         "year": 2024,
         "config_path": "candidates/inps-cig/dataset.yml"
       }
@@ -82,7 +114,15 @@
       "status": "ok",
       "label": "inps-pensioni",
       "detail": "anno 2024 — fonte: inps_pensioni_csv — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2024,
+        "config_path": "candidates/inps-pensioni/dataset.yml"
+      }
     },
     {
       "id": "irpef-comunale",
@@ -96,7 +136,15 @@
       "status": "ok",
       "label": "ispra-consumo-suolo",
       "detail": "anno 2024 — fonte: ispra_consumo_suolo_xlsx — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2024,
+        "config_path": "candidates/ispra-consumo-suolo/dataset.yml"
+      }
     },
     {
       "id": "ispra-ru-costi-kg",
@@ -106,9 +154,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25315407298",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25315407298",
-        "checked_at": "2026-05-04",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
         "years": [
           2024
         ],
@@ -136,21 +184,45 @@
       "status": "ok",
       "label": "istat-gini-regionale",
       "detail": "anno 2023 — fonte: istat_sdmx_gini — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2023,
+        "config_path": "candidates/istat-gini-regionale/dataset.yml"
+      }
     },
     {
       "id": "istat-housing-crowding",
       "status": "ok",
       "label": "istat-housing-crowding",
       "detail": "anno 2024 — fonte: istat_sdmx_housing_crowding — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2024,
+        "config_path": "candidates/istat-housing-crowding/dataset.yml"
+      }
     },
     {
       "id": "istat-ipab-aree",
       "status": "ok",
       "label": "istat-ipab-aree",
       "detail": "anno 2024 — fonte: istat_sdmx_ipab_aree — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2024,
+        "config_path": "candidates/istat-ipab-aree/dataset.yml"
+      }
     },
     {
       "id": "malasanita-struttura-mortalita",
@@ -164,14 +236,30 @@
       "status": "ok",
       "label": "mef-partecipazioni",
       "detail": "anni 2020-2023 — fonti: mef_partecipazioni_2020, mef_partecipazioni_2021 — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2023,
+        "config_path": "candidates/mef-partecipazioni/dataset.yml"
+      }
     },
     {
       "id": "mim-alunni-corso-eta",
       "status": "ok",
       "label": "mim-alunni-corso-eta",
       "detail": "anni 2016-2025 — fonte: mim_alunni_corso_eta_csv — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2025,
+        "config_path": "candidates/mim-alunni-corso-eta/dataset.yml"
+      }
     },
     {
       "id": "mit-incidentalita-mensile-2001-2018",
@@ -180,10 +268,10 @@
       "detail": "anno 2001 — fonte: mit_incidentalita_mensile_csv — mart: sì",
       "action": "",
       "sample_run": {
-        "status": "failed",
-        "run_id": "25156933674",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25156933674",
-        "checked_at": "2026-04-30",
+        "status": "passed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
         "year": 2001,
         "config_path": "candidates/mit-incidentalita-mensile-2001-2018/dataset.yml"
       }
@@ -196,9 +284,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25171144965",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25171144965",
-        "checked_at": "2026-04-30",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
         "year": 2020,
         "config_path": "candidates/mit-opere-incompiute-2020/dataset.yml"
       }
@@ -208,14 +296,43 @@
       "status": "ok",
       "label": "mur-contribuzione-universitaria",
       "detail": "anni 2017-2024 — fonte: mur_gettito_ckan — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "failed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2024,
+        "config_path": "candidates/mur-contribuzione-universitaria/dataset.yml"
+      }
     },
     {
       "id": "opencivitas-fsc-rso",
       "status": "ok",
       "label": "opencivitas-fsc-rso",
       "detail": "anno 2025 — multi-source (2 fonti) — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "failed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "years": [
+          2025
+        ],
+        "configs": [
+          {
+            "status": "failed",
+            "year": 2025,
+            "config_path": "candidates/opencivitas-fsc-rso/sources/a_fsc/dataset.yml"
+          },
+          {
+            "status": "failed",
+            "year": 2025,
+            "config_path": "candidates/opencivitas-fsc-rso/sources/b_enti/dataset.yml"
+          }
+        ]
+      }
     },
     {
       "id": "opencoesione-pagamenti-ue-2014-2020",
@@ -229,7 +346,15 @@
       "status": "ok",
       "label": "pensioni-pa-dag",
       "detail": "anno 2024 — fonte: dag_pensioni_totale_local — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "failed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2024,
+        "config_path": "candidates/pensioni-pa-dag/dataset.yml"
+      }
     },
     {
       "id": "terna-capacita-rinnovabile",
@@ -239,9 +364,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25218876358",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25218876358",
-        "checked_at": "2026-05-01",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
         "year": 2024,
         "config_path": "candidates/terna-capacita-rinnovabile/dataset.yml"
       }
@@ -251,21 +376,45 @@
       "status": "ok",
       "label": "terna-electricity-by-source",
       "detail": "anni 2023-2024 — fonte: terna_electricity_by_source_xlsx — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2024,
+        "config_path": "candidates/terna-electricity-by-source/dataset.yml"
+      }
     },
     {
       "id": "bdap-anagrafe-enti",
       "status": "ok",
       "label": "bdap-anagrafe-enti",
       "detail": "anni: ? — fonte: ? — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2024,
+        "config_path": "support_datasets/bdap-anagrafe-enti/dataset.yml"
+      }
     },
     {
       "id": "mim-anagrafica-scuole-statali",
       "status": "ok",
       "label": "mim-anagrafica-scuole-statali",
       "detail": "anni: ? — fonte: ? — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "year": 2024,
+        "config_path": "support_datasets/mim-anagrafica-scuole-statali/dataset.yml"
+      }
     },
     {
       "id": "popolazione-istat-comunale-2019-2025",


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #261 — chore: rimuovi ovunque artifact policy minimal (28 file)

Changed candidate/support roots:

- `aifa-spesa-consumo` (candidate, `candidates/aifa-spesa-consumo`)
- `bdap-entrate-stato` (candidate, `candidates/bdap-entrate-stato`)
- `bdap-lea` (candidate, `candidates/bdap-lea`)
- `camera-deputati-legislature` (candidate, `candidates/camera-deputati-legislature`)
- `dipendenti-pubblici` (candidate, `candidates/dipendenti-pubblici`)
- `inps-cig` (candidate, `candidates/inps-cig`)
- `inps-pensioni` (candidate, `candidates/inps-pensioni`)
- `ispra-consumo-suolo` (candidate, `candidates/ispra-consumo-suolo`)
- `ispra-ru-costi-kg` (candidate, `candidates/ispra-ru-costi-kg`)
- `istat-gini-regionale` (candidate, `candidates/istat-gini-regionale`)
- `istat-housing-crowding` (candidate, `candidates/istat-housing-crowding`)
- `istat-ipab-aree` (candidate, `candidates/istat-ipab-aree`)
- `mef-partecipazioni` (candidate, `candidates/mef-partecipazioni`)
- `mim-alunni-corso-eta` (candidate, `candidates/mim-alunni-corso-eta`)
- `mit-incidentalita-mensile-2001-2018` (candidate, `candidates/mit-incidentalita-mensile-2001-2018`)
- `mit-opere-incompiute-2020` (candidate, `candidates/mit-opere-incompiute-2020`)
- `mur-contribuzione-universitaria` (candidate, `candidates/mur-contribuzione-universitaria`)
- `opencivitas-fsc-rso` (candidate, `candidates/opencivitas-fsc-rso`)
- `pensioni-pa-dag` (candidate, `candidates/pensioni-pa-dag`)
- `terna-capacita-rinnovabile` (candidate, `candidates/terna-capacita-rinnovabile`)
- `terna-electricity-by-source` (candidate, `candidates/terna-electricity-by-source`)
- `bdap-anagrafe-enti` (support_dataset, `support_datasets/bdap-anagrafe-enti`)
- `mim-anagrafica-scuole-statali` (support_dataset, `support_datasets/mim-anagrafica-scuole-statali`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [ ] Sample-run CI completed (failure)
- [ ] Full maintainer run completed
- [ ] Clean parquet pushed to GCS/BQ
- [ ] `registry/clean_catalog.json` updated after GCS push
- [ ] `python scripts/build_clean_catalog.py --check-gcs` passes

## Sample-run artifacts

- `candidates/aifa-spesa-consumo/dataset.yml` -> artifact `sample-run-aifa-spesa-consumo`
- `candidates/bdap-entrate-stato/dataset.yml` -> artifact `sample-run-bdap-entrate-stato`
- `candidates/bdap-lea/dataset.yml` -> artifact `sample-run-bdap-lea`
- `candidates/camera-deputati-legislature/dataset.yml` -> artifact `sample-run-camera-deputati-legislature`
- `candidates/dipendenti-pubblici/dataset.yml` -> artifact `sample-run-dipendenti-pubblici`
- `candidates/inps-cig/dataset.yml` -> artifact `sample-run-inps-cig`
- `candidates/inps-pensioni/dataset.yml` -> artifact `sample-run-inps-pensioni`
- `candidates/ispra-consumo-suolo/dataset.yml` -> artifact `sample-run-ispra-consumo-suolo`
- `candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml` -> artifact `sample-run-ispra-ru-costi-kg-a_ru_base`
- `candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/dataset.yml` -> artifact `sample-run-ispra-ru-costi-kg-b_kg_per_abitante`
- `candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/dataset.yml` -> artifact `sample-run-ispra-ru-costi-kg-c_costo_per_abitante`
- `candidates/istat-gini-regionale/dataset.yml` -> artifact `sample-run-istat-gini-regionale`
- `candidates/istat-housing-crowding/dataset.yml` -> artifact `sample-run-istat-housing-crowding`
- `candidates/istat-ipab-aree/dataset.yml` -> artifact `sample-run-istat-ipab-aree`
- `candidates/mef-partecipazioni/dataset.yml` -> artifact `sample-run-mef-partecipazioni`
- `candidates/mim-alunni-corso-eta/dataset.yml` -> artifact `sample-run-mim-alunni-corso-eta`
- `candidates/mit-incidentalita-mensile-2001-2018/dataset.yml` -> artifact `sample-run-mit-incidentalita-mensile-2001-2018`
- `candidates/mit-opere-incompiute-2020/dataset.yml` -> artifact `sample-run-mit-opere-incompiute-2020`
- `candidates/mur-contribuzione-universitaria/dataset.yml` -> artifact `sample-run-mur-contribuzione-universitaria`
- `candidates/opencivitas-fsc-rso/sources/a_fsc/dataset.yml` -> artifact `sample-run-opencivitas-fsc-rso-a_fsc`
- `candidates/opencivitas-fsc-rso/sources/b_enti/dataset.yml` -> artifact `sample-run-opencivitas-fsc-rso-b_enti`
- `candidates/pensioni-pa-dag/dataset.yml` -> artifact `sample-run-pensioni-pa-dag`
- `candidates/terna-capacita-rinnovabile/dataset.yml` -> artifact `sample-run-terna-capacita-rinnovabile`
- `candidates/terna-electricity-by-source/dataset.yml` -> artifact `sample-run-terna-electricity-by-source`
- `support_datasets/bdap-anagrafe-enti/dataset.yml` -> artifact `sample-run-bdap-anagrafe-enti`
- `support_datasets/mim-anagrafica-scuole-statali/dataset.yml` -> artifact `sample-run-mim-anagrafica-scuole-statali`

## Maintainer commands

```bash
toolkit run all --config candidates/aifa-spesa-consumo/dataset.yml
toolkit validate all --config candidates/aifa-spesa-consumo/dataset.yml
python scripts/push_archive.py --layer clean --slug aifa-spesa-consumo --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/bdap-entrate-stato/dataset.yml
toolkit validate all --config candidates/bdap-entrate-stato/dataset.yml
python scripts/push_archive.py --layer clean --slug bdap-entrate-stato --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/bdap-lea/dataset.yml
toolkit validate all --config candidates/bdap-lea/dataset.yml
python scripts/push_archive.py --layer clean --slug bdap-lea --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/camera-deputati-legislature/dataset.yml
toolkit validate all --config candidates/camera-deputati-legislature/dataset.yml
python scripts/push_archive.py --layer clean --slug camera-deputati-legislature --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/dipendenti-pubblici/dataset.yml
toolkit validate all --config candidates/dipendenti-pubblici/dataset.yml
python scripts/push_archive.py --layer clean --slug dipendenti-pubblici --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/inps-cig/dataset.yml
toolkit validate all --config candidates/inps-cig/dataset.yml
python scripts/push_archive.py --layer clean --slug inps-cig --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/inps-pensioni/dataset.yml
toolkit validate all --config candidates/inps-pensioni/dataset.yml
python scripts/push_archive.py --layer clean --slug inps-pensioni --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/ispra-consumo-suolo/dataset.yml
toolkit validate all --config candidates/ispra-consumo-suolo/dataset.yml
python scripts/push_archive.py --layer clean --slug ispra-consumo-suolo --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml
toolkit validate all --config candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml
python scripts/push_archive.py --layer clean --slug ispra-ru-costi-kg_a_ru_base --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/dataset.yml
toolkit validate all --config candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/dataset.yml
python scripts/push_archive.py --layer clean --slug ispra-ru-costi-kg_b_kg_per_abitante --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/dataset.yml
toolkit validate all --config candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/dataset.yml
python scripts/push_archive.py --layer clean --slug ispra-ru-costi-kg_c_costo_per_abitante --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/istat-gini-regionale/dataset.yml
toolkit validate all --config candidates/istat-gini-regionale/dataset.yml
python scripts/push_archive.py --layer clean --slug istat-gini-regionale --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/istat-housing-crowding/dataset.yml
toolkit validate all --config candidates/istat-housing-crowding/dataset.yml
python scripts/push_archive.py --layer clean --slug istat-housing-crowding --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/istat-ipab-aree/dataset.yml
toolkit validate all --config candidates/istat-ipab-aree/dataset.yml
python scripts/push_archive.py --layer clean --slug istat-ipab-aree --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/mef-partecipazioni/dataset.yml
toolkit validate all --config candidates/mef-partecipazioni/dataset.yml
python scripts/push_archive.py --layer clean --slug mef-partecipazioni --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/mim-alunni-corso-eta/dataset.yml
toolkit validate all --config candidates/mim-alunni-corso-eta/dataset.yml
python scripts/push_archive.py --layer clean --slug mim-alunni-corso-eta --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/mit-incidentalita-mensile-2001-2018/dataset.yml
toolkit validate all --config candidates/mit-incidentalita-mensile-2001-2018/dataset.yml
python scripts/push_archive.py --layer clean --slug mit-incidentalita-mensile-2001-2018 --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/mit-opere-incompiute-2020/dataset.yml
toolkit validate all --config candidates/mit-opere-incompiute-2020/dataset.yml
python scripts/push_archive.py --layer clean --slug mit-opere-incompiute-2020 --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/mur-contribuzione-universitaria/dataset.yml
toolkit validate all --config candidates/mur-contribuzione-universitaria/dataset.yml
python scripts/push_archive.py --layer clean --slug mur-contribuzione-universitaria --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/opencivitas-fsc-rso/sources/a_fsc/dataset.yml
toolkit validate all --config candidates/opencivitas-fsc-rso/sources/a_fsc/dataset.yml
python scripts/push_archive.py --layer clean --slug opencivitas-fsc-rso_a_fsc --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/opencivitas-fsc-rso/sources/b_enti/dataset.yml
toolkit validate all --config candidates/opencivitas-fsc-rso/sources/b_enti/dataset.yml
python scripts/push_archive.py --layer clean --slug opencivitas-fsc-rso_b_enti --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/pensioni-pa-dag/dataset.yml
toolkit validate all --config candidates/pensioni-pa-dag/dataset.yml
python scripts/push_archive.py --layer clean --slug pensioni-pa-dag --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/terna-capacita-rinnovabile/dataset.yml
toolkit validate all --config candidates/terna-capacita-rinnovabile/dataset.yml
python scripts/push_archive.py --layer clean --slug terna-capacita-rinnovabile --create-bq-table --update-catalog --status clean_ready
toolkit run all --config candidates/terna-electricity-by-source/dataset.yml
toolkit validate all --config candidates/terna-electricity-by-source/dataset.yml
python scripts/push_archive.py --layer clean --slug terna-electricity-by-source --create-bq-table --update-catalog --status clean_ready
toolkit run all --config support_datasets/bdap-anagrafe-enti/dataset.yml
toolkit validate all --config support_datasets/bdap-anagrafe-enti/dataset.yml
python scripts/push_archive.py --layer clean --slug bdap-anagrafe-enti --create-bq-table --update-catalog --status clean_ready
toolkit run all --config support_datasets/mim-anagrafica-scuole-statali/dataset.yml
toolkit validate all --config support_datasets/mim-anagrafica-scuole-statali/dataset.yml
python scripts/push_archive.py --layer clean --slug mim-anagrafica-scuole-statali --create-bq-table --update-catalog --status clean_ready
python scripts/build_clean_catalog.py --write
python scripts/build_clean_catalog.py --check-gcs
```

Keep this PR as draft until the GCS/BQ push and clean catalog validation are complete.
