### PR TITLE
fix: aggiorna riferimento da catalog/themes.json a src/data/themes.json.py

### DIFF
--- a/scripts/create_de_followup_issue.py
+++ b/scripts/create_de_followup_issue.py
@@ -124,7 +124,7 @@ def main() -> int:
 
     # Costruisci lista items
     item_lines = "\n".join(
-        f"- [ ] {i['slug']}: aggiungere a themes.json e creare pagina dataset"
+        f"- [ ] {i['slug']}: aggiungere tema in src/data/themes.json.py (data-explorer) e creare pagina dataset"
         for i in new_items
     )
 
@@ -142,7 +142,7 @@ def main() -> int:
         f"Sono disponibili nel catalogo tecnico ma **mancano di pagina curata e tema**.\n\n"
         f"### Da fare\n\n{item_lines}\n\n"
         f"### Workflow\n\n"
-        f"1. Aggiungere a `catalog/themes.json` (decisione editoriale)\n"
+        f"1. Aggiungere/modificare in `src/data/themes.json.py` in data-explorer (decisione editoriale)\n"
         f"2. Creare pagina dataset in data-explorer con query curate\n\n"
         f"### Riferimenti\n\n"
         f"- PR dataset-incubator #{pr_number}"


### PR DESCRIPTION
## Cosa

Aggiorna `create_de_followup_issue.py` dopo la migrazione Observable di data-explorer (PR #98).

## Perché

`catalog/themes.json` non esiste più come asset statico. I temi editoriali ora vivono in `src/data/themes.json.py` in data-explorer, generati a build time.

Il template issue faceva ancora riferimento al vecchio path `catalog/themes.json` — ora punta al file corretto.

## Modifiche

- `scripts/create_de_followup_issue.py`: riferimenti aggiornati da `catalog/themes.json` a `src/data/themes.json.py` (data-explorer)

## Contratto

Nessun contratto pubblico modificato. L'ADR 2026-05-12 è stato aggiornato localmente per registrare la dismissione del contratto themes.json tra ACB e data-explorer.