### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-14",
+  "generated_at": "2026-05-15",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -69,10 +69,12 @@
       "action": "",
       "sample_run": {
         "status": "failed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "run_id": "25921541669",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25921541669",
+        "checked_at": "2026-05-15",
+        "years": [
+          2024
+        ],
         "config_path": "candidates/camera-deputati-legislature/dataset.yml"
       }
     },


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `camera-deputati-legislature` (candidate, `candidates/camera-deputati-legislature`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [ ] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/camera-deputati-legislature/dataset.yml` -> artifact `sample-run-camera-deputati-legislature`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug camera_deputati_legislature --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
