### PR TITLE
chore(post-merge): aggiorna registry per PR #332

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-15",
+  "generated_at": "2026-05-16",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -53,10 +53,12 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "run_id": "25958075744",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25958075744",
+        "checked_at": "2026-05-16",
+        "years": [
+          2024
+        ],
         "config_path": "candidates/bdap-lea/dataset.yml"
       }
     },


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #332 — feat(template): notebook v1 — review-readiness, inspect schema -c, skill docs

Changed candidate/support roots:

- `bdap-lea` (candidate, `candidates/bdap-lea`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/bdap-lea/dataset.yml` -> artifact `sample-run-bdap-lea`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug bdap_lea --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
