### PR TITLE
chore(post-merge): aggiorna registry per PR #328

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-14",
+  "generated_at": "2026-05-15",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -378,14 +378,16 @@
       "source_id": "",
       "status": "ok",
       "label": "pensioni-pa-dag",
-      "detail": "anno 2024 — fonte: dag_pensioni_totale_local — mart: sì",
+      "detail": "anno 2024 — fonte: dag_pensioni_totale — mart: sì",
       "action": "",
       "sample_run": {
-        "status": "failed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "status": "passed",
+        "run_id": "25921989453",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25921989453",
+        "checked_at": "2026-05-15",
+        "years": [
+          2024
+        ],
         "config_path": "candidates/pensioni-pa-dag/dataset.yml"
       }
     },


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #328 — feat(pensioni-pa-dag): allinea a source type http_post_file

Changed candidate/support roots:

- `pensioni-pa-dag` (candidate, `candidates/pensioni-pa-dag`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/pensioni-pa-dag/dataset.yml` -> artifact `sample-run-pensioni-pa-dag`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug pensioni_pa_dag --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
