### PR TITLE
refactor: centralizza operazioni GCS in lab_connectors.gcs

### DIFF
--- a/scripts/build_clean_catalog.py
+++ b/scripts/build_clean_catalog.py
@@ -8,8 +8,7 @@ from datetime import date
 from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote, urlencode
-from urllib.request import Request, urlopen
+from lab_connectors.gcs import list_objects, object_exists
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -255,11 +254,8 @@ def resolve_gcs_path(path: str) -> list[str]:
         raise ValueError(f"not a GCS path: {path}")
     bucket, key = path[5:].split("/", 1)
     if "*" not in key:
-        url = f"https://storage.googleapis.com/{bucket}/{quote(key, safe='/._-')}"
-        request = Request(url, method="HEAD")
-        with urlopen(request, timeout=30) as response:
-            if response.status >= 400:
-                return []
+        if not object_exists(bucket, key):
+            return []
         return [key]
 
     prefix = key.split("*", 1)[0]
@@ -268,22 +264,12 @@ def resolve_gcs_path(path: str) -> list[str]:
 
 
 def list_gcs_objects(bucket: str, prefix: str) -> list[str]:
-    params = urlencode({"prefix": prefix, "fields": "items(name),nextPageToken"})
-    url = f"https://storage.googleapis.com/storage/v1/b/{quote(bucket)}/o?{params}"
-    names: list[str] = []
-    while url:
-        with urlopen(url, timeout=30) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-        names.extend(item["name"] for item in payload.get("items", []))
-        token = payload.get("nextPageToken")
-        if token:
-            url = (
-                f"https://storage.googleapis.com/storage/v1/b/{quote(bucket)}/o?"
-                f"{params}&pageToken={quote(token)}"
-            )
-        else:
-            url = ""
-    return names
+    """Lista oggetti GCS per un bucket/prefix.
+
+    Delega a lab_connectors.gcs.list_objects con auth=False (HTTP API pubblica).
+    """
+    results = list_objects(bucket, prefix=prefix, auth=False)
+    return [r["name"] for r in results]
 
 
 def missing_period_years(paths: list[str], period: dict[str, Any]) -> list[int]:

--- a/scripts/push_archive.py
+++ b/scripts/push_archive.py
@@ -26,7 +26,6 @@ import argparse
 import sys
 import json
 import datetime
-import os
 from pathlib import Path
 
 import pandas as pd

--- a/scripts/push_archive.py
+++ b/scripts/push_archive.py
@@ -31,9 +31,10 @@ from pathlib import Path
 
 import pandas as pd
 import pyarrow.parquet as pq
-from google.cloud import bigquery, storage
+from google.cloud import bigquery
 from google.api_core.exceptions import Conflict
-from google.oauth2 import credentials as google_oauth2_credentials
+
+from lab_connectors.gcs import upload_file, upload_string
 
 # ---------------------------------------------------------------------------
 # Config
@@ -51,23 +52,7 @@ MART_ROOT = DI_ROOT / "out" / "data" / "mart"
 RUNS_ROOT = DI_ROOT / "out" / "data" / "_runs"
 
 SKIP_DIRS = {"_validate", "_run"}
-# NOTE: if specific slugs need to be skipped, pass --slug via CLI instead of hardcoding here.
 SKIP_SLUGS: set[str] = set()
-
-
-def load_google_credentials():
-    """Carica credenziali esplicite se GOOGLE_APPLICATION_CREDENTIALS punta a un ADC user file.
-
-    In alcuni ambienti WSL la discovery standard resta appesa sul `gcloud` Windows nel PATH.
-    """
-    adc_path = Path(
-        os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
-    ).expanduser()
-    if adc_path.is_file():
-        return google_oauth2_credentials.Credentials.from_authorized_user_file(
-            str(adc_path)
-        )
-    return None
 
 
 # ---------------------------------------------------------------------------
@@ -110,26 +95,24 @@ def get_latest_run(slug, year):
 
 
 # ---------------------------------------------------------------------------
-# GCS
+# GCS — delegato a lab_connectors.gcs
 # ---------------------------------------------------------------------------
-def push_gcs(gcs_client, local_path, bucket_name, gcs_path, dry_run=False):
+def push_gcs(local_path, bucket_name, gcs_path, dry_run=False):
     if dry_run:
         print(f"  [dry] GCS: gs://{bucket_name}/{gcs_path}")
         return
-    bucket = gcs_client.bucket(bucket_name)
-    blob = bucket.blob(gcs_path)
-    blob.upload_from_filename(str(local_path))
+    upload_file(str(local_path), bucket_name, gcs_path)
     print(f"  GCS: gs://{bucket_name}/{gcs_path}")
 
 
-def upload_manifest(gcs_client, manifest, dry_run=False):
+def upload_manifest(manifest, dry_run=False):
     if dry_run:
         print(f"  [dry] GCS: gs://{GCS_CLEAN_BUCKET}/{CATALOG_MANIFEST_PATH}")
         return
-    bucket = gcs_client.bucket(GCS_CLEAN_BUCKET)
-    blob = bucket.blob(CATALOG_MANIFEST_PATH)
-    blob.upload_from_string(
+    upload_string(
         json.dumps(manifest, ensure_ascii=False, indent=2),
+        GCS_CLEAN_BUCKET,
+        CATALOG_MANIFEST_PATH,
         content_type="application/json",
     )
     print(f"  GCS: gs://{GCS_CLEAN_BUCKET}/{CATALOG_MANIFEST_PATH}")
@@ -303,7 +286,7 @@ def update_catalog(slug: str, years: list[str], status: str, dry_run: bool = Fal
 # ---------------------------------------------------------------------------
 # Layer: CLEAN
 # ---------------------------------------------------------------------------
-def push_clean(gcs_client, slug_filter=None, year_filter=None, dry_run=False):
+def push_clean(slug_filter=None, year_filter=None, dry_run=False):
     slugs = get_slugs(CLEAN_ROOT, slug_filter)
     print(f"[clean] slug: {slugs}\n")
 
@@ -324,7 +307,7 @@ def push_clean(gcs_client, slug_filter=None, year_filter=None, dry_run=False):
         for year in years:
             for parq in get_parquets(slug_dir / year):
                 gcs_path = f"{slug}/{year}/{parq.name}"
-                push_gcs(gcs_client, parq, GCS_CLEAN_BUCKET, gcs_path, dry_run)
+                push_gcs(parq, GCS_CLEAN_BUCKET, gcs_path, dry_run)
                 if dry_run:
                     rows = None
                 else:
@@ -347,19 +330,19 @@ def push_clean(gcs_client, slug_filter=None, year_filter=None, dry_run=False):
             run_record = get_latest_run(slug, year)
             if run_record is not None:
                 run_gcs_path = f"{slug}/{year}/pipeline_run.json"
-                push_gcs(gcs_client, run_record, GCS_CLEAN_BUCKET, run_gcs_path, dry_run)
+                push_gcs(run_record, GCS_CLEAN_BUCKET, run_gcs_path, dry_run)
             else:
                 print(f"  [{slug}/{year}] nessun run record trovato, pipeline_run.json non pushato.")
         print()
 
     if manifest["items"]:
-        upload_manifest(gcs_client, manifest, dry_run)
+        upload_manifest(manifest, dry_run)
 
 
 # ---------------------------------------------------------------------------
 # Layer: MART
 # ---------------------------------------------------------------------------
-def push_mart(gcs_client, bq_client, slug_filter=None, year_filter=None, dry_run=False):
+def push_mart(bq_client, slug_filter=None, year_filter=None, dry_run=False):
     slugs = get_slugs(MART_ROOT, slug_filter)
     print(f"[mart] slug: {slugs}\n")
 
@@ -377,7 +360,7 @@ def push_mart(gcs_client, bq_client, slug_filter=None, year_filter=None, dry_run
         for year in years:
             for parq in get_parquets(slug_dir / year):
                 gcs_path = f"{slug}/{year}/{parq.name}"
-                push_gcs(gcs_client, parq, GCS_MART_BUCKET, gcs_path, dry_run)
+                push_gcs(parq, GCS_MART_BUCKET, gcs_path, dry_run)
                 if bq_client:
                     push_bq(bq_client, parq, slug, year, dry_run)
         print()
@@ -403,16 +386,14 @@ def main():
                         help="Status da impostare nel catalog per i nuovi entry (default: candidate)")
     args = parser.parse_args()
 
-    google_credentials = load_google_credentials()
-    gcs_client = storage.Client(project=GCP_PROJECT, credentials=google_credentials)
     bq_client = (
-        bigquery.Client(project=GCP_PROJECT, credentials=google_credentials)
+        bigquery.Client(project=GCP_PROJECT)
         if (not args.no_bq or args.create_bq_table)
         else None
     )
 
     if args.layer in ("clean", "all"):
-        push_clean(gcs_client, args.slug, args.year, args.dry_run)
+        push_clean(args.slug, args.year, args.dry_run)
 
     if args.update_catalog or args.create_bq_table:
         slugs = get_slugs(CLEAN_ROOT, args.slug)
@@ -424,7 +405,7 @@ def main():
                 create_bq_external_table(bq_client, slug, args.dry_run)
 
     if args.layer in ("mart", "all"):
-        push_mart(gcs_client, bq_client, args.slug, args.year, args.dry_run)
+        push_mart(bq_client, args.slug, args.year, args.dry_run)
 
     print("Done.")
 

--- a/tools/clean-query-mcp/catalog.py
+++ b/tools/clean-query-mcp/catalog.py
@@ -7,8 +7,9 @@ import time
 import json
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote, urlencode
-from urllib.request import urlopen
+from urllib.parse import quote
+
+from lab_connectors.gcs import list_objects
 
 DI_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CATALOG_PATH = DI_ROOT / "registry" / "clean_catalog.json"
@@ -23,33 +24,14 @@ _gcs_res_cache_ttl = int(
 )  # 5 min default
 _gcs_res_lock = threading.Lock()
 
-# Lazy GCS client
-_gcs_instance = None
-
-
-def _get_gcs_client():
-    global _gcs_instance
-    if _gcs_instance is None:
-        use_auth = os.environ.get("CLEAN_QUERY_GCS_AUTH", "").lower() in {
-            "1",
-            "true",
-            "yes",
-        }
-        if use_auth:
-            try:
-                from google.cloud import storage
-
-                _gcs_instance = storage.Client(project="dataciviclab")
-            except Exception:
-                _gcs_instance = False
-        else:
-            try:
-                from google.cloud import storage
-
-                _gcs_instance = storage.Client.create_anonymous_client()
-            except Exception:
-                _gcs_instance = False
-    return _gcs_instance
+# GCS auth mode: auto = try SDK, fallback HTTP; true = force SDK; false = force HTTP
+def _gcs_auth_mode() -> bool | None:
+    val = os.environ.get("CLEAN_QUERY_GCS_AUTH", "").lower()
+    if val in ("1", "true", "yes"):
+        return True
+    if val in ("0", "false", "no"):
+        return False
+    return None
 
 
 def _load_catalog() -> list[dict[str, Any]]:
@@ -250,28 +232,13 @@ def gcs_cache_clear() -> None:
 
 
 def _list_gcs_blobs(bucket: str, prefix: str) -> list[str]:
-    """List blob names from GCS bucket with given prefix."""
-    client = _get_gcs_client()
-    if client:
-        blobs = client.list_blobs(bucket, prefix=prefix)
-        return [b.name for b in blobs]
+    """List blob names from GCS bucket with given prefix.
 
-    params = urlencode({"prefix": prefix, "fields": "items(name),nextPageToken"})
-    url = f"https://storage.googleapis.com/storage/v1/b/{quote(bucket)}/o?{params}"
-    names: list[str] = []
-    while url:
-        with urlopen(url, timeout=30) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-        names.extend(item["name"] for item in payload.get("items", []))
-        token = payload.get("nextPageToken")
-        if token:
-            url = (
-                f"https://storage.googleapis.com/storage/v1/b/{quote(bucket)}/o?"
-                f"{params}&pageToken={quote(token)}"
-            )
-        else:
-            url = ""
-    return names
+    Delega a lab_connectors.gcs.list_objects con auth mode da env.
+    """
+    auth = _gcs_auth_mode()
+    results = list_objects(bucket, prefix=prefix, auth=auth)
+    return [r["name"] for r in results]
 
 
 def _glob_to_regex(pattern: str) -> re.Pattern:

--- a/tools/clean-query-mcp/requirements.txt
+++ b/tools/clean-query-mcp/requirements.txt
@@ -1,3 +1,3 @@
 mcp>=1.26.0
 duckdb==1.5.1
-git+https://github.com/dataciviclab/lab-connectors.git@v0.2.0
+git+https://github.com/dataciviclab/lab-connectors.git@v0.3.0


### PR DESCRIPTION
## Cosa

Refactor dei 3 consumer GCS in dataset-incubator per usare il nuovo `lab_connectors.gcs` (v0.3.0) invece di SDK diretto o HTTP API fatta a mano.

## Modifiche

| File | Prima | Dopo | Delta |
|---|---|---|---|
| `scripts/push_archive.py` | `google.cloud.storage` SDK diretto + `load_google_credentials()` | `lab_connectors.gcs.upload_file` / `upload_string` | -19 righe |
| `scripts/build_clean_catalog.py` | HTTP API `urllib` per list + HEAD | `lab_connectors.gcs.list_objects` / `object_exists` | -14 righe |
| `tools/clean-query-mcp/catalog.py` | SDK + HTTP fallback per list blob | `lab_connectors.gcs.list_objects` | -33 righe |
| `tools/clean-query-mcp/requirements.txt` | pin `lab-connectors@v0.2.0` | `@v0.3.0` | — |

## Perché

- Rimuove 3 implementazioni GCS diverse dentro DI (SDK, HTTP API, SDK+fallback)
- Sostituisce con unico client condiviso (`lab_connectors.gcs`) con 3 modalità auth
- Prepara il terreno per il post-merge workflow che userà `push_archive.py` via `lab_connectors.gcs`

## Verifica

- `push_archive.py --dry-run`: tutti i path GCS corretti
- `build_clean_catalog.py --check-gcs`: 22 dataset validati
- `catalog.resolve_parquet_path()`: single-file e multi-file funzionanti
- Test DI esistenti: tutti verdi