### PR TITLE
chore(post-merge): aggiorna registry per PR #320

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -166,28 +166,21 @@
       "detail": "anni 2020-2024 — multi-source (3 fonti) — mart: sì",
       "action": "",
       "sample_run": {
-        "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "years": [
-          2024
-        ],
+        "status": "failed",
+        "run_id": "25872101214",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25872101214",
+        "checked_at": "2026-05-14",
+        "years": [],
         "configs": [
           {
-            "status": "passed",
-            "year": 2024,
+            "status": "failed",
+            "year": null,
             "config_path": "candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml"
           },
           {
             "status": "passed",
-            "year": 2024,
+            "year": null,
             "config_path": "candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/dataset.yml"
-          },
-          {
-            "status": "passed",
-            "year": 2024,
-            "config_path": "candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/dataset.yml"
           }
         ]
       }


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #320 — fix(ispra-ru): aggiungi colonna anno nei 3 source nested

Changed candidate/support roots:

- `ispra-ru-costi-kg` (candidate, `candidates/ispra-ru-costi-kg`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [ ] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml` -> artifact `sample-run-ispra-ru-costi-kg-a_ru_base`
- `candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/dataset.yml` -> artifact `sample-run-ispra-ru-costi-kg-b_kg_per_abitante`
- `candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/dataset.yml` -> artifact `sample-run-ispra-ru-costi-kg-c_costo_per_abitante`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug ispra-ru-costi-kg_a_ru_base --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug ispra-ru-costi-kg_b_kg_per_abitante --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug ispra-ru-costi-kg_c_costo_per_abitante --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
