### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -190,6 +190,7 @@ jobs:
               repo = os.environ.get("GITHUB_REPOSITORY", "")
               payload = {
                   "id": slug, "status": status, "year": params.get("sample_year"),
+                  "years": params.get("all_years", []),
                   "config_path": config_path, "config_exists": config_exists,
                   "run_id": run_id,
                   "run_url": f"https://github.com/{repo}/actions/runs/{run_id}",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -150,11 +150,26 @@
     },
     {
       "id": "irpef-comunale",
-      "source_id": "",
+      "source_id": "mef_irpef",
       "status": "ok",
       "label": "irpef-comunale",
       "detail": "anni 2019-2023 — fonte: finanze_http_zip — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25802384251",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25802384251",
+        "checked_at": "2026-05-13",
+        "year": 2023,
+        "years": [
+          2019,
+          2020,
+          2021,
+          2022,
+          2023
+        ],
+        "config_path": "candidates/irpef-comunale/dataset.yml"
+      }
     },
     {
       "id": "ispra-consumo-suolo",

--- a/scripts/push_archive.py
+++ b/scripts/push_archive.py
@@ -181,6 +181,8 @@ def ensure_bq_dataset(bq_client, dataset_id, dry_run=False):
 
 
 def push_bq(bq_client, local_path, slug, year, dry_run=False):
+    from google.cloud import bigquery
+
     df = pd.read_parquet(local_path)
     table_name = local_path.stem
     table_id = f"{GCP_PROJECT}.{slug}.{table_name}"

--- a/scripts/update_pipeline_sample_runs.py
+++ b/scripts/update_pipeline_sample_runs.py
@@ -95,6 +95,7 @@ def summarize_sample_results(results: list[dict[str, Any]]) -> dict[str, Any]:
     if len(ordered) == 1:
         only = ordered[0]
         summary["year"] = only.get("year")
+        summary["years"] = only.get("years", [only.get("year")] if only.get("year") else [])
         summary["config_path"] = only.get("config_path", "")
         if only.get("config_exists") is False:
             summary["config_exists"] = False


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `irpef-comunale` (candidate, `candidates/irpef-comunale`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/irpef-comunale/dataset.yml` -> artifact `sample-run-irpef-comunale`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug irpef-comunale --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
