### PR TITLE
fix(pr-toolkit-check): sostituisce inline support resolution con chiamata a resolve_sample_run.py

### DIFF
--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -151,37 +151,21 @@ jobs:
           python - <<'PY'
           import json
           import os
-          from pathlib import Path
+          import subprocess
 
-          import yaml
+          result = subprocess.run(
+              ["python", "scripts/resolve_sample_run.py", os.environ["CONFIG_PATH"]],
+              capture_output=True, text=True
+          )
 
-          root = Path(os.environ["GITHUB_WORKSPACE"])
-          cfg_path = root / os.environ["CONFIG_PATH"]
-          support_map = {}
+          support_list = []
+          if result.returncode == 0:
+              try:
+                  data = json.loads(result.stdout)
+                  support_list = data.get("support", [])
+              except json.JSONDecodeError:
+                  pass
 
-          if cfg_path.exists():
-              with open(cfg_path, encoding="utf-8") as f:
-                  cfg = yaml.safe_load(f) or {}
-
-              raw_support = cfg.get("support", []) or []
-              dataset_support = cfg.get("dataset", {}).get("support", []) or []
-              for entry in raw_support + dataset_support:
-                  rel_config = entry.get("config", "")
-                  if not rel_config:
-                      continue
-                  support_path = (cfg_path.parent / rel_config).resolve()
-                  try:
-                      support_rel = support_path.relative_to(root)
-                  except ValueError:
-                      support_rel = support_path
-                  key = str(support_rel)
-                  support_map.setdefault(key, {
-                      "name": entry.get("name", ""),
-                      "config": key,
-                      "years": entry.get("years", []),
-                  })
-
-          support_list = list(support_map.values())
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
               out.write(f"has_support={str(bool(support_list)).lower()}\n")
               out.write("support_configs<<JSON\n")

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -152,19 +152,20 @@ jobs:
           import json
           import os
           import subprocess
+          import sys
 
           result = subprocess.run(
               ["python", "scripts/resolve_sample_run.py", os.environ["CONFIG_PATH"]],
               capture_output=True, text=True
           )
 
-          support_list = []
-          if result.returncode == 0:
-              try:
-                  data = json.loads(result.stdout)
-                  support_list = data.get("support", [])
-              except json.JSONDecodeError:
-                  pass
+          if result.returncode != 0:
+              print("::error::resolve_sample_run.py failed — stderr follows")
+              print(result.stderr)
+              sys.exit(1)
+
+          data = json.loads(result.stdout)
+          support_list = data.get("support", [])
 
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
               out.write(f"has_support={str(bool(support_list)).lower()}\n")


### PR DESCRIPTION
## Cosa

Sostituisce 28 righe di logica inline in `pr-toolkit-check.yml` (lettura dataset.yml, parsing `support:` e `dataset.support:`, dedup) con una chiamata a `scripts/resolve_sample_run.py`, che già implementa la stessa logica.

## Perché

La logica di support resolution era duplicata in 2 posti:
- `scripts/resolve_sample_run.py`
- inline in `.github/workflows/pr-toolkit-check.yml` (questo)

L'inline nel workflow YAML aggiungeva 28 righe di Python con dipendenza `yaml` (già presente via pyproject), quando bastava chiamare lo script esistente.

## Bilancio

```
1 file modificato, +12 / -28 = -16 righe nette
```

Zero nuovo codice, zero nuovi test (contratto invariato).

## Verifica

Il comportamento è lo stesso: `resolve_sample_run.py` parsia `support:` e `dataset.support:` con la stessa identica logica. L'output `has_support` e `support_configs` per GITHUB_OUTPUT rimane invariato.