### PR TITLE
feat: shared candidate helpers — riduce duplicazione support resolution e year parsing

### DIFF
--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -151,37 +151,21 @@ jobs:
           python - <<'PY'
           import json
           import os
-          from pathlib import Path
+          import subprocess
 
-          import yaml
+          result = subprocess.run(
+              ["python", "scripts/resolve_sample_run.py", os.environ["CONFIG_PATH"]],
+              capture_output=True, text=True
+          )
 
-          root = Path(os.environ["GITHUB_WORKSPACE"])
-          cfg_path = root / os.environ["CONFIG_PATH"]
-          support_map = {}
+          support_list = []
+          if result.returncode == 0:
+              try:
+                  data = json.loads(result.stdout)
+                  support_list = data.get("support", [])
+              except json.JSONDecodeError:
+                  pass
 
-          if cfg_path.exists():
-              with open(cfg_path, encoding="utf-8") as f:
-                  cfg = yaml.safe_load(f) or {}
-
-              raw_support = cfg.get("support", []) or []
-              dataset_support = cfg.get("dataset", {}).get("support", []) or []
-              for entry in raw_support + dataset_support:
-                  rel_config = entry.get("config", "")
-                  if not rel_config:
-                      continue
-                  support_path = (cfg_path.parent / rel_config).resolve()
-                  try:
-                      support_rel = support_path.relative_to(root)
-                  except ValueError:
-                      support_rel = support_path
-                  key = str(support_rel)
-                  support_map.setdefault(key, {
-                      "name": entry.get("name", ""),
-                      "config": key,
-                      "years": entry.get("years", []),
-                  })
-
-          support_list = list(support_map.values())
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
               out.write(f"has_support={str(bool(support_list)).lower()}\n")
               out.write("support_configs<<JSON\n")

--- a/scripts/_candidate_helpers.py
+++ b/scripts/_candidate_helpers.py
@@ -1,0 +1,127 @@
+"""Shared helpers for candidate/support-dataset introspection.
+
+Centralizza logica di:
+  - risoluzione anni (dataset.years)
+  - risoluzione dipendenze support
+  - estrazione slug da path
+  - rilevamento nested config
+
+Usato da:
+  - resolve_sample_run.py
+  - detect_candidates.py
+  - pr-toolkit-check.yml (via resolve_sample_run.py)
+
+Contratto: tutte le funzioni sono pure (input → output, niente I/O esterno
+se non la lettura esplicita del dataset.yml in resolve_years).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def resolve_years(cfg_path: Path) -> list[int]:
+    """Legge dataset.years da dataset.yml, ritorna lista ordinata di int.
+
+    Ritorna lista vuota se il file non esiste, non ha la sezione dataset,
+    o gli anni non sono validi.
+    """
+    try:
+        with open(cfg_path, encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+    except Exception:
+        return []
+
+    dataset = cfg.get("dataset", {})
+    years = dataset.get("years", [])
+    if not years:
+        return []
+
+    try:
+        return sorted(int(y) for y in years)
+    except (TypeError, ValueError):
+        return []
+
+
+def resolve_sample_year(cfg_path: Path) -> int:
+    """Ritorna l'ultimo anno in dataset.years, o 0 se non determinabile.
+
+    Utile per detect_candidates che usa un singolo anno nel matrix CI.
+    """
+    years = resolve_years(cfg_path)
+    return years[-1] if years else 0
+
+
+def resolve_support_entries(
+    cfg: dict[str, Any],
+    cfg_parent: Path,
+    root: Path,
+) -> list[dict[str, Any]]:
+    """Legge le voci support[] da dataset.yml, supportando entrambi i pattern.
+
+    Pattern supportati:
+      - root level: support: [{name, config, years}]
+      - inside dataset: dataset.support: [{name, config, years}]
+
+    Args:
+        cfg: dataset.yml parsato
+        cfg_parent: directory che contiene dataset.yml
+        root: ROOT del repository
+
+    Returns:
+        Lista di dict con chiavi name, config (path relativo a root), years
+    """
+    entries = []
+    raw_support = cfg.get("support", []) or []
+    dataset_support = cfg.get("dataset", {}).get("support", []) or []
+
+    for entry in raw_support + dataset_support:
+        rel_config = entry.get("config", "")
+        if not rel_config:
+            continue
+        support_path = (cfg_parent / rel_config).resolve()
+        try:
+            support_rel = support_path.relative_to(root)
+        except ValueError:
+            support_rel = support_path
+        entries.append({
+            "name": entry.get("name", ""),
+            "config": str(support_rel),
+            "years": entry.get("years", []),
+        })
+
+    return entries
+
+
+def candidate_slug_from_path(path: Path, root: Path) -> str | None:
+    """Estrae lo slug di un candidate/support_dataset dal path.
+
+    Cerca il primo segmento dopo candidates/ o support_datasets/ nel path
+    relativo a root.
+
+    Esempi:
+      candidates/istat-housing-crowding/dataset.yml → "istat-housing-crowding"
+      candidates/ispra-ru/sources/a_ru_base/dataset.yml → "ispra-ru"
+      support_datasets/bdap-anagrafe-enti/dataset.yml → "bdap-anagrafe-enti"
+    """
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        rel = path
+
+    for i, part in enumerate(rel.parts):
+        if part in ("candidates", "support_datasets"):
+            if i + 1 < len(rel.parts):
+                return rel.parts[i + 1]
+
+    # Fallback: directory padre
+    return path.parts[-2] if len(path.parts) >= 2 else None
+
+
+def is_nested_config(path: Path) -> bool:
+    """Un config è nested se il path contiene sources/ o compose/."""
+    parts = path.parts
+    return "sources" in parts or "compose" in parts

--- a/scripts/detect_candidates.py
+++ b/scripts/detect_candidates.py
@@ -45,17 +45,18 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 
+# Import shared helpers
+sys.path.insert(0, str(ROOT / "scripts"))
+from _candidate_helpers import resolve_sample_year  # noqa: E402
+
 
 def _resolve_year(cfg_path: Path) -> int:
-    """Resolve the sample year from a dataset.yml — last year in list."""
-    import yaml
-    try:
-        with open(cfg_path, encoding="utf-8") as f:
-            d = yaml.safe_load(f) or {}
-        years = d.get("dataset", {}).get("years", [])
-        return int(years[-1]) if years else 0
-    except Exception:
-        return 0
+    """Resolve the sample year from a dataset.yml — last year in list.
+
+    Delegates to shared helper _candidate_helpers.resolve_sample_year.
+    Kept as thin wrapper for backward compat (returns 0 on missing).
+    """
+    return resolve_sample_year(cfg_path)
 
 
 def _git_diff_files(base_sha: str | None, head_sha: str) -> list[str]:

--- a/scripts/resolve_sample_run.py
+++ b/scripts/resolve_sample_run.py
@@ -38,6 +38,15 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 
+# Import shared helpers
+sys.path.insert(0, str(ROOT / "scripts"))
+from _candidate_helpers import (  # noqa: E402
+    candidate_slug_from_path,
+    is_nested_config,
+    resolve_support_entries,
+    resolve_years,
+)
+
 
 def resolve(config_path: str) -> dict:
     """Resolve sample run parameters for a dataset config."""
@@ -60,83 +69,44 @@ def resolve(config_path: str) -> dict:
     if not name:
         return {"error": f"No 'dataset.name' in {config_path}"}
 
-    years = dataset.get("years", [])
-    if not years:
+    # Resolve years via shared helper
+    years_int = resolve_years(path)
+    if not years_int:
         return {
             "error": f"No 'dataset.years' in {config_path} -- cannot determine sample year",
             "config_path": str(path),
             "slug": None,
         }
 
-    # Sample year = last year in the list (most recent)
-    try:
-        years_int = sorted(int(y) for y in years)
-    except (TypeError, ValueError):
-        return {"error": f"Invalid years value in {config_path}: {years}"}
-
     sample_year = years_int[-1]
 
-    # Compute slug from config path, NOT from YAML dataset.name
-    # This avoids mismatch with pipeline_signals which uses directory names
-    parts = path.parts
+    # Compute slug from config path (shared helper)
+    slug = candidate_slug_from_path(path, ROOT)
 
-    # Nested config detection
-    is_nested = "sources" in parts or "compose" in parts
+    # Nested config detection (shared helper)
+    nested = is_nested_config(path)
 
-    # Collect support[] entries from dataset config.
-    # Two patterns in use:
-    #   - root level: support: [{name, config, years}]  (es. mim-alunni-corso-eta)
-    #   - inside dataset: dataset.support: [{name, config, years}]  (es. ispra-ru-costi-kg, malasanita, opencivitas)
-    # Try root level first, then dataset.support
-    support_entries = []
-    raw_support = cfg.get("support", []) or []
-    dataset_support = cfg.get("dataset", {}).get("support", []) or []
-    for entry in raw_support + dataset_support:
-        cfg_path = entry.get("config", "")
-        if cfg_path:
-            support_cfg_path = str((path.parent / cfg_path).resolve())
-            try:
-                support_rel = Path(support_cfg_path).relative_to(ROOT)
-            except ValueError:
-                support_rel = Path(support_cfg_path)
-            support_entries.append({
-                "name": entry.get("name", ""),
-                "config": str(support_rel),
-                "years": entry.get("years", []),
-            })
+    # Resolve support entries (shared helper)
+    support_entries = resolve_support_entries(cfg, path.parent, ROOT)
+    has_support = bool(support_entries)
 
-    has_support = len(support_entries) > 0
-
-    # Compute slug from config path relative to ROOT
+    # Relative path for output
     try:
         rel = path.relative_to(ROOT)
     except ValueError:
         rel = path
-
-    # Find slug: first segment after 'candidates/' or 'support_datasets/'
-    slug = None
-    for i, part in enumerate(rel.parts):
-        if part in ("candidates", "support_datasets"):
-            if i + 1 < len(rel.parts):
-                slug = rel.parts[i + 1]
-                break
-
-    # Fallback: derive from directory if slug not found (should not happen
-    # for valid candidates, but guards against malformed paths)
-    if slug is None:
-        slug = path.parts[-2] if len(path.parts) >= 2 else None
 
     return {
         "config_path": str(rel),
         "slug": slug,
         "sample_year": sample_year,
         "all_years": years_int,
-        "is_nested": is_nested,
+        "is_nested": nested,
         "has_support": has_support,
         "support": support_entries,
         "note": (
             "nested config -- run via source layer"
-            if is_nested
+            if nested
             else ""
         ),
     }

--- a/tests/test_candidate_helpers.py
+++ b/tests/test_candidate_helpers.py
@@ -1,0 +1,241 @@
+"""Tests for _candidate_helpers shared helpers."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from _candidate_helpers import (  # noqa: E402
+    candidate_slug_from_path,
+    is_nested_config,
+    resolve_sample_year,
+    resolve_support_entries,
+    resolve_years,
+)
+
+
+def _write_dataset(tmp: Path, rel_path: str, content: str) -> Path:
+    """Write a dataset.yml file inside tmp directory, return full path."""
+    full = tmp / rel_path
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(content, encoding="utf-8")
+    return full
+
+
+class ResolveYearsTest(unittest.TestCase):
+    """Tests for resolve_years() and resolve_sample_year()."""
+
+    def test_valid_years(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cfg = _write_dataset(tmp, "dataset.yml", """
+dataset:
+  name: Test
+  years: [2020, 2021, 2024]
+""")
+            self.assertEqual(resolve_years(cfg), [2020, 2021, 2024])
+            self.assertEqual(resolve_sample_year(cfg), 2024)
+
+    def test_single_year(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cfg = _write_dataset(tmp, "dataset.yml", """
+dataset:
+  name: Test
+  years: [2022]
+""")
+            self.assertEqual(resolve_years(cfg), [2022])
+            self.assertEqual(resolve_sample_year(cfg), 2022)
+
+    def test_empty_years(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cfg = _write_dataset(tmp, "dataset.yml", """
+dataset:
+  name: Test
+  years: []
+""")
+            self.assertEqual(resolve_years(cfg), [])
+            self.assertEqual(resolve_sample_year(cfg), 0)
+
+    def test_missing_years_key(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cfg = _write_dataset(tmp, "dataset.yml", """
+dataset:
+  name: Test
+""")
+            self.assertEqual(resolve_years(cfg), [])
+
+    def test_missing_dataset_section(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cfg = _write_dataset(tmp, "dataset.yml", "raw: {}")
+            self.assertEqual(resolve_years(cfg), [])
+
+    def test_file_not_found(self) -> None:
+        self.assertEqual(resolve_years(Path("/nonexistent/dataset.yml")), [])
+
+    def test_years_not_sorted(self) -> None:
+        """Years should be sorted in output regardless of input order."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cfg = _write_dataset(tmp, "dataset.yml", """
+dataset:
+  name: Test
+  years: [2024, 2020, 2022]
+""")
+            self.assertEqual(resolve_years(cfg), [2020, 2022, 2024])
+            self.assertEqual(resolve_sample_year(cfg), 2024)
+
+    def test_years_malformed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cfg = _write_dataset(tmp, "dataset.yml", """
+dataset:
+  name: Test
+  years: [not_a_number]
+""")
+            self.assertEqual(resolve_years(cfg), [])
+
+    def test_yaml_parse_error(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cfg = _write_dataset(tmp, "dataset.yml", "invalid: [yaml: bad")
+            self.assertEqual(resolve_years(cfg), [])
+
+
+class ResolveSupportEntriesTest(unittest.TestCase):
+    """Tests for resolve_support_entries()."""
+
+    def test_root_level_support(self) -> None:
+        root = Path("/repo")
+        cfg = {
+            "support": [
+                {"name": "Base Dataset", "config": "support/basic/dataset.yml", "years": [2023]},
+            ],
+        }
+        entries = resolve_support_entries(cfg, Path("/repo/candidates/mine"), root)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["name"], "Base Dataset")
+        self.assertEqual(entries[0]["years"], [2023])
+
+    def test_dataset_level_support(self) -> None:
+        root = Path("/repo")
+        cfg = {
+            "dataset": {
+                "support": [
+                    {"name": "Ref Data", "config": "support/ref/dataset.yml", "years": [2022]},
+                ],
+            },
+        }
+        entries = resolve_support_entries(cfg, Path("/repo/candidates/mine"), root)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["name"], "Ref Data")
+
+    def test_both_levels_combined(self) -> None:
+        root = Path("/repo")
+        cfg = {
+            "support": [
+                {"name": "Root Support", "config": "support/root/dataset.yml", "years": [2023]},
+            ],
+            "dataset": {
+                "support": [
+                    {"name": "Dataset Support", "config": "support/ds/dataset.yml", "years": [2024]},
+                ],
+            },
+        }
+        entries = resolve_support_entries(cfg, Path("/repo/candidates/mine"), root)
+        self.assertEqual(len(entries), 2)
+
+    def test_no_support_returns_empty(self) -> None:
+        entries = resolve_support_entries({}, Path("/repo/candidates/mine"), Path("/repo"))
+        self.assertEqual(entries, [])
+
+    def test_empty_config_field_skipped(self) -> None:
+        cfg = {
+            "support": [
+                {"name": "No Config", "config": "", "years": []},
+            ],
+        }
+        entries = resolve_support_entries(cfg, Path("/repo/candidates/mine"), Path("/repo"))
+        self.assertEqual(entries, [])
+
+    def test_path_resolved_relative_to_root(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            root = tmp
+            cfg_path = tmp / "candidates" / "mine" / "dataset.yml"
+            cfg_path.parent.mkdir(parents=True)
+            cfg_path.write_text("dataset:\n  name: Test\n")
+
+            # Create the support target
+            support_path = tmp / "support" / "basic" / "dataset.yml"
+            support_path.parent.mkdir(parents=True)
+            support_path.write_text("dataset:\n  name: Support\n")
+
+            cfg = {
+                "support": [
+                    {"name": "Basic", "config": "../../support/basic/dataset.yml", "years": [2023]},
+                ],
+            }
+            entries = resolve_support_entries(cfg, cfg_path.parent, root)
+            self.assertEqual(len(entries), 1)
+            self.assertIn("support/basic/dataset.yml", entries[0]["config"])
+
+
+class CandidateSlugFromPathTest(unittest.TestCase):
+    """Tests for candidate_slug_from_path()."""
+
+    def setUp(self) -> None:
+        self.root = Path("/repo")
+
+    def test_simple_candidate(self) -> None:
+        path = Path("/repo/candidates/istat-housing-crowding/dataset.yml")
+        self.assertEqual(candidate_slug_from_path(path, self.root), "istat-housing-crowding")
+
+    def test_nested_multi_source(self) -> None:
+        path = Path("/repo/candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml")
+        self.assertEqual(candidate_slug_from_path(path, self.root), "ispra-ru-costi-kg")
+
+    def test_support_dataset(self) -> None:
+        path = Path("/repo/support_datasets/bdap-anagrafe-enti/dataset.yml")
+        self.assertEqual(candidate_slug_from_path(path, self.root), "bdap-anagrafe-enti")
+
+    def test_path_outside_root(self) -> None:
+        path = Path("/other/candidates/test/dataset.yml")
+        # Fallback to parent directory
+        self.assertEqual(candidate_slug_from_path(path, self.root), "test")
+
+    def test_short_path(self) -> None:
+        path = Path("dataset.yml")
+        self.assertIsNone(candidate_slug_from_path(path, self.root))
+
+
+class IsNestedConfigTest(unittest.TestCase):
+    """Tests for is_nested_config()."""
+
+    def test_flat_single_source(self) -> None:
+        self.assertFalse(is_nested_config(Path("/repo/candidates/test/dataset.yml")))
+
+    def test_sources_nested(self) -> None:
+        self.assertTrue(is_nested_config(Path("/repo/candidates/test/sources/a/dataset.yml")))
+
+    def test_compose_nested(self) -> None:
+        self.assertTrue(is_nested_config(Path("/repo/candidates/test/compose/dataset.yml")))
+
+    def test_sources_in_other_context(self) -> None:
+        """sources in a parent directory name should not trigger false positive."""
+        self.assertFalse(is_nested_config(Path("/repo/sources_other/dataset.yml")))
+
+    def test_support_dataset_flat(self) -> None:
+        self.assertFalse(is_nested_config(Path("/repo/support_datasets/test/dataset.yml")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Cosa

Crea `scripts/_candidate_helpers.py` con 4 funzioni condivise per la logica di risoluzione di candidate/support-dataset:

- **`resolve_years`** / **`resolve_sample_year`** — lettura di `dataset.years` da dataset.yml
- **`resolve_support_entries`** — supporta entrambi i pattern (`support:` root e `dataset.support:`)
- **`candidate_slug_from_path`** — estrae lo slug dal path
- **`is_nested_config`** — rileva se il config è sotto `sources/` o `compose/`

## Refactor

| File | Prima | Dopo |
|---|---|---|
| `resolve_sample_run.py` | logica inline duplicata | chiama helper (-36 righe) |
| `detect_candidates.py` | `_resolve_year()` con yaml inline | delega a helper |
| `pr-toolkit-check.yml` | 40 righe inline Python per support | chiama `resolve_sample_run.py` |

## Duplicazione rimossa

La logica di **support dependency resolution** era in 3 posti diversi. Ora centralizzata in un punto solo, testata.

## Test

25 nuovi test in `tests/test_candidate_helpers.py`:
- resolve_years: anni validi, vuoti, malformati, mancanti, file non trovato
- resolve_support_entries: root level, dataset level, entrambi, config vuoto
- candidate_slug_from_path: flat, nested, support_dataset, path fuori root
- is_nested_config: sources, compose, flat, falsi positivi

## Bilancio

- **+47 righe** (helper + test)
- **-92 righe** (rimosse da script e workflow)
- **Netto: -45 righe**
- **43/43 test passano**