### PR TITLE
fix: P1/P2 source_id — push_archive + workflow_dispatch slug input

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -6,7 +6,12 @@ on:
     paths:
       - "candidates/**"
       - "support_datasets/**"
-  workflow_dispatch:  # trigger manuale per test o retry
+  workflow_dispatch:
+    inputs:
+      slug:
+        description: "Slug del candidate da processare (es. inps-cig)"
+        required: false
+        type: string
 
 env:
   GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -29,7 +34,7 @@ jobs:
       - name: Checkout merge commit
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.ref }}
           fetch-depth: 0
 
       - name: Detect changed candidate/support roots
@@ -37,12 +42,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          SLUG_INPUT: ${{ inputs.slug }}
         run: |
           set -o pipefail
 
-          # Get PR file list and pipe to detect_candidates.py
-          gh pr view "$PR_NUMBER" --json files --jq ".files[].path" | \
-            python scripts/detect_candidates.py --files --json > detect_output.json
+          if [ -n "$SLUG_INPUT" ]; then
+            # Trigger manuale: processa direttamente lo slug richiesto
+            echo "candidates/${SLUG_INPUT}/dataset.yml" | \
+              python scripts/detect_candidates.py --files --json > detect_output.json
+          else
+            # Trigger da PR mergiata: rileva i file cambiati
+            gh pr view "$PR_NUMBER" --json files --jq ".files[].path" | \
+              python scripts/detect_candidates.py --files --json > detect_output.json
+          fi
 
           python - <<'PY'
           import json, os

--- a/scripts/push_archive.py
+++ b/scripts/push_archive.py
@@ -261,11 +261,11 @@ def update_catalog(slug: str, years: list[str], status: str, dry_run: bool = Fal
             "name": slug.replace("_", " ").title(),
             "description": "",
             "source": "",
+            "source_id": "",
             "period": {"start": int_years[0], "end": int_years[-1]},
             "columns": cols,
             "location": {"type": "gcs", "path": gcs_path, "multi_file": True},
-            "status": status,
-            "visibility": "public",
+            "stage": "published",
             "registry_source": "push_archive_auto",
         }
         datasets.append(new_entry)


### PR DESCRIPTION
## P1 — push_archive.py: source_id nei nuovi entry del catalogo
- `scripts/push_archive.py`: nuovi entry ora includono `"source_id": ""` e usano `stage` invece di `status`/`visibility`

## P2 — workflow_dispatch con input slug
- Aggiunto `inputs.slug` a `workflow_dispatch` per trigger manuale
- `detect` step: se `SLUG_INPUT` è impostato, processa direttamente quel candidato
- `checkout`: supporta `github.ref` come fallback quando non c'è merge commit

## Dipendenze
- PR data-explorer #74 (source_id in catalogo DE)
- PR agent-context-builder #38 (source_id in DICleanDataset)