### PR TITLE
fix(tranche1): 3 bug audit — mef, mit, ispra

### DIFF
--- a/candidates/ispra-consumo-suolo/notes.md
+++ b/candidates/ispra-consumo-suolo/notes.md
@@ -28,7 +28,7 @@ toolkit/.venv/Scripts/python.exe -m toolkit.cli.app run all \
 | comune | Nome comune |
 | provincia | Nome provincia |
 | regione | Nome regione |
-| incremento_ha_2023_2024 | Incremento netto consumo suolo 2023-2024 [ha] (alias backward-compatible) |
+| incremento_netto_ha_2023_2024 | Incremento netto consumo suolo 2023-2024 [ha] |
 | incremento_netto_ha_<periodo> | Serie degli incrementi netti per periodo ISPRA [ha] |
 | incremento_lordo_ha_<periodo> | Serie degli incrementi lordi per periodo ISPRA [ha] |
 | ripristino_ha_<periodo> | Serie delle aree ripristinate per periodo ISPRA [ha] |

--- a/candidates/ispra-consumo-suolo/sql/clean.sql
+++ b/candidates/ispra-consumo-suolo/sql/clean.sql
@@ -173,11 +173,6 @@ SELECT
         REPLACE(
             TRIM(CAST("Incremento netto 2023-2024 [ettari]" AS VARCHAR)), ',', '.'
         ) AS DOUBLE
-    )                                                    AS incremento_ha_2023_2024,
-    TRY_CAST(
-        REPLACE(
-            TRIM(CAST("Incremento netto 2023-2024 [ettari]" AS VARCHAR)), ',', '.'
-        ) AS DOUBLE
     )                                                    AS incremento_netto_ha_2023_2024,
     TRY_CAST(
         REPLACE(

--- a/candidates/ispra-consumo-suolo/sql/mart.sql
+++ b/candidates/ispra-consumo-suolo/sql/mart.sql
@@ -36,7 +36,6 @@ SELECT
     ROUND(clean.incremento_netto_ha_2022_2023, 4) AS incremento_netto_ha_2022_2023,
     ROUND(clean.incremento_lordo_ha_2022_2023, 4) AS incremento_lordo_ha_2022_2023,
     ROUND(clean.ripristino_ha_2022_2023, 4)       AS ripristino_ha_2022_2023,
-    ROUND(clean.incremento_ha_2023_2024, 4)       AS incremento_ha_2023_2024,
     ROUND(clean.incremento_netto_ha_2023_2024, 4) AS incremento_netto_ha_2023_2024,
     ROUND(clean.incremento_lordo_ha_2023_2024, 4) AS incremento_lordo_ha_2023_2024,
     ROUND(clean.ripristino_ha_2023_2024, 4)       AS ripristino_ha_2023_2024,

--- a/candidates/mef-partecipazioni/sql/clean.sql
+++ b/candidates/mef-partecipazioni/sql/clean.sql
@@ -46,7 +46,7 @@ select
   trim("Servizio affidato 5") as servizio_affidato_5,
   trim("Modalità affidamento servizio 5") as modalita_affidamento_servizio_5,
   trim("Ente affidante servizio 5") as ente_affidante_servizio_5,
-  try_cast("Importo impegnato servizio 5" as varchar) as importo_impegnato_servizio_5,
+  try_cast("Importo impegnato servizio 5" as bigint) as importo_impegnato_servizio_5,
   try_cast("Quota partecipazione diretta (%)" as double) as quota_partecipazione_diretta,
   trim("Partecipazione indiretta") as partecipazione_indiretta,
   trim("Tipo controllo") as tipo_controllo,

--- a/candidates/mit-incidentalita-mensile-2001-2018/sql/clean.sql
+++ b/candidates/mit-incidentalita-mensile-2001-2018/sql/clean.sql
@@ -41,13 +41,15 @@ mensili as (
         'Settembre', 'Ottobre', 'Novembre', 'Dicembre'
     )
 )
-select *
+select
+    *,
+    case mese
+        when 'Gennaio'   then 1  when 'Febbraio'  then 2
+        when 'Marzo'     then 3  when 'Aprile'    then 4
+        when 'Maggio'    then 5  when 'Giugno'    then 6
+        when 'Luglio'    then 7  when 'Agosto'    then 8
+        when 'Settembre' then 9  when 'Ottobre'   then 10
+        when 'Novembre'  then 11 when 'Dicembre'  then 12
+    end as mese_numero
 from mensili
-order by anno, case mese
-    when 'Gennaio'   then 1  when 'Febbraio'  then 2
-    when 'Marzo'     then 3  when 'Aprile'    then 4
-    when 'Maggio'    then 5  when 'Giugno'    then 6
-    when 'Luglio'    then 7  when 'Agosto'    then 8
-    when 'Settembre' then 9  when 'Ottobre'   then 10
-    when 'Novembre'  then 11 when 'Dicembre'  then 12
-end
+order by anno, mese_numero


### PR DESCRIPTION
Tranche 1 dei bug fix dall'audit.\n\nBug #10 — mef_partecipazioni: importo_impegnato_servizio_5 da VARCHAR a BIGINT (era l'unico servizio con tipo diverso dagli altri 4).\n\nBug #9 — mit_incidentalita_mensile: aggiunta colonna mese_numero (INTEGER) calcolata dal nome mese. Mese come stringa non era ordinabile nè usabile per join.\n\nBug #4 — ispra_consumo_suolo: rimossa colonna duplicata incremento_ha_2023_2024 (identica a incremento_netto_ha_2023_2024 in 7.896/7.896 righe). Aggiornati mart.sql e notes.md.