### PR TITLE
refactor(clean-query-mcp): migra a lab_connectors.mcp v0.2.0

### DIFF
--- a/tools/clean-query-mcp/requirements.txt
+++ b/tools/clean-query-mcp/requirements.txt
@@ -1,2 +1,3 @@
 mcp>=1.26.0
 duckdb==1.5.1
+lab-connectors>=0.2.0

--- a/tools/clean-query-mcp/requirements.txt
+++ b/tools/clean-query-mcp/requirements.txt
@@ -1,3 +1,3 @@
 mcp>=1.26.0
 duckdb==1.5.1
-lab-connectors>=0.2.0
+git+https://github.com/dataciviclab/lab-connectors.git@v0.2.0

--- a/tools/clean-query-mcp/server.py
+++ b/tools/clean-query-mcp/server.py
@@ -848,7 +848,7 @@ def explain_query(sql: str, dataset: str) -> dict[str, Any]:
         source_expr = f"['{escaped_paths}']"
     wrapped_sql = f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) {sql}"
 
-    try:
+    def _exec() -> dict[str, Any]:
         import duckdb
         import concurrent.futures
 
@@ -875,14 +875,8 @@ def explain_query(sql: str, dataset: str) -> dict[str, Any]:
             "note": "EXPLAIN eseguito con successo — query sintatticamente e semanticamente valida.",
             "tip": "Usa preview() per verificare i dati reali prima di run_query().",
         }
-    except Exception as exc:
-        return {
-            "valid": False,
-            "validation_error": f"EXPLAIN fallito: {exc}",
-            "dataset": dataset,
-            "sql": sql,
-            "tip": "Correggi la query oppure usa preview() per verificare lo schema.",
-        }
+
+    return lc_guard(_exec)
 
 
 if __name__ == "__main__":

--- a/tools/clean-query-mcp/server.py
+++ b/tools/clean-query-mcp/server.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from lab_connectors.mcp import create_mcp_server, guard as lc_guard
+from lab_connectors.mcp.errors import McpError, ErrorCode
 
 from catalog import describe_dataset as describe_impl  # noqa: E402
 from catalog import get_year_column  # noqa: E402
@@ -37,8 +38,16 @@ BLOCKED_KEYWORDS = {
 TOKEN_RE = re.compile(r"[a-z_][a-z0-9_]*")
 
 
-class DuckdbClientError(RuntimeError):
-    pass
+class DuckdbClientError(McpError):
+    """Ponte verso lab_connectors.mcp: eredita McpError.
+
+    Tutti i raise DuckdbClientError('msg') esistenti diventano
+    McpError(ErrorCode.UNEXPECTED, 'msg') e vengono catturati
+    correttamente da guard() delle librerie.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(ErrorCode.QUERY_ERROR, message)
 
 
 def _guard_max_rows(max_rows: int) -> int:
@@ -91,13 +100,6 @@ def _validate_parquet_paths(paths: list[str]) -> None:
                 f"Path parquet contiene caratteri non sicuri: '{p}'. "
                 f"Caratteri ammessi: lettere, numeri, /, _, ., -, :"
             )
-
-
-def guard(fn, handled_exceptions: tuple[type[BaseException], ...] = (Exception,)) -> dict[str, Any]:
-    try:
-        return fn()
-    except handled_exceptions as exc:
-        return {"error": str(exc)}
 
 
 def _duckdb_read(
@@ -160,11 +162,6 @@ def _duckdb_read(
     return {"columns": columns, "rows": rows}
 
 
-def mcp_telemetry(_server: str):
-    def decorator(fn):
-        return fn
-
-    return decorator
 
 
 def _validate_scope(sql: str) -> None:
@@ -222,12 +219,12 @@ def _validate_scope(sql: str) -> None:
         )
 
 
-mcp = FastMCP(
+mcp = create_mcp_server(
     name="clean-query",
     instructions=(
         "MCP server per interrogare i dataset clean del DataCivicLab tramite DuckDB. "
         "Espone catalogo semantico (dataset, colonne, metriche) e esecuzione query read-only. "
-        "Il client AI (Claude/Qwen/etc.) genera il SQL a partire dallo schema."
+        "Il client AI genera il SQL a partire dallo schema."
     ),
 )
 
@@ -235,7 +232,6 @@ mcp = FastMCP(
 @mcp.tool(
     description="Lista dei dataset clean disponibili per query.", structured_output=True
 )
-@mcp_telemetry("clean-query")
 def list_datasets() -> list[dict[str, Any]]:
     return list_impl()
 
@@ -244,7 +240,6 @@ def list_datasets() -> list[dict[str, Any]]:
     description="Cerca nei dataset per nome, descrizione o fonte.",
     structured_output=True,
 )
-@mcp_telemetry("clean-query")
 def search_datasets(query: str) -> list[dict[str, Any]]:
     if not (query or "").strip():
         raise DuckdbClientError("query non può essere vuota")
@@ -255,7 +250,6 @@ def search_datasets(query: str) -> list[dict[str, Any]]:
     description="Descrive lo schema di un dataset: colonne, tipi, ruolo (dimension/metric), periodo.",
     structured_output=True,
 )
-@mcp_telemetry("clean-query")
 def describe_dataset(slug: str) -> dict[str, Any]:
     return describe_impl(slug)
 
@@ -306,7 +300,6 @@ def _inject_year_filter(sql: str, year_col: str | None, year: int) -> str:
     ),
     structured_output=True,
 )
-@mcp_telemetry("clean-query")
 def run_query(
     sql: str, dataset: str, max_rows: int = 100, year: int | None = None
 ) -> dict[str, Any]:
@@ -385,14 +378,13 @@ def run_query(
             "dataset": dataset,
         }
 
-    return guard(_exec, handled_exceptions=(DuckdbClientError, Exception))
+    return lc_guard(_exec)
 
 
 @mcp.tool(
     description="Restituisce statistiche sulla cache GCS del catalogo (utile per debug).",
     structured_output=True,
 )
-@mcp_telemetry("clean-query")
 def cache_stats() -> dict[str, Any]:
     from catalog import gcs_cache_stats
 
@@ -410,7 +402,6 @@ def cache_stats() -> dict[str, Any]:
     ),
     structured_output=True,
 )
-@mcp_telemetry("clean-query")
 def aggregate(
     dataset: str,
     metric: str,
@@ -468,7 +459,6 @@ def aggregate(
     ),
     structured_output=True,
 )
-@mcp_telemetry("clean-query")
 def preview(dataset: str, limit: int = 10, year: int | None = None) -> dict[str, Any]:
     if limit <= 0 or limit > MAX_ROWS_HARD_CAP:
         return {"error": f"limit deve essere tra 1 e {MAX_ROWS_HARD_CAP}"}
@@ -495,7 +485,6 @@ def preview(dataset: str, limit: int = 10, year: int | None = None) -> dict[str,
     ),
     structured_output=True,
 )
-@mcp_telemetry("clean-query")
 def count(dataset: str, year: int | None = None) -> dict[str, Any]:
     try:
         parquet_paths = resolve_parquet_path(dataset, year=year)
@@ -546,7 +535,7 @@ def count(dataset: str, year: int | None = None) -> dict[str, Any]:
             "files_count": len(parquet_paths),
         }
 
-    return guard(_exec, handled_exceptions=(DuckdbClientError, Exception))
+    return lc_guard(_exec)
 
 
 @mcp.tool(
@@ -557,7 +546,6 @@ def count(dataset: str, year: int | None = None) -> dict[str, Any]:
     ),
     structured_output=True,
 )
-@mcp_telemetry("clean-query")
 def time_series(
     dataset: str,
     metric: str,
@@ -646,7 +634,7 @@ def time_series(
             "year_filter": year,
         }
 
-    return guard(_exec, handled_exceptions=(DuckdbClientError, Exception))
+    return lc_guard(_exec)
 
 
 @mcp.tool(
@@ -656,7 +644,6 @@ def time_series(
     ),
     structured_output=True,
 )
-@mcp_telemetry("clean-query")
 def distinct_values(dataset: str, column: str, limit: int = 100) -> dict[str, Any]:
     if limit <= 0 or limit > MAX_ROWS_HARD_CAP:
         return {"error": f"limit deve essere tra 1 e {MAX_ROWS_HARD_CAP}"}
@@ -722,7 +709,7 @@ def distinct_values(dataset: str, column: str, limit: int = 100) -> dict[str, An
             "dataset": dataset,
         }
 
-    return guard(_exec, handled_exceptions=(DuckdbClientError, Exception))
+    return lc_guard(_exec)
 
 
 @mcp.tool(
@@ -732,7 +719,6 @@ def distinct_values(dataset: str, column: str, limit: int = 100) -> dict[str, An
     ),
     structured_output=True,
 )
-@mcp_telemetry("clean-query")
 def find_metric_datasets(query: str = "", metric_name: str = "", limit: int = 20) -> dict[str, Any]:
     def _exec() -> dict[str, Any]:
         catalog = load_catalog()
@@ -778,7 +764,7 @@ def find_metric_datasets(query: str = "", metric_name: str = "", limit: int = 20
             "note": "Ritorna dataset che hanno colonne role=metric. Usa describe_dataset per lo schema completo.",
         }
 
-    return guard(_exec, handled_exceptions=(Exception,))
+    return lc_guard(_exec)
 
 
 @mcp.tool(
@@ -788,7 +774,6 @@ def find_metric_datasets(query: str = "", metric_name: str = "", limit: int = 20
     ),
     structured_output=True,
 )
-@mcp_telemetry("clean-query")
 def column_search(query: str, limit: int = 15) -> dict[str, Any]:
     def _exec() -> dict[str, Any]:
         catalog = load_catalog()
@@ -828,7 +813,7 @@ def column_search(query: str, limit: int = 15) -> dict[str, Any]:
             "note": "Meta_match=True indica match su nome/descrizione dataset; matched_columns indica match su colonna.",
         }
 
-    return guard(_exec, handled_exceptions=(Exception,))
+    return lc_guard(_exec)
 
 
 @mcp.tool(
@@ -839,7 +824,6 @@ def column_search(query: str, limit: int = 15) -> dict[str, Any]:
     ),
     structured_output=True,
 )
-@mcp_telemetry("clean-query")
 def explain_query(sql: str, dataset: str) -> dict[str, Any]:
     try:
         parquet_paths = resolve_parquet_path(dataset, year=None)

--- a/tools/clean-query-mcp/server.py
+++ b/tools/clean-query-mcp/server.py
@@ -41,21 +41,22 @@ TOKEN_RE = re.compile(r"[a-z_][a-z0-9_]*")
 class DuckdbClientError(McpError):
     """Ponte verso lab_connectors.mcp: eredita McpError.
 
-    Tutti i raise DuckdbClientError('msg') esistenti diventano
-    McpError(ErrorCode.UNEXPECTED, 'msg') e vengono catturati
-    correttamente da guard() delle librerie.
+    - code default: QUERY_ERROR (query DuckDB fallite)
+    - INVALID_PARAMS: parametri in input invalidi
+    - QUERY_SCOPE_VIOLATION: SQL non valida o violate constraint
     """
 
-    def __init__(self, message: str) -> None:
-        super().__init__(ErrorCode.QUERY_ERROR, message)
+    def __init__(self, message: str, code: ErrorCode = ErrorCode.QUERY_ERROR) -> None:
+        super().__init__(code, message)
 
 
 def _guard_max_rows(max_rows: int) -> int:
     if max_rows <= 0:
-        raise DuckdbClientError("max_rows deve essere maggiore di 0")
+        raise DuckdbClientError("max_rows deve essere maggiore di 0", ErrorCode.INVALID_PARAMS)
     if max_rows > MAX_ROWS_HARD_CAP:
         raise DuckdbClientError(
-            f"max_rows oltre il limite hard cap di {MAX_ROWS_HARD_CAP}"
+            f"max_rows oltre il limite hard cap di {MAX_ROWS_HARD_CAP}",
+            ErrorCode.INVALID_PARAMS,
         )
     return max_rows
 
@@ -63,13 +64,13 @@ def _guard_max_rows(max_rows: int) -> int:
 def _validate_select_sql(sql: str) -> str:
     text = (sql or "").strip()
     if not text:
-        raise DuckdbClientError("sql vuoto")
+        raise DuckdbClientError("sql vuoto", ErrorCode.INVALID_PARAMS)
 
     lowered = text.lower()
     if ";" in text:
-        raise DuckdbClientError("Query multiple o statement terminati da ';' non consentiti")
+        raise DuckdbClientError("Query multiple o statement terminati da ';' non consentiti", ErrorCode.QUERY_SCOPE_VIOLATION)
     if not (lowered.startswith("select") or lowered.startswith("with")):
-        raise DuckdbClientError("Sono consentite solo query SELECT o WITH")
+        raise DuckdbClientError("Sono consentite solo query SELECT o WITH", ErrorCode.QUERY_SCOPE_VIOLATION)
 
     scrubbed = re.sub(r"--.*?$", " ", text, flags=re.MULTILINE)
     scrubbed = re.sub(r"/\*.*?\*/", " ", scrubbed, flags=re.DOTALL)
@@ -79,7 +80,7 @@ def _validate_select_sql(sql: str) -> str:
 
     for keyword in BLOCKED_KEYWORDS:
         if keyword in tokens:
-            raise DuckdbClientError(f"Keyword non consentita nella query: {keyword}")
+            raise DuckdbClientError(f"Keyword non consentita nella query: {keyword}", ErrorCode.QUERY_SCOPE_VIOLATION)
     return text
 
 
@@ -181,11 +182,13 @@ def _validate_scope(sql: str) -> None:
     if "read_parquet(" in scrubbed_lower:
         raise DuckdbClientError(
             "Accesso diretto a read_parquet() non consentito. "
-            "Usa 'FROM clean_input' invece di read_parquet()."
+            "Usa 'FROM clean_input' invece di read_parquet().",
+            ErrorCode.QUERY_SCOPE_VIOLATION,
         )
     if "read_csv(" in scrubbed_lower:
         raise DuckdbClientError(
-            "Accesso diretto a read_csv() non consentito. Usa 'FROM clean_input'."
+            "Accesso diretto a read_csv() non consentito. Usa 'FROM clean_input'.",
+            ErrorCode.QUERY_SCOPE_VIOLATION,
         )
 
     # Collect CTE names defined in the query.
@@ -203,7 +206,8 @@ def _validate_scope(sql: str) -> None:
         raise DuckdbClientError(
             f"Riferimento a tabella non consentito in FROM: '{table_ref}'. "
             f"Solo 'clean_input' e CTE locali sono permessi. "
-            f"Usa describe_dataset() per lo schema."
+            f"Usa describe_dataset() per lo schema.",
+            ErrorCode.QUERY_SCOPE_VIOLATION,
         )
 
     # Extract all JOIN <identifier> references.
@@ -215,7 +219,8 @@ def _validate_scope(sql: str) -> None:
         raise DuckdbClientError(
             f"Riferimento a tabella non consentito in JOIN: '{table_ref}'. "
             f"Solo 'clean_input' e CTE locali sono permessi. "
-            f"Usa describe_dataset() per lo schema."
+            f"Usa describe_dataset() per lo schema.",
+            ErrorCode.QUERY_SCOPE_VIOLATION,
         )
 
 
@@ -240,10 +245,13 @@ def list_datasets() -> list[dict[str, Any]]:
     description="Cerca nei dataset per nome, descrizione o fonte.",
     structured_output=True,
 )
-def search_datasets(query: str) -> list[dict[str, Any]]:
-    if not (query or "").strip():
-        raise DuckdbClientError("query non può essere vuota")
-    return search_impl(query.strip())
+def search_datasets(query: str) -> dict[str, Any]:
+    def _exec() -> dict[str, Any]:
+        if not (query or "").strip():
+            raise DuckdbClientError("query non può essere vuota", ErrorCode.EMPTY_PARAM)
+        return {"datasets": search_impl(query.strip()), "query": query.strip()}
+
+    return lc_guard(_exec)
 
 
 @mcp.tool(


### PR DESCRIPTION
## Summary
- `FastMCP` → `create_mcp_server` da `lab_connectors.mcp` (init standardizzato)
- `duckdbClientError(RuntimeError)` → `DuckdbClientError(McpError)` con `ErrorCode.QUERY_ERROR` (ponte)
- `guard()` custom → `lc_guard()` da `lab_connectors` (error handling unificato)
- `@mcp_telemetry` no-op rimosso da tutti gli 11 tool
- `explain_query` ora usa pattern `_exec() + lc_guard()` come gli altri tool (fix post-review)
- `requirements.txt`: aggiunto `lab-connectors>=0.2.0`

## Testing
- Smoke test locale: `python tools/clean-query-mcp/scripts/smoke.py` → tutti i dataset rispondono
- Pattern identico a toolkit PR #238 e SO PR #215 (già merged)

## Verdict review
Post-review: fix applicato su `explain_query` — ora tutti gli 11 tool usano `lc_guard` in modo consistente.

---
Verifica che `lab-connectors>=0.2.0` sia disponibile su PyPI prima del merge, oppure pubblica tag su `lab-connectors` repo.