### PR TITLE
chore(post-merge): aggiorna registry per PR #352

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2971,7 +2971,8 @@
         "multi_file": false
       },
       "registry_source": "push_archive_auto",
-      "stage": "incubating"
+      "stage": "incubating",
+      "source_id": "mit_opendata"
     },
     {
       "slug": "mit_opere_incompiute_2020",
@@ -3128,7 +3129,8 @@
         "multi_file": false
       },
       "registry_source": "push_archive_auto",
-      "stage": "incubating"
+      "stage": "incubating",
+      "source_id": "mit_opendata"
     },
     {
       "slug": "mur_contribuzione_universitaria",
@@ -3513,9 +3515,9 @@
     {
       "slug": "terna_electricity_by_source",
       "name": "Terna Electricity By Source",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "description": "Terna - Produzione di energia elettrica per fonte, regione e provincia (GWh): dati mensili per tipo di produzione (termoelettrico, idroelettrico, fotovoltaico, eolico, geotermico) anni 2023-2024.",
+      "source": "Terna S.p.A. - dati.terna.it",
+      "source_id": "terna_opendata",
       "period": {
         "start": 2023,
         "end": 2024
@@ -3524,38 +3526,38 @@
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di riferimento"
         },
         {
           "name": "tipo_produzione",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Macrotipo di produzione (Termoelettrico, Idroelettrico, Fotovoltaico, Eolico, Geotermico)"
         },
         {
           "name": "regione",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Regione"
         },
         {
           "name": "provincia",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Provincia"
         },
         {
           "name": "fonte",
           "type": "VARCHAR",
-          "role": "",
-          "description": ""
+          "role": "dimension",
+          "description": "Fonte energetica specifica"
         },
         {
           "name": "produzione_gwh",
           "type": "DOUBLE",
-          "role": "",
-          "description": ""
+          "role": "metric",
+          "description": "Produzione di energia elettrica in GWh"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3509,6 +3509,62 @@
       "registry_source": "push_archive_auto",
       "stage": "published",
       "source_id": "terna"
+    },
+    {
+      "slug": "terna_electricity_by_source",
+      "name": "Terna Electricity By Source",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2023,
+        "end": 2024
+      },
+      "columns": [
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "tipo_produzione",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "regione",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "provincia",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "fonte",
+          "type": "VARCHAR",
+          "role": "",
+          "description": ""
+        },
+        {
+          "name": "produzione_gwh",
+          "type": "DOUBLE",
+          "role": "",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/terna_electricity_by_source/*/terna_electricity_by_source_*_clean.parquet",
+        "multi_file": true
+      },
+      "stage": "published",
+      "registry_source": "push_archive_auto"
     }
   ]
 }

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -333,33 +333,37 @@
     },
     {
       "id": "mit-incidentalita-mensile-2001-2018",
-      "source_id": "",
+      "source_id": "mit_opendata",
       "status": "ok",
       "label": "mit-incidentalita-mensile-2001-2018",
       "detail": "anno 2001 — fonte: mit_incidentalita_mensile_csv — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2001,
+        "run_id": "26091471735",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26091471735",
+        "checked_at": "2026-05-19",
+        "years": [
+          2001
+        ],
         "config_path": "candidates/mit-incidentalita-mensile-2001-2018/dataset.yml"
       }
     },
     {
       "id": "mit-opere-incompiute-2020",
-      "source_id": "",
+      "source_id": "mit_opendata",
       "status": "ok",
       "label": "mit-opere-incompiute-2020",
       "detail": "anno 2020 — fonte: mit_opere_incompiute_csv — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2020,
+        "run_id": "26091471735",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26091471735",
+        "checked_at": "2026-05-19",
+        "years": [
+          2020
+        ],
         "config_path": "candidates/mit-opere-incompiute-2020/dataset.yml"
       }
     },
@@ -423,33 +427,39 @@
     },
     {
       "id": "terna-capacita-rinnovabile",
-      "source_id": "terna",
+      "source_id": "terna_opendata",
       "status": "ok",
       "label": "terna-capacita-rinnovabile",
       "detail": "anni 2023-2024 — fonte: terna_capacity_renewable_sources_xlsx — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "run_id": "26091471735",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26091471735",
+        "checked_at": "2026-05-19",
+        "years": [
+          2023,
+          2024
+        ],
         "config_path": "candidates/terna-capacita-rinnovabile/dataset.yml"
       }
     },
     {
       "id": "terna-electricity-by-source",
-      "source_id": "",
+      "source_id": "terna_opendata",
       "status": "ok",
       "label": "terna-electricity-by-source",
       "detail": "anni 2023-2024 — fonte: terna_electricity_by_source_xlsx — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "run_id": "26091471735",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26091471735",
+        "checked_at": "2026-05-19",
+        "years": [
+          2023,
+          2024
+        ],
         "config_path": "candidates/terna-electricity-by-source/dataset.yml"
       }
     },
@@ -534,9 +544,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "26036720971",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26036720971",
-        "checked_at": "2026-05-18",
+        "run_id": "26091030726",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26091030726",
+        "checked_at": "2026-05-19",
         "years": [
           2020,
           2021,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #352 — chore: batch mit + terna - source_id

Changed candidate/support roots:

- `mit-incidentalita-mensile-2001-2018` (candidate, `candidates/mit-incidentalita-mensile-2001-2018`)
- `mit-opere-incompiute-2020` (candidate, `candidates/mit-opere-incompiute-2020`)
- `terna-capacita-rinnovabile` (candidate, `candidates/terna-capacita-rinnovabile`)
- `terna-electricity-by-source` (candidate, `candidates/terna-electricity-by-source`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/mit-incidentalita-mensile-2001-2018/dataset.yml` -> artifact `sample-run-mit-incidentalita-mensile-2001-2018`
- `candidates/mit-opere-incompiute-2020/dataset.yml` -> artifact `sample-run-mit-opere-incompiute-2020`
- `candidates/terna-capacita-rinnovabile/dataset.yml` -> artifact `sample-run-terna-capacita-rinnovabile`
- `candidates/terna-electricity-by-source/dataset.yml` -> artifact `sample-run-terna-electricity-by-source`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug mit_incidentalita_mensile --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug mit_opere_incompiute_2020 --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug terna_capacita_rinnovabile --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug terna_electricity_by_source --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
