### PR TITLE
chore(post-merge): aggiorna registry per PR #350

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -178,17 +178,19 @@
     },
     {
       "id": "ispra-consumo-suolo",
-      "source_id": "",
+      "source_id": "ispra_linked_data",
       "status": "ok",
       "label": "ispra-consumo-suolo",
       "detail": "anno 2024 — fonte: ispra_consumo_suolo_xlsx — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "run_id": "26091030726",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26091030726",
+        "checked_at": "2026-05-19",
+        "years": [
+          2024
+        ],
         "config_path": "candidates/ispra-consumo-suolo/dataset.yml"
       }
     },
@@ -201,9 +203,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "26036720971",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26036720971",
-        "checked_at": "2026-05-18",
+        "run_id": "26091030726",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26091030726",
+        "checked_at": "2026-05-19",
         "years": [
           2020,
           2021,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #350 — chore: batch ispra - source_id

Changed candidate/support roots:

- `ispra-consumo-suolo` (candidate, `candidates/ispra-consumo-suolo`)
- `ispra-ru-costi-kg` (candidate, `candidates/ispra-ru-costi-kg`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [ ] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/ispra-consumo-suolo/dataset.yml` -> artifact `sample-run-ispra-consumo-suolo`
- `candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml` -> artifact `sample-run-ispra-ru-costi-kg-a_ru_base`
- `candidates/ispra-ru-costi-kg/sources/b_kg_per_abitante/dataset.yml` -> artifact `sample-run-ispra-ru-costi-kg-b_kg_per_abitante`
- `candidates/ispra-ru-costi-kg/sources/c_costo_per_abitante/dataset.yml` -> artifact `sample-run-ispra-ru-costi-kg-c_costo_per_abitante`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug ispra_consumo_suolo --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug ispra-ru-costi-kg_a_ru_base --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug ispra-ru-costi-kg_b_kg_per_abitante --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug ispra-ru-costi-kg_c_costo_per_abitante --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
