### PR TITLE
chore(post-merge): aggiorna registry per PR #326

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -462,6 +462,98 @@
       "stage": "published"
     },
     {
+      "slug": "consip_consumi_convenzione",
+      "name": "Consip Consumi Convenzione",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2023,
+        "end": 2025
+      },
+      "columns": [
+        {
+          "name": "anno_riferimento",
+          "type": "INTEGER",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "tipologia_amministrazione",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "regione_pa",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "provincia_pa",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "sigla_provincia_pa",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "regione_fornitore",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "convenzione",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "lotto",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "valore_economico_consumi",
+          "type": "DOUBLE",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "numero_ordini_con_consumi",
+          "type": "INTEGER",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "n_pa_con_consumi",
+          "type": "INTEGER",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "n_po_con_consumi",
+          "type": "INTEGER",
+          "role": "",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/consip_consumi_convenzione/*/consip_consumi_convenzione_*_clean.parquet",
+        "multi_file": true
+      },
+      "stage": "published",
+      "registry_source": "push_archive_auto"
+    },
+    {
       "slug": "dipendenti_pubblici",
       "name": "Dipendenti Pubblici - Occupazione e Turnover",
       "description": "Dipendenti pubblici per ente, comparto, categoria, genere e tipo di orario (2010-2023)",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -511,38 +511,38 @@
         {
           "name": "convenzione",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Convenzione Consip di riferimento"
         },
         {
           "name": "lotto",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Lotto della convenzione"
         },
         {
           "name": "valore_economico_consumi",
           "type": "DOUBLE",
-          "role": "",
-          "description": ""
+          "role": "metric",
+          "description": "Valore economico dei consumi (€)"
         },
         {
           "name": "numero_ordini_con_consumi",
           "type": "INTEGER",
-          "role": "",
-          "description": ""
+          "role": "metric",
+          "description": "Numero di ordini con consumi"
         },
         {
           "name": "n_pa_con_consumi",
           "type": "INTEGER",
-          "role": "",
-          "description": ""
+          "role": "metric",
+          "description": "Numero di PA con consumi"
         },
         {
           "name": "n_po_con_consumi",
           "type": "INTEGER",
-          "role": "",
-          "description": ""
+          "role": "metric",
+          "description": "Numero di PO (Punti Ordine) con consumi"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -464,9 +464,9 @@
     {
       "slug": "consip_consumi_convenzione",
       "name": "Consip Consumi Convenzione",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "description": "Consumi generati tramite ordini diretti di acquisto in convenzione Consip. Spesa delle PA per regione, provincia, tipologia amministrazione e fornitore (2023-2025).",
+      "source": "Consip SpA / MEF — dati.consip.it (CKAN)",
+      "source_id": "consip",
       "period": {
         "start": 2023,
         "end": 2025
@@ -475,38 +475,38 @@
         {
           "name": "anno_riferimento",
           "type": "INTEGER",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di riferimento del consumo"
         },
         {
           "name": "tipologia_amministrazione",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Tipologia di amministrazione acquirente"
         },
         {
           "name": "regione_pa",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Regione della PA acquirente"
         },
         {
           "name": "provincia_pa",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Provincia della PA acquirente"
         },
         {
           "name": "sigla_provincia_pa",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Sigla della provincia della PA acquirente"
         },
         {
           "name": "regione_fornitore",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Regione del fornitore"
         },
         {
           "name": "convenzione",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -4,9 +4,9 @@
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 30,
+    "total": 31,
     "by_status": {
-      "ok": 30,
+      "ok": 31,
       "warn": 0,
       "error": 0
     }
@@ -85,6 +85,26 @@
       "label": "civile-flussi",
       "detail": "anno 2025 — fonte: ministero_giustizia_xlsx — mart: sì",
       "action": ""
+    },
+    {
+      "id": "consip-consumi-convenzione",
+      "source_id": "",
+      "status": "ok",
+      "label": "consip-consumi-convenzione",
+      "detail": "anni 2023-2025 — fonti: consip_consumi_convenzione_2023, consip_consumi_convenzione_2024 — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25962931378",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25962931378",
+        "checked_at": "2026-05-16",
+        "years": [
+          2023,
+          2024,
+          2025
+        ],
+        "config_path": "candidates/consip-consumi-convenzione/dataset.yml"
+      }
     },
     {
       "id": "dipendenti-pubblici",


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #326 — intake: Consip consumi in convenzione — geografia della spesa delle PA (2023-2025)

Changed candidate/support roots:

- `consip-consumi-convenzione` (candidate, `candidates/consip-consumi-convenzione`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/consip-consumi-convenzione/dataset.yml` -> artifact `sample-run-consip-consumi-convenzione`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug consip_consumi_convenzione --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
