### PR TITLE
fix: build-and-pr resiliente a sample_run skippato + workflow_dispatch

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "candidates/**"
       - "support_datasets/**"
+  workflow_dispatch:  # trigger manuale per test o retry
 
 env:
   GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -278,14 +279,14 @@ jobs:
         run: python scripts/build_pipeline_signals.py
 
       - name: Download sample-run artifacts
-        if: needs.detect.outputs.has_configs == 'true'
+        if: needs.detect.outputs.has_configs == 'true' && needs.sample_run.result != 'skipped'
         uses: actions/download-artifact@v8
         with:
           pattern: sample-run-*
           path: sample_run_artifacts
 
       - name: Apply sample-run results to pipeline_signals.json
-        if: needs.detect.outputs.has_configs == 'true'
+        if: needs.detect.outputs.has_configs == 'true' && needs.sample_run.result != 'skipped'
         run: python scripts/update_pipeline_sample_runs.py --samples-dir sample_run_artifacts
 
       - name: Check registry diff


### PR DESCRIPTION
## Fix

- `build-and-pr`: download e apply sample-run artifacts condizionati a `sample_run.result != 'skipped'`
- Risolve il caso in cui `sample_run` ha matrix vuota (candidate senza configs runnabili) e non produce artifact
- Senza fix, `build-and-pr` falliva con `no sample_run_result.json files found`

## Nuovo trigger

- Aggiunto `workflow_dispatch:` per trigger manuale del post-merge workflow
- Utile per test e retry senza dover mergiare una PR fittizia