### PR TITLE
chore(post-merge): aggiorna registry per PR #339

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -4,9 +4,9 @@
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 31,
+    "total": 32,
     "by_status": {
-      "ok": 31,
+      "ok": 32,
       "warn": 0,
       "error": 0
     }
@@ -201,29 +201,17 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
+        "run_id": "26036720971",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26036720971",
+        "checked_at": "2026-05-18",
         "years": [
+          2020,
+          2021,
+          2022,
+          2023,
           2024
         ],
-        "configs": [
-          {
-            "status": "passed",
-            "year": 2024,
-            "config_path": "candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml"
-          },
-          {
-            "status": "passed",
-            "year": 2024,
-            "config_path": "candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/dataset.yml"
-          },
-          {
-            "status": "passed",
-            "year": 2024,
-            "config_path": "candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/dataset.yml"
-          }
-        ]
+        "config_path": "candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml"
       }
     },
     {
@@ -527,6 +515,40 @@
           2025
         ],
         "config_path": "support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml"
+      }
+    },
+    {
+      "id": "compose:ispra-ru-costi-kg",
+      "source_id": "",
+      "status": "ok",
+      "label": "compose:ispra-ru-costi-kg",
+      "detail": "anni 2020-2024 — fonti: a, b — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "25509412527",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
+        "checked_at": "2026-05-07",
+        "years": [
+          2024
+        ],
+        "configs": [
+          {
+            "status": "passed",
+            "year": 2024,
+            "config_path": "candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml"
+          },
+          {
+            "status": "passed",
+            "year": 2024,
+            "config_path": "candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/dataset.yml"
+          },
+          {
+            "status": "passed",
+            "year": 2024,
+            "config_path": "candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/dataset.yml"
+          }
+        ]
       }
     }
   ]


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #339 — feat: compose/ come root di prima classe + ispra-ru-costi-kg rifattorizzato

Changed candidate/support roots:

- `ispra-ru-costi-kg` (candidate, `candidates/ispra-ru-costi-kg`)
- `ispra-ru-costi-kg` (compose, `compose/ispra-ru-costi-kg`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [ ] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml` -> artifact `sample-run-ispra-ru-costi-kg-a_ru_base`
- `candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/dataset.yml` -> artifact `sample-run-ispra-ru-costi-kg-b_kg_per_abitante`
- `candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/dataset.yml` -> artifact `sample-run-ispra-ru-costi-kg-c_costo_per_abitante`
- `compose/ispra-ru-costi-kg/dataset.yml` -> artifact `sample-run-ispra-ru-costi-kg`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug ispra-ru-costi-kg_a_ru_base --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug ispra-ru-costi-kg_b_kg_per_abitante --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug ispra-ru-costi-kg_c_costo_per_abitante --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug ispra_ru_costi_kg_compose --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
