### PR TITLE
chore(post-merge): aggiorna registry per PR #311

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-13",
+  "generated_at": "2026-05-14",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 31,
+    "total": 30,
     "by_status": {
-      "ok": 31,
+      "ok": 30,
       "warn": 0,
       "error": 0
     }
@@ -30,7 +30,7 @@
     },
     {
       "id": "bdap-entrate-stato",
-      "source_id": "",
+      "source_id": "openbdap",
       "status": "ok",
       "label": "bdap-entrate-stato",
       "detail": "anno 2024 — fonte: openbdap_entrate_csv — mart: sì",
@@ -118,23 +118,25 @@
     },
     {
       "id": "inps-pensioni",
-      "source_id": "",
+      "source_id": "inps",
       "status": "ok",
       "label": "inps-pensioni",
       "detail": "anno 2024 — fonte: inps_pensioni_csv — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "run_id": "25862718345",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25862718345",
+        "checked_at": "2026-05-14",
+        "years": [
+          2024
+        ],
         "config_path": "candidates/inps-pensioni/dataset.yml"
       }
     },
     {
       "id": "irpef-comunale",
-      "source_id": "",
+      "source_id": "mef_irpef",
       "status": "ok",
       "label": "irpef-comunale",
       "detail": "anni 2019-2023 — fonte: finanze_http_zip — mart: sì",


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #311 — fix(inps-pensioni): rinomina dataset, correggi periodo, source_id, allinea docs

Changed candidate/support roots:

- `inps-pensioni` (candidate, `candidates/inps-pensioni`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/inps-pensioni/dataset.yml` -> artifact `sample-run-inps-pensioni`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug inps-pensioni --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
