### PR TITLE
fix: output detect su singola riga evita secret scanner GH

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -62,7 +62,7 @@ jobs:
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
               out.write(f"has_items={str(d['has_items']).lower()}\n")
               out.write(f"has_configs={str(d['has_configs']).lower()}\n")
-              out.write("items<<JSON\n")
+              out.write(f"items={json.dumps(d['items'], ensure_ascii=False)}\n")
               out.write(json.dumps(d["items"], ensure_ascii=False))
               out.write("\nJSON\n")
               out.write("configs<<JSON\n")
@@ -291,14 +291,14 @@ jobs:
         run: python scripts/build_pipeline_signals.py
 
       - name: Download sample-run artifacts
-        if: needs.detect.outputs.has_configs == 'true' && needs.sample_run.result != 'skipped'
+        if: needs.detect.outputs.has_configs == 'true' && needs.sample_run.result == 'success'
         uses: actions/download-artifact@v8
         with:
           pattern: sample-run-*
           path: sample_run_artifacts
 
       - name: Apply sample-run results to pipeline_signals.json
-        if: needs.detect.outputs.has_configs == 'true' && needs.sample_run.result != 'skipped'
+        if: needs.detect.outputs.has_configs == 'true' && needs.sample_run.result == 'success'
         run: |
           # Se non ci sono artifact (sample_run senza risultati), skip senza errore
           if [ ! -d sample_run_artifacts ] || [ -z "$(ls -A sample_run_artifacts)" ]; then

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -60,14 +60,10 @@ jobs:
           import json, os
           d = json.load(open("detect_output.json"))
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
-              out.write(f"has_items={str(d['has_items']).lower()}\n")
-              out.write(f"has_configs={str(d['has_configs']).lower()}\n")
-              out.write(f"items={json.dumps(d['items'], ensure_ascii=False)}\n")
-              out.write(json.dumps(d["items"], ensure_ascii=False))
-              out.write("\nJSON\n")
-              out.write("configs<<JSON\n")
-              out.write(json.dumps(d["configs"], ensure_ascii=False))
-              out.write("\nJSON\n")
+               out.write(f"has_items={str(d['has_items']).lower()}\n")
+               out.write(f"has_configs={str(d['has_configs']).lower()}\n")
+               out.write(f"items={json.dumps(d['items'], ensure_ascii=False)}\n")
+               out.write(f"configs={json.dumps(d['configs'], ensure_ascii=False)}\n")
           PY
 
   sample_run:


### PR DESCRIPTION
## Root cause

GitHub Actions secret scanner redatta gli output `items` e `configs` quando scritti con formato heredoc (`name<<DELIM`). `fromJson()` riceve stringa vuota → matrix 0 job.

Conferma: nei log i valori appaiono come `***` (redatto).

## Fix

6 righe:

1. Output format: `<<JSON heredoc` → `name=value` su singola riga (4 righe)
2. Guard condition: `!= 'skipped'` → `== 'success'` (1 riga)

Nessun refactor, nessuna rimozione di step (GCS push, CA cert, support datasets, matrice — tutto invariato).