### PR TITLE
chore: batch openbdap - source_id + notebook helpers

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -455,6 +455,7 @@ jobs:
           GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           ITEMS_JSON=$(python -c "import json; print(json.dumps(json.load(open('detect_output.json'))['items']))") \
             python scripts/create_de_followup_issue.py

--- a/candidates/bdap-lea/dataset.yml
+++ b/candidates/bdap-lea/dataset.yml
@@ -3,6 +3,7 @@ schema_version: 1
 
 dataset:
   name: "bdap_lea"
+  source_id: "openbdap"
   years: [2024]
 
 raw:

--- a/candidates/bdap-lea/notebooks/bdap_lea_v0.ipynb
+++ b/candidates/bdap-lea/notebooks/bdap_lea_v0.ipynb
@@ -1,333 +1,318 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "intro",
-      "metadata": {},
-      "source": [
-        "# bdap_lea - notebook v0\n",
-        "\n",
-        "Validazione rapida + analisi esplorativa della pipeline **raw → clean → mart**.\n",
-        "\n",
-        "- i check tecnici (righe, null, readiness) sono delegati al toolkit\n",
-        "- le SQL sono la fonte di verità: leggile prima di interpretare i numeri\n",
-        "- il notebook serve l'analisi, non sostituisce la validazione della pipeline\n",
-        "- evitare output pesanti o immagini embeddate nel commit"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "setup",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import json, subprocess, sys, duckdb, yaml\n",
-        "from pathlib import Path\n",
-        "\n",
-        "# --- Unico parametro da impostare ---\n",
-        "SLUG = \"bdap_lea\"\n",
-        "\n",
-        "# --- Trova dataset.yml e parsa anno ---\n",
-        "_start = Path.cwd().resolve()\n",
-        "for probe in [_start, *_start.parents]:\n",
-        "    if (probe / \"dataset.yml\").exists():\n",
-        "        CANDIDATE_DIR = probe\n",
-        "        break\n",
-        "else:\n",
-        "    raise FileNotFoundError(f\"dataset.yml non trovato risalendo da {_start}\")\n",
-        "\n",
-        "CFG_PATH = CANDIDATE_DIR / \"dataset.yml\"\n",
-        "SQL_DIR  = CANDIDATE_DIR / \"sql\"\n",
-        "_cfg_raw = yaml.safe_load(CFG_PATH.read_text())\n",
-        "ANNO = _cfg_raw[\"dataset\"][\"years\"][-1]\n",
-        "\n",
-        "def tk(*args: str) -> dict:\n",
-        "    \"\"\"Esegue toolkit e torna JSON.\"\"\"\n",
-        "    cmd = [\"toolkit\", *args, \"-c\", str(CFG_PATH), \"--json\"]\n",
-        "    r = subprocess.run(cmd, capture_output=True, text=True)\n",
-        "    if r.returncode != 0:\n",
-        "        print(r.stderr, file=sys.stderr)\n",
-        "        r.check_returncode()\n",
-        "    return json.loads(r.stdout) if r.stdout.strip() else {}\n",
-        "\n",
-        "def tk_year(*args: str) -> dict:\n",
-        "    \"\"\"Chiamata con --year per comandi che lo richiedono.\"\"\"\n",
-        "    return tk(*args, \"--year\", str(ANNO))\n",
-        "\n",
-        "def show(df) -> None:\n",
-        "    \"\"\"Stampa un DataFrame: display() in Jupyter, print() altrove.\"\"\"\n",
-        "    try:\n",
-        "        display(df)\n",
-        "    except NameError:\n",
-        "        print(df.to_string())\n",
-        "\n",
-        "WORKSPACE_ROOT = CANDIDATE_DIR.parent.parent  # dataset-incubator/\n",
-        "def _rel(p: Path) -> str:\n",
-        "    \"\"\"Path relativo al workspace, per output leggibile e portabile.\"\"\"\n",
-        "    try: return str(p.relative_to(WORKSPACE_ROOT))\n",
-        "    except ValueError: return str(p)\n",
-        "\n",
-        "print(f\"slug: {SLUG}    anno: {ANNO}\")\n",
-        "print(f\"config: {_rel(CFG_PATH)}\")\n",
-        "\n",
-        "# Paths dei layer (con anno esplicito)\n",
-        "paths = tk_year(\"inspect\", \"paths\")\n",
-        "P = paths.get(\"paths\", {})\n",
-        "RAW_DIR   = Path(P.get(\"raw\", {}).get(\"dir\", \"\"))\n",
-        "CLEAN_DIR = Path(P.get(\"clean\", {}).get(\"dir\", \"\"))\n",
-        "MART_DIR  = Path(P.get(\"mart\", {}).get(\"dir\", \"\"))\n",
-        "MART_OUTPUTS = P.get(\"mart\", {}).get(\"outputs\", [])\n",
-        "MART_PATH = Path(MART_OUTPUTS[0]) if MART_OUTPUTS else None\n",
-        "MART_TABLE = MART_PATH.stem if MART_PATH else None\n",
-        "print(f\"raw:   {_rel(RAW_DIR)}\")\n",
-        "print(f\"clean: {_rel(CLEAN_DIR)}\")\n",
-        "print(f\"mart:  {_rel(MART_DIR)}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "header-sql",
-      "metadata": {},
-      "source": [
-        "## SQL di riferimento\n",
-        "\n",
-        "Le SQL sono la fonte di verità per capire cosa deve contenere ogni layer.\n",
-        "Leggile prima di interpretare i check numerici."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "sql-show",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "for sql_file in sorted(SQL_DIR.glob(\"*.sql\")):\n",
-        "    print(f\"{'='*60}\")\n",
-        "    print(f\"  {sql_file.name}\")\n",
-        "    print(f\"{'='*60}\")\n",
-        "    print(sql_file.read_text())\n",
-        "    print()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "header-gates",
-      "metadata": {},
-      "source": [
-        "## Quality gates\n",
-        "\n",
-        "Il toolkit ha già eseguito run + validate + readiness. Qui si riassume il risultato."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "gates",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run_info = paths.get(\"latest_run\", {})\n",
-        "print(f\"Ultimo run: {run_info.get('status','?')}  (ID: {run_info.get('run_id','?')})\")\n",
-        "print()\n",
-        "\n",
-        "# Schema clean\n",
-        "schema_clean = tk(\"inspect\", \"schema\", \"-l\", \"clean\")\n",
-        "cols_clean = schema_clean.get(\"schema\", [])\n",
-        "print(f\"Clean: {schema_clean.get('columns', 0)} colonne\")\n",
-        "for c in cols_clean[:5]:\n",
-        "    print(f\"  {c.get('name','?'):35s} {c.get('type','?')}\")\n",
-        "if len(cols_clean) > 5: print(f\"  ... ({len(cols_clean)} totali)\")\n",
-        "print()\n",
-        "\n",
-        "# Schema mart\n",
-        "schema_mart = tk(\"inspect\", \"schema\", \"-l\", \"mart\")\n",
-        "cols_mart = schema_mart.get(\"schema\", [])\n",
-        "print(f\"Mart: {schema_mart.get('columns', 0)} colonne\")\n",
-        "for c in cols_mart[:5]:\n",
-        "    print(f\"  {c.get('name','?'):35s} {c.get('type','?')}\")\n",
-        "if len(cols_mart) > 5: print(f\"  ... ({len(cols_mart)} totali)\")\n",
-        "print()\n",
-        "\n",
-        "# Profili layer da inspect paths\n",
-        "profiles = paths.get(\"layer_profiles\", {})\n",
-        "clean_prof = profiles.get(\"clean_output\", {})\n",
-        "if clean_prof:\n",
-        "    print(f\"Clean: {clean_prof.get('row_count','?')} righe, {clean_prof.get('columns_count','?')} colonne\")\n",
-        "for tbl in profiles.get(\"mart_tables\", []):\n",
-        "    print(f\"Mart: {tbl.get('row_count','?')} righe ({tbl.get('name','?')})\")\n",
-        "for trans in profiles.get(\"clean_to_mart\", []):\n",
-        "    print(f\"Transizione: {trans.get('source_row_count','?')} -> {trans.get('target_row_count','?')} righe\")\n",
-        "    print(f\"  rimosse: {trans.get('removed_columns', [])}, aggiunte: {trans.get('added_columns', [])}\")\n",
-        "print()\n",
-        "\n",
-        "# Raw hints (encoding, delim, etc.)\n",
-        "rh = paths.get(\"raw_hints\", {})\n",
-        "print(f\"Raw: {rh.get('primary_output_file','?')}  |  encoding={rh.get('encoding','?')}  delim={rh.get('delim','?')}  skip={rh.get('skip','?')}\")\n",
-        "for w in rh.get('warnings', []):\n",
-        "    print(f\"  warning: {w}\")\n",
-        "print()\n",
-        "\n",
-        "# Review readiness\n",
-        "readiness = tk(\"review-readiness\")\n",
-        "rd = readiness.get(\"readiness\", \"?\")\n",
-        "icon = {\"ready\": \"✅\", \"needs-review\": \"⚠️\", \"incomplete\": \"🔴\"}.get(rd, \"?\")\n",
-        "print(f\"Readiness: {icon} {rd}\")\n",
-        "print(f\"Checks: {readiness.get('ok_count',0)}/{readiness.get('check_count',0)} ok, {readiness.get('fail_count',0)} falliti\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "header-analysis",
-      "metadata": {},
-      "source": [
-        "## Anteprima dati\n",
-        "\n",
-        "Un colpo d'occhio sui dati del mart. Query esplorative, non analisi.\n",
-        "Personalizza in base al candidate."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "analysis-setup",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "con = duckdb.connect()\n",
-        "if MART_PATH and MART_PATH.exists():\n",
-        "    p = str(MART_PATH).replace(\"'\", \"''\")\n",
-        "    con.execute(f\"CREATE OR REPLACE VIEW mart AS SELECT * FROM read_parquet('{p}')\")\n",
-        "    cnt = con.execute(\"SELECT count(*) FROM mart\").fetchone()[0]\n",
-        "    print(f\"Mart: {MART_PATH.name}  |  {cnt} righe\")\n",
-        "else:\n",
-        "    print(\"Mart non disponibile. Esegui: toolkit run mart\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "analysis-query",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# --- Query di esempio ---\n",
-        "# Sostituisci con la query specifica del candidate\n",
-        "if MART_PATH:\n",
-        "    df = con.execute(\"SELECT * FROM mart LIMIT 10\").fetchdf()\n",
-        "    show(df)\n",
-        "else:\n",
-        "    print(\"Esegui il mart prima di fare analisi.\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "analysis-nulls-profile",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Profilo null rapido sul mart (prime 8 colonne)\n",
-        "if MART_PATH:\n",
-        "    cols = con.execute(\"DESCRIBE mart\").fetchall()\n",
-        "    exprs = []\n",
-        "    for c in cols[:8]:\n",
-        "        safe = c[0].replace('\"', '\"\"')\n",
-        "        exprs.append(f'round(100.0 * sum(CASE WHEN \"{safe}\" IS NULL THEN 1 ELSE 0 END) / count(*), 2) as \"null_{c[0]}\"')\n",
-        "    if exprs:\n",
-        "        q = 'SELECT count(*) as tot, ' + ', '.join(exprs) + ' FROM mart'\n",
-        "        nulls = con.execute(q).fetchdf()\n",
-        "        show(nulls)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "header-boundary",
-      "metadata": {},
-      "source": [
-        "## Boundary e note\n",
-        "\n",
-        "Documenta scelte di perimetro, esclusioni, anomalie."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "boundary",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "PERIMETRO = \"...\"  # descrizione del perimetro\n",
-        "\n",
-        "print(f\"Slug      : {SLUG}\")\n",
-        "print(f\"Perimetro : {PERIMETRO}\")\n",
-        "print()\n",
-        "print(\"Note boundary:\")\n",
-        "print(\"  -\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "header-verdict",
-      "metadata": {},
-      "source": [
-        "## Verdetto\n",
-        "\n",
-        "Riepilogo end-to-end della pipeline, come `run-candidate`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "verdict-code",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run_info = paths.get(\"latest_run\", {})\n",
-        "run_status = run_info.get(\"status\", \"?\")\n",
-        "rd = readiness.get(\"readiness\", \"?\")\n",
-        "profiles = paths.get(\"layer_profiles\", {})\n",
-        "clean_p = profiles.get(\"clean_output\", {})\n",
-        "mart_tables = profiles.get(\"mart_tables\", [])\n",
-        "transitions = profiles.get(\"clean_to_mart\", [])\n",
-        "\n",
-        "pipeline_icon = {'SUCCESS': '✅', 'FAILED': '❌', 'IN_PROGRESS': '⏳'}.get(run_status, '?')\n",
-        "rd_icon = {\"ready\": \"✅\", \"needs-review\": \"⚠️\", \"incomplete\": \"🔴\"}.get(rd, \"?\")\n",
-        "print(f\"Pipeline  : {pipeline_icon} {run_status}\")\n",
-        "print(f\"Readiness : {rd_icon} {rd}\")\n",
-        "print()\n",
-        "if clean_p:\n",
-        "    print(f\"  Clean: {clean_p.get('row_count', '?'):>8} righe, {clean_p.get('columns_count', '?')} colonne\")\n",
-        "for tbl in mart_tables:\n",
-        "    print(f\"  Mart:  {tbl.get('row_count', '?'):>8} righe ({tbl.get('name', '?')})\")\n",
-        "for t in transitions:\n",
-        "    print(f\"  Transizione: {t.get('source_row_count','?')} → {t.get('target_row_count','?')} righe\")\n",
-        "    if t.get(\"removed_columns\"):\n",
-        "        print(f\"    colonne rimosse: {t['removed_columns']}\")\n",
-        "    if t.get(\"added_columns\"):\n",
-        "        print(f\"    colonne aggiunte: {t['added_columns']}\")\n",
-        "print()\n",
-        "if rd == \"ready\":\n",
-        "    print(\"✅ Notebook v0 completato — pipeline verificata, dati coerenti.\")\n",
-        "elif rd == \"needs-review\":\n",
-        "    print(\"⚠️  Qualche anomalia — verificare i check falliti prima del merge.\")\n",
-        "else:\n",
-        "    print(\"🔴 Candidate non pronto — risolvere i check falliti.\")"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.12.0"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# bdap_lea - notebook v0\n",
+    "\n",
+    "Validazione rapida + analisi esplorativa della pipeline **raw → clean → mart**.\n",
+    "\n",
+    "- i check tecnici (righe, null, readiness) sono delegati al toolkit\n",
+    "- le SQL sono la fonte di verità: leggile prima di interpretare i numeri\n",
+    "- il notebook serve l'analisi, non sostituisce la validazione della pipeline\n",
+    "- evitare output pesanti o immagini embeddate nel commit"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, duckdb, yaml\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# --- Unico parametro da impostare ---\n",
+    "SLUG = \"bdap-lea\"\n",
+    "\n",
+    "# --- Trova dataset.yml ---\n",
+    "_start = Path.cwd().resolve()\n",
+    "for probe in [_start, *_start.parents]:\n",
+    "    if (probe / \"dataset.yml\").exists():\n",
+    "        CANDIDATE_DIR = probe\n",
+    "        break\n",
+    "else:\n",
+    "    raise FileNotFoundError(f\"dataset.yml non trovato risalendo da {_start}\")\n",
+    "\n",
+    "CFG_PATH = CANDIDATE_DIR / \"dataset.yml\"\n",
+    "SQL_DIR = CANDIDATE_DIR / \"sql\"\n",
+    "_cfg_raw = yaml.safe_load(CFG_PATH.read_text())\n",
+    "ANNO = _cfg_raw[\"dataset\"][\"years\"][-1]\n",
+    "\n",
+    "# Aggiungi scripts/ al path per importare notebook_helpers\n",
+    "sys.path.insert(0, str(CANDIDATE_DIR.parent.parent / \"scripts\"))\n",
+    "from notebook_helpers import NotebookHelper, show\n",
+    "\n",
+    "h = NotebookHelper(CFG_PATH, ANNO)\n",
+    "WORKSPACE_ROOT = CANDIDATE_DIR.parent.parent  # dataset-incubator/\n",
+    "\n",
+    "def _rel(p: Path) -> str:\n",
+    "    try: return str(p.relative_to(WORKSPACE_ROOT))\n",
+    "    except ValueError: return str(p)\n",
+    "\n",
+    "# Paths dei layer (con anno esplicito)\n",
+    "paths = h.tk_year(\"inspect\", \"paths\")\n",
+    "P = paths.get(\"paths\", {})\n",
+    "RAW_DIR   = Path(P.get(\"raw\", {}).get(\"dir\", \"\"))\n",
+    "CLEAN_DIR = Path(P.get(\"clean\", {}).get(\"dir\", \"\"))\n",
+    "MART_DIR  = Path(P.get(\"mart\", {}).get(\"dir\", \"\"))\n",
+    "MART_OUTPUTS = P.get(\"mart\", {}).get(\"outputs\", [])\n",
+    "MART_PATH = Path(MART_OUTPUTS[0]) if MART_OUTPUTS else None\n",
+    "MART_TABLE = MART_PATH.stem if MART_PATH else None\n",
+    "\n",
+    "print(f\"slug: {SLUG}    anno: {ANNO}\")\n",
+    "print(f\"config: {_rel(CFG_PATH)}\")\n",
+    "print(f\"raw:   {_rel(RAW_DIR)}\")\n",
+    "print(f\"clean: {_rel(CLEAN_DIR)}\")\n",
+    "print(f\"mart:  {_rel(MART_DIR)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-sql",
+   "metadata": {},
+   "source": [
+    "## SQL di riferimento\n",
+    "\n",
+    "Le SQL sono la fonte di verità per capire cosa deve contenere ogni layer.\n",
+    "Leggile prima di interpretare i check numerici."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "sql-show",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for sql_file in sorted(SQL_DIR.glob(\"*.sql\")):\n",
+    "    print(f\"{'='*60}\")\n",
+    "    print(f\"  {sql_file.name}\")\n",
+    "    print(f\"{'='*60}\")\n",
+    "    print(sql_file.read_text())\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-gates",
+   "metadata": {},
+   "source": [
+    "## Quality gates\n",
+    "\n",
+    "Il toolkit ha già eseguito run + validate + readiness. Qui si riassume il risultato."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "gates",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_info = paths.get(\"latest_run\", {})\n",
+    "print(f\"Ultimo run: {run_info.get('status','?')}  (ID: {run_info.get('run_id','?')})\")\n",
+    "print()\n",
+    "\n",
+    "# Schema clean\n",
+    "schema_clean = h.tk_schema(\"clean\")\n",
+    "cols_clean = schema_clean.get(\"schema\", [])\n",
+    "print(f\"Clean: {schema_clean.get('columns', 0)} colonne\")\n",
+    "for c in cols_clean[:5]:\n",
+    "    print(f\"  {c.get('name','?'):35s} {c.get('type','?')}\")\n",
+    "if len(cols_clean) > 5: print(f\"  ... ({len(cols_clean)} totali)\")\n",
+    "print()\n",
+    "\n",
+    "# Schema mart\n",
+    "schema_mart = h.tk_schema(\"mart\")\n",
+    "cols_mart = schema_mart.get(\"schema\", [])\n",
+    "print(f\"Mart: {schema_mart.get('columns', 0)} colonne\")\n",
+    "for c in cols_mart[:5]:\n",
+    "    print(f\"  {c.get('name','?'):35s} {c.get('type','?')}\")\n",
+    "if len(cols_mart) > 5: print(f\"  ... ({len(cols_mart)} totali)\")\n",
+    "print()\n",
+    "\n",
+    "# Profili layer da inspect paths\n",
+    "profiles = paths.get(\"layer_profiles\", {})\n",
+    "clean_prof = profiles.get(\"clean_output\", {})\n",
+    "if clean_prof:\n",
+    "    print(f\"Clean: {clean_prof.get('row_count','?')} righe, {clean_prof.get('columns_count','?')} colonne\")\n",
+    "for tbl in profiles.get(\"mart_tables\", []):\n",
+    "    print(f\"Mart: {tbl.get('row_count','?')} righe ({tbl.get('name','?')})\")\n",
+    "for trans in profiles.get(\"clean_to_mart\", []):\n",
+    "    print(f\"Transizione: {trans.get('source_row_count','?')} -> {trans.get('target_row_count','?')} righe\")\n",
+    "    print(f\"  rimosse: {trans.get('removed_columns', [])}, aggiunte: {trans.get('added_columns', [])}\")\n",
+    "print()\n",
+    "\n",
+    "# Raw hints (encoding, delim, etc.)\n",
+    "rh = paths.get(\"raw_hints\", {})\n",
+    "print(f\"Raw: {rh.get('primary_output_file','?')}  |  encoding={rh.get('encoding','?')}  delim={rh.get('delim','?')}  skip={rh.get('skip','?')}\")\n",
+    "for w in rh.get('warnings', []):\n",
+    "    print(f\"  warning: {w}\")\n",
+    "print()\n",
+    "\n",
+    "# Review readiness\n",
+    "readiness = h.tk(\"review-readiness\")\n",
+    "rd = readiness.get(\"readiness\", \"?\")\n",
+    "icon = {\"ready\": \"✅\", \"needs-review\": \"⚠️\", \"incomplete\": \"🔴\"}.get(rd, \"?\")\n",
+    "print(f\"Readiness: {icon} {rd}\")\n",
+    "print(f\"Checks: {readiness.get('ok_count',0)}/{readiness.get('check_count',0)} ok, {readiness.get('fail_count',0)} falliti\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-analysis",
+   "metadata": {},
+   "source": [
+    "## Anteprima dati\n",
+    "\n",
+    "Un colpo d'occhio sui dati del mart. Query esplorative, non analisi.\n",
+    "Personalizza in base al candidate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "analysis-setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con = duckdb.connect()\n",
+    "if MART_PATH and MART_PATH.exists():\n",
+    "    p = str(MART_PATH).replace(\"'\", \"''\")\n",
+    "    con.execute(f\"CREATE OR REPLACE VIEW mart AS SELECT * FROM read_parquet('{p}')\")\n",
+    "    cnt = con.execute(\"SELECT count(*) FROM mart\").fetchone()[0]\n",
+    "    print(f\"Mart: {MART_PATH.name}  |  {cnt} righe\")\n",
+    "else:\n",
+    "    print(\"Mart non disponibile. Esegui: toolkit run mart\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "analysis-query",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Query di esempio ---\n",
+    "# Sostituisci con la query specifica del candidate\n",
+    "if MART_PATH:\n",
+    "    df = con.execute(\"SELECT * FROM mart LIMIT 10\").fetchdf()\n",
+    "    show(df)\n",
+    "else:\n",
+    "    print(\"Esegui il mart prima di fare analisi.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "analysis-nulls-profile",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Profilo null rapido sul mart (prime 8 colonne)\n",
+    "if MART_PATH:\n",
+    "    cols = con.execute(\"DESCRIBE mart\").fetchall()\n",
+    "    exprs = []\n",
+    "    for c in cols[:8]:\n",
+    "        safe = c[0].replace('\"', '\"\"')\n",
+    "        exprs.append(f'round(100.0 * sum(CASE WHEN \"{safe}\" IS NULL THEN 1 ELSE 0 END) / count(*), 2) as \"null_{c[0]}\"')\n",
+    "    if exprs:\n",
+    "        q = 'SELECT count(*) as tot, ' + ', '.join(exprs) + ' FROM mart'\n",
+    "        nulls = con.execute(q).fetchdf()\n",
+    "        show(nulls)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-boundary",
+   "metadata": {},
+   "source": [
+    "## Boundary e note\n",
+    "\n",
+    "Documenta scelte di perimetro, esclusioni, anomalie."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "boundary",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PERIMETRO = \"...\"  # descrizione del perimetro\n",
+    "\n",
+    "print(f\"Slug      : {SLUG}\")\n",
+    "print(f\"Perimetro : {PERIMETRO}\")\n",
+    "print()\n",
+    "print(\"Note boundary:\")\n",
+    "print(\"  -\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-verdict",
+   "metadata": {},
+   "source": [
+    "## Verdetto\n",
+    "\n",
+    "Riepilogo end-to-end della pipeline, come `run-candidate`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "verdict-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_info = paths.get(\"latest_run\", {})\n",
+    "run_status = run_info.get(\"status\", \"?\")\n",
+    "rd = readiness.get(\"readiness\", \"?\")\n",
+    "profiles = paths.get(\"layer_profiles\", {})\n",
+    "clean_p = profiles.get(\"clean_output\", {})\n",
+    "mart_tables = profiles.get(\"mart_tables\", [])\n",
+    "transitions = profiles.get(\"clean_to_mart\", [])\n",
+    "\n",
+    "pipeline_icon = {'SUCCESS': '✅', 'FAILED': '❌', 'IN_PROGRESS': '⏳'}.get(run_status, '?')\n",
+    "rd_icon = {\"ready\": \"✅\", \"needs-review\": \"⚠️\", \"incomplete\": \"🔴\"}.get(rd, \"?\")\n",
+    "print(f\"Pipeline  : {pipeline_icon} {run_status}\")\n",
+    "print(f\"Readiness : {rd_icon} {rd}\")\n",
+    "print()\n",
+    "if clean_p:\n",
+    "    print(f\"  Clean: {clean_p.get('row_count', '?'):>8} righe, {clean_p.get('columns_count', '?')} colonne\")\n",
+    "for tbl in mart_tables:\n",
+    "    print(f\"  Mart:  {tbl.get('row_count', '?'):>8} righe ({tbl.get('name', '?')})\")\n",
+    "for t in transitions:\n",
+    "    print(f\"  Transizione: {t.get('source_row_count','?')} → {t.get('target_row_count','?')} righe\")\n",
+    "    if t.get(\"removed_columns\"):\n",
+    "        print(f\"    colonne rimosse: {t['removed_columns']}\")\n",
+    "    if t.get(\"added_columns\"):\n",
+    "        print(f\"    colonne aggiunte: {t['added_columns']}\")\n",
+    "print()\n",
+    "if rd == \"ready\":\n",
+    "    print(\"✅ Notebook v0 completato — pipeline verificata, dati coerenti.\")\n",
+    "elif rd == \"needs-review\":\n",
+    "    print(\"⚠️  Qualche anomalia — verificare i check falliti prima del merge.\")\n",
+    "else:\n",
+    "    print(\"🔴 Candidate non pronto — risolvere i check falliti.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/candidates/dipendenti-pubblici/dataset.yml
+++ b/candidates/dipendenti-pubblici/dataset.yml
@@ -3,6 +3,7 @@ schema_version: 1
 
 dataset:
   name: "dipendenti_pubblici"
+  source_id: "openbdap"
   years: [2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023]
 
 raw:

--- a/candidates/dipendenti-pubblici/notebooks/dipendenti_pubblici_v0.ipynb
+++ b/candidates/dipendenti-pubblici/notebooks/dipendenti_pubblici_v0.ipynb
@@ -1,303 +1,326 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "intro",
-      "metadata": {},
-      "source": [
-        "# dipendenti-pubblici - notebook v0\n",
-        "\n",
-        "Validazione della pipeline per fasi: **raw → clean → mart**.\n",
-        "\n",
-        "- scopo: verificare che ogni layer sia corretto e coerente con il precedente\n",
-        "- le SQL sono la fonte di verità: i check numerici devono essere letti alla luce di quello che dichiarano\n",
-        "- evitare output pesanti o immagini embeddate nel commit"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "setup",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import re\n",
-        "import yaml\n",
-        "import pandas as pd\n",
-        "from pathlib import Path\n",
-        "\n",
-        "# --- Unici parametri da impostare manualmente ---\n",
-        "METRICA       = \"dipendenti_totali\"  # colonna numerica principale nel mart\n",
-        "METRICA_CLEAN = \"donne_tempo_pieno\"  # colonna corrispondente nel clean\n",
-        "\n",
-        "# --- Anchor: usa il path del notebook se disponibile (VSCode), altrimenti cwd ---\n",
-        "try:\n",
-        "    _start = Path(__vsc_ipynb_file__).resolve().parent  # VSCode Jupyter\n",
-        "except NameError:\n",
-        "    _start = Path.cwd().resolve()\n",
-        "\n",
-        "# Walk up finché non troviamo dataset.yml\n",
-        "candidate_dir = None\n",
-        "for probe in [_start, *_start.parents]:\n",
-        "    if (probe / \"dataset.yml\").exists():\n",
-        "        candidate_dir = probe\n",
-        "        break\n",
-        "\n",
-        "if candidate_dir is None:\n",
-        "    raise FileNotFoundError(f\"dataset.yml non trovato risalendo da {_start}\")\n",
-        "\n",
-        "cfg = yaml.safe_load((candidate_dir / \"dataset.yml\").read_text())\n",
-        "\n",
-        "SLUG       = cfg[\"dataset\"][\"name\"]\n",
-        "ANNO_RUN   = cfg[\"dataset\"][\"years\"][-1]\n",
-        "MART_TABLE = cfg[\"mart\"][\"tables\"][0][\"name\"]\n",
-        "ENCODING   = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"encoding\", \"utf-8\")\n",
-        "DELIM      = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"delim\", \",\")\n",
-        "HEADER     = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"header\", True)\n",
-        "SKIP       = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"skip\", 0)\n",
-        "\n",
-        "DI_ROOT   = (candidate_dir / cfg[\"root\"]).resolve()\n",
-        "RAW_DIR   = DI_ROOT / \"data\" / \"raw\"   / SLUG / str(ANNO_RUN)\n",
-        "CLEAN_DIR = DI_ROOT / \"data\" / \"clean\" / SLUG / str(ANNO_RUN)\n",
-        "MART_DIR  = DI_ROOT / \"data\" / \"mart\"  / SLUG / str(ANNO_RUN)\n",
-        "SQL_DIR   = candidate_dir / \"sql\"\n",
-        "\n",
-        "print(f\"slug      : {SLUG}\")\n",
-        "print(f\"anno_run  : {ANNO_RUN}\")\n",
-        "print(f\"mart table: {MART_TABLE}\")\n",
-        "print(f\"encoding  : {ENCODING}  delim: {repr(DELIM)}\")\n",
-        "print(f\"header    : {HEADER}  skip: {SKIP}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "header-sql",
-      "metadata": {},
-      "source": [
-        "## SQL di riferimento\n",
-        "\n",
-        "Le SQL sono la fonte di verità per capire cosa deve contenere ogni layer.\n",
-        "Leggile prima di interpretare i check numerici."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "sql-show",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "for sql_file in sorted(SQL_DIR.glob(\"*.sql\")):\n",
-        "    print(f\"{'='*60}\")\n",
-        "    print(f\"  {sql_file.name}\")\n",
-        "    print(f\"{'='*60}\")\n",
-        "    print(sql_file.read_text())\n",
-        "    print()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "header-raw",
-      "metadata": {},
-      "source": [
-        "## 1. Raw\n",
-        "\n",
-        "Verifica che il file raw esista, sia leggibile con i parametri dichiarati in `dataset.yml` e abbia il numero di righe atteso."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "raw-load",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "raw_files = sorted(RAW_DIR.glob(\"*.csv\")) + sorted(RAW_DIR.glob(\"*.xlsx\")) + sorted(RAW_DIR.glob(\"*.parquet\"))\n",
-        "if not raw_files:\n",
-        "    raise FileNotFoundError(f\"Nessun file raw trovato in {RAW_DIR}\")\n",
-        "\n",
-        "raw_path = raw_files[0]\n",
-        "print(f\"File: {raw_path.name}  ({raw_path.stat().st_size / 1024:.0f} KB)\")\n",
-        "\n",
-        "N_RAW = None\n",
-        "raw_full = None\n",
-        "try:\n",
-        "    if raw_path.suffix == \".parquet\":\n",
-        "        raw_full = pd.read_parquet(raw_path)\n",
-        "    elif raw_path.suffix in (\".csv\", \".tsv\"):\n",
-        "        header_row = 0 if HEADER else None\n",
-        "        raw_full = pd.read_csv(raw_path, encoding=ENCODING, sep=DELIM, header=header_row, skiprows=SKIP)\n",
-        "    elif raw_path.suffix == \".xlsx\":\n",
-        "        raw_full = pd.read_excel(raw_path, header=0 if HEADER else None, skiprows=SKIP)\n",
-        "    N_RAW = len(raw_full)\n",
-        "    print(f\"Righe raw   : {N_RAW}\")\n",
-        "    print(f\"Colonne raw : {len(raw_full.columns)} -> {list(raw_full.columns)}\")\n",
-        "    print(\"Raw caricato OK\")\n",
-        "    raw_full.head(3)\n",
-        "except Exception as e:\n",
-        "    print(f\"WARNING: raw non leggibile con pandas ({e})\")\n",
-        "    print(\"-> Skip raw-load, il clean parquet e gia validato dalla pipeline.\")\n",
-        "    N_RAW = None\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "header-clean",
-      "metadata": {},
-      "source": [
-        "## 2. Clean\n",
-        "\n",
-        "Verifica schema e null. I null su colonne `try_cast` sono attesi se il raw contiene valori non parsabili.\n",
-        "Il confronto righe raw vs clean mostra quante righe sono state filtrate dal `WHERE` della clean.sql."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "clean-load",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "clean_files = sorted(CLEAN_DIR.glob(\"*.parquet\"))\n",
-        "if not clean_files:\n",
-        "    raise FileNotFoundError(f\"Clean non trovato in {CLEAN_DIR}. Eseguire: toolkit run clean\")\n",
-        "\n",
-        "clean = pd.read_parquet(clean_files[0])\n",
-        "N_CLEAN = len(clean)\n",
-        "\n",
-        "print(f\"Righe clean : {N_CLEAN}\")\n",
-        "print(f\"Colonne     : {list(clean.columns)}\")\n",
-        "clean.head(3)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "raw-clean-diff",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "if N_RAW is not None:\n",
-        "    dropped = N_RAW - N_CLEAN\n",
-        "    dropped_pct = dropped / N_RAW * 100 if N_RAW > 0 else 0\n",
-        "    print(f\"Righe raw         : {N_RAW}\")\n",
-        "    print(f\"Righe clean       : {N_CLEAN}\")\n",
-        "    print(f\"Righe filtrate    : {dropped} ({dropped_pct:.1f}%)\")\n",
-        "    print()\n",
-        "    if dropped > 0:\n",
-        "        print(\"-> Verificare la WHERE in clean.sql per capire quali righe vengono escluse.\")\n",
-        "    else:\n",
-        "        print(\"-> Nessuna riga filtrata: clean e fedele al raw.\")\n",
-        "else:\n",
-        "    print(f\"Raw non caricato (parsing error) -- righe clean: {N_CLEAN}\")\n",
-        "    print(\"-> Check raw-vs-clean saltato. Clean gia validato dalla pipeline.\")\n",
-        "\n",
-        "print(\"\\nNull per colonna clean:\")\n",
-        "null_counts = clean.isnull().sum()\n",
-        "print(null_counts[null_counts > 0].to_string() if null_counts.any() else \"  nessuno\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "header-mart",
-      "metadata": {},
-      "source": [
-        "## 3. Mart\n",
-        "\n",
-        "Verifica unicità sulle chiavi del GROUP BY, anni presenti, null e consistenza dei totali con il clean."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "mart-load",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "mart_path = MART_DIR / f\"{MART_TABLE}.parquet\"\n",
-        "if not mart_path.exists():\n",
-        "    raise FileNotFoundError(f\"Mart non trovato: {mart_path}. Eseguire: toolkit run mart\")\n",
-        "\n",
-        "mart = pd.read_parquet(mart_path)\n",
-        "print(f\"Righe mart  : {len(mart)}\")\n",
-        "print(f\"Colonne     : {list(mart.columns)}\")\n",
-        "mart.head(3)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "mart-keys",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Estrai chiavi GROUP BY dalla mart.sql per il check di unicità.\n",
-        "mart_sql_path = SQL_DIR / Path(cfg[\"mart\"][\"tables\"][0][\"sql\"]).name\n",
-        "groupby_keys = []\n",
-        "if mart_sql_path.exists():\n",
-        "    sql_text = mart_sql_path.read_text()\n",
-        "    match = re.search(r'group\\s+by\\s+([\\d\\s,]+)', sql_text, re.IGNORECASE)\n",
-        "    if match:\n",
-        "        positions = [int(p.strip()) for p in match.group(1).split(',')]\n",
-        "        groupby_keys = [mart.columns[i - 1] for i in positions if i <= len(mart.columns)]\n",
-        "    else:\n",
-        "        match = re.search(r'group\\s+by\\s+((?:[\\w.]+(?:\\s*,\\s*)?)+)', sql_text, re.IGNORECASE)\n",
-        "        if match:\n",
-        "            groupby_keys = [k.strip().split('.')[-1] for k in match.group(1).split(',')]\n",
-        "            groupby_keys = [k for k in groupby_keys if k in mart.columns]\n",
-        "if groupby_keys:\n",
-        "    dups = mart.duplicated(subset=groupby_keys).sum()\n",
-        "    print(f\"Chiavi GROUP BY: {groupby_keys}\")\n",
-        "    print(f\"Duplicati      : {dups}\")\n",
-        "    assert dups == 0, f\"FAIL: {dups} righe duplicate\"\n",
-        "    print(\"OK: nessun duplicato.\")\n",
-        "else:\n",
-        "    print(\"GROUP BY non trovato: check saltato.\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "mart-coverage",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "if \"anno\" in mart.columns:\n",
-        "    anni_mart = sorted(mart[\"anno\"].unique())\n",
-        "    print(f\"Anni nel mart ({len(anni_mart)}): {anni_mart}\")\n",
-        "\n",
-        "null_mart = mart.isnull().sum()\n",
-        "print(\"\\nNull per colonna mart:\")\n",
-        "print(null_mart[null_mart > 0].to_string() if null_mart.any() else \"  nessuno\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "notes",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "PERIMETRO = \" tutti i comparti della PA, serie 2010-2023, aggregati per anno e comparto\"",
-        "",
-        "print(f\"Slug         : {SLUG}\")",
-        "print(f\"Anno run     : {ANNO_RUN}\")",
-        "print(f\"Tabella mart : {MART_TABLE}\")",
-        "print(f\"Perimetro    : {PERIMETRO}\")"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.12.0"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# dipendenti-pubblici - notebook v0\n",
+    "\n",
+    "Validazione rapida + analisi esplorativa della pipeline **raw → clean → mart**.\n",
+    "\n",
+    "- i check tecnici (righe, null, readiness) sono delegati al toolkit\n",
+    "- le SQL sono la fonte di verità: leggile prima di interpretare i numeri\n",
+    "- il notebook serve l'analisi, non sostituisce la validazione della pipeline\n",
+    "- evitare output pesanti o immagini embeddate nel commit"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, duckdb, yaml\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# --- Unico parametro da impostare ---\n",
+    "SLUG = \"dipendenti-pubblici\"\n",
+    "\n",
+    "# --- Trova dataset.yml ---\n",
+    "_start = Path.cwd().resolve()\n",
+    "for probe in [_start, *_start.parents]:\n",
+    "    if (probe / \"dataset.yml\").exists():\n",
+    "        CANDIDATE_DIR = probe\n",
+    "        break\n",
+    "else:\n",
+    "    raise FileNotFoundError(f\"dataset.yml non trovato risalendo da {_start}\")\n",
+    "\n",
+    "CFG_PATH = CANDIDATE_DIR / \"dataset.yml\"\n",
+    "SQL_DIR = CANDIDATE_DIR / \"sql\"\n",
+    "_cfg_raw = yaml.safe_load(CFG_PATH.read_text())\n",
+    "ANNO = _cfg_raw[\"dataset\"][\"years\"][-1]\n",
+    "\n",
+    "# Aggiungi scripts/ al path per importare notebook_helpers\n",
+    "sys.path.insert(0, str(CANDIDATE_DIR.parent.parent / \"scripts\"))\n",
+    "from notebook_helpers import NotebookHelper, show\n",
+    "\n",
+    "h = NotebookHelper(CFG_PATH, ANNO)\n",
+    "WORKSPACE_ROOT = CANDIDATE_DIR.parent.parent\n",
+    "\n",
+    "def _rel(p: Path) -> str:\n",
+    "    try: return str(p.relative_to(WORKSPACE_ROOT))\n",
+    "    except ValueError: return str(p)\n",
+    "\n",
+    "# Paths dei layer (con anno esplicito)\n",
+    "paths = h.tk_year(\"inspect\", \"paths\")\n",
+    "P = paths.get(\"paths\", {})\n",
+    "RAW_DIR   = Path(P.get(\"raw\", {}).get(\"dir\", \"\"))\n",
+    "CLEAN_DIR = Path(P.get(\"clean\", {}).get(\"dir\", \"\"))\n",
+    "MART_DIR  = Path(P.get(\"mart\", {}).get(\"dir\", \"\"))\n",
+    "MART_OUTPUTS = P.get(\"mart\", {}).get(\"outputs\", [])\n",
+    "MART_PATH = Path(MART_OUTPUTS[0]) if MART_OUTPUTS else None\n",
+    "MART_TABLE = MART_PATH.stem if MART_PATH else None\n",
+    "\n",
+    "print(f\"slug: {SLUG}    anno: {ANNO}\")\n",
+    "print(f\"config: {_rel(CFG_PATH)}\")\n",
+    "print(f\"raw:   {_rel(RAW_DIR)}\")\n",
+    "print(f\"clean: {_rel(CLEAN_DIR)}\")\n",
+    "print(f\"mart:  {_rel(MART_DIR)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-sql",
+   "metadata": {},
+   "source": [
+    "## SQL di riferimento\n",
+    "\n",
+    "Le SQL sono la fonte di verità per capire cosa deve contenere ogni layer.\n",
+    "Leggile prima di interpretare i check numerici."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "sql-show",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for sql_file in sorted(SQL_DIR.glob(\"*.sql\")):\n",
+    "    print(f\"{'='*60}\")\n",
+    "    print(f\"  {sql_file.name}\")\n",
+    "    print(f\"{'='*60}\")\n",
+    "    print(sql_file.read_text())\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-gates",
+   "metadata": {},
+   "source": [
+    "## Quality gates\n",
+    "\n",
+    "Il toolkit ha già eseguito run + validate + readiness. Qui si riassume il risultato."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "gates",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_info = paths.get(\"latest_run\", {})\n",
+    "print(f\"Ultimo run: {run_info.get('status','?')}  (ID: {run_info.get('run_id','?')})\")\n",
+    "print()\n",
+    "\n",
+    "# Schema clean\n",
+    "schema_clean = h.tk_schema(\"clean\")\n",
+    "cols_clean = schema_clean.get(\"schema\", [])\n",
+    "print(f\"Clean: {schema_clean.get('columns', 0)} colonne\")\n",
+    "for c in cols_clean[:5]:\n",
+    "    print(f\"  {c.get('name','?'):35s} {c.get('type','?')}\")\n",
+    "if len(cols_clean) > 5: print(f\"  ... ({len(cols_clean)} totali)\")\n",
+    "print()\n",
+    "\n",
+    "# Schema mart\n",
+    "schema_mart = h.tk_schema(\"mart\")\n",
+    "cols_mart = schema_mart.get(\"schema\", [])\n",
+    "print(f\"Mart: {schema_mart.get('columns', 0)} colonne\")\n",
+    "for c in cols_mart[:5]:\n",
+    "    print(f\"  {c.get('name','?'):35s} {c.get('type','?')}\")\n",
+    "if len(cols_mart) > 5: print(f\"  ... ({len(cols_mart)} totali)\")\n",
+    "print()\n",
+    "\n",
+    "# Profili layer\n",
+    "profiles = paths.get(\"layer_profiles\", {})\n",
+    "clean_prof = profiles.get(\"clean_output\", {})\n",
+    "if clean_prof:\n",
+    "    print(f\"Clean: {clean_prof.get('row_count','?')} righe, {clean_prof.get('columns_count','?')} colonne\")\n",
+    "for tbl in profiles.get(\"mart_tables\", []):\n",
+    "    print(f\"Mart: {tbl.get('row_count','?')} righe ({tbl.get('name','?')})\")\n",
+    "for trans in profiles.get(\"clean_to_mart\", []):\n",
+    "    print(f\"Transizione: {trans.get('source_row_count','?')} -> {trans.get('target_row_count','?')} righe\")\n",
+    "    print(f\"  rimosse: {trans.get('removed_columns', [])}, aggiunte: {trans.get('added_columns', [])}\")\n",
+    "print()\n",
+    "\n",
+    "# Raw hints\n",
+    "rh = paths.get(\"raw_hints\", {})\n",
+    "print(f\"Raw: {rh.get('primary_output_file','?')}  |  encoding={rh.get('encoding','?')}  delim={rh.get('delim','?')}  skip={rh.get('skip','?')}\")\n",
+    "for w in rh.get(\"warnings\", []):\n",
+    "    print(f\"  warning: {w}\")\n",
+    "print()\n",
+    "\n",
+    "# Review readiness\n",
+    "readiness = h.tk(\"review-readiness\")\n",
+    "rd = readiness.get(\"readiness\", \"?\")\n",
+    "icon = {\"ready\": \"✅\", \"needs-review\": \"⚠️\", \"incomplete\": \"🔴\"}.get(rd, \"?\")\n",
+    "print(f\"Readiness: {icon} {rd}\")\n",
+    "print(f\"Checks: {readiness.get('ok_count',0)}/{readiness.get('check_count',0)} ok, {readiness.get('fail_count',0)} falliti\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-analysis",
+   "metadata": {},
+   "source": [
+    "## Anteprima dati\n",
+    "\n",
+    "Un colpo d'occhio sui dati del mart. Query esplorative, non analisi."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "analysis-setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con = duckdb.connect()\n",
+    "if MART_PATH and MART_PATH.exists():\n",
+    "    p = str(MART_PATH).replace(\"'\", \"''\")\n",
+    "    con.execute(f\"CREATE OR REPLACE VIEW mart AS SELECT * FROM read_parquet('{p}')\")\n",
+    "    cnt = con.execute(\"SELECT count(*) FROM mart\").fetchone()[0]\n",
+    "    print(f\"Mart: {MART_PATH.name}  |  {cnt} righe\")\n",
+    "else:\n",
+    "    print(\"Mart non disponibile. Esegui: toolkit run mart\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "analysis-query",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Dipendenti per comparto: distribuzione e saldo netto ---\n",
+    "if MART_PATH:\n",
+    "    df = con.execute(\"\"\"\n",
+    "        SELECT anno, comparto, \n",
+    "               sum(dipendenti_totali) as dipendenti,\n",
+    "               sum(assunti_totali) as assunti,\n",
+    "               sum(cessati_totali) as cessati,\n",
+    "               round(avg(quota_donne_pct), 1) as quota_donne_pct\n",
+    "        FROM mart\n",
+    "        GROUP BY anno, comparto\n",
+    "        ORDER BY anno, comparto\n",
+    "    \"\"\").fetchdf()\n",
+    "    show(df)\n",
+    "else:\n",
+    "    print(\"Esegui il mart prima di fare analisi.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "analysis-nulls-profile",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Profilo null rapido sul mart (prime 8 colonne)\n",
+    "if MART_PATH:\n",
+    "    cols = con.execute(\"DESCRIBE mart\").fetchall()\n",
+    "    exprs = []\n",
+    "    for c in cols[:8]:\n",
+    "        safe = c[0].replace('\"', '\"\"')\n",
+    "        exprs.append(f'round(100.0 * sum(CASE WHEN \"{safe}\" IS NULL THEN 1 ELSE 0 END) / count(*), 2) as \"null_{c[0]}\"')\n",
+    "    if exprs:\n",
+    "        q = 'SELECT count(*) as tot, ' + ', '.join(exprs) + ' FROM mart'\n",
+    "        nulls = con.execute(q).fetchdf()\n",
+    "        show(nulls)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-boundary",
+   "metadata": {},
+   "source": [
+    "## Boundary e note\n",
+    "\n",
+    "Documenta scelte di perimetro, esclusioni, anomalie."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "boundary",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PERIMETRO = \"tutti i comparti della PA, serie 2010-2023, aggregati per anno e comparto\"\n",
+    "\n",
+    "print(f\"Slug      : {SLUG}\")\n",
+    "print(f\"Perimetro : {PERIMETRO}\")\n",
+    "print()\n",
+    "print(\"Note boundary:\")\n",
+    "print(\"  - Clean: rename colonne, cast tipi, normalizzazione contratto_lavoro\")\n",
+    "print(\"  - Mart: aggregazione per anno e comparto, nessun join esterno\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-verdict",
+   "metadata": {},
+   "source": [
+    "## Verdetto\n",
+    "\n",
+    "Riepilogo end-to-end della pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "verdict-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_info = paths.get(\"latest_run\", {})\n",
+    "run_status = run_info.get(\"status\", \"?\")\n",
+    "rd = readiness.get(\"readiness\", \"?\")\n",
+    "profiles = paths.get(\"layer_profiles\", {})\n",
+    "clean_p = profiles.get(\"clean_output\", {})\n",
+    "mart_tables = profiles.get(\"mart_tables\", [])\n",
+    "transitions = profiles.get(\"clean_to_mart\", [])\n",
+    "\n",
+    "pipeline_icon = {'SUCCESS': '✅', 'FAILED': '❌', 'IN_PROGRESS': '⏳'}.get(run_status, '?')\n",
+    "rd_icon = {\"ready\": \"✅\", \"needs-review\": \"⚠️\", \"incomplete\": \"🔴\"}.get(rd, \"?\")\n",
+    "print(f\"Pipeline  : {pipeline_icon} {run_status}\")\n",
+    "print(f\"Readiness : {rd_icon} {rd}\")\n",
+    "print()\n",
+    "if clean_p:\n",
+    "    print(f\"  Clean: {clean_p.get('row_count', '?'):>8} righe, {clean_p.get('columns_count', '?')} colonne\")\n",
+    "for tbl in mart_tables:\n",
+    "    print(f\"  Mart:  {tbl.get('row_count', '?'):>8} righe ({tbl.get('name', '?')})\")\n",
+    "for t in transitions:\n",
+    "    print(f\"  Transizione: {t.get('source_row_count','?')} → {t.get('target_row_count','?')} righe\")\n",
+    "    if t.get(\"removed_columns\"):\n",
+    "        print(f\"    colonne rimosse: {t['removed_columns']}\")\n",
+    "    if t.get(\"added_columns\"):\n",
+    "        print(f\"    colonne aggiunte: {t['added_columns']}\")\n",
+    "print()\n",
+    "if rd == \"ready\":\n",
+    "    print(\"✅ Notebook v0 completato — pipeline verificata, dati coerenti.\")\n",
+    "elif rd == \"needs-review\":\n",
+    "    print(\"⚠️  Qualche anomalia — verificare i check falliti prima del merge.\")\n",
+    "else:\n",
+    "    print(\"🔴 Candidate non pronto — risolvere i check falliti.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/scripts/create_de_followup_issue.py
+++ b/scripts/create_de_followup_issue.py
@@ -1,5 +1,8 @@
 """Crea una issue di follow-up in data-explorer per nuovi dataset pubblicati.
 
+Filtra gli slug già presenti in ``registry/clean_catalog.json``:
+se un dataset è già nel catalogo tecnico, non serve una nuova issue DE.
+
 Usage (env vars):
   ITEMS_JSON  JSON array di items con slug
   PR_NUMBER   numero della PR mergiata
@@ -11,6 +14,37 @@ import json
 import os
 import subprocess
 import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent  # dataset-incubator/
+
+
+def _load_catalog_slugs() -> set[str]:
+    """Carica gli slug dal catalogo pulito e restituisce un set.
+
+    Gli slug nel catalogo usano underscore (``aifa_spesa_consumo``),
+    mentre gli item di detect usano trattini (``aifa-spesa-consumo``).
+    Normalizza tutto a trattini per il confronto.
+    """
+    catalog_path = REPO_ROOT / "registry" / "clean_catalog.json"
+    if not catalog_path.exists():
+        print(f"AVVISO: {catalog_path} non trovato — nessun filtro applicato")
+        return set()
+
+    try:
+        data = json.loads(catalog_path.read_text())
+        # La struttura ha una lista "datasets" con campo "slug"
+        slugs = {
+            entry["slug"].replace("_", "-")
+            for entry in data.get("datasets", [])
+            if "slug" in entry
+        }
+        print(f"DEBUG: {len(slugs)} slug noti dal catalogo pulito")
+        return slugs
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        print(f"AVVISO: impossibile leggere {catalog_path}: {exc}")
+        return set()
 
 
 def main() -> int:
@@ -28,17 +62,32 @@ def main() -> int:
         print("Nessun item — skip")
         return 0
 
+    # Filtra item già presenti nel catalogo pulito
+    known_slugs = _load_catalog_slugs()
+    new_items = [i for i in items if i.get("slug") not in known_slugs]
+
+    if not new_items:
+        print(
+            f"Tutti gli item ({len(items)}) sono già presenti nel catalogo — "
+            f"nessuna issue DE creata"
+        )
+        return 0
+
+    skipped = len(items) - len(new_items)
+    if skipped:
+        print(f"Saltati {skipped} item già in catalogo")
+
     # Costruisci lista items
     item_lines = "\n".join(
         f"- [ ] {i['slug']}: aggiungere a themes.json e creare pagina dataset"
-        for i in items
+        for i in new_items
     )
 
     # Titolo
-    if len(items) == 1:
-        title = f"follow-up: pagina e tema per {items[0]['slug']}"
+    if len(new_items) == 1:
+        title = f"follow-up: pagina e tema per {new_items[0]['slug']}"
     else:
-        title = f"follow-up: pagina e tema per {len(items)} nuovi dataset"
+        title = f"follow-up: pagina e tema per {len(new_items)} nuovi dataset"
 
     # Body
     body = (

--- a/scripts/create_de_followup_issue.py
+++ b/scripts/create_de_followup_issue.py
@@ -1,12 +1,17 @@
 """Crea una issue di follow-up in data-explorer per nuovi dataset pubblicati.
 
-Filtra gli slug già presenti in ``registry/clean_catalog.json``:
-se un dataset è già nel catalogo tecnico, non serve una nuova issue DE.
+Filtra gli slug già presenti nel catalogo pulito **prima del merge**
+(``BASE_SHA``), non dopo. In questo modo:
+- un nuovo dataset appena pubblicato genera regolarmente la issue DE
+- una PR tecnica su un dataset già noto non genera rumore
 
 Usage (env vars):
   ITEMS_JSON  JSON array di items con slug
   PR_NUMBER   numero della PR mergiata
   PR_TITLE    titolo della PR mergiata
+  BASE_SHA    (opzionale) SHA del base branch prima del merge.
+              Se omesso (es. workflow_dispatch), confronta col catalogo
+              corrente su filesystem.
   GH_TOKEN    token GitHub con scope issues:write su data-explorer
 """
 
@@ -20,37 +25,75 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent  # dataset-incubator/
 
 
-def _load_catalog_slugs() -> set[str]:
+def _read_catalog_json(git_ref: str | None = None) -> dict | None:
+    """Legge il catalogo pulito e restituisce il dict parsato, o None.
+
+    Se ``git_ref`` è specificato, legge da git (alberino pre-merge).
+    Altrimenti legge dal filesystem.
+    """
+    if git_ref:
+        try:
+            result = subprocess.run(
+                ["git", "show", f"{git_ref}:registry/clean_catalog.json"],
+                capture_output=True, text=True, cwd=REPO_ROOT,
+            )
+            if result.returncode != 0:
+                print(
+                    f"AVVISO: git show {git_ref}:registry/clean_catalog.json "
+                    f"fallito ({result.stderr.strip()})"
+                )
+                return None
+            return json.loads(result.stdout)
+        except (json.JSONDecodeError, subprocess.CalledProcessError) as exc:
+            print(f"AVVISO: impossibile leggere catalogo da git@{git_ref}: {exc}")
+            return None
+
+    # Filesystem
+    catalog_path = REPO_ROOT / "registry" / "clean_catalog.json"
+    if not catalog_path.exists():
+        print(f"AVVISO: {catalog_path} non trovato — nessun filtro applicato")
+        return None
+    try:
+        return json.loads(catalog_path.read_text())
+    except (json.JSONDecodeError, TypeError) as exc:
+        print(f"AVVISO: impossibile leggere {catalog_path}: {exc}")
+        return None
+
+
+def _extract_slugs(catalog: dict | None) -> set[str]:
+    """Estrae gli slug normalizzati (trattini) da un dict catalogo."""
+    if not catalog:
+        return set()
+    return {
+        entry["slug"].replace("_", "-")
+        for entry in catalog.get("datasets", [])
+        if "slug" in entry
+    }
+
+
+def _load_catalog_slugs(git_ref: str | None = None) -> set[str]:
     """Carica gli slug dal catalogo pulito e restituisce un set.
+
+    Se ``git_ref`` è specificato, legge il catalogo da git (pre-merge).
+    Altrimenti legge dal filesystem (catalogo corrente, eventualmente
+    già aggiornato dal post-merge pipeline).
 
     Gli slug nel catalogo usano underscore (``aifa_spesa_consumo``),
     mentre gli item di detect usano trattini (``aifa-spesa-consumo``).
     Normalizza tutto a trattini per il confronto.
     """
-    catalog_path = REPO_ROOT / "registry" / "clean_catalog.json"
-    if not catalog_path.exists():
-        print(f"AVVISO: {catalog_path} non trovato — nessun filtro applicato")
-        return set()
-
-    try:
-        data = json.loads(catalog_path.read_text())
-        # La struttura ha una lista "datasets" con campo "slug"
-        slugs = {
-            entry["slug"].replace("_", "-")
-            for entry in data.get("datasets", [])
-            if "slug" in entry
-        }
-        print(f"DEBUG: {len(slugs)} slug noti dal catalogo pulito")
-        return slugs
-    except (json.JSONDecodeError, KeyError, TypeError) as exc:
-        print(f"AVVISO: impossibile leggere {catalog_path}: {exc}")
-        return set()
+    catalog = _read_catalog_json(git_ref=git_ref)
+    slugs = _extract_slugs(catalog)
+    source = f"git@{git_ref[:12]}" if git_ref else "filesystem"
+    print(f"DEBUG: {len(slugs)} slug noti dal catalogo ({source})")
+    return slugs
 
 
 def main() -> int:
     items_raw = os.environ.get("ITEMS_JSON", "[]")
     pr_number = os.environ.get("PR_NUMBER", "?")
     pr_title = os.environ.get("PR_TITLE", "?")
+    base_sha = os.environ.get("BASE_SHA", None)
 
     try:
         items = json.loads(items_raw)
@@ -62,20 +105,22 @@ def main() -> int:
         print("Nessun item — skip")
         return 0
 
-    # Filtra item già presenti nel catalogo pulito
-    known_slugs = _load_catalog_slugs()
-    new_items = [i for i in items if i.get("slug") not in known_slugs]
+    # Filtra item già presenti nel catalogo **pre-merge** (base branch)
+    known_slugs = _load_catalog_slugs(git_ref=base_sha)
+    # Se il catalogo non è stato leggibile, known_slugs sarà vuoto
+    # e nessun filtro verrà applicato (tutti gli item passano)
+    new_items = [i for i in items if i.get("slug") not in known_slugs] if known_slugs else items
 
     if not new_items:
         print(
-            f"Tutti gli item ({len(items)}) sono già presenti nel catalogo — "
-            f"nessuna issue DE creata"
+            f"Tutti gli item ({len(items)}) sono già presenti nel catalogo "
+            f"pre-merge — nessuna issue DE creata"
         )
         return 0
 
     skipped = len(items) - len(new_items)
     if skipped:
-        print(f"Saltati {skipped} item già in catalogo")
+        print(f"Saltati {skipped} item già in catalogo pre-merge")
 
     # Costruisci lista items
     item_lines = "\n".join(

--- a/scripts/notebook_helpers.py
+++ b/scripts/notebook_helpers.py
@@ -93,7 +93,11 @@ class NotebookHelper:
         if result.returncode:
             print(result.stderr, file=sys.stderr)
             return {"columns": 0, "schema": []}
-        return json.loads(result.stdout) if result.stdout.strip() else {}
+        data = json.loads(result.stdout) if result.stdout.strip() else {}
+        if isinstance(data, dict) and "column_count" in data and "columns" in data:
+            # Normalizza: toolkit torna column_count/columns → columns/schema
+            return {"columns": data["column_count"], "schema": data["columns"]}
+        return data
 
     # ── ricerca dataset.yml ───────────────────────────────────────────────
 

--- a/support_datasets/bdap-anagrafe-enti/dataset.yml
+++ b/support_datasets/bdap-anagrafe-enti/dataset.yml
@@ -3,6 +3,7 @@ schema_version: 1
 
 dataset:
   name: "bdap_anagrafe_enti"
+  source_id: "openbdap"
   years: [2024]
 
 raw:

--- a/tests/test_create_de_followup_issue.py
+++ b/tests/test_create_de_followup_issue.py
@@ -1,0 +1,181 @@
+"""Test per scripts/create_de_followup_issue.py.
+
+Verifica il filtro slug:
+- slug già nel catalogo pre-merge -> non crea issue
+- slug nuovo (non in catalogo pre-merge) -> crea issue
+- misto: solo i nuovi passano
+- git_ref non raggiungibile -> fallback a catalogo corrente
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+from create_de_followup_issue import _extract_slugs, _read_catalog_json
+
+FIXTURE_CATALOG = {
+    "schema_version": 1,
+    "datasets": [
+        {"slug": "aifa_spesa_consumo", "name": "AIFA Spesa"},
+        {"slug": "bdap_lea", "name": "BDAP LEA"},
+        {"slug": "consip_consumi_convenzione", "name": "Consip Consumi"},
+        {"slug": "dipendenti_pubblici", "name": "Dipendenti Pubblici"},
+    ],
+}
+
+FIXTURE_ITEMS = [
+    {"slug": "bdap-lea", "kind": "candidate"},            # già in catalogo
+    {"slug": "dipendenti-pubblici", "kind": "candidate"},  # già in catalogo
+    {"slug": "mega-nuovo-dataset", "kind": "candidate"},   # NUOVO
+]
+
+
+class TestExtractSlugs:
+    def test_extract_normalizes_underscore_to_hyphen(self):
+        slugs = _extract_slugs(FIXTURE_CATALOG)
+        assert "aifa-spesa-consumo" in slugs
+        assert "bdap-lea" in slugs
+        assert "consip-consumi-convenzione" in slugs
+        assert len(slugs) == 4
+
+    def test_extract_empty_on_none(self):
+        assert _extract_slugs(None) == set()
+
+    def test_extract_empty_on_empty_dict(self):
+        assert _extract_slugs({}) == set()
+
+    def test_extract_skips_entries_without_slug(self):
+        catalog = {"datasets": [{"name": "no-slug"}, {"slug": "ok", "name": "OK"}]}
+        slugs = _extract_slugs(catalog)
+        assert slugs == {"ok"}
+
+
+class TestReadCatalogJson:
+    def test_read_from_disk(self, tmp_path, monkeypatch):
+        """Legge dal filesystem quando git_ref è None."""
+        # Scrive un catalogo temporaneo
+        catalog_path = tmp_path / "registry" / "clean_catalog.json"
+        catalog_path.parent.mkdir(parents=True)
+        catalog_path.write_text(json.dumps(FIXTURE_CATALOG))
+
+        monkeypatch.chdir(tmp_path)
+        # Dobbiamo far puntare REPO_ROOT a tmp_path
+        import create_de_followup_issue as module
+        original_root = module.REPO_ROOT
+        module.REPO_ROOT = tmp_path
+
+        try:
+            catalog = _read_catalog_json(git_ref=None)
+            assert catalog is not None
+            assert len(catalog["datasets"]) == 4
+        finally:
+            module.REPO_ROOT = original_root
+
+    def test_read_from_git(self):
+        """Legge da git quando git_ref è specificato."""
+        catalog = _read_catalog_json(git_ref="HEAD")
+        # HEAD punta al commit corrente, che ha il catalogo
+        if catalog is not None:
+            assert "datasets" in catalog
+        # Se git non è disponibile (CI senza git), catalog è None -> skip
+
+    def test_read_from_git_bad_ref_returns_none(self):
+        """Un git_ref inesistente restituisce None senza crash."""
+        catalog = _read_catalog_json(git_ref="nonexistent-sha-1234567")
+        assert catalog is None
+
+
+class TestFilterSlugs:
+    """Testa la logica di filtro nel main, con mock di subprocess e gh."""
+
+    def _run_main(self, items, base_sha=None):
+        """Avvia main() con env vars controllate e mock di subprocess.run."""
+        env = {
+            "ITEMS_JSON": json.dumps(items),
+            "PR_NUMBER": "999",
+            "PR_TITLE": "test PR",
+            "GH_TOKEN": "fake-token",
+        }
+        if base_sha:
+            env["BASE_SHA"] = base_sha
+
+        with patch.dict(os.environ, env, clear=True):
+            from create_de_followup_issue import main
+
+            # Mock git show per restituire il catalogo fixture
+            def fake_subprocess_run(cmd, **kwargs):
+                if "git" in cmd and "show" in cmd and "nonexistent" not in " ".join(cmd):
+                    return MagicMock(
+                        returncode=0,
+                        stdout=json.dumps(FIXTURE_CATALOG),
+                        stderr="",
+                    )
+                elif "gh" in cmd and "issue" in cmd and "create" in cmd:
+                    return MagicMock(
+                        returncode=0,
+                        stdout="https://github.com/dataciviclab/data-explorer/issues/999",
+                        stderr="",
+                    )
+                return MagicMock(returncode=0, stdout="", stderr="")
+
+            with patch("subprocess.run", side_effect=fake_subprocess_run):
+                return main()
+
+    def test_all_existing_skips_issue(self):
+        """Tutti gli item già in catalogo pre-merge -> nessuna issue."""
+        rc = self._run_main(
+            items=[
+                {"slug": "bdap-lea", "kind": "candidate"},
+            ],
+            base_sha="main",
+        )
+        assert rc == 0  # Successo: skip senza creare issue
+
+    def test_new_item_creates_issue(self):
+        """Item nuovo (non in catalogo pre-merge) -> crea issue."""
+        rc = self._run_main(
+            items=[
+                {"slug": "mega-nuovo-dataset", "kind": "candidate"},
+            ],
+            base_sha="main",
+        )
+        assert rc == 0  # Issue creata
+
+    def test_mixed_only_new_passes(self):
+        """Misto: solo gli item nuovi generano issue."""
+        rc = self._run_main(
+            items=[
+                {"slug": "bdap-lea", "kind": "candidate"},            # già noto
+                {"slug": "mega-nuovo-dataset", "kind": "candidate"},  # nuovo
+            ],
+            base_sha="main",
+        )
+        assert rc == 0
+
+    def test_empty_items_skips(self):
+        """Lista vuota -> skip."""
+        rc = self._run_main(items=[], base_sha="main")
+        assert rc == 0
+
+    def test_without_base_sha_falls_back_to_disk(self):
+        """Senza BASE_SHA (workflow_dispatch) usa catalogo da filesystem.
+
+        Se il catalogo su disco non esiste, nessun filtro -> item passa.
+        """
+        with patch.object(Path, "exists", return_value=False):
+            rc = self._run_main(
+                items=[
+                    {"slug": "bdap-lea", "kind": "candidate"},
+                ],
+                base_sha=None,
+            )
+        assert rc == 0  # Issue creata perché catalogo non trovato


### PR DESCRIPTION
## Summary

Primo batch della campagna di allineamento candidate: fix source_id + migrazione notebook a NotebookHelper per i candidati di fonte openbdap (BDAP MEF).

### Fix infrastrutturali
- create_de_followup_issue.py: filtro slug gia in clean_catalog (rumore DE zero per fix tecnici)
- notebook_helpers.py: tk_schema() normalizza column_count/columns -> columns/schema

### Fix per fonte openbdap
- bdap-lea: source_id + setup cell migrato a NotebookHelper
- dipendenti-pubblici: source_id + notebook riscritto al nuovo template (14 celle, quality gates, duckdb)
- bdap-anagrafe-enti (support): source_id

### Test
Entrambi i notebook eseguiti con jupyter nbconvert --execute.
- bdap-lea: 23+21 colonne, readiness ready, 24813->23321 righe
- dipendenti-pubblici: 23+10 colonne, readiness ready, 40376->6 righe