### PR TITLE
feat: schema JSON formale per pipeline_signals

### DIFF
--- a/.github/workflows/build-pipeline-signals.yml
+++ b/.github/workflows/build-pipeline-signals.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install pyyaml
+        run: pip install pyyaml jsonschema
 
       - name: Build pipeline_signals.json
         run: python scripts/build_pipeline_signals.py

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -282,7 +282,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: python -m pip install pyyaml
+        run: python -m pip install pyyaml jsonschema
 
       - name: Download detect output
         if: needs.detect.outputs.has_items == 'true'

--- a/registry/pipeline_signals.schema.json
+++ b/registry/pipeline_signals.schema.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://dataciviclab.org/schemas/pipeline_signals.schema.json",
+  "title": "PipelineSignals",
+  "description": "Schema per pipeline_signals.json — stato dei candidati dataset-incubator per ACB. Segue lo standard repo-signals (agent-context-builder/schemas/repo-signals.md).",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "generated_at",
+    "repo",
+    "topic",
+    "signals"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1"],
+      "description": "Versione dello schema (stringa)."
+    },
+    "generated_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "Data di generazione in formato YYYY-MM-DD."
+    },
+    "repo": {
+      "type": "string",
+      "description": "Nome del repo GitHub (es. 'dataset-incubator')."
+    },
+    "topic": {
+      "type": "string",
+      "description": "Dominio del segnale (es. 'pipeline_state')."
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total", "by_status"],
+      "properties": {
+        "total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "by_status": {
+          "type": "object",
+          "required": ["ok", "warn", "error"],
+          "properties": {
+            "ok": { "type": "integer", "minimum": 0 },
+            "warn": { "type": "integer", "minimum": 0 },
+            "error": { "type": "integer", "minimum": 0 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "description": "Conteggi aggregati per stato."
+    },
+    "signals": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/Signal" },
+      "description": "Lista dei segnali, uno per candidate."
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Signal": {
+      "type": "object",
+      "required": ["id", "status", "label", "detail", "action"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Identificativo unico del candidate (slug)."
+        },
+        "source_id": {
+          "type": "string",
+          "description": "Identificativo della fonte dati (opzionale, puo' essere stringa vuota)."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["ok", "warn", "error"],
+          "description": "Stato del candidate: ok=valido, warn=anomalia, error=bloccante."
+        },
+        "label": {
+          "type": "string",
+          "description": "Etichetta leggibile del candidate."
+        },
+        "detail": {
+          "type": "string",
+          "description": "Descrizione estesa del candidate (anni, fonte, layer)."
+        },
+        "action": {
+          "type": "string",
+          "description": "Azione suggerita. Stringa vuota se nessuna."
+        },
+        "sample_run": {
+          "$ref": "#/definitions/SampleRun",
+          "description": "Risultato dell'ultimo sample run (opzionale, presente solo se eseguito)."
+        }
+      },
+      "additionalProperties": false
+    },
+    "SampleRun": {
+      "type": "object",
+      "required": ["status", "run_id", "run_url", "checked_at"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["passed", "failed"],
+          "description": "Esito del sample run."
+        },
+        "run_id": {
+          "type": "string",
+          "description": "ID del workflow run GitHub Actions."
+        },
+        "run_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL del workflow run GitHub Actions."
+        },
+        "checked_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}",
+          "description": "Data del check in formato YYYY-MM-DD."
+        },
+        "year": {
+          "type": "integer",
+          "description": "Anno singolo testato (alternativo a years per single-year)."
+        },
+        "years": {
+          "type": "array",
+          "items": { "type": "integer" },
+          "description": "Anni testati (alternativo a year per multi-year)."
+        },
+        "config_path": {
+          "type": "string",
+          "description": "Path del dataset.yml testato (singolo config)."
+        },
+        "config_exists": {
+          "type": "boolean",
+          "description": "False se il dataset.yml non esiste piu' nel branch target."
+        },
+        "configs": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/ConfigEntry" },
+          "description": "Lista dei config testati (post-merge con multi-anno)."
+        }
+      },
+      "additionalProperties": false,
+      "anyOf": [
+        { "required": ["year"] },
+        { "required": ["years"] }
+      ]
+    },
+    "ConfigEntry": {
+      "type": "object",
+      "required": ["status", "year", "config_path"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["passed", "failed"],
+          "description": "Esito del run per questo config."
+        },
+        "year": {
+          "type": "integer",
+          "description": "Anno testato."
+        },
+        "config_path": {
+          "type": "string",
+          "description": "Path del dataset.yml."
+        },
+        "config_exists": {
+          "type": "boolean",
+          "description": "False se il dataset.yml non esiste piu'."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/scripts/build_pipeline_signals.py
+++ b/scripts/build_pipeline_signals.py
@@ -20,9 +20,26 @@ import sys
 from datetime import date
 from pathlib import Path
 
+import jsonschema
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
+
+_SCHEMA_DIR = ROOT / "registry"
+
+
+def _validate_schema(instance: dict) -> None:
+    """Validate a dict against registry/pipeline_signals.schema.json."""
+    schema_path = _SCHEMA_DIR / "pipeline_signals.schema.json"
+    if not schema_path.exists():
+        print("⚠️  pipeline_signals.schema.json non trovato — skip validazione")
+        return
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    try:
+        jsonschema.validate(instance=instance, schema=schema)
+    except jsonschema.ValidationError as exc:
+        print(f"❌ Validazione fallita (pipeline_signals.schema.json): {exc.message}")
+        raise
 
 # Import helpers from the existing validation script — no duplication
 sys.path.insert(0, str(ROOT / "scripts"))
@@ -276,6 +293,8 @@ def build_signals(out_path: Path) -> int:
         },
         "signals": signals,
     }
+
+    _validate_schema(payload)
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")

--- a/scripts/update_pipeline_sample_runs.py
+++ b/scripts/update_pipeline_sample_runs.py
@@ -6,9 +6,24 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import jsonschema
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CATALOG = ROOT / "registry" / "pipeline_signals.json"
+_SCHEMA_PATH = ROOT / "registry" / "pipeline_signals.schema.json"
+
+
+def _validate_schema(instance: dict) -> None:
+    """Validate a dict against registry/pipeline_signals.schema.json."""
+    if not _SCHEMA_PATH.exists():
+        print("⚠️  pipeline_signals.schema.json non trovato — skip validazione")
+        return
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    try:
+        jsonschema.validate(instance=instance, schema=schema)
+    except jsonschema.ValidationError as exc:
+        print(f"❌ Validazione fallita (pipeline_signals.schema.json): {exc.message}")
+        raise
 
 
 def main() -> int:
@@ -35,6 +50,8 @@ def main() -> int:
         for error in errors:
             print(f"ERROR: {error}", file=sys.stderr)
         return 1
+
+    _validate_schema(catalog)
 
     args.catalog.write_text(
         json.dumps(catalog, indent=2, ensure_ascii=False) + "\n",

--- a/tests/test_pipeline_sample_runs.py
+++ b/tests/test_pipeline_sample_runs.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
+import json
 import sys
 import unittest
 from pathlib import Path
 
+import jsonschema
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
 from update_pipeline_sample_runs import apply_sample_results, summarize_sample_results  # noqa: E402
+
+_SCHEMA_PATH = ROOT / "registry" / "pipeline_signals.schema.json"
+
+
+def _load_schema() -> dict:
+    return json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
 
 
 class PipelineSampleRunTest(unittest.TestCase):
@@ -100,6 +108,144 @@ class PipelineSampleRunTest(unittest.TestCase):
         errors = apply_sample_results(catalog, [{"id": "missing"}])
 
         self.assertEqual(errors, ["missing: no matching signal in catalog"])
+
+
+class PipelineSignalsSchemaTest(unittest.TestCase):
+    """Validate pipeline_signals.json against its JSON Schema."""
+
+    def test_live_artifact_complies_with_schema(self) -> None:
+        """Il pipeline_signals.json committato deve rispettare lo schema."""
+        artifact_path = ROOT / "registry" / "pipeline_signals.json"
+        self.assertTrue(artifact_path.exists(), "pipeline_signals.json not found")
+        payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+        schema = _load_schema()
+        jsonschema.validate(instance=payload, schema=schema)
+
+    def test_minimal_signals_payload_complies(self) -> None:
+        """Un payload minimale con un segnale senza sample_run deve essere valido."""
+        payload = {
+            "schema_version": "1",
+            "generated_at": "2026-05-17",
+            "repo": "dataset-incubator",
+            "topic": "pipeline_state",
+            "summary": {"total": 1, "by_status": {"ok": 1, "warn": 0, "error": 0}},
+            "signals": [
+                {
+                    "id": "test-candidate",
+                    "status": "ok",
+                    "label": "test-candidate",
+                    "detail": "test — fonte test",
+                    "action": "",
+                }
+            ],
+        }
+        schema = _load_schema()
+        jsonschema.validate(instance=payload, schema=schema)
+
+    def test_signal_with_single_year_sample_run(self) -> None:
+        """Segnale con sample_run single-year."""
+        payload = {
+            "schema_version": "1",
+            "generated_at": "2026-05-17",
+            "repo": "dataset-incubator",
+            "topic": "pipeline_state",
+            "summary": {"total": 1, "by_status": {"ok": 1, "warn": 0, "error": 0}},
+            "signals": [
+                {
+                    "id": "test-candidate",
+                    "source_id": "test_source",
+                    "status": "ok",
+                    "label": "test-candidate",
+                    "detail": "anno 2024 — fonte test_csv — mart: sì",
+                    "action": "",
+                    "sample_run": {
+                        "status": "passed",
+                        "run_id": "123",
+                        "run_url": "https://github.com/test/actions/runs/123",
+                        "checked_at": "2026-05-07",
+                        "year": 2024,
+                        "config_path": "candidates/test-candidate/dataset.yml",
+                    },
+                }
+            ],
+        }
+        schema = _load_schema()
+        jsonschema.validate(instance=payload, schema=schema)
+
+    def test_signal_with_multi_year_sample_run(self) -> None:
+        """Segnale con sample_run multi-year."""
+        payload = {
+            "schema_version": "1",
+            "generated_at": "2026-05-17",
+            "repo": "dataset-incubator",
+            "topic": "pipeline_state",
+            "summary": {"total": 1, "by_status": {"ok": 1, "warn": 0, "error": 0}},
+            "signals": [
+                {
+                    "id": "test-candidate",
+                    "status": "ok",
+                    "label": "test-candidate",
+                    "detail": "anni 2023-2025 — fonte test_csv — mart: sì",
+                    "action": "",
+                    "sample_run": {
+                        "status": "passed",
+                        "run_id": "123",
+                        "run_url": "https://github.com/test/actions/runs/123",
+                        "checked_at": "2026-05-07",
+                        "years": [2023, 2024, 2025],
+                        "config_path": "candidates/test-candidate/dataset.yml",
+                    },
+                }
+            ],
+        }
+        schema = _load_schema()
+        jsonschema.validate(instance=payload, schema=schema)
+
+    def test_signal_with_configs_sample_run(self) -> None:
+        """Segnale con sample_run multi-config (post-merge multi-anno)."""
+        payload = {
+            "schema_version": "1",
+            "generated_at": "2026-05-17",
+            "repo": "dataset-incubator",
+            "topic": "pipeline_state",
+            "summary": {"total": 1, "by_status": {"ok": 1, "warn": 0, "error": 0}},
+            "signals": [
+                {
+                    "id": "test-candidate",
+                    "status": "ok",
+                    "label": "test-candidate",
+                    "detail": "anni 2023-2025 — fonte test_csv — mart: sì",
+                    "action": "",
+                    "sample_run": {
+                        "status": "passed",
+                        "run_id": "123",
+                        "run_url": "https://github.com/test/actions/runs/123",
+                        "checked_at": "2026-05-07",
+                        "years": [2023, 2024, 2025],
+                        "configs": [
+                            {
+                                "status": "passed",
+                                "year": 2023,
+                                "config_path": "candidates/test-candidate/dataset.yml",
+                            },
+                            {
+                                "status": "passed",
+                                "year": 2024,
+                                "config_path": "candidates/test-candidate/dataset.yml",
+                            },
+                            {
+                                "status": "failed",
+                                "year": 2025,
+                                "config_path": "candidates/test-candidate/dataset.yml",
+                                "config_exists": False,
+                            },
+                        ],
+                    },
+                }
+            ],
+        }
+        schema = _load_schema()
+        jsonschema.validate(instance=payload, schema=schema)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Aggiunto schema JSON formale per `pipeline_signals.json` con validazione
automatica nei producer e 5 test di regressione.

### Schema

`registry/pipeline_signals.schema.json` definisce:
- Struttura top-level (schema_version, generated_at, repo, topic, summary, signals)
- Segnale con id, status (ok/warn/error), label, detail, action
- SampleRun con 3 varianti: single-year (year), multi-year (years), e
  post-merge multi-config (configs)
- Campi opzionali: source_id, sample_run

### Validazione

- `build_pipeline_signals.py`: valida prima di scrivere
- `update_pipeline_sample_runs.py`: valida prima di riscrivere
- Se un producer genera JSON fuori schema, errore in CI

### Test

5 test aggiunti:
- `test_live_artifact_complies_with_schema` — l'artifact committato
- `test_minimal_signals_payload_complies` — segnale senza sample_run
- `test_signal_with_single_year_sample_run` — single-year
- `test_signal_with_multi_year_sample_run` — multi-year
- `test_signal_with_configs_sample_run` — post-merge multi-config

28/28 test passati.

### Impatto

Nessuna rottura downstream. Il nuovo schema formalizza la struttura
esistente documentata in agent-context-builder/schemas/repo-signals.md.