### PR TITLE
docs(skills): intake v0.5 + post-merge v0.4 — venv, new init, BQ separate

### DIFF
--- a/skills/intake-candidate.md
+++ b/skills/intake-candidate.md
@@ -3,7 +3,7 @@ name: intake-candidate
 description: Skill canonico di dataset-incubator per portare un caso da issue intake a PR pronta per merge.
 license: MIT
 metadata:
-  version: "0.4"
+  version: "0.5"
   owner: "DataCivicLab"
   tags: [dataset-incubator, intake, candidate, support-dataset]
 ---
@@ -11,7 +11,7 @@ metadata:
 # Skill: intake-candidate
 
 Skill canonico di `dataset-incubator`.
-Versione: 0.4 - 2026-05-06
+Versione: 0.5 - 2026-05-09
 
 ## Obiettivo
 
@@ -20,7 +20,7 @@ Portare un caso da issue intake a PR mergiata — candidate strutturato, runnabl
 ## Entry point
 
 - Issue con label `intake` e template `new-candidate.yml`
-- Creata automaticamente da `discussion-to-intake.yml` (in `dataciviclab`) oppure aperta direttamente
+- URL di una fonte pubblica verificata
 
 ## Stop rule
 
@@ -30,97 +30,69 @@ Non proseguire se: source-check debole, `clean` è già mart, caso troppo esplor
 
 ### 1. Valuta e allinea l'issue
 
-Legate: domanda guida, fonte, perimetro, output minimo, rischi noti, prossimo passo.
+Leggi: domanda guida, fonte, perimetro, output minimo, rischi noti, prossimo passo.
 
 Se il candidate esiste già → riallinea l'issue al perimetro reale. Mai aprire un doppione.
 
-### 2. Crea la struttura
+### 2. Bootstrap
 
-Single-source:
+Due modalità secondo il punto di partenza:
 
-```
-candidates/<slug>/
-  dataset.yml
-  README.md
-  notes.md
-  notebooks/<slug>_v0.ipynb
-  sql/clean.sql, mart.sql
-```
-
-Nota scaffold toolkit:
-
-- `sql/clean.sql` può partire dal placeholder del template (`SELECT * FROM raw_input`) oppure essere generato da `toolkit run init`.
-- Non scrivere parsing CSV dentro `clean.sql`: il parsing sta in `clean.read`, mentre `clean.sql` legge sempre da `raw_input`.
-- Dopo il bootstrap, revisiona sempre `clean.sql` e la proposta `clean.read` prima di considerare runnable il candidate.
-
-Copia il notebook da `templates/candidate/notebooks/` e imposta `METRICA` / `METRICA_CLEAN` in cima alla cella setup.
-
-### 3. Two-phase se c'è support
-
-Se `dataset.yml` dichiara `support`, i support girano prima del main.
-
-Verifica che siano necessari e non sostituibili con un join a mart esistente.
-
-### 4. Bootstrap, run e valida
-
-Check rapido pre-flight:
-
+**Source nuova, hai un URL diretto al file:**
 ```bash
-toolkit inspect paths --config candidates/{slug}/dataset.yml --json
+toolkit init --url https://example.com/data.csv --years 2024
 ```
+Scarica, profile (encoding, delimiter, colonne), genera `dataset.yml`, `sql/clean.sql`, `sql/mart.sql`, `README.md`, `notes.md`, `notebooks/`.
 
-Oppure MCP: `toolkit_inspect_paths(config_path)` → path contract verificato.
-
-Primo bootstrap su candidate nuovo o su source appena aggiunta:
-
+**Candidate strutturato già esistente, vuoi rigenerare lo scaffold:**
 ```bash
-toolkit run init --config candidates/{slug}/dataset.yml --years 2024
+toolkit init --config candidates/{slug}/dataset.yml --years 2024
 ```
 
-`run init` esegue RAW, profiling e scaffold assistito. Se genera o aggiorna indicazioni per `clean.read`, incorpora nel `dataset.yml` solo la parte verificata. Poi revisiona:
+### 3. Struttura
 
-- `sql/clean.sql` generato/placeholder: deve leggere da `raw_input`
-- `clean.read`: deve contenere parsing RAW esplicito quando serve
-- boundary clean/mart: clean raw-faithful, mart analitico
+Completa quello che `init --url` ha lasciato vuoto. Template in `templates/candidate/`:
+- `README.md` — descrivi il candidate
+- `notes.md` — domanda guida, rischi, note operative
+- `notebooks/<slug>_v0.ipynb` — copia dal template, imposta `METRICA` / `METRICA_CLEAN` nella cella setup
 
-Run completo solo dopo revisione dello scaffold:
+Se il candidate usa `support`, verifica che sia necessario e non sostituibile con un join a mart esistente.
+
+### 4. Revisiona scaffold
+
+Prima di lanciare il run, revisiona:
+
+- `sql/clean.sql` — deve leggere da `raw_input`, niente parsing inline
+- `clean.read` — parsing RAW esplicito quando serve (encoding, delimiter, skip rows)
+- `dataset.yml` — campi `clean.read` e `clean.sql` coerenti col source profile
+- boundary clean/mart — clean raw-faithful, mart analitico
+
+### 5. Run e valida
+
+Vedi [run-candidate.md](./run-candidate.md) per procedura completa.
 
 ```bash
 toolkit run all --config candidates/{slug}/dataset.yml --years 2024
 toolkit validate all --config candidates/{slug}/dataset.yml --years 2024
 ```
 
-Usa `--strict-config` per intercettare campi legacy o deprecati:
+Usa `--strict-config` per intercettare campi legacy o deprecati.
 
-```bash
-toolkit run all --config candidates/{slug}/dataset.yml --years 2024 --strict-config
-```
+Se fallisce → `toolkit_blocker_hints(config_path)` per isolare il primo errore. Blocker specifico documentato, non formulaico.
 
-Non usare `run all` come bootstrap da zero: se manca `clean.sql`, il comando deve fallire prima di RAW. Usa `run init`.
-
-Se fallisce → MCP `toolkit_blocker_hints(config_path)` per isolare il primo errore. Blocker specifico documentato, non formulaico.
-
-### 5. PR
+### 6. PR
 
 Apri PR con:
-
 - branch da `main`
 - perimetro stretto
 - issue collegata
 - esito del run in descrizione (passed / failed / blocker)
-
-### 6. Chiudi l'issue
-
-Passa label: `intake` → `incubating`.
-
-Stato candidato: `runnable` se il run passa, `scaffolded_with_blocker` se c'è blocker, `wait` se non è il momento.
 
 ## Definition of done
 
 - PR aperta con candidate strutturato
 - issue e struttura coerenti
 - almeno un run verificato oppure blocker documentato
-- notebook v0 reale
 - boundary clean/mart rispettato
 
 ## Dove orientarsi

--- a/skills/intake-candidate.md
+++ b/skills/intake-candidate.md
@@ -39,10 +39,23 @@ Se il candidate esiste già → riallinea l'issue al perimetro reale. Mai aprire
 Due modalità secondo il punto di partenza:
 
 **Source nuova, hai un URL diretto al file:**
+
+`toolkit init --url` genera i file nella directory corrente (`./{slug}/`). Il candidate deve stare in `candidates/{slug}/`, quindi esegui il comando da dentro `candidates/`:
+
+```bash
+cd candidates
+toolkit init --url https://example.com/data.csv --years 2024
+cd ..
+```
+
+Oppure, se preferisci inizializzare dalla root e poi spostare:
+
 ```bash
 toolkit init --url https://example.com/data.csv --years 2024
+mv ./{slug} candidates/{slug}
 ```
-Scarica, profile (encoding, delimiter, colonne), genera `dataset.yml`, `sql/clean.sql`, `sql/mart.sql`, `README.md`, `notes.md`, `notebooks/`.
+
+`init` scarica, profile (encoding, delimiter, colonne), genera `dataset.yml`, `sql/clean.sql`, `sql/mart.sql`, `README.md`, `notes.md`, `notebooks/`.
 
 **Candidate strutturato già esistente, vuoi rigenerare lo scaffold:**
 ```bash

--- a/skills/post-merge-candidate.md
+++ b/skills/post-merge-candidate.md
@@ -3,7 +3,7 @@ name: post-merge-candidate
 description: Skill per il maintainer dopo il merge di un candidate in dataset-incubator. Run completo, push GCS, clean catalog.
 license: MIT
 metadata:
-  version: "0.3"
+  version: "0.4"
   owner: "DataCivicLab"
   tags: [dataset-incubator, candidate, gcs, push, maintainer]
 ---
@@ -49,49 +49,66 @@ Copre tutti gli anni dichiarati nel config.
 toolkit validate all --config candidates/{slug}/dataset.yml
 ```
 
-### 4. Push GCS + BQ
+### 4. Push GCS
 
+**Trova lo slug GCS** (underscore, non trattino):
 ```bash
-cd ../dataset-incubator
-python scripts/push_archive.py --layer clean --slug {slug} --create-bq-table --update-catalog --status clean_ready --dry-run
+ls out/data/clean/          # per vedere lo slug corretto
 ```
 
-Se dry-run ok:
-
+**Dry run** (usa sempre il venv DI, non system python):
 ```bash
-python scripts/push_archive.py --layer clean --slug {slug} --create-bq-table --update-catalog --status clean_ready
+cd /path/to/dataset-incubator
+.venv/bin/python scripts/push_archive.py --layer clean --slug {gcs_slug} --no-bq --update-catalog --status clean_ready --dry-run
 ```
 
-Include: parquet per ogni anno + `pipeline_run.json` + BQ external table `dataciviclab.{slug}.clean`.
-
-### 5. Clean catalog
-
+Se dry-run ok, push reale senza BQ (BQ table creata separatamente dopo verifica):
 ```bash
-python scripts/build_clean_catalog.py --write
-python scripts/build_clean_catalog.py --check-gcs
+.venv/bin/python scripts/push_archive.py --layer clean --slug {gcs_slug} --no-bq --update-catalog --status clean_ready
 ```
 
-Aggiorna `clean_catalog.json` nella draft PR (`post-merge-candidate/pr-<N>-registry`):
+Parquet per ogni anno + `pipeline_run.json` → `gs://dataciviclab-clean/{gcs_slug}/{year}/`.
 
-- **sempre** — per compilare i campi mancanti: `name`, `description`, `source`, `columns[].role`, `columns[].description`
-- **se slug nuovo** — crea l'entry completa
-- **se `multi_file` flag cambiato** o **GCS path cambiato** — aggiorna struttura e path
+**BQ table — solo dopo verifica GCS ok:**
+```bash
+.venv/bin/python scripts/push_archive.py --layer clean --slug {gcs_slug} --create-bq-table --update-catalog --status clean_ready
+```
+
+### 5. Clean catalog — compila e normalizza
+
+**Prima riscrivi** il catalog con `--write` per normalizzare, poi arricchisci i campi mancanti:
 
 ```bash
-# Checkout del branch della draft PR (creato dal workflow post-merge)
-git fetch origin post-merge-candidate/pr-<N>-registry
-git checkout post-merge-candidate/pr-<N>-registry
+.venv/bin/python scripts/build_clean_catalog.py --write
+```
 
-# Aggiungi le modifiche al catalog e pusha sul branch della PR
+**Compila entry per lo slug** (campi sempre da riempire):
+- `name`: nome canonico, es. "MEF - Irpef Regionale"
+- `description`: una frase che dice cosa contiene e da dove viene
+- `source`: URL della fonte
+- `columns[].role`: `dimension` o `metric`
+- `columns[].description`: descrizione breve della colonna
+
+Regole per `role`:
+- colonne temporali, geografiche, categoriche → `dimension`
+- colonne numeriche (freq, eur, count) → `metric`
+
+**Verifica e push**:
+```bash
+.venv/bin/python scripts/build_clean_catalog.py --check-gcs   # deve tornare "ok"
 git add registry/clean_catalog.json
-git commit -m "chore({slug}): aggiorna clean_catalog post-push GCS"
+git commit -m "chore(post-merge): aggiorna registry per PR #<N>"
 git push origin post-merge-candidate/pr-<N>-registry
 ```
 
+Aggiorna `clean_catalog.json` nella draft PR (`post-merge-candidate/pr-<N>-registry`):
+- **sempre** — per compilare i campi mancanti
+- **se slug nuovo** — crea l'entry completa
+- **se `multi_file` flag cambiato** o **GCS path cambiato** — aggiorna struttura e path
+
 ### 6. Chiudi draft PR
 
-`validate-clean-catalog.yml` gira automaticamente sulla PR quando il catalog cambia.
-Verifica che passi, poi marca ready for review e fai merge.
+Verifica che `--check-gcs` sia green, poi marca la PR ready for review e fai merge.
 
 ## Stop rule
 

--- a/skills/post-merge-candidate.md
+++ b/skills/post-merge-candidate.md
@@ -69,7 +69,10 @@ Se dry-run ok, push reale senza BQ (BQ table creata separatamente dopo verifica)
 
 Parquet per ogni anno + `pipeline_run.json` → `gs://dataciviclab-clean/{gcs_slug}/{year}/`.
 
-**BQ table — solo dopo verifica GCS ok:**
+**BQ external table — solo dopo verifica GCS ok:**
+
+Il comando usa `--layer clean` con `--create-bq-table`, che esegue un re-run idempotente: ripusha parquet GCS (sovrascrittura innocua) + crea/aggiorna external table BQ. Non esiste un flag BQ-only — il re-run è sicuro perché i file GCS sono già presenti.
+
 ```bash
 .venv/bin/python scripts/push_archive.py --layer clean --slug {gcs_slug} --create-bq-table --update-catalog --status clean_ready
 ```


### PR DESCRIPTION
## Skill update — v0.4/v0.5

**intake-candidate.md v0.5**
- `run init` → `toolkit init --url` / `toolkit init --config`
- Flusso riscritto: bootstrap → struttura → revisiona → run → PR
- Entry point: URL fonte pubblica verificata
- Rimanda a run-candidate per step run completo
- Rimosso passo "chiudi issue" (si chiude col merge)

**post-merge-candidate.md v0.4**
- `--no-bq` di default, BQ table separata dopo verifica GCS
- `.venv/bin/python` obbligatorio per script DI
- `--write` → compila entry → check-gcs → push
- Regole per role dimension/metric

## Files changed
- `skills/intake-candidate.md`
- `skills/post-merge-candidate.md`