### PR TITLE
chore(post-merge): aggiorna registry per PR #323

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -151,10 +151,12 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "run_id": "25879194542",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25879194542",
+        "checked_at": "2026-05-14",
+        "years": [
+          2024
+        ],
         "config_path": "candidates/ispra-consumo-suolo/dataset.yml"
       }
     },


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #323 — fix(tranche1): 3 bug audit — mef, mit, ispra

Changed candidate/support roots:

- `ispra-consumo-suolo` (candidate, `candidates/ispra-consumo-suolo`)
- `mef-partecipazioni` (candidate, `candidates/mef-partecipazioni`)
- `mit-incidentalita-mensile-2001-2018` (candidate, `candidates/mit-incidentalita-mensile-2001-2018`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [ ] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/ispra-consumo-suolo/dataset.yml` -> artifact `sample-run-ispra-consumo-suolo`
- `candidates/mef-partecipazioni/dataset.yml` -> artifact `sample-run-mef-partecipazioni`
- `candidates/mit-incidentalita-mensile-2001-2018/dataset.yml` -> artifact `sample-run-mit-incidentalita-mensile-2001-2018`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug ispra_consumo_suolo --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug mef_partecipazioni --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug mit_incidentalita_mensile --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
