### PR TITLE
chore(post-merge): aggiorna registry per PR #356

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3413,8 +3413,8 @@
       ],
       "location": {
         "type": "gcs",
-        "path": "gs://dataciviclab-clean/pensioni_pa_dag/*/pensioni_pa_dag_*_clean.parquet",
-        "multi_file": true
+        "path": "gs://dataciviclab-clean/pensioni_pa_dag/2024/pensioni_pa_dag_2024_clean.parquet",
+        "multi_file": false
       },
       "registry_source": "push_archive_auto",
       "source_id": "inps",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -98,16 +98,16 @@
     },
     {
       "id": "consip-consumi-convenzione",
-      "source_id": "",
+      "source_id": "consip_open_data",
       "status": "ok",
       "label": "consip-consumi-convenzione",
       "detail": "anni 2023-2025 — fonti: consip_consumi_convenzione_2023, consip_consumi_convenzione_2024 — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25962931378",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25962931378",
-        "checked_at": "2026-05-16",
+        "run_id": "26107821546",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26107821546",
+        "checked_at": "2026-05-19",
         "years": [
           2023,
           2024,
@@ -429,16 +429,16 @@
     },
     {
       "id": "pensioni-pa-dag",
-      "source_id": "",
+      "source_id": "inps",
       "status": "ok",
       "label": "pensioni-pa-dag",
       "detail": "anno 2024 — fonte: dag_pensioni_totale — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25921989453",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25921989453",
-        "checked_at": "2026-05-15",
+        "run_id": "26107821546",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26107821546",
+        "checked_at": "2026-05-19",
         "years": [
           2024
         ],


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #356 — chore: batch consip + pensioni - source_id

Changed candidate/support roots:

- `consip-consumi-convenzione` (candidate, `candidates/consip-consumi-convenzione`)
- `pensioni-pa-dag` (candidate, `candidates/pensioni-pa-dag`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/consip-consumi-convenzione/dataset.yml` -> artifact `sample-run-consip-consumi-convenzione`
- `candidates/pensioni-pa-dag/dataset.yml` -> artifact `sample-run-pensioni-pa-dag`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug consip_consumi_convenzione --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug pensioni_pa_dag --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
