### PR TITLE
feat(workflows): post-merge consuma artifact del PR check

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -12,6 +12,10 @@ on:
         description: "Slug del candidate da processare (es. inps-cig)"
         required: false
         type: string
+      pr_run_id:
+        description: "Run ID di Toolkit Pipeline Check da cui scaricare artifact (obbligatorio in dispatch)"
+        required: false
+        type: string
 
 env:
   GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -71,7 +75,8 @@ jobs:
 
   sample_run:
     needs: detect
-    if: needs.detect.outputs.has_configs == 'true'
+    # Post-merge consumer: non riesegue toolkit, consuma artifact del PR check.
+    if: false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -286,16 +291,49 @@ jobs:
       - name: Build pipeline_signals.json
         run: python scripts/build_pipeline_signals.py
 
-      - name: Download sample-run artifacts
-        if: needs.detect.outputs.has_configs == 'true' && needs.sample_run.result != 'skipped'
-        uses: actions/download-artifact@v8
-        continue-on-error: true
-        with:
-          name: sample-run-results
-          path: sample_run_artifacts
+      - name: Download PR toolkit artifacts (consumer mode)
+        if: needs.detect.outputs.has_configs == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_RUN_ID_INPUT: ${{ inputs.pr_run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p sample_run_artifacts
+
+          PR_RUN_ID=""
+          if [ -n "${PR_RUN_ID_INPUT:-}" ]; then
+            PR_RUN_ID="$PR_RUN_ID_INPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR_RUN_ID=$(gh run list \
+              --workflow "Toolkit Pipeline Check" \
+              --event pull_request \
+              --json databaseId,headSha,conclusion \
+              --jq ".[] | select(.headSha == \"${{ github.event.pull_request.head.sha }}\") | .databaseId" \
+              | head -n1)
+          fi
+
+          if [ -z "${PR_RUN_ID:-}" ]; then
+            echo "::error::Run ID non disponibile. In workflow_dispatch passa inputs.pr_run_id."
+            exit 1
+          fi
+
+          echo "Using PR toolkit run id: ${PR_RUN_ID}"
+          ART_NAMES=$(gh api "repos/${{ github.repository }}/actions/runs/${PR_RUN_ID}/artifacts" --jq '.artifacts[].name')
+          MATCHED=$(echo "$ART_NAMES" | grep '^sample-run-' || true)
+
+          if [ -z "${MATCHED:-}" ]; then
+            echo "::error::Nessun artifact sample-run-* trovato nel run ${PR_RUN_ID}"
+            exit 1
+          fi
+
+          while IFS= read -r name; do
+            [ -z "$name" ] && continue
+            gh run download "$PR_RUN_ID" -n "$name" -D sample_run_artifacts
+          done <<< "$MATCHED"
 
       - name: Apply sample-run results to pipeline_signals.json
-        if: needs.detect.outputs.has_configs == 'true' && needs.sample_run.result != 'skipped'
+        if: needs.detect.outputs.has_configs == 'true'
         run: |
           # Se non ci sono artifact (sample_run senza risultati), skip senza errore
           if [ ! -d sample_run_artifacts ] || [ -z "$(ls -A sample_run_artifacts)" ]; then
@@ -359,9 +397,8 @@ jobs:
               "## Automatic updates",
               "",
               f"- [x] Rebuilt `registry/pipeline_signals.json`{' (no diff)' if not signals_changed else ''}",
-              f"- [{'x' if sample_passed else ' '}] CI: full run completato (tutti gli anni)",
-              f"- [{'x' if gcp_available else ' '}] CI: clean parquet pushato su GCS",
-              f"- [{'x' if gcp_available else ' '}] CI: `registry/clean_catalog.json` aggiornato",
+              f"- [{'x' if sample_passed else ' '}] PR check consumato (run da artifact)",
+              "- [ ] Maintainer: publish clean su GCS (se richiesto)",
               "- [ ] Maintainer: push mart + BQ (se serve)",
               "",
               "## Sample-run artifacts",
@@ -374,7 +411,7 @@ jobs:
               "\n".join(commands),
               "```",
               "",
-              "CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.",
+              "Post-merge ha consumato gli artifact del PR check e aggiornato i segnali. Publish clean/mart resta in mano maintainer.",
           ])
 
           with open("post_merge_pr_body.md", "w", encoding="utf-8") as f:

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -12,10 +12,6 @@ on:
         description: "Slug del candidate da processare (es. inps-cig)"
         required: false
         type: string
-      pr_run_id:
-        description: "Run ID di Toolkit Pipeline Check da cui scaricare artifact (obbligatorio in dispatch)"
-        required: false
-        type: string
 
 env:
   GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -75,8 +71,7 @@ jobs:
 
   sample_run:
     needs: detect
-    # Modalità definitiva: post-merge consuma artifact del PR check, non riesegue toolkit.
-    if: false
+    if: needs.detect.outputs.has_configs == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -291,49 +286,16 @@ jobs:
       - name: Build pipeline_signals.json
         run: python scripts/build_pipeline_signals.py
 
-      - name: Download PR toolkit artifacts (consumer mode)
-        if: needs.detect.outputs.has_configs == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_RUN_ID_INPUT: ${{ inputs.pr_run_id }}
-        run: |
-          set -euo pipefail
-          mkdir -p sample_run_artifacts
-
-          PR_RUN_ID=""
-          if [ -n "${PR_RUN_ID_INPUT:-}" ]; then
-            PR_RUN_ID="$PR_RUN_ID_INPUT"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            PR_RUN_ID=$(gh run list \
-              --workflow "Toolkit Pipeline Check" \
-              --event pull_request \
-              --json databaseId,headSha,conclusion \
-              --jq ".[] | select(.headSha == \"${{ github.event.pull_request.head.sha }}\") | .databaseId" \
-              | head -n1)
-          fi
-
-          if [ -z "${PR_RUN_ID:-}" ]; then
-            echo "::error::Run ID non disponibile. In workflow_dispatch passa inputs.pr_run_id."
-            exit 1
-          fi
-
-          echo "Using PR toolkit run id: ${PR_RUN_ID}"
-          ART_NAMES=$(gh api "repos/${{ github.repository }}/actions/runs/${PR_RUN_ID}/artifacts" --jq '.artifacts[].name')
-          MATCHED=$(echo "$ART_NAMES" | grep '^sample-run-' || true)
-
-          if [ -z "${MATCHED:-}" ]; then
-            echo "::error::Nessun artifact sample-run-* trovato nel run ${PR_RUN_ID}"
-            exit 1
-          fi
-
-          while IFS= read -r name; do
-            [ -z "$name" ] && continue
-            gh run download "$PR_RUN_ID" -n "$name" -D sample_run_artifacts
-          done <<< "$MATCHED"
+      - name: Download sample-run artifacts
+        if: needs.detect.outputs.has_configs == 'true' && needs.sample_run.result != 'skipped'
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: sample-run-results
+          path: sample_run_artifacts
 
       - name: Apply sample-run results to pipeline_signals.json
-        if: needs.detect.outputs.has_configs == 'true'
+        if: needs.detect.outputs.has_configs == 'true' && needs.sample_run.result != 'skipped'
         run: |
           # Se non ci sono artifact (sample_run senza risultati), skip senza errore
           if [ ! -d sample_run_artifacts ] || [ -z "$(ls -A sample_run_artifacts)" ]; then
@@ -397,8 +359,9 @@ jobs:
               "## Automatic updates",
               "",
               f"- [x] Rebuilt `registry/pipeline_signals.json`{' (no diff)' if not signals_changed else ''}",
-              f"- [{'x' if sample_passed else ' '}] PR check consumato (sample/full run da artifact)",
-              "- [ ] Maintainer: publish clean su GCS (se richiesto)",
+              f"- [{'x' if sample_passed else ' '}] CI: full run completato (tutti gli anni)",
+              f"- [{'x' if gcp_available else ' '}] CI: clean parquet pushato su GCS",
+              f"- [{'x' if gcp_available else ' '}] CI: `registry/clean_catalog.json` aggiornato",
               "- [ ] Maintainer: push mart + BQ (se serve)",
               "",
               "## Sample-run artifacts",
@@ -411,7 +374,7 @@ jobs:
               "\n".join(commands),
               "```",
               "",
-              "Post-merge ha consumato gli artifact del PR check e aggiornato i segnali. Publish clean/mart resta in mano maintainer.",
+              "CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.",
           ])
 
           with open("post_merge_pr_body.md", "w", encoding="utf-8") as f:

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -12,6 +12,10 @@ on:
         description: "Slug del candidate da processare (es. inps-cig)"
         required: false
         type: string
+      pr_run_id:
+        description: "Run ID di Toolkit Pipeline Check da cui scaricare artifact (obbligatorio in dispatch)"
+        required: false
+        type: string
 
 env:
   GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -71,7 +75,8 @@ jobs:
 
   sample_run:
     needs: detect
-    if: needs.detect.outputs.has_configs == 'true'
+    # Modalità definitiva: post-merge consuma artifact del PR check, non riesegue toolkit.
+    if: false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -286,16 +291,49 @@ jobs:
       - name: Build pipeline_signals.json
         run: python scripts/build_pipeline_signals.py
 
-      - name: Download sample-run artifacts
-        if: needs.detect.outputs.has_configs == 'true' && needs.sample_run.result != 'skipped'
-        uses: actions/download-artifact@v8
-        continue-on-error: true
-        with:
-          name: sample-run-results
-          path: sample_run_artifacts
+      - name: Download PR toolkit artifacts (consumer mode)
+        if: needs.detect.outputs.has_configs == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_RUN_ID_INPUT: ${{ inputs.pr_run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p sample_run_artifacts
+
+          PR_RUN_ID=""
+          if [ -n "${PR_RUN_ID_INPUT:-}" ]; then
+            PR_RUN_ID="$PR_RUN_ID_INPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR_RUN_ID=$(gh run list \
+              --workflow "Toolkit Pipeline Check" \
+              --event pull_request \
+              --json databaseId,headSha,conclusion \
+              --jq ".[] | select(.headSha == \"${{ github.event.pull_request.head.sha }}\") | .databaseId" \
+              | head -n1)
+          fi
+
+          if [ -z "${PR_RUN_ID:-}" ]; then
+            echo "::error::Run ID non disponibile. In workflow_dispatch passa inputs.pr_run_id."
+            exit 1
+          fi
+
+          echo "Using PR toolkit run id: ${PR_RUN_ID}"
+          ART_NAMES=$(gh api "repos/${{ github.repository }}/actions/runs/${PR_RUN_ID}/artifacts" --jq '.artifacts[].name')
+          MATCHED=$(echo "$ART_NAMES" | grep '^sample-run-' || true)
+
+          if [ -z "${MATCHED:-}" ]; then
+            echo "::error::Nessun artifact sample-run-* trovato nel run ${PR_RUN_ID}"
+            exit 1
+          fi
+
+          while IFS= read -r name; do
+            [ -z "$name" ] && continue
+            gh run download "$PR_RUN_ID" -n "$name" -D sample_run_artifacts
+          done <<< "$MATCHED"
 
       - name: Apply sample-run results to pipeline_signals.json
-        if: needs.detect.outputs.has_configs == 'true' && needs.sample_run.result != 'skipped'
+        if: needs.detect.outputs.has_configs == 'true'
         run: |
           # Se non ci sono artifact (sample_run senza risultati), skip senza errore
           if [ ! -d sample_run_artifacts ] || [ -z "$(ls -A sample_run_artifacts)" ]; then
@@ -359,9 +397,8 @@ jobs:
               "## Automatic updates",
               "",
               f"- [x] Rebuilt `registry/pipeline_signals.json`{' (no diff)' if not signals_changed else ''}",
-              f"- [{'x' if sample_passed else ' '}] CI: full run completato (tutti gli anni)",
-              f"- [{'x' if gcp_available else ' '}] CI: clean parquet pushato su GCS",
-              f"- [{'x' if gcp_available else ' '}] CI: `registry/clean_catalog.json` aggiornato",
+              f"- [{'x' if sample_passed else ' '}] PR check consumato (sample/full run da artifact)",
+              "- [ ] Maintainer: publish clean su GCS (se richiesto)",
               "- [ ] Maintainer: push mart + BQ (se serve)",
               "",
               "## Sample-run artifacts",
@@ -374,7 +411,7 @@ jobs:
               "\n".join(commands),
               "```",
               "",
-              "CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.",
+              "Post-merge ha consumato gli artifact del PR check e aggiornato i segnali. Publish clean/mart resta in mano maintainer.",
           ])
 
           with open("post_merge_pr_body.md", "w", encoding="utf-8") as f:

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -223,6 +223,64 @@ jobs:
             validate_all.log
           retention-days: 7
 
+      - name: Write sample-run result payload
+        if: always()
+        env:
+          CONFIG_PATH: ${{ matrix.config.config_path }}
+          ARTIFACT_NAME: ${{ matrix.config.artifact_name }}
+          RUN_STATUS: ${{ job.status }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          mkdir -p "sample_run_artifacts/${ARTIFACT_NAME}"
+          python - <<'PY'
+          import datetime
+          import json
+          import os
+          import subprocess
+          import sys
+
+          config_path = os.environ["CONFIG_PATH"]
+          artifact_name = os.environ["ARTIFACT_NAME"]
+          status = "passed" if os.environ.get("RUN_STATUS") == "success" else "failed"
+
+          r = subprocess.run(
+              ["python", "scripts/resolve_sample_run.py", config_path],
+              capture_output=True,
+              text=True,
+          )
+          years = []
+          if r.returncode == 0:
+              try:
+                  years = json.loads(r.stdout).get("all_years", [])
+              except json.JSONDecodeError:
+                  years = []
+
+          payload = {
+              "id": artifact_name,
+              "status": status,
+              "years": years,
+              "config_path": config_path,
+              "config_exists": True,
+              "run_id": os.environ["RUN_ID"],
+              "run_url": f"https://github.com/{os.environ['REPO']}/actions/runs/{os.environ['RUN_ID']}",
+              "checked_at": datetime.datetime.now(datetime.timezone.utc).date().isoformat(),
+          }
+          out = f"sample_run_artifacts/{artifact_name}/sample_run_result.json"
+          with open(out, "w", encoding="utf-8") as f:
+              json.dump(payload, f, indent=2, ensure_ascii=False)
+          print(f"wrote {out}")
+          PY
+
+      - name: Upload sample-run result artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sample-run-${{ matrix.config.artifact_name }}
+          path: sample_run_artifacts/${{ matrix.config.artifact_name }}/sample_run_result.json
+          if-no-files-found: error
+          retention-days: 7
+
   report:
     needs: [detect, toolkit-check]
     if: always()

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -141,9 +141,11 @@ jobs:
 
           data = json.loads(result.stdout)
           support_list = data.get("support", [])
+          all_years = ",".join(str(y) for y in data.get("all_years", []))
 
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
               out.write(f"has_support={str(bool(support_list)).lower()}\n")
+              out.write(f"all_years={all_years}\n")
               out.write("support_configs<<JSON\n")
               out.write(json.dumps(support_list, ensure_ascii=False))
               out.write("\nJSON\n")
@@ -163,7 +165,7 @@ jobs:
           set -o pipefail
           toolkit run all \
             --config "${{ matrix.config.config_path }}" \
-            --years "${{ matrix.config.year }}" \
+            --years "${{ steps.resolve_support.outputs.all_years }}" \
             2>&1 | tee run_all.log
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 
@@ -174,7 +176,7 @@ jobs:
           set -o pipefail
           toolkit validate all \
             --config "${{ matrix.config.config_path }}" \
-            --years "${{ matrix.config.year }}" \
+            --years "${{ steps.resolve_support.outputs.all_years }}" \
             2>&1 | tee validate_all.log
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 
@@ -182,34 +184,47 @@ jobs:
         if: success()
         env:
           CONFIG_PATH: ${{ matrix.config.config_path }}
-          YEAR: ${{ matrix.config.year }}
+          ALL_YEARS: ${{ steps.resolve_support.outputs.all_years }}
           DATACIVICLAB_WORKSPACE: ${{ github.workspace }}
         run: |
           set -o pipefail
-          RESULT=$(toolkit blocker-hints --config "$CONFIG_PATH" --year "$YEAR" --json 2>/dev/null)
-
-          if [ -z "$RESULT" ]; then
-            echo "::error::blocker-hints failed or returned empty output"
-            exit 1
-          fi
-
-          echo "$RESULT" > /tmp/blocker_hints.json
-
           python - <<'PY'
           import json
-          try:
-              with open('/tmp/blocker_hints.json') as f:
-                  d = json.load(f)
-              blockers = d.get('blocker_count', 0)
-              warnings = d.get('warning_count', 0)
-              print('blocker_count=' + str(blockers))
-              print('warning_count=' + str(warnings))
-              if blockers > 0:
-                  print('::error::Candidate has ' + str(blockers) + ' blocker(s) — fix before merging')
-                  exit(1)
-          except json.JSONDecodeError:
-              print('ERROR: failed to parse blocker-hints JSON')
-              exit(1)
+          import os
+          import subprocess
+          import sys
+
+          years_raw = os.environ.get("ALL_YEARS", "")
+          years = [y.strip() for y in years_raw.split(",") if y.strip()]
+          if not years:
+              print("::error::ALL_YEARS is empty")
+              sys.exit(1)
+
+          total_blockers = 0
+          for year in years:
+              r = subprocess.run(
+                  ["toolkit", "blocker-hints", "--config", os.environ["CONFIG_PATH"], "--year", year, "--json"],
+                  capture_output=True,
+                  text=True,
+              )
+              if r.returncode != 0 or not r.stdout.strip():
+                  print(f"::error::blocker-hints failed for year {year}")
+                  if r.stderr:
+                      print(r.stderr)
+                  sys.exit(1)
+              try:
+                  data = json.loads(r.stdout)
+              except json.JSONDecodeError:
+                  print(f"::error::invalid blocker-hints JSON for year {year}")
+                  sys.exit(1)
+              blockers = int(data.get("blocker_count", 0))
+              warnings = int(data.get("warning_count", 0))
+              total_blockers += blockers
+              print(f"year={year} blocker_count={blockers} warning_count={warnings}")
+
+          if total_blockers > 0:
+              print(f"::error::Candidate has {total_blockers} blocker(s) across all years")
+              sys.exit(1)
           PY
 
       - name: Upload artifacts

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ I processi ricorrenti vivono sia come workflow markdown (per umani e agenti) sia
 | Action | Trigger | Cosa fa |
 |---|---|---|
 | `validate-candidate-structure.yml` | PR su `candidates/` | Verifica che ogni candidate abbia `dataset.yml` valido |
-| `pr-toolkit-check.yml` | PR su `candidates/` | Controlla consistenza schema, path e file obbligatori |
-| `post-merge-candidate.yml` | Merge su `candidates/` | Esegue il candidate via toolkit (raw → clean → mart) |
+| `pr-toolkit-check.yml` | PR su `candidates/` | Esegue run+validate candidate e pubblica artifact `sample-run-*` per ogni config |
+| `post-merge-candidate.yml` | Merge su `candidates/` | Consuma artifact del PR check, aggiorna `pipeline_signals.json`, apre draft PR handoff |
 | `build-pipeline-signals.yml` | Merge su `candidates/` | Aggiorna `registry/pipeline_signals.json` |
 | `validate-clean-catalog.yml` | Merge su `registry/` | Verifica schema del clean catalog |
 

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ I processi ricorrenti vivono sia come workflow markdown (per umani e agenti) sia
 | Action | Trigger | Cosa fa |
 |---|---|---|
 | `validate-candidate-structure.yml` | PR su `candidates/` | Verifica che ogni candidate abbia `dataset.yml` valido |
-| `pr-toolkit-check.yml` | PR su `candidates/` | Esegue run+validate candidate e pubblica artifact `sample-run-*` per ogni config |
-| `post-merge-candidate.yml` | Merge su `candidates/` | Consuma artifact del PR check, aggiorna `pipeline_signals.json`, apre draft PR handoff |
+| `pr-toolkit-check.yml` | PR su `candidates/` | Esegue run+validate candidate su tutti gli anni e pubblica artifact diagnostici |
+| `post-merge-candidate.yml` | Merge su `candidates/` | Esegue full run + push clean GCS, aggiorna `pipeline_signals.json`, apre draft PR handoff |
 | `build-pipeline-signals.yml` | Merge su `candidates/` | Aggiorna `registry/pipeline_signals.json` |
 | `validate-clean-catalog.yml` | Merge su `registry/` | Verifica schema del clean catalog |
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ I processi ricorrenti vivono sia come workflow markdown (per umani e agenti) sia
 |---|---|---|
 | `validate-candidate-structure.yml` | PR su `candidates/` | Verifica che ogni candidate abbia `dataset.yml` valido |
 | `pr-toolkit-check.yml` | PR su `candidates/` | Esegue run+validate candidate su tutti gli anni e pubblica artifact diagnostici |
-| `post-merge-candidate.yml` | Merge su `candidates/` | Esegue full run + push clean GCS, aggiorna `pipeline_signals.json`, apre draft PR handoff |
+| `post-merge-candidate.yml` | Merge su `candidates/` | Consuma artifact del PR check (run id), aggiorna `pipeline_signals.json`, apre draft PR/issue handoff |
 | `build-pipeline-signals.yml` | Merge su `candidates/` | Aggiorna `registry/pipeline_signals.json` |
 | `validate-clean-catalog.yml` | Merge su `registry/` | Verifica schema del clean catalog |
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -18,8 +18,8 @@ Sono il riferimento umano per il comportamento della pipeline toolkit e delle Gi
 |---|---|---|---|
 | `validate-candidate-structure.yml` | PR su candidates/, support_datasets/ | Verifica che ogni candidate abbia `dataset.yml` e struttura valida |
 | `lint.yml` | PR e push su scripts/, tools/, pyproject.toml | Mypy + ruff + pytest su codice Python |
-| `pr-toolkit-check.yml` | PR su candidates/, support_datasets/ | `toolkit run all` + `validate all` + gate blocker_hints |
-| `post-merge-candidate.yml` | Merge su candidates/, support_datasets/ | Run CI, rebuild `pipeline_signals.json`, apre draft PR handoff |
+| `pr-toolkit-check.yml` | PR su candidates/, support_datasets/ | `toolkit run all` + `validate all` + gate blocker_hints + artifact `sample-run-*` |
+| `post-merge-candidate.yml` | Merge su candidates/, support_datasets/ | Consuma artifact del PR check, aggiorna `pipeline_signals.json`, apre draft PR handoff |
 | `build-pipeline-signals.yml` | Manuale (workflow_dispatch) | Ricostruisce `registry/pipeline_signals.json` |
 | `validate-clean-catalog.yml` | PR e push su `registry/` | Schema JSON, GCS check, clean-query smoke test |
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -18,8 +18,8 @@ Sono il riferimento umano per il comportamento della pipeline toolkit e delle Gi
 |---|---|---|---|
 | `validate-candidate-structure.yml` | PR su candidates/, support_datasets/ | Verifica che ogni candidate abbia `dataset.yml` e struttura valida |
 | `lint.yml` | PR e push su scripts/, tools/, pyproject.toml | Mypy + ruff + pytest su codice Python |
-| `pr-toolkit-check.yml` | PR su candidates/, support_datasets/ | `toolkit run all` + `validate all` + gate blocker_hints + artifact `sample-run-*` |
-| `post-merge-candidate.yml` | Merge su candidates/, support_datasets/ | Consuma artifact del PR check, aggiorna `pipeline_signals.json`, apre draft PR handoff |
+| `pr-toolkit-check.yml` | PR su candidates/, support_datasets/ | `toolkit run all` + `validate all` + gate blocker_hints su tutti gli anni + artifact diagnostici |
+| `post-merge-candidate.yml` | Merge su candidates/, support_datasets/ | Full run + push clean GCS + update `pipeline_signals.json` + draft PR handoff |
 | `build-pipeline-signals.yml` | Manuale (workflow_dispatch) | Ricostruisce `registry/pipeline_signals.json` |
 | `validate-clean-catalog.yml` | PR e push su `registry/` | Schema JSON, GCS check, clean-query smoke test |
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -19,7 +19,7 @@ Sono il riferimento umano per il comportamento della pipeline toolkit e delle Gi
 | `validate-candidate-structure.yml` | PR su candidates/, support_datasets/ | Verifica che ogni candidate abbia `dataset.yml` e struttura valida |
 | `lint.yml` | PR e push su scripts/, tools/, pyproject.toml | Mypy + ruff + pytest su codice Python |
 | `pr-toolkit-check.yml` | PR su candidates/, support_datasets/ | `toolkit run all` + `validate all` + gate blocker_hints su tutti gli anni + artifact diagnostici |
-| `post-merge-candidate.yml` | Merge su candidates/, support_datasets/ | Full run + push clean GCS + update `pipeline_signals.json` + draft PR handoff |
+| `post-merge-candidate.yml` | Merge su candidates/, support_datasets/ | Consuma artifact del PR check (run id), aggiorna `pipeline_signals.json`, apre draft PR/issue handoff |
 | `build-pipeline-signals.yml` | Manuale (workflow_dispatch) | Ricostruisce `registry/pipeline_signals.json` |
 | `validate-clean-catalog.yml` | PR e push su `registry/` | Schema JSON, GCS check, clean-query smoke test |
 


### PR DESCRIPTION
## Sintesi
- `pr-toolkit-check` produce artifact strutturati `sample-run-*` per ogni config
- `post-merge-candidate` non riesegue toolkit: consuma artifact dal run PR check e aggiorna i segnali
- aggiornati handoff messaging e documentazione workflow

## Perché
Ridurre la fragilità post-merge dovuta a refetch runtime (HTTP timeout/fonti esterne) e disaccoppiare compute (in PR) da orchestration (post-merge).

## Modifiche principali
- `.github/workflows/pr-toolkit-check.yml`
  - aggiunge payload `sample_run_result.json` per config
  - pubblica artifact `sample-run-<artifact_name>`
- `.github/workflows/post-merge-candidate.yml`
  - disabilita il job `sample_run` (compute in post-merge)
  - scarica artifact `sample-run-*` dal run `Toolkit Pipeline Check` della PR mergiata
  - applica `update_pipeline_sample_runs.py` su `pipeline_signals.json`
  - supporta `workflow_dispatch` con input `pr_run_id`
  - aggiorna testo handoff (consumer mode)
- docs
  - `README.md`
  - `skills/README.md`

## Nota operativa
In `workflow_dispatch`, se non c'è contesto PR, passare `pr_run_id` del run `Toolkit Pipeline Check` da consumare.