### PR TITLE
fix(ci): allinea GCP auth a source-observatory

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -104,11 +104,14 @@ jobs:
 
       - name: GCP Auth (for GCS push)
         if: env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != ''
-        continue-on-error: true
         uses: google-github-actions/auth@v3
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        if: env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != ''
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Process each detected config
         run: |


### PR DESCRIPTION
Allinea `post-merge-candidate.yml` alla configurazione GCP già funzionante in `source-observatory/observatory.yml`.\n\n### Cosa cambia\n\n1. **`continue-on-error: true`** rimosso — se l'auth fallisce, meglio scoprirlo subito\n2. **`secrets.GCP_*`** → **`env.GCP_*`** nel `with:` dell'auth (come SO)\n3. **`setup-gcloud@v3`** aggiunto dopo auth — presente in SO, mancante in DI\n\n### Perché\n\nIl GCS push nei workflow DI fallisce con `Unable to acquire impersonated credentials`. In SO la stessa configurazione (con `env.*` e `setup-gcloud`) funziona. Questo allineamento dovrebbe risolvere il problema.