### PR TITLE
chore(post-merge): aggiorna registry per PR #304

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -30,17 +30,19 @@
     },
     {
       "id": "bdap-entrate-stato",
-      "source_id": "",
+      "source_id": "openbdap",
       "status": "ok",
       "label": "bdap-entrate-stato",
       "detail": "anno 2024 — fonte: openbdap_entrate_csv — mart: sì",
       "action": "",
       "sample_run": {
-        "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "status": "failed",
+        "run_id": "25809401995",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25809401995",
+        "checked_at": "2026-05-13",
+        "years": [
+          2024
+        ],
         "config_path": "candidates/bdap-entrate-stato/dataset.yml"
       }
     },
@@ -150,7 +152,7 @@
     },
     {
       "id": "irpef-comunale",
-      "source_id": "",
+      "source_id": "mef_irpef",
       "status": "ok",
       "label": "irpef-comunale",
       "detail": "anni 2019-2023 — fonte: finanze_http_zip — mart: sì",


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #304 — feat(bdap-entrate-stato): aggiunge source_id openbdap

Changed candidate/support roots:

- `bdap-entrate-stato` (candidate, `candidates/bdap-entrate-stato`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [ ] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/bdap-entrate-stato/dataset.yml` -> artifact `sample-run-bdap-entrate-stato`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug bdap-entrate-stato --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
