### PR TITLE
fix(popolazione-istat-comunale): aggiungi colonna anno

### DIFF
--- a/support_datasets/popolazione-istat-comunale-2019-2025/sql/clean.sql
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/sql/clean.sql
@@ -1,4 +1,5 @@
 select
+  {year}::INTEGER                                            as anno,
   trim(cast("Codice comune" as varchar)) as codice_comune,
   trim(cast("Comune" as varchar)) as comune,
   try_cast("Età" as integer) as eta,


### PR DESCRIPTION
Stesso fix di #315: `{year}::INTEGER as anno` nel clean.sql.\n\nMart aveva gia' `{year} as anno_riferimento` — solo clean era senza.\n\nRun verificato per 2023: 805.902 righe con colonna `anno: INTEGER`.\n\nRiferimento bug #1 dall'audit.