### PR TITLE
feat(aifa-spesa-consumo): source_id: aifa

### DIFF
--- a/candidates/aifa-spesa-consumo/dataset.yml
+++ b/candidates/aifa-spesa-consumo/dataset.yml
@@ -3,6 +3,7 @@ schema_version: 1
 
 dataset:
   name: "aifa_spesa_consumo"
+  source_id: "aifa"
   years: [ 2018, 2019, 2020, 2021, 2022, 2023, 2024 ]
 
 raw:


### PR DESCRIPTION
## Cosa cambia

- `candidates/aifa-spesa-consumo/dataset.yml`: aggiunto `source_id: aifa`

### Catena attesa dopo il merge

1. Post-merge workflow: full run + GCS push + build_clean_catalog
2. `build_clean_catalog.py` arricchisce `source_id: aifa` in `clean_catalog.json`
3. Dispatch su data-explorer → rebuild
4. SO (notturno): sync_datasets_in_use da DI catalog

### Test

Il meccanismo di auto-enrichment e' stato testato localmente con `terna-capacita-rinnovabile`:
```
[enrich] source_id aggiunto a 1 dataset da dataset.yml
```