### PR TITLE
chore(post-merge): aggiorna registry per PR #345

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
-  "updated_at": "2026-05-16",
+  "updated_at": "2026-05-18",
   "source_repo": "dataciviclab/dataset-incubator",
   "datasets": [
     {
@@ -459,7 +459,8 @@
         "multi_file": false
       },
       "registry_source": "push_archive_auto",
-      "stage": "published"
+      "stage": "published",
+      "source_id": "giustizia_statistiche"
     },
     {
       "slug": "consip_consumi_convenzione",
@@ -769,7 +770,8 @@
         "multi_file": false
       },
       "registry_source": "push_archive_auto",
-      "stage": "incubating"
+      "stage": "incubating",
+      "source_id": "giustizia_statistiche"
     },
     {
       "slug": "inps_pensioni_trimestrale",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-16",
+  "generated_at": "2026-05-18",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -46,7 +46,7 @@
     },
     {
       "id": "bdap-lea",
-      "source_id": "",
+      "source_id": "openbdap",
       "status": "ok",
       "label": "bdap-lea",
       "detail": "anno 2024 — fonte: bdap_lea_csv — mart: sì",
@@ -80,11 +80,21 @@
     },
     {
       "id": "civile-flussi",
-      "source_id": "",
+      "source_id": "giustizia_statistiche",
       "status": "ok",
       "label": "civile-flussi",
       "detail": "anno 2025 — fonte: ministero_giustizia_xlsx — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "26036106012",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26036106012",
+        "checked_at": "2026-05-18",
+        "years": [
+          2025
+        ],
+        "config_path": "candidates/civile-flussi/dataset.yml"
+      }
     },
     {
       "id": "consip-consumi-convenzione",
@@ -108,7 +118,7 @@
     },
     {
       "id": "dipendenti-pubblici",
-      "source_id": "",
+      "source_id": "openbdap",
       "status": "ok",
       "label": "dipendenti-pubblici",
       "detail": "anni 2010-2023 — fonte: bdap_csv — mart: sì",
@@ -124,17 +134,19 @@
     },
     {
       "id": "giustizia-penale-indicatori",
-      "source_id": "",
+      "source_id": "giustizia_statistiche",
       "status": "ok",
       "label": "giustizia-penale-indicatori",
       "detail": "anno 2024 — fonte: tribunali_xlsx — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25691344640",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25691344640",
-        "checked_at": "2026-05-11",
-        "year": 2024,
+        "run_id": "26036106012",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26036106012",
+        "checked_at": "2026-05-18",
+        "years": [
+          2024
+        ],
         "config_path": "candidates/giustizia-penale-indicatori/dataset.yml"
       }
     },
@@ -447,7 +459,7 @@
     },
     {
       "id": "bdap-anagrafe-enti",
-      "source_id": "",
+      "source_id": "openbdap",
       "status": "ok",
       "label": "bdap-anagrafe-enti",
       "detail": "anni: ? — fonte: ? — mart: sì",


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #345 — chore: batch giustizia - source_id + notebook helpers

Changed candidate/support roots:

- `civile-flussi` (candidate, `candidates/civile-flussi`)
- `giustizia-penale-indicatori` (candidate, `candidates/giustizia-penale-indicatori`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/civile-flussi/dataset.yml` -> artifact `sample-run-civile-flussi`
- `candidates/giustizia-penale-indicatori/dataset.yml` -> artifact `sample-run-giustizia-penale-indicatori`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug civile_flussi --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug giustizia_penale_indicatori --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
