### PR TITLE
chore: aggiorna toolkit a v1.5.0, estrae support datasets in script condiviso

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install ruff mypy types-pyyaml types-requests pytest
-          pip install git+https://github.com/dataciviclab/toolkit.git@v1.4.0
+          pip install git+https://github.com/dataciviclab/toolkit.git@v1.5.0
           pip install -r tools/clean-query-mcp/requirements.txt 2>/dev/null || true
 
       - name: Ruff

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -164,44 +164,16 @@ jobs:
           echo "support_configs=$SUPPORT_JSON" >> "$GITHUB_OUTPUT"
 
       - name: Install toolkit
-        run: python -m pip install git+https://github.com/dataciviclab/toolkit.git@v1.4.0
+        run: python -m pip install git+https://github.com/dataciviclab/toolkit.git@v1.5.0
 
       - name: Run support datasets first (if has_support)
-        if: steps.resolve.outputs.has_support == 'true'
+        if: steps.resolve.outputs.has_support == "true"
         env:
           SUPPORT_JSON: ${{ steps.resolve.outputs.support_configs }}
         run: |
           echo "::notice::This candidate has support dependencies. Running support datasets first."
           echo "$SUPPORT_JSON" > /tmp/support_configs.json
-
-          python - <<'PY'
-          import json, os, subprocess
-
-          with open("/tmp/support_configs.json") as f:
-              support_list = json.load(f)
-
-          for entry in support_list:
-              config = entry["config"]
-              years = entry.get("years", [])
-              name = entry.get("name", config)
-              print(f"::notice::Running support dataset: {name} ({config})")
-              for year in years:
-                  log_tag = config.replace("/", "_").replace(".", "_")
-                  print(f"::notice::Running support {config} for year {year}")
-                  for cmd, log_name in [
-                      (["toolkit", "run", "all", "--config", config, "--years", str(year)], f"support_run_{log_tag}_{year}.log"),
-                      (["toolkit", "validate", "all", "--config", config, "--years", str(year)], f"support_validate_{log_tag}_{year}.log"),
-                  ]:
-                      with open(log_name, "w") as lf:
-                          result = subprocess.run(cmd, capture_output=True, text=True)
-                          lf.write(result.stdout)
-                          if result.stderr:
-                              lf.write("\nSTDERR:\n" + result.stderr)
-                          if result.returncode != 0:
-                              print(f"::error::{cmd[0]} {cmd[1]} fallito per {config} anno {year} (exit={result.returncode})")
-                              exit(1)
-          PY
-
+          python scripts/run_support_datasets.py --support-json /tmp/support_configs.json
       - name: Toolkit inspect paths
         run: |
           toolkit inspect paths \

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -190,9 +190,9 @@ jobs:
           PY
 
       - name: Run support datasets first (if has_support)
-        if: steps.resolve.outputs.has_support == "true"
+        if: steps.resolve_support.outputs.has_support == "true"
         env:
-          SUPPORT_JSON: ${{ steps.resolve.outputs.support_configs }}
+          SUPPORT_JSON: ${{ steps.resolve_support.outputs.support_configs }}
         run: |
           echo "::notice::This candidate has support dependencies. Running support datasets first."
           echo "$SUPPORT_JSON" > /tmp/support_configs.json

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -141,7 +141,7 @@ jobs:
           echo "SSL_CERT_FILE=$bundle" >> "$GITHUB_ENV"
 
       - name: Install toolkit
-        run: pip install git+https://github.com/dataciviclab/toolkit.git@v1.4.0
+        run: pip install git+https://github.com/dataciviclab/toolkit.git@v1.5.0
 
       - name: Resolve support dependencies
         id: resolve_support
@@ -189,42 +189,14 @@ jobs:
               out.write("\nJSON\n")
           PY
 
-      - name: Run support datasets first
-        if: steps.resolve_support.outputs.has_support == 'true'
+      - name: Run support datasets first (if has_support)
+        if: steps.resolve.outputs.has_support == "true"
         env:
-          SUPPORT_JSON: ${{ steps.resolve_support.outputs.support_configs }}
+          SUPPORT_JSON: ${{ steps.resolve.outputs.support_configs }}
         run: |
-          echo "::notice::This candidate has support dependencies. Running support datasets in the same runner."
+          echo "::notice::This candidate has support dependencies. Running support datasets first."
           echo "$SUPPORT_JSON" > /tmp/support_configs.json
-
-          python - <<'PY'
-          import json, os, subprocess
-
-          with open("/tmp/support_configs.json") as f:
-              support_list = json.load(f)
-
-          for entry in support_list:
-              config = entry["config"]
-              years = entry.get("years", [])
-              name = entry.get("name", config)
-              print(f"::notice::Running support dataset: {name} ({config})")
-              for year in years:
-                  log_tag = config.replace("/", "_").replace(".", "_")
-                  print(f"::notice::Running support {config} for year {year}")
-                  for cmd, log in [
-                      (["toolkit", "run", "all", "--config", config, "--years", str(year)], f"support_run_{log_tag}_{year}.log"),
-                      (["toolkit", "validate", "all", "--config", config, "--years", str(year)], f"support_validate_{log_tag}_{year}.log"),
-                  ]:
-                      with open(log, "w") as lf:
-                          result = subprocess.run(cmd, capture_output=True, text=True)
-                          lf.write(result.stdout)
-                          if result.stderr:
-                              lf.write("\nSTDERR:\n" + result.stderr)
-                          if result.returncode != 0:
-                              print(f"::error::{cmd[0]} {cmd[1]} fallito per {config} anno {year} (exit={result.returncode})")
-                              exit(1)
-          PY
-
+          python scripts/run_support_datasets.py --support-json /tmp/support_configs.json
       - name: Toolkit inspect paths (pre-flight)
         run: |
           echo "=== inspect paths ==="

--- a/.github/workflows/sample-candidate-run.yml
+++ b/.github/workflows/sample-candidate-run.yml
@@ -113,47 +113,19 @@ jobs:
       # ------------------------------------------------------------------
       - name: Install toolkit
         run: |
-          pip install git+https://github.com/dataciviclab/toolkit.git@v1.4.0
+          pip install git+https://github.com/dataciviclab/toolkit.git@v1.5.0
 
       # ------------------------------------------------------------------
       # Step 1b — Run support datasets first (if has_support)
       # ------------------------------------------------------------------
       - name: Run support datasets first (if has_support)
-        if: steps.resolve.outputs.has_support == 'true'
+        if: steps.resolve.outputs.has_support == "true"
         env:
           SUPPORT_JSON: ${{ steps.resolve.outputs.support_configs }}
         run: |
           echo "::notice::This candidate has support dependencies. Running support datasets first."
           echo "$SUPPORT_JSON" > /tmp/support_configs.json
-
-          python - <<'PY'
-          import json, os, subprocess
-
-          with open("/tmp/support_configs.json") as f:
-              support_list = json.load(f)
-
-          for entry in support_list:
-              config = entry["config"]
-              years = entry.get("years", [])
-              name = entry.get("name", config)
-              print(f"::notice::Running support dataset: {name} ({config})")
-              for year in years:
-                  log_tag = config.replace("/", "_").replace(".", "_")
-                  print(f"::notice::Running support {config} for year {year}")
-                  for cmd, log_name in [
-                      (["toolkit", "run", "all", "--config", config, "--years", str(year)], f"support_run_{log_tag}_{year}.log"),
-                      (["toolkit", "validate", "all", "--config", config, "--years", str(year)], f"support_validate_{log_tag}_{year}.log"),
-                  ]:
-                      with open(log_name, "w") as lf:
-                          result = subprocess.run(cmd, capture_output=True, text=True)
-                          lf.write(result.stdout)
-                          if result.stderr:
-                              lf.write("\nSTDERR:\n" + result.stderr)
-                          if result.returncode != 0:
-                              print(f"::error::{cmd[0]} {cmd[1]} fallito per {config} anno {year} (exit={result.returncode})")
-                              exit(1)
-          PY
-
+          python scripts/run_support_datasets.py --support-json /tmp/support_configs.json
       # ------------------------------------------------------------------
       # Step 3 — Inspect paths + pre-flight check
       # ------------------------------------------------------------------

--- a/scripts/run_support_datasets.py
+++ b/scripts/run_support_datasets.py
@@ -1,0 +1,54 @@
+"""Run `toolkit run all` + `toolkit validate all` for each support dataset.
+
+Usage:
+    python scripts/run_support_datasets.py --support-json <path>
+
+The support JSON file should contain a list of dicts with keys:
+    - config (str): path to the dataset.yml
+    - years (list[int]): years to run
+    - name (str, optional): display name
+"""
+
+import json
+import subprocess
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) != 3 or sys.argv[1] != "--support-json":
+        print(f"Usage: {sys.argv[0]} --support-json <path>", file=sys.stderr)
+        sys.exit(1)
+
+    support_path = sys.argv[2]
+    with open(support_path) as f:
+        support_list = json.load(f)
+
+    for entry in support_list:
+        config = entry["config"]
+        years = entry.get("years", [])
+        name = entry.get("name", config)
+        print(f"::notice::Running support dataset: {name} ({config})")
+        log_tag = config.replace("/", "_").replace(".", "_")
+
+        for year in years:
+            print(f"::notice::Running support {config} for year {year}")
+            for cmd, log_suffix in [
+                (["toolkit", "run", "all", "--config", config, "--years", str(year)], "run"),
+                (["toolkit", "validate", "all", "--config", config, "--years", str(year)], "validate"),
+            ]:
+                log_name = f"support_{log_suffix}_{log_tag}_{year}.log"
+                result = subprocess.run(cmd, capture_output=True, text=True)
+                with open(log_name, "w") as lf:
+                    lf.write(result.stdout)
+                    if result.stderr:
+                        lf.write("\nSTDERR:\n" + result.stderr)
+                if result.returncode != 0:
+                    print(
+                        f"::error::{cmd[0]} {cmd[1]} fallito per {config} "
+                        f"anno {year} (exit={result.returncode})"
+                    )
+                    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Cosa

Aggiornamento toolkit da `v1.4.0` a `v1.5.0` + refactor del blocco support datasets duplicato in 3 workflow.

### Cambiamenti

| File | Cosa |
|---|---|
| `scripts/run_support_datasets.py` | **Nuovo** — script condiviso che esegue `toolkit run all` + `validate all` per ogni support dataset |
| `post-merge-candidate.yml` | Sostituito blocco Python inline (35 righe) con chiamata allo script |
| `pr-toolkit-check.yml` | Stesso |
| `sample-candidate-run.yml` | Stesso |
| `lint.yml` | `v1.4.0` → `v1.5.0` |

### Righe

97 rimosse, 67 aggiunte (netto -30). Codice duplicato ora in un unico script condiviso.

### Cosa contiene v1.5.0 del toolkit

Dalla v1.4.0: rimozione debug/minimal policy, dead code sweep, fix multi-year crash, contratti TypedDict, SSL fallback, rimozione subprocess MCP (test suite da 65s a 29s).