### PR TITLE
fix(ispra-ru): aggiungi colonna anno nei 3 source nested

### DIFF
--- a/candidates/ispra-ru-costi-kg/sources/a_ru_base/sql/clean.sql
+++ b/candidates/ispra-ru-costi-kg/sources/a_ru_base/sql/clean.sql
@@ -1,4 +1,5 @@
 select
+  {year}::INTEGER                                            as anno,
   trim(replace(cast("IstatComune" as varchar), chr(9), '')) as codice_comune_istat,
   trim(cast("Regione" as varchar)) as regione,
   trim(cast("Provincia" as varchar)) as provincia,

--- a/candidates/ispra-ru-costi-kg/sources/a_ru_base/sql/mart.sql
+++ b/candidates/ispra-ru-costi-kg/sources/a_ru_base/sql/mart.sql
@@ -1,4 +1,5 @@
 select
+  anno,
   codice_comune_istat,
   regione,
   provincia,
@@ -11,4 +12,4 @@ select
   round(totale_rd_tonnellate * 1000.0 / nullif(popolazione, 0), 3) as kg_rd_per_abitante_calc
 from clean_input
 where popolazione > 0
-order by regione, provincia, comune
+order by anno, regione, provincia, comune

--- a/candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/sql/clean.sql
+++ b/candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/sql/clean.sql
@@ -1,4 +1,5 @@
 select
+  {year}::INTEGER                                            as anno,
   trim(replace(cast("IstatComune" as varchar), chr(9), '')) as codice_comune_istat,
   trim(cast("Comune o Aggregazione" as varchar)) as comune_o_aggregazione,
   trim(cast("Provincia" as varchar)) as provincia,

--- a/candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/sql/mart.sql
+++ b/candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/sql/mart.sql
@@ -1,4 +1,5 @@
 select
+  anno,
   codice_comune_istat,
   comune_o_aggregazione as comune,
   provincia,
@@ -11,4 +12,4 @@ select
   ctot_cent_kg
 from clean_input
 where popolazione > 0
-order by provincia, comune
+order by anno, provincia, comune

--- a/candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/sql/clean.sql
+++ b/candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/sql/clean.sql
@@ -1,4 +1,5 @@
 select
+  {year}::INTEGER                                            as anno,
   trim(replace(cast("IstatComune" as varchar), chr(9), '')) as codice_comune_istat,
   trim(cast("Comune o Aggregazione" as varchar)) as comune_o_aggregazione,
   trim(cast("Provincia" as varchar)) as provincia,

--- a/candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/sql/mart.sql
+++ b/candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/sql/mart.sql
@@ -1,4 +1,5 @@
 select
+  anno,
   codice_comune_istat,
   comune_o_aggregazione as comune,
   provincia,


### PR DESCRIPTION
Stesso fix di #315 e #318: `{year}::INTEGER as anno` nei 3 source nested di ispra-ru-costi-kg:\n\n- `a_ru_base` → ispra_ru_base\n- `b_kg_per_abitante` → ispra_ru_costi_kg\n- `c_costo_per_abitante` → ispra_ru_costi_procapite\n\n### Cosa cambia\n\n- **clean.sql**: `{year}::INTEGER as anno` come prima colonna\n- **mart.sql**: `anno` in SELECT + ORDER BY\n\nRun verificato per 2024: tutti e 3 i source OK.\n\nRiferimento bug #2 e #3 dall'audit.