### PR TITLE
fix(mef-partecipazioni): aggiungi colonna anno nel clean

### DIFF
--- a/candidates/mef-partecipazioni/sql/clean.sql
+++ b/candidates/mef-partecipazioni/sql/clean.sql
@@ -1,4 +1,5 @@
 select
+  {year}::INTEGER                                            as anno,
   trim("Amministrazione Settore Istituzionale") as amministrazione_settore_istituzionale,
   trim("Amministrazione Macrocategoria") as amministrazione_macrocategoria,
   trim("Amministrazione Categoria") as amministrazione_categoria,

--- a/candidates/mef-partecipazioni/sql/mart.sql
+++ b/candidates/mef-partecipazioni/sql/mart.sql
@@ -1,4 +1,5 @@
 select
+  anno,
   amministrazione_regione_sede as amministrazione_regione,
   amministrazione_provincia_sede as amministrazione_provincia,
   amministrazione_comune_sede as amministrazione_comune,
@@ -9,5 +10,5 @@ select
   round(100.0 * count(*) filter (where appartenenza_perimetro_tusp = 'SI') / count(*), 1) as pct_perimetro_tusp,
   round(100.0 * count(*) filter (where appartenenza_perimetro_revisione_periodica = 'SI') / count(*), 1) as pct_perimetro_revisione
 from clean_input
-group by amministrazione_regione_sede, amministrazione_provincia_sede, amministrazione_comune_sede, amministrazione_categoria
-order by amministrazione_regione_sede, amministrazione_provincia_sede, amministrazione_comune_sede, amministrazione_categoria
+group by anno, amministrazione_regione_sede, amministrazione_provincia_sede, amministrazione_comune_sede, amministrazione_categoria
+order by anno, amministrazione_regione_sede, amministrazione_provincia_sede, amministrazione_comune_sede, amministrazione_categoria


### PR DESCRIPTION
## Problema

Il dataset `mef_partecipazioni` viene processato dalla pipeline per 4 anni distinti (2020, 2021, 2022, 2023), producendo un parquet separato per anno. **Né le righe nel parquet né il nome della tabella contengono l'anno di riferimento**, quindi chi consuma i dati (es. data-explorer via UNION ALL) non può filtrare per anno.

## Causa

La `clean.sql` faceva una semplice selezione delle colonne del CSV, ma nessuna colonna del CSV contiene l'anno del dataset. Il toolkit mette a disposizione il placeholder `{year}` che viene renderizzato con l'anno del run corrente, ma non veniva usato.

## Fix

Aggiunta la prima colonna in `clean.sql`:

```sql
{year}::INTEGER as anno,
```

Il toolkit sostituisce `{year}` con 2020, 2021, 2022 o 2023 a seconda dell'anno in esecuzione. Ogni parquet prodotto avrà la colonna `anno` valorizzata con l'anno corretto.

## Run verificato (2023)

- `toolkit run all --year 2023` → OK
- Parquet: 53.656 righe, colonna `anno: INTEGER` presente come prima colonna

Closes #308.