### PR TITLE
feat: full run su tutti gli anni + GCS push + catalog update + dispatch DE

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,12 +3,14 @@ name: Lint
 on:
   pull_request:
     paths:
+      - ".github/workflows/**"
       - "scripts/**"
       - "tools/**"
       - "pyproject.toml"
   push:
     branches: [main]
     paths:
+      - ".github/workflows/**"
       - "scripts/**"
       - "tools/**"
       - "pyproject.toml"

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -416,4 +416,47 @@ jobs:
             https://api.github.com/repos/dataciviclab/data-explorer/dispatches \
             -d '{"event_type":"catalog_updated"}'
 
+      - name: Open follow-up issue in data-explorer
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN }}
+          ITEMS_JSON: ${{ needs.detect.outputs.items }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Estrai slug degli items cambiati
+          ITEMS=$(echo "$ITEMS_JSON" | python3 -c "
+import json, sys
+items = json.load(sys.stdin)
+for i in items:
+    print(f\"- [ ] {i['slug']}: aggiungere a themes.json e creare pagina dataset\")
+")
+          if [ -z "$ITEMS" ]; then
+            echo "No items to create issues for"
+            exit 0
+          fi
+
+          # Crea issue in data-explorer
+          gh issue create \
+            --repo dataciviclab/data-explorer \
+            --title "follow-up: pagina e tema per $(echo "$ITEMS" | head -1 | sed 's/- \[ \] //')" \
+            --label "curation" \
+            --body "## Nuovo/i dataset pubblicato/i
+
+Il seguente/i dataset sono stati pubblicati automaticamente da PR #${PR_NUMBER} — ${PR_TITLE}.
+Sono disponibili nel catalogo tecnico ma **mancano di pagina curata e tema**.
+
+### Da fare
+
+${ITEMS}
+
+### Workflow
+
+1. Aggiungere a \`catalog/themes.json\` (decisione editoriale)
+2. Creare \`pages/dataset/{slug}.md\` con query curate
+
+### Riferimenti
+
+- PR dataset-incubator #${PR_NUMBER}"
+
 

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -316,6 +316,7 @@ jobs:
           signals_changed = os.environ.get("PIPELINE_SIGNALS_CHANGED", "false") == "true"
           pr_number = os.environ.get("PR_NUMBER", "?")
           pr_title = os.environ.get("PR_TITLE", "?")
+          gcp_available = os.environ.get("GCP_WORKLOAD_IDENTITY_PROVIDER", "") != "" and os.environ.get("GCP_SERVICE_ACCOUNT", "") != ""
 
           item_list = "\n".join(f'- `{i["slug"]}` ({i["kind"]}, `{i["root"]}`)' for i in items)
           sample_list = "\n".join(
@@ -323,8 +324,6 @@ jobs:
               for c in configs
           ) or "- No sample-run config detected"
 
-          # CI ora esegue: toolkit run/validate (tutti gli anni), push_archive --layer clean, build_clean_catalog
-          # Il maintainer deve solo mart + BQ se serve
           commands = []
           for c in configs:
               commands.append(
@@ -345,8 +344,8 @@ jobs:
               "",
               f"- [x] Rebuilt `registry/pipeline_signals.json`{' (no diff)' if not signals_changed else ''}",
               f"- [{'x' if sample_passed else ' '}] CI: full run completato (tutti gli anni)",
-              "- [x] CI: clean parquet pushato su GCS",
-              "- [x] CI: `registry/clean_catalog.json` aggiornato",
+              f"- [{'x' if gcp_available else ' '}] CI: clean parquet pushato su GCS",
+              f"- [{'x' if gcp_available else ' '}] CI: `registry/clean_catalog.json` aggiornato",
               "- [ ] Maintainer: push mart + BQ (se serve)",
               "",
               "## Sample-run artifacts",
@@ -408,13 +407,13 @@ jobs:
           fi
 
       - name: Notify data-explorer
-        if: success() && env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != ''
+        if: success()
         run: |
           curl -X POST \
             -H "Authorization: Bearer ${{ secrets.LAB_OPS_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/dataciviclab/data-explorer/dispatches \
-            -d '{"event_type":"catalog_updated"}'
+            -d '{"event_type":"catalog_updated"}' || echo "WARN: dispatch non configurato (LAB_OPS_TOKEN mancante?)"
 
       - name: Open follow-up issue in data-explorer
         if: success()
@@ -437,9 +436,15 @@ for i in items:
           fi
 
           # Crea issue in data-explorer
+          ITEM_COUNT=$(echo "$ITEMS" | wc -l)
+          if [ "$ITEM_COUNT" -eq 1 ]; then
+            TITLE="follow-up: pagina e tema per $(echo "$ITEMS" | head -1 | sed 's/- \[ \] //')"
+          else
+            TITLE="follow-up: pagina e tema per ${ITEM_COUNT} nuovi dataset"
+          fi
           gh issue create \
             --repo dataciviclab/data-explorer \
-            --title "follow-up: pagina e tema per $(echo "$ITEMS" | head -1 | sed 's/- \[ \] //')" \
+            --title "$TITLE" \
             --label "curation" \
             --body "## Nuovo/i dataset pubblicato/i
 

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -7,6 +7,10 @@ on:
       - "candidates/**"
       - "support_datasets/**"
 
+env:
+  GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+  GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
 jobs:
   detect:
     if: github.event.pull_request.merged == true
@@ -128,12 +132,14 @@ jobs:
 
           SLUG=$(python -c "import json; d=json.load(open('sample_params.json')); print(d['slug'])")
           FINAL_YEAR=$(python -c "import json; d=json.load(open('sample_params.json')); print(d['sample_year'])")
+          ALL_YEARS=$(python -c "import json; d=json.load(open('sample_params.json')); print(','.join(str(y) for y in d['all_years']))")
           IS_NESTED=$(python -c "import json; d=json.load(open('sample_params.json')); print(str(d['is_nested']).lower())")
           HAS_SUPPORT=$(python -c "import json; d=json.load(open('sample_params.json')); print(str(d.get('has_support', False)).lower())")
           SUPPORT_JSON=$(python -c "import json; d=json.load(open('sample_params.json')); print(json.dumps(d.get('support', [])))")
 
           echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
           echo "final_year=$FINAL_YEAR" >> "$GITHUB_OUTPUT"
+          echo "all_years_csv=$ALL_YEARS" >> "$GITHUB_OUTPUT"
           echo "is_nested=$IS_NESTED" >> "$GITHUB_OUTPUT"
           echo "has_support=$HAS_SUPPORT" >> "$GITHUB_OUTPUT"
           echo "support_configs=$SUPPORT_JSON" >> "$GITHUB_OUTPUT"
@@ -155,7 +161,7 @@ jobs:
           set -o pipefail
           toolkit run all \
             --config "$CONFIG_PATH" \
-            --years "${{ steps.resolve.outputs.final_year }}" \
+            --years "${{ steps.resolve.outputs.all_years_csv }}" \
             2>&1 | tee run_all.log
 
       - name: Toolkit validate all
@@ -165,7 +171,7 @@ jobs:
           set -o pipefail
           toolkit validate all \
             --config "$CONFIG_PATH" \
-            --years "${{ steps.resolve.outputs.final_year }}" \
+            --years "${{ steps.resolve.outputs.all_years_csv }}" \
             2>&1 | tee validate_all.json
 
       - name: Write sample-run result
@@ -220,6 +226,28 @@ jobs:
             support_*.log
           if-no-files-found: warn
           retention-days: 14
+
+      - name: GCP Auth (for GCS push)
+        if: success() && env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != ''
+        id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Push clean parquet to GCS
+        if: success() && steps.auth.outcome == 'success'
+        run: |
+          python -m pip install google-cloud-storage
+          python scripts/push_archive.py --layer clean \
+            --slug ${{ steps.resolve.outputs.slug }} \
+            --update-catalog
+
+      - name: Build clean catalog
+        if: success() && steps.auth.outcome == 'success'
+        run: |
+          python scripts/build_clean_catalog.py --write
+          python scripts/build_clean_catalog.py --check-gcs
 
   build-and-pr:
     needs:
@@ -295,16 +323,14 @@ jobs:
               for c in configs
           ) or "- No sample-run config detected"
 
+          # CI ora esegue: toolkit run/validate (tutti gli anni), push_archive --layer clean, build_clean_catalog
+          # Il maintainer deve solo mart + BQ se serve
           commands = []
           for c in configs:
-              commands.append(f"toolkit run all --config {c['config_path']}")
-              commands.append(f"toolkit validate all --config {c['config_path']}")
               commands.append(
-                  f"python scripts/push_archive.py --layer clean --slug {c['push_slug']} "
-                  f"--create-bq-table --update-catalog --status clean_ready"
+                  f"python scripts/push_archive.py --mart --slug {c['push_slug']} "
+                  f"--create-bq-table --update-catalog"
               )
-          commands.append("python scripts/build_clean_catalog.py --write")
-          commands.append("python scripts/build_clean_catalog.py --check-gcs")
 
           body = "\n".join([
               "## Post-merge registry handoff",
@@ -318,11 +344,10 @@ jobs:
               "## Automatic updates",
               "",
               f"- [x] Rebuilt `registry/pipeline_signals.json`{' (no diff)' if not signals_changed else ''}",
-              f"- [{'x' if sample_passed else ' '}] Sample-run CI completed ({sample_result})",
-              "- [ ] Full maintainer run completed",
-              "- [ ] Clean parquet pushed to GCS/BQ",
-              "- [ ] `registry/clean_catalog.json` updated after GCS push",
-              "- [ ] `python scripts/build_clean_catalog.py --check-gcs` passes",
+              f"- [{'x' if sample_passed else ' '}] CI: full run completato (tutti gli anni)",
+              "- [x] CI: clean parquet pushato su GCS",
+              "- [x] CI: `registry/clean_catalog.json` aggiornato",
+              "- [ ] Maintainer: push mart + BQ (se serve)",
               "",
               "## Sample-run artifacts",
               "",
@@ -334,7 +359,7 @@ jobs:
               "\n".join(commands),
               "```",
               "",
-              "Keep this PR as draft until the GCS/BQ push and clean catalog validation are complete.",
+              "CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.",
           ])
 
           with open("post_merge_pr_body.md", "w", encoding="utf-8") as f:
@@ -381,5 +406,14 @@ jobs:
               --label post-merge \
               --draft
           fi
+
+      - name: Notify data-explorer
+        if: success() && env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != ''
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.LAB_OPS_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/dataciviclab/data-explorer/dispatches \
+            -d '{"event_type":"catalog_updated"}'
 
 

--- a/scripts/build_clean_catalog.py
+++ b/scripts/build_clean_catalog.py
@@ -8,6 +8,8 @@ from datetime import date
 from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any
+
+import yaml
 from lab_connectors.gcs import list_objects, object_exists
 
 
@@ -81,11 +83,58 @@ def normalize_catalog(catalog: dict[str, Any], *, refresh_date: bool = False) ->
     datasets = []
     for dataset in normalized.get("datasets", []):
         item = dict(dataset)
-        item.setdefault("status", "clean_ready")
-        item.setdefault("visibility", "public")
+        item.pop("status", None)       # vecchio nome, rimosso
+        item.pop("visibility", None)   # sempre public, rimosso
+        item.setdefault("stage", "incubating")
         datasets.append(item)
     normalized["datasets"] = sorted(datasets, key=lambda item: item["slug"])
+
+    # Arricchisci source_id dai dataset.yml dei candidati
+    _enrich_source_ids(normalized, ROOT)
+
     return normalized
+
+
+def _enrich_source_ids(catalog: dict[str, Any], root: Path) -> None:
+    """Legge source_id dai dataset.yml dei candidati e li fonde nel catalogo.
+
+    Per ogni dataset nel catalogo, se esiste un candidate dataset.yml con source_id,
+    lo aggiunge al catalogo (non sovrascrive se già presente).
+    """
+    candidates_dir = root / "candidates"
+    if not candidates_dir.is_dir():
+        return
+
+    slug_to_source: dict[str, str] = {}
+    for cand_dir in sorted(candidates_dir.iterdir()):
+        yml_path = cand_dir / "dataset.yml"
+        if not yml_path.is_file():
+            continue
+        try:
+            with open(yml_path) as f:
+                cfg = yaml.safe_load(f) or {}
+        except Exception:
+            continue
+        sid = cfg.get("source_id")
+        slug = cfg.get("slug")
+        if sid and slug:
+            # Conversione underscore slug (es. "aifa-spesa-consumo" → "aifa_spesa_consumo")
+            di_slug = slug.replace("-", "_")
+            slug_to_source[di_slug] = sid
+
+    if not slug_to_source:
+        return
+
+    updated = 0
+    for ds in catalog.get("datasets", []):
+        slug = ds.get("slug", "")
+        sid = slug_to_source.get(slug)
+        if sid and "source_id" not in ds:
+            ds["source_id"] = sid
+            updated += 1
+
+    if updated:
+        print(f"[enrich] source_id aggiunto a {updated} dataset da dataset.yml")
 
 
 def validate_catalog(catalog: dict[str, Any], schema: dict[str, Any]) -> list[str]:

--- a/scripts/build_clean_catalog.py
+++ b/scripts/build_clean_catalog.py
@@ -9,7 +9,6 @@ from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any
 
-import yaml
 from lab_connectors.gcs import list_objects, object_exists
 
 
@@ -101,6 +100,10 @@ def _enrich_source_ids(catalog: dict[str, Any], root: Path) -> None:
     Per ogni dataset nel catalogo, se esiste un candidate dataset.yml con source_id,
     lo aggiunge al catalogo (non sovrascrive se già presente).
     """
+    try:
+        import yaml
+    except ImportError:
+        return  # PyYAML non installato — salta arricchimento
     candidates_dir = root / "candidates"
     if not candidates_dir.is_dir():
         return


### PR DESCRIPTION
## Cosa cambia

### Full run su tutti gli anni
- `toolkit run` e `toolkit validate` ora processano tutti gli anni del dataset (via `all_years_csv` da `resolve_sample_run.py`)
- Non piu' solo 1 anno sample

### GCS push + Catalog update (condizionale)
- GCP Auth via Workload Identity Federation (stessi secrets di SO: `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`)
- `push_archive.py --layer clean --update-catalog` dopo validate
- `build_clean_catalog.py --write --check-gcs` dopo push
- Se i secrets non sono configurati, gli step vengono saltati (nessun errore)

### Dispatch a data-explorer
- `repository_dispatch` verso `dataciviclab/data-explorer` con evento `catalog_updated`
- DE ha gia' il listener configurato (PR #70)

### PR body aggiornata
- Le checklist riflettono che CI fa tutto (full run, GCS push, catalog update)
- I comandi maintainer rimossi: solo mart + BQ se serve

## Catena completa dopo questo merge

```
PR candidate mergiata
  → CI: toolkit run/validate (tutti gli anni)
  → CI: push_archive --layer clean (GCS)
  → CI: build_clean_catalog
  → CI: dispatch su data-explorer
  → DE rebuilda con catalogo aggiornato
```

## Riferimenti
- Closes #279
- Closes #283
- PR data-explorer #70 (refactor catalogo + dispatch listener)
