### PR TITLE
feat(bdap-entrate-stato): aggiunge source_id openbdap

### DIFF
--- a/candidates/bdap-entrate-stato/dataset.yml
+++ b/candidates/bdap-entrate-stato/dataset.yml
@@ -3,6 +3,7 @@ schema_version: 1
 
 dataset:
   name: "bdap_entrate_stato"
+  source_id: "openbdap"
   years: [2024]
 
 raw:
@@ -54,4 +55,3 @@ mart:
 
 validation:
   fail_on_error: true
-


### PR DESCRIPTION
## Sintesi
- aggiunge `dataset.source_id: "openbdap"` al candidate `bdap-entrate-stato`

## Perché
Allinea il candidate al source registry (SO) e abilita propagazione corretta del `source_id` nei segnali/registry derivati.

## Modifica
- `candidates/bdap-entrate-stato/dataset.yml`

## Verifica
- parsing YAML locale OK
- nessun altro file toccato