### PR TITLE
fix(post-merge): clean_catalog.json condiviso da sample_run a build-and-pr

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -263,7 +263,9 @@ jobs:
         if: always()
         with:
           name: sample-run-results
-          path: sample_run_artifacts/
+          path: |
+            sample_run_artifacts/
+            registry/clean_catalog.json
           if-no-files-found: warn
           retention-days: 14
 
@@ -309,6 +311,16 @@ jobs:
         with:
           name: sample-run-results
           path: sample_run_artifacts
+
+      - name: Restore clean_catalog from sample_run
+        if: needs.detect.outputs.has_configs == 'true' && needs.sample_run.result != 'skipped'
+        run: |
+          if [ -f sample_run_artifacts/registry/clean_catalog.json ]; then
+            cp sample_run_artifacts/registry/clean_catalog.json registry/clean_catalog.json
+            echo "clean_catalog.json ripristinato da sample_run"
+          else
+            echo "clean_catalog.json non presente negli artifact — skip"
+          fi
 
       - name: Apply sample-run results to pipeline_signals.json
         if: needs.detect.outputs.has_configs == 'true' && needs.sample_run.result != 'skipped'


### PR DESCRIPTION
## Problema

Il post-merge CI esegue `build_clean_catalog.py --write` e `push_archive.py --update-catalog` 
nel job `sample_run`, che modificano `registry/clean_catalog.json`. 
Ma `build-and-pr` parte con un checkout fresco — le modifiche andavano perse.

Risultato: `git diff` non vedeva cambiamenti a clean_catalog.json, la registry PR 
non veniva creata, e i nuovi dataset non finivano mai nel file git.

## Fix

Due modifiche al workflow `post-merge-candidate.yml`:

1. **Upload** (linea 266): aggiunto `registry/clean_catalog.json` agli artifact
2. **Restore** (nuovo step prima di apply pipeline signals): copia il file ripristinato 
   nella posizione attesa prima del `git diff`

## Effetto

Dopo il merge di questa PR, il prossimo candidate mergiato:
- sample_run modifica clean_catalog.json ✅
- build-and-pr riceve il file aggiornato ✅
- git diff vede il cambiamento ✅
- Registry PR viene creata con clean_catalog aggiornato ✅