### PR TITLE
chore(post-merge): aggiorna registry per PR #343

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-16",
+  "generated_at": "2026-05-18",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -46,16 +46,16 @@
     },
     {
       "id": "bdap-lea",
-      "source_id": "",
+      "source_id": "openbdap",
       "status": "ok",
       "label": "bdap-lea",
       "detail": "anno 2024 — fonte: bdap_lea_csv — mart: sì",
       "action": "",
       "sample_run": {
-        "status": "passed",
-        "run_id": "25958889635",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25958889635",
-        "checked_at": "2026-05-16",
+        "status": "failed",
+        "run_id": "26032519569",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26032519569",
+        "checked_at": "2026-05-18",
         "years": [
           2024
         ],
@@ -108,17 +108,32 @@
     },
     {
       "id": "dipendenti-pubblici",
-      "source_id": "",
+      "source_id": "openbdap",
       "status": "ok",
       "label": "dipendenti-pubblici",
       "detail": "anni 2010-2023 — fonte: bdap_csv — mart: sì",
       "action": "",
       "sample_run": {
-        "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2023,
+        "status": "failed",
+        "run_id": "26032519569",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26032519569",
+        "checked_at": "2026-05-18",
+        "years": [
+          2010,
+          2011,
+          2012,
+          2013,
+          2014,
+          2015,
+          2016,
+          2017,
+          2018,
+          2019,
+          2020,
+          2021,
+          2022,
+          2023
+        ],
         "config_path": "candidates/dipendenti-pubblici/dataset.yml"
       }
     },
@@ -447,17 +462,19 @@
     },
     {
       "id": "bdap-anagrafe-enti",
-      "source_id": "",
+      "source_id": "openbdap",
       "status": "ok",
       "label": "bdap-anagrafe-enti",
       "detail": "anni: ? — fonte: ? — mart: sì",
       "action": "",
       "sample_run": {
-        "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "status": "failed",
+        "run_id": "26032519569",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26032519569",
+        "checked_at": "2026-05-18",
+        "years": [
+          2024
+        ],
         "config_path": "support_datasets/bdap-anagrafe-enti/dataset.yml"
       }
     },


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #343 — chore: batch openbdap - source_id + notebook helpers

Changed candidate/support roots:

- `bdap-lea` (candidate, `candidates/bdap-lea`)
- `dipendenti-pubblici` (candidate, `candidates/dipendenti-pubblici`)
- `bdap-anagrafe-enti` (support_dataset, `support_datasets/bdap-anagrafe-enti`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [ ] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/bdap-lea/dataset.yml` -> artifact `sample-run-bdap-lea`
- `candidates/dipendenti-pubblici/dataset.yml` -> artifact `sample-run-dipendenti-pubblici`
- `support_datasets/bdap-anagrafe-enti/dataset.yml` -> artifact `sample-run-bdap-anagrafe-enti`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug bdap_lea --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug dipendenti_pubblici --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug bdap_anagrafe_enti --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
