### PR TITLE
chore(post-merge): aggiorna registry per PR #348

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -1955,11 +1955,11 @@
       "slug": "istat_ipab_aree",
       "name": "Istat Ipab Aree",
       "description": "ISTAT — Indice dei prezzi delle abitazioni (IPAB) trimestrale: prezzi per tipo di abitazione (nuove costruzioni, esistenti) e area geografica, base 2015=100, serie 2015-2025.",
-      "source": "ISTAT \u2014 Dataflow 33_292 (IPAB trimestrale), SDMX-CSV",
+      "source": "ISTAT — Dataflow 33_292 (IPAB trimestrale), SDMX-CSV",
       "source_id": "istat_sdmx",
       "period": {
-        "start": 2024,
-        "end": 2024
+        "start": 2010,
+        "end": 2025
       },
       "columns": [
         {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -1954,9 +1954,9 @@
     {
       "slug": "istat_ipab_aree",
       "name": "Istat Ipab Aree",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "description": "ISTAT — Indice dei prezzi delle abitazioni (IPAB) trimestrale: prezzi per tipo di abitazione (nuove costruzioni, esistenti) e area geografica, base 2015=100, serie 2015-2025.",
+      "source": "ISTAT \u2014 Dataflow 33_292 (IPAB trimestrale), SDMX-CSV",
+      "source_id": "istat_sdmx",
       "period": {
         "start": 2024,
         "end": 2024
@@ -1965,44 +1965,44 @@
         {
           "name": "area_codice",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Codice area geografica (IT=nazionale, ITC=Nord-ovest, ITD=Sud, ecc.)"
         },
         {
           "name": "area",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Denominazione area geografica"
         },
         {
           "name": "livello_geografico",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Livello geografico (Nazionale, Ripartizione geografica)"
         },
         {
           "name": "tipo_abitazione",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Codice tipo abitazione (NEW_DW=nuove costruzioni, EXST_DW=esistenti)"
         },
         {
           "name": "tipo_abitazione_label",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Etichetta tipo abitazione"
         },
         {
           "name": "trimestre",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Trimestre di riferimento (YYYY-QQ)"
         },
         {
           "name": "indice_prezzi",
           "type": "DOUBLE",
-          "role": "",
-          "description": ""
+          "role": "metric",
+          "description": "Indice dei prezzi delle abitazioni (base 2015=100)"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -1954,7 +1954,7 @@
     {
       "slug": "istat_ipab_aree",
       "name": "Istat Ipab Aree",
-      "description": "ISTAT — Indice dei prezzi delle abitazioni (IPAB) trimestrale: prezzi per tipo di abitazione (nuove costruzioni, esistenti) e area geografica, base 2015=100, serie 2015-2025.",
+      "description": "ISTAT — Indice dei prezzi delle abitazioni (IPAB) trimestrale: prezzi per tipo di abitazione (nuove costruzioni, esistenti) e area geografica, base 2015=100, serie 2010-2025.",
       "source": "ISTAT — Dataflow 33_292 (IPAB trimestrale), SDMX-CSV",
       "source_id": "istat_sdmx",
       "period": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
-  "updated_at": "2026-05-18",
+  "updated_at": "2026-05-19",
   "source_repo": "dataciviclab/dataset-incubator",
   "datasets": [
     {
@@ -1950,6 +1950,68 @@
       },
       "source_id": "istat_sdmx",
       "stage": "incubating"
+    },
+    {
+      "slug": "istat_ipab_aree",
+      "name": "Istat Ipab Aree",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2024,
+        "end": 2024
+      },
+      "columns": [
+        {
+          "name": "area_codice",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "area",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "livello_geografico",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "tipo_abitazione",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "tipo_abitazione_label",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "trimestre",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "indice_prezzi",
+          "type": "DOUBLE",
+          "role": "",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/istat_ipab_aree/2024/istat_ipab_aree_2024_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "push_archive_auto"
     },
     {
       "slug": "mef_irpef_regionale",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-18",
+  "generated_at": "2026-05-19",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -216,49 +216,55 @@
     },
     {
       "id": "istat-gini-regionale",
-      "source_id": "",
+      "source_id": "istat_sdmx",
       "status": "ok",
       "label": "istat-gini-regionale",
       "detail": "anno 2023 — fonte: istat_sdmx_gini — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2023,
+        "run_id": "26088201871",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26088201871",
+        "checked_at": "2026-05-19",
+        "years": [
+          2023
+        ],
         "config_path": "candidates/istat-gini-regionale/dataset.yml"
       }
     },
     {
       "id": "istat-housing-crowding",
-      "source_id": "",
+      "source_id": "istat_sdmx",
       "status": "ok",
       "label": "istat-housing-crowding",
       "detail": "anno 2024 — fonte: istat_sdmx_housing_crowding — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "run_id": "26088201871",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26088201871",
+        "checked_at": "2026-05-19",
+        "years": [
+          2024
+        ],
         "config_path": "candidates/istat-housing-crowding/dataset.yml"
       }
     },
     {
       "id": "istat-ipab-aree",
-      "source_id": "",
+      "source_id": "istat_sdmx",
       "status": "ok",
       "label": "istat-ipab-aree",
       "detail": "anno 2024 — fonte: istat_sdmx_ipab_aree — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "run_id": "26088201871",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26088201871",
+        "checked_at": "2026-05-19",
+        "years": [
+          2024
+        ],
         "config_path": "candidates/istat-ipab-aree/dataset.yml"
       }
     },
@@ -495,16 +501,16 @@
     },
     {
       "id": "popolazione-istat-comunale-2019-2025",
-      "source_id": "",
+      "source_id": "istat_sdmx",
       "status": "ok",
       "label": "popolazione-istat-comunale-2019-2025",
       "detail": "anni: ? — fonte: ? — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25870731832",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25870731832",
-        "checked_at": "2026-05-14",
+        "run_id": "26088201871",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26088201871",
+        "checked_at": "2026-05-19",
         "years": [
           2019,
           2020,
@@ -526,29 +532,17 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
+        "run_id": "26036720971",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26036720971",
+        "checked_at": "2026-05-18",
         "years": [
+          2020,
+          2021,
+          2022,
+          2023,
           2024
         ],
-        "configs": [
-          {
-            "status": "passed",
-            "year": 2024,
-            "config_path": "candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml"
-          },
-          {
-            "status": "passed",
-            "year": 2024,
-            "config_path": "candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/dataset.yml"
-          },
-          {
-            "status": "passed",
-            "year": 2024,
-            "config_path": "candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/dataset.yml"
-          }
-        ]
+        "config_path": "candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml"
       }
     }
   ]


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #348 — chore: batch istat - source_id

Changed candidate/support roots:

- `istat-gini-regionale` (candidate, `candidates/istat-gini-regionale`)
- `istat-housing-crowding` (candidate, `candidates/istat-housing-crowding`)
- `istat-ipab-aree` (candidate, `candidates/istat-ipab-aree`)
- `popolazione-istat-comunale-2019-2025` (support_dataset, `support_datasets/popolazione-istat-comunale-2019-2025`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/istat-gini-regionale/dataset.yml` -> artifact `sample-run-istat-gini-regionale`
- `candidates/istat-housing-crowding/dataset.yml` -> artifact `sample-run-istat-housing-crowding`
- `candidates/istat-ipab-aree/dataset.yml` -> artifact `sample-run-istat-ipab-aree`
- `support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml` -> artifact `sample-run-popolazione-istat-comunale-2019-2025`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug istat_gini_regionale --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug istat_housing_crowding --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug istat_ipab_aree --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug popolazione_istat_comunale_2019_2025 --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
