### PR TITLE
chore(post-merge): aggiorna registry per PR #315

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -273,10 +273,15 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2023,
+        "run_id": "25865950424",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25865950424",
+        "checked_at": "2026-05-14",
+        "years": [
+          2020,
+          2021,
+          2022,
+          2023
+        ],
         "config_path": "candidates/mef-partecipazioni/dataset.yml"
       }
     },


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #315 — fix(mef-partecipazioni): aggiungi colonna anno nel clean

Changed candidate/support roots:

- `mef-partecipazioni` (candidate, `candidates/mef-partecipazioni`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/mef-partecipazioni/dataset.yml` -> artifact `sample-run-mef-partecipazioni`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug mef_partecipazioni --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
