### PR TITLE
fix: rimuove inspect paths e pre-flight check — rumore in CI

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -149,40 +149,6 @@ jobs:
           echo "::notice::This candidate has support dependencies. Running support datasets first."
           echo "$SUPPORT_JSON" > /tmp/support_configs.json
           python scripts/run_support_datasets.py --support-json /tmp/support_configs.json
-      - name: Toolkit inspect paths
-        run: |
-          toolkit inspect paths \
-            --config "$CONFIG_PATH" \
-            --year "${{ steps.resolve.outputs.final_year }}" \
-            --json \
-            2>&1 | tee inspect_paths.json || true
-
-      - name: Pre-flight check
-        run: |
-          python - <<'PY'
-          import json, sys
-
-          try:
-              d = json.load(open("inspect_paths.json"))
-          except Exception:
-              print("::warning::Could not parse inspect_paths.json — skipping pre-flight checks")
-              sys.exit(0)
-
-          run_count = d.get("run_file_count", 0)
-          latest = d.get("latest_run") or {}
-          latest_status = latest.get("status", "N/A")
-          latest_run_id = latest.get("run_id", "N/A")
-
-          print(f"::notice::run_file_count={run_count}, latest_run={latest_run_id} ({latest_status})")
-
-          if run_count == 0:
-              print("::warning::No previous runs found for this candidate — this will be a first run")
-          elif latest_status == "FAILED":
-              print(f"::warning::Latest run was FAILED ({latest_run_id})")
-          elif latest_status == "SUCCESS":
-              print(f"::notice::Latest run was SUCCESS ({latest_run_id})")
-          PY
-
       - name: Toolkit run all
         id: run_all
         run: |
@@ -248,7 +214,6 @@ jobs:
           name: sample-run-${{ matrix.artifact_name }}
           path: |
             sample_params.json
-            inspect_paths.json
             run_all.log
             validate_all.json
             sample_run_result.json

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -157,15 +157,6 @@ jobs:
           echo "::notice::This candidate has support dependencies. Running support datasets first."
           echo "$SUPPORT_JSON" > /tmp/support_configs.json
           python scripts/run_support_datasets.py --support-json /tmp/support_configs.json
-      - name: Toolkit inspect paths (pre-flight)
-        run: |
-          echo "=== inspect paths ==="
-          toolkit inspect paths \
-            --config "${{ matrix.config.config_path }}" \
-            --year "${{ matrix.config.year }}" \
-            --json \
-            2>&1 || true
-
       - name: Toolkit run all
         id: run_all
         run: |

--- a/.github/workflows/sample-candidate-run.yml
+++ b/.github/workflows/sample-candidate-run.yml
@@ -16,10 +16,9 @@ name: Sample Candidate Run
 # Steps:
 #   1. Resolve sample year from config
 #   2. Install toolkit
-#   3. Inspect paths + pre-flight check (run_file_count, latest_run status)
-#   4. Run all layers
-#   5. Validate all layers (only if run succeeded)
-#   6. Upload artifacts
+#   3. Run all layers
+#   4. Validate all layers (only if run succeeded)
+#   5. Upload artifacts
 
 on:
   workflow_dispatch:
@@ -148,7 +147,7 @@ jobs:
           pip install git+https://github.com/dataciviclab/toolkit.git@v1.5.0
 
       # ------------------------------------------------------------------
-      # Step 1b — Run support datasets first (if has_support)
+      # Run support datasets first (if has_support)
       # ------------------------------------------------------------------
       - name: Run support datasets first (if has_support)
         if: steps.resolve.outputs.has_support == 'true'
@@ -159,47 +158,7 @@ jobs:
           echo "$SUPPORT_JSON" > /tmp/support_configs.json
           python scripts/run_support_datasets.py --support-json /tmp/support_configs.json
       # ------------------------------------------------------------------
-      # Step 3 — Inspect paths + pre-flight check
-      # ------------------------------------------------------------------
-      - name: Toolkit inspect paths
-        run: |
-          toolkit inspect paths \
-            --config "$CONFIG_PATH" \
-            --year "${{ steps.resolve.outputs.final_year }}" \
-            --json \
-            $STRICT_FLAG \
-            2>&1 | tee inspect_paths.json || true
-
-      - name: Pre-flight check
-        env:
-          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          python - <<'PY'
-          import json, sys
-
-          try:
-              d = json.load(open("inspect_paths.json"))
-          except Exception:
-              print("::warning::Could not parse inspect_paths.json — skipping pre-flight checks")
-              sys.exit(0)
-
-          run_count = d.get("run_file_count", 0)
-          latest = d.get("latest_run") or {}
-          latest_status = latest.get("status", "N/A")
-          latest_run_id = latest.get("run_id", "N/A")
-
-          print(f"::notice::run_file_count={run_count}, latest_run={latest_run_id} ({latest_status})")
-
-          if run_count == 0:
-              print("::warning::No previous runs found for this candidate — this will be a first run")
-          elif latest_status == "FAILED":
-              print(f"::warning::Latest run was FAILED ({latest_run_id}) — check artifact from previous run before proceeding")
-          elif latest_status == "SUCCESS":
-              print(f"::notice::Latest run was SUCCESS ({latest_run_id}) — proceeding with sample run")
-          PY
-
-      # ------------------------------------------------------------------
-      # Step 4 — Run all layers
+      # Step 3 — Run all layers
       # ------------------------------------------------------------------
       - name: Toolkit run all
         id: run_all
@@ -212,7 +171,7 @@ jobs:
             2>&1 | tee run_all.log
 
       # ------------------------------------------------------------------
-      # Step 5 — Validate all layers (only if run succeeded)
+      # Step 4 — Validate all layers (only if run succeeded)
       # ------------------------------------------------------------------
       - name: Toolkit validate all
         if: success()
@@ -234,7 +193,6 @@ jobs:
           name: sample-run-${{ github.run_id }}
           path: |
             ${{ github.run_id }}_params.json
-            inspect_paths.json
             run_all.log
             validate_all.json
             support_*.log


### PR DESCRIPTION
## Cosa

Rimuove `toolkit inspect paths` e lo step `Pre-flight check` da tutti e 3 i workflow CI.

## Perché

In CI `out/` è gitignorato, quindi `toolkit inspect paths` mostrava sempre `run_file_count=0` e `latest_run=null`. Il `Pre-flight check` che analizzava quei valori stampava sempre "No previous runs found". Zero informazione utile.

## Modifiche

| Workflow | Cosa rimosso |
|---|---|
| `pr-toolkit-check.yml` | Step `inspect paths` (era decorativo con `|| true`) |
| `sample-candidate-run.yml` | Step `inspect paths` + `Pre-flight check` + file da artifact |
| `post-merge-candidate.yml` | Step `inspect paths` + `Pre-flight check` + file da artifact |

Rinumerati i commenti Step in sample-candidate-run per coerenza.

## Bilancio

3 files, **-86 righe nette**, zero nuovo codice.