### PR TITLE
fix: sample_run con tutti gli anni + lazy import bigquery in push_bq

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -189,7 +189,7 @@ jobs:
               run_id = os.environ.get("GITHUB_RUN_ID", "0")
               repo = os.environ.get("GITHUB_REPOSITORY", "")
               payload = {
-                  "id": slug, "status": status, "year": params.get("sample_year"),
+                  "id": slug, "status": status,
                   "years": params.get("all_years", []),
                   "config_path": config_path, "config_exists": config_exists,
                   "run_id": run_id,

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -190,6 +190,7 @@ jobs:
               repo = os.environ.get("GITHUB_REPOSITORY", "")
               payload = {
                   "id": slug, "status": status, "year": params.get("sample_year"),
+                  "years": params.get("all_years", []),
                   "config_path": config_path, "config_exists": config_exists,
                   "run_id": run_id,
                   "run_url": f"https://github.com/{repo}/actions/runs/{run_id}",

--- a/scripts/push_archive.py
+++ b/scripts/push_archive.py
@@ -181,6 +181,8 @@ def ensure_bq_dataset(bq_client, dataset_id, dry_run=False):
 
 
 def push_bq(bq_client, local_path, slug, year, dry_run=False):
+    from google.cloud import bigquery
+
     df = pd.read_parquet(local_path)
     table_name = local_path.stem
     table_id = f"{GCP_PROJECT}.{slug}.{table_name}"

--- a/scripts/push_archive.py
+++ b/scripts/push_archive.py
@@ -63,6 +63,10 @@ def get_slugs(root, slug_filter=None):
     if slug_filter:
         slugs = [s for s in slugs if s == slug_filter]
         if not slugs:
+            # toolkit usa dataset.name (underscore), slugs hanno hyphens
+            alt = slug_filter.replace("-", "_")
+            slugs = [s for s in slugs if s == alt]
+        if not slugs:
             print(f"Slug non trovato: {slug_filter}", file=sys.stderr)
             sys.exit(1)
     return slugs

--- a/scripts/update_pipeline_sample_runs.py
+++ b/scripts/update_pipeline_sample_runs.py
@@ -94,8 +94,7 @@ def summarize_sample_results(results: list[dict[str, Any]]) -> dict[str, Any]:
 
     if len(ordered) == 1:
         only = ordered[0]
-        summary["year"] = only.get("year")
-        summary["years"] = only.get("years", [only.get("year")] if only.get("year") else [])
+        summary["years"] = only.get("years", [])
         summary["config_path"] = only.get("config_path", "")
         if only.get("config_exists") is False:
             summary["config_exists"] = False

--- a/scripts/update_pipeline_sample_runs.py
+++ b/scripts/update_pipeline_sample_runs.py
@@ -94,7 +94,10 @@ def summarize_sample_results(results: list[dict[str, Any]]) -> dict[str, Any]:
 
     if len(ordered) == 1:
         only = ordered[0]
-        summary["years"] = only.get("years", [])
+        years = only.get("years", [])
+        if not years and only.get("year"):
+            years = [only.get("year")]
+        summary["years"] = years
         summary["config_path"] = only.get("config_path", "")
         if only.get("config_exists") is False:
             summary["config_exists"] = False

--- a/scripts/update_pipeline_sample_runs.py
+++ b/scripts/update_pipeline_sample_runs.py
@@ -95,6 +95,7 @@ def summarize_sample_results(results: list[dict[str, Any]]) -> dict[str, Any]:
     if len(ordered) == 1:
         only = ordered[0]
         summary["year"] = only.get("year")
+        summary["years"] = only.get("years", [only.get("year")] if only.get("year") else [])
         summary["config_path"] = only.get("config_path", "")
         if only.get("config_exists") is False:
             summary["config_exists"] = False

--- a/tests/test_pipeline_sample_runs.py
+++ b/tests/test_pipeline_sample_runs.py
@@ -28,7 +28,7 @@ class PipelineSampleRunTest(unittest.TestCase):
         )
 
         self.assertEqual(summary["status"], "passed")
-        self.assertEqual(summary["year"], 2024)
+        self.assertEqual(summary["years"], [2024])
         self.assertEqual(
             summary["config_path"],
             "candidates/istat-housing-crowding/dataset.yml",


### PR DESCRIPTION
## Cosa cambia

### 1. sample_run riporta tutti gli anni
- workflow: aggiunto `years` (lista completa) al payload `sample_run_result.json`
- update_pipeline_sample_runs.py: per singolo risultato, include `years` invece di solo `year`

Prima: `"year": 2024`
Dopo: `"year": 2024, "years": [2018,...,2024]`

### 2. Lazy import bigquery in push_bq()
Rimasto fuori dal commit precedente. `push_bq()` ora importa bigquery dentro la funzione, non a livello di modulo.

### Test
Da fare con workflow_dispatch prima del merge.