### PR TITLE
feat: source_id in pipeline_signals + workflow_dispatch con slug input

### DIFF
--- a/scripts/build_pipeline_signals.py
+++ b/scripts/build_pipeline_signals.py
@@ -142,6 +142,17 @@ def _build_signal(slug: str, base_dir: Path) -> dict:
     """Build a single signal entry for a candidate."""
     from typing import Any
 
+    # Leggi source_id dal dataset.yml se presente
+    source_id = ""
+    yml_path = base_dir / "dataset.yml"
+    if yml_path.is_file():
+        try:
+            cfg = _read_yaml(yml_path)
+            dataset_cfg = cfg.get("dataset") or {}
+            source_id = dataset_cfg.get("source_id", "") or ""
+        except Exception:
+            pass
+
     layout_info = detect_candidate_layout(base_dir)
     layout = layout_info["layout"]
 
@@ -212,6 +223,7 @@ def _build_signal(slug: str, base_dir: Path) -> dict:
 
     return {
         "id": slug,
+        "source_id": source_id,
         "status": status,
         "label": slug,
         "detail": detail,


### PR DESCRIPTION
## Cosa cambia

### pipeline_signals.json
- Aggiunto `source_id` a ogni segnale (letto da `dataset.source_id` in dataset.yml)
- Se `dataset.yml` non ha `source_id`, il campo è vuoto (`""`)
- Consente ad ACB di cross-referenziare segnali pipeline con fonti SO

### workflow_dispatch
- Aggiunto input `slug` per trigger manuale del post-merge workflow
- Se specificato, processa direttamente il candidate indicato senza bisogno di PR
- Se non specificato, comportamento invariato (rileva file da PR mergiata)
- Utile per test e retry

## Riferimenti
- PR ACB #37 (source_id in RepoSignal)