### PR TITLE
fix: estrae CA cert URLs in script condiviso, allinea sample-candidate-run.yml

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -88,32 +88,7 @@ jobs:
           set -euo pipefail
 
           urls_file="${RUNNER_TEMP:-/tmp}/extra-ca-cert-urls.txt"
-
-          python - <<'PY' > "$urls_file"
-          import os
-          from pathlib import Path
-
-          import yaml
-
-          root = Path(os.environ["GITHUB_WORKSPACE"])
-          cfg_path = root / os.environ["CONFIG_PATH"]
-          cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
-
-          urls = []
-          for source in (cfg.get("raw", {}).get("sources") or []):
-              args = source.get("args") or {}
-              for key in ("extra_ca_cert_url", "extra_ca_cert_urls"):
-                  value = args.get(key)
-                  if not value:
-                      continue
-                  if isinstance(value, str):
-                      urls.append(value)
-                  else:
-                      urls.extend(str(item) for item in value)
-
-          for url in dict.fromkeys(urls):
-              print(url)
-          PY
+          python scripts/get_extra_ca_cert_urls.py "$CONFIG_PATH" > "$urls_file"
 
           if [ ! -s "$urls_file" ]; then
             echo "::notice::No extra CA certificates configured for ${CONFIG_PATH}"

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -88,32 +88,7 @@ jobs:
           set -euo pipefail
 
           urls_file="${RUNNER_TEMP:-/tmp}/extra-ca-cert-urls.txt"
-
-          python - <<'PY' > "$urls_file"
-          import os
-          from pathlib import Path
-
-          import yaml
-
-          root = Path(os.environ["GITHUB_WORKSPACE"])
-          cfg_path = root / os.environ["CONFIG_PATH"]
-          cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
-
-          urls = []
-          for source in (cfg.get("raw", {}).get("sources") or []):
-              args = source.get("args") or {}
-              for key in ("extra_ca_cert_url", "extra_ca_cert_urls"):
-                  value = args.get(key)
-                  if not value:
-                      continue
-                  if isinstance(value, str):
-                      urls.append(value)
-                  else:
-                      urls.extend(str(item) for item in value)
-
-          for url in dict.fromkeys(urls):
-              print(url)
-          PY
+          python scripts/get_extra_ca_cert_urls.py "$CONFIG_PATH" > "$urls_file"
 
           if [ ! -s "$urls_file" ]; then
             echo "::notice::No extra CA certificates configured for ${CONFIG_PATH}"

--- a/.github/workflows/sample-candidate-run.yml
+++ b/.github/workflows/sample-candidate-run.yml
@@ -67,6 +67,38 @@ jobs:
       - name: Install dependencies
         run: pip install pyyaml
 
+      - name: Configure extra source CA certificates
+        run: |
+          set -euo pipefail
+
+          urls_file="${RUNNER_TEMP:-/tmp}/extra-ca-cert-urls.txt"
+          python scripts/get_extra_ca_cert_urls.py "$CONFIG_PATH" > "$urls_file"
+
+          if [ ! -s "$urls_file" ]; then
+            echo "::notice::No extra CA certificates configured for ${CONFIG_PATH}"
+            exit 0
+          fi
+
+          command -v curl >/dev/null
+          command -v openssl >/dev/null
+
+          bundle="${RUNNER_TEMP:-/tmp}/ca-certificates-with-extra-source-cas.pem"
+          cp /etc/ssl/certs/ca-certificates.crt "$bundle"
+
+          i=0
+          while IFS= read -r url; do
+            i=$((i + 1))
+            cert_raw="${RUNNER_TEMP:-/tmp}/extra-source-ca-${i}.crt"
+            cert_pem="${RUNNER_TEMP:-/tmp}/extra-source-ca-${i}.pem"
+            curl -fsSL "$url" -o "$cert_raw"
+            openssl x509 -inform DER -in "$cert_raw" -out "$cert_pem" 2>/dev/null \
+              || openssl x509 -in "$cert_raw" -out "$cert_pem"
+            cat "$cert_pem" >> "$bundle"
+          done < "$urls_file"
+
+          echo "REQUESTS_CA_BUNDLE=$bundle" >> "$GITHUB_ENV"
+          echo "SSL_CERT_FILE=$bundle" >> "$GITHUB_ENV"
+
       # ------------------------------------------------------------------
       # Step 1 — Resolve sample year
       # ------------------------------------------------------------------

--- a/scripts/get_extra_ca_cert_urls.py
+++ b/scripts/get_extra_ca_cert_urls.py
@@ -1,0 +1,68 @@
+"""Extract extra CA certificate URLs from a dataset.yml.
+
+Legge la config, estrae extra_ca_cert_url e extra_ca_cert_urls
+da raw.sources[].args, e stampa le URL deduplicate una per riga.
+
+Usage:
+    python scripts/get_extra_ca_cert_urls.py candidates/.../dataset.yml
+    CONFIG_PATH=... python scripts/get_extra_ca_cert_urls.py
+
+Exit code 0 anche se non trova URL (nessun output).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def get_urls(cfg_path: Path) -> list[str]:
+    """Extract deduplicated extra CA cert URLs from a dataset.yml."""
+    if not cfg_path.exists():
+        return []
+
+    try:
+        cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return []
+
+    seen: list[str] = []
+    for source in cfg.get("raw", {}).get("sources") or []:
+        if not isinstance(source, dict):
+            continue
+        args = source.get("args") or {}
+        for key in ("extra_ca_cert_url", "extra_ca_cert_urls"):
+            value = args.get(key)
+            if not value:
+                continue
+            if isinstance(value, str):
+                urls = [value]
+            elif isinstance(value, list):
+                urls = [str(item) for item in value if item]
+            else:
+                continue
+            for url in urls:
+                if url and url not in seen:
+                    seen.append(url)
+    return seen
+
+
+def main() -> int:
+    if len(sys.argv) > 1:
+        config_path = Path(sys.argv[1])
+    elif os.environ.get("CONFIG_PATH"):
+        config_path = Path(os.environ["CONFIG_PATH"])
+    else:
+        print("Usage: get_extra_ca_cert_urls.py <dataset.yml path>", file=sys.stderr)
+        return 1
+
+    for url in get_urls(config_path):
+        print(url)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/get_extra_ca_cert_urls.py
+++ b/scripts/get_extra_ca_cert_urls.py
@@ -26,7 +26,7 @@ def get_urls(cfg_path: Path) -> list[str]:
 
     try:
         cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
-    except Exception:
+    except FileNotFoundError:
         return []
 
     seen: list[str] = []

--- a/tests/test_get_extra_ca_cert_urls.py
+++ b/tests/test_get_extra_ca_cert_urls.py
@@ -1,0 +1,65 @@
+"""Tests for get_extra_ca_cert_urls.py."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from get_extra_ca_cert_urls import get_urls  # noqa: E402
+
+
+class GetExtraCaCertUrlsTest(unittest.TestCase):
+    """Fail-fast su YAML/config invalida, tollerante su file mancante."""
+
+    def test_missing_file_returns_empty(self) -> None:
+        self.assertEqual(get_urls(Path("/nonexistent/dataset.yml")), [])
+
+    def test_no_extra_ca_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            cfg = Path(td) / "dataset.yml"
+            cfg.write_text("dataset:\n  name: Test\n")
+            self.assertEqual(get_urls(cfg), [])
+
+    def test_single_url(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            cfg = Path(td) / "dataset.yml"
+            cfg.write_text("""
+raw:
+  sources:
+    - args:
+        extra_ca_cert_url: https://example.test/cert.crt
+""")
+            self.assertEqual(get_urls(cfg), ["https://example.test/cert.crt"])
+
+    def test_multiple_urls_deduplicated(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            cfg = Path(td) / "dataset.yml"
+            cfg.write_text("""
+raw:
+  sources:
+    - args:
+        extra_ca_cert_urls:
+          - https://example.test/a.crt
+          - https://example.test/b.crt
+          - https://example.test/a.crt
+""")
+            self.assertEqual(get_urls(cfg), [
+                "https://example.test/a.crt",
+                "https://example.test/b.crt",
+            ])
+
+    def test_malformed_yaml_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            cfg = Path(td) / "dataset.yml"
+            cfg.write_text("invalid: [yaml: bad")
+            with self.assertRaises(Exception):
+                get_urls(cfg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Cosa

Crea `scripts/get_extra_ca_cert_urls.py` che estrae `extra_ca_cert_url` e `extra_ca_cert_urls` da `dataset.yml` (raw.sources[].args).

## Perché

La stessa logica di parsing YAML per estrarre URL certificati CA extra era inline identica in 2 workflow (`pr-toolkit-check.yml`, `post-merge-candidate.yml`). Inoltre `sample-candidate-run.yml` non aveva affatto lo step CA cert, pur eseguendo toolkit.

## Modifiche

| File | Prima | Dopo |
|---|---|---|
| `pr-toolkit-check.yml` | 27 righe inline Python+YAML | chiamata a script (-27) |
| `post-merge-candidate.yml` | 27 righe inline Python+YAML | chiamata a script (-27) |
| `sample-candidate-run.yml` | step CA cert mancante | step aggiunto (+32) |
| `get_extra_ca_cert_urls.py` | — | nuovo script (~50 righe) |

## Bilancio

- 2 workflow perdono 27 righe ciascuno di duplicazione
- 1 workflow viene allineato (colma un buco)
- La logica di parsing YAML vive in un punto solo

## Verifica

- Script testato con candidate reale (nessuna CA extra → output vuoto)
- Script testato con file inesistente (exit 0, output vuoto)
- 18/18 test passano