### PR TITLE
fix(detect): usa dataset.name come push_slug per allineare GCS push

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -224,6 +224,7 @@ jobs:
                       capture_output=True,
                       check=True,
                   )
+                  push_slug = cfg.get("push_slug", slug)
                   subprocess.run(
                       [
                           "python",
@@ -231,14 +232,14 @@ jobs:
                           "--layer",
                           "clean",
                           "--slug",
-                          slug,
+                          push_slug,
                           "--update-catalog",
                           "--no-bq",
                       ],
                       cwd=root,
                       check=True,
                   )
-                  print(f"  GCS push completato per {slug}")
+                  print(f"  GCS push completato per {slug} (push_slug={push_slug})")
 
           # --- Build clean catalog (solo se GCP Auth riuscito) ---
           if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):

--- a/scripts/detect_candidates.py
+++ b/scripts/detect_candidates.py
@@ -58,6 +58,17 @@ def _resolve_year(cfg_path: Path) -> int:
         return 0
 
 
+def _dataset_name(cfg_path: Path) -> str | None:
+    """Read dataset.name from a dataset.yml — None if missing/unreadable."""
+    import yaml
+    try:
+        with open(cfg_path, encoding="utf-8") as f:
+            d = yaml.safe_load(f) or {}
+        return d.get("dataset", {}).get("name")
+    except Exception:
+        return None
+
+
 def _git_diff_files(base_sha: str | None, head_sha: str) -> list[str]:
     """Return list of file paths changed between base and head."""
     if base_sha:
@@ -125,13 +136,15 @@ def _detect_from_files(files: list[str]) -> tuple[list[dict], list[dict]]:
                 })
         else:
             config_path = root / "dataset.yml"
+            cfg_exists = config_path.exists()
+            ds_name = _dataset_name(config_path) if cfg_exists else None
             configs.append({
                 **item,
                 "config_path": config_path.as_posix(),
-                "config_exists": config_path.exists(),
-                "push_slug": item["slug"],
+                "config_exists": cfg_exists,
+                "push_slug": ds_name or item["slug"],
                 "artifact_name": item["slug"],
-                "year": _resolve_year(config_path) if config_path.exists() else 0,
+                "year": _resolve_year(config_path) if cfg_exists else 0,
                 "is_nested": False,
             })
 
@@ -181,11 +194,14 @@ def detect_candidates(
                     })
             else:
                 cfg = root_candidates / "dataset.yml"
+                cfg_exists = cfg.exists()
+                ds_name = _dataset_name(cfg) if cfg_exists else None
                 configs.append({
                     "kind": kind, "slug": slug, "config_path": cfg.as_posix(),
-                    "config_exists": cfg.exists(),
-                    "push_slug": slug, "artifact_name": slug,
-                    "year": _resolve_year(cfg) if cfg.exists() else 0,
+                    "config_exists": cfg_exists,
+                    "push_slug": ds_name or slug,
+                    "artifact_name": slug,
+                    "year": _resolve_year(cfg) if cfg_exists else 0,
                     "is_nested": False,
                 })
         elif root_support.exists():


### PR DESCRIPTION
## Root cause

`detect_candidates.py` usa il nome directory come slug (es. `opencivitas-fsc-rso`).
Il workflow post-merge passa questo slug a `push_archive.py`, che cerca i file
in `out/data/clean/{dataset.name}`. Quando directory name \u2260 dataset.name,
il push fallisce con `Slug non trovato`.

Il fallback `- \u2192 _` in `push_archive.py` copre i casi semplici ma non
quelli con differenze semantiche (es. `opencivitas-fsc-rso` cerca
`opencivitas_fsc_rso`, ma esiste `opencivitas_fsc_2025_rso`).

## Cosa cambia

### `scripts/detect_candidates.py`
- Nuova funzione `_dataset_name()` che legge `dataset.name` dal `dataset.yml`
- Per config non-nested: `push_slug` = `dataset.name` (se leggibile)
- `slug` (nome directory) resta invariato per path su disco e artifact naming

### `.github/workflows/post-merge-candidate.yml`
- Clean push: `--slug {slug}` \u2192 `--slug {push_slug}`
- Resto del workflow invariato

## Effetto

| Situazione | Prima | Dopo |
|---|---|---|
| directory == dataset.name | funziona | funziona |
| directory \u2260 dataset.name (solo trattino) | funziona per fallback | funziona direttamente |
| directory \u2260 dataset.name (differenza semantica) | \u274c fallisce | \u2705 push corretto |

Fixes il bug GCS push per candidati con disallineamento directory/dataset.name.