### PR TITLE
chore(post-merge): aggiorna registry per PR #318

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -475,7 +475,23 @@
       "status": "ok",
       "label": "popolazione-istat-comunale-2019-2025",
       "detail": "anni: ? — fonte: ? — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25870731832",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25870731832",
+        "checked_at": "2026-05-14",
+        "years": [
+          2019,
+          2020,
+          2021,
+          2022,
+          2023,
+          2024,
+          2025
+        ],
+        "config_path": "support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #318 — fix(popolazione-istat-comunale): aggiungi colonna anno

Changed candidate/support roots:

- `popolazione-istat-comunale-2019-2025` (support_dataset, `support_datasets/popolazione-istat-comunale-2019-2025`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml` -> artifact `sample-run-popolazione-istat-comunale-2019-2025`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug popolazione_istat_comunale_2019_2025 --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
