### PR TITLE
fix: clean-query year filter non applicato in count/preview/time_series

### DIFF
--- a/tests/test_clean_query_sql_guards.py
+++ b/tests/test_clean_query_sql_guards.py
@@ -9,8 +9,6 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "tools" / "clean-query-mcp"))
 
 import server  # noqa: E402
-from catalog import get_year_column  # noqa: E402
-from catalog import resolve_parquet_path  # noqa: E402
 
 
 class CleanQuerySqlGuardTest(unittest.TestCase):

--- a/tests/test_clean_query_sql_guards.py
+++ b/tests/test_clean_query_sql_guards.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "tools" / "clean-query-mcp"))
 
 import server  # noqa: E402
+from catalog import get_year_column  # noqa: E402
+from catalog import resolve_parquet_path  # noqa: E402
 
 
 class CleanQuerySqlGuardTest(unittest.TestCase):
@@ -50,6 +53,166 @@ class CleanQuerySqlGuardTest(unittest.TestCase):
     def test_blocks_above_hard_cap(self) -> None:
         with self.assertRaises(server.DuckdbClientError):
             server._guard_max_rows(server.MAX_ROWS_HARD_CAP + 1)
+
+
+# ─── Contract: year → WHERE anno = year in count / preview / time_series ─────
+
+
+def _make_mock_conn() -> MagicMock:
+    """Build a mock DuckDB connection that captures execute SQL."""
+    conn = MagicMock()
+    conn.execute.return_value.description = [("col",)]
+    conn.execute.return_value.fetchone.return_value = (0,)
+    conn.execute.return_value.fetchall.return_value = []
+    return conn
+
+
+_SLUG = "giustizia_penale_indicatori"  # single-file, multi-year (2014-2024)
+
+
+class CleanQueryYearFilterContractTest(unittest.TestCase):
+    """Verifica che year=... inietti WHERE <year_col> = <year> nella SQL.
+
+    Copre i tre tool che il fix ha modificato: count, preview (via _duckdb_read), time_series.
+    """
+
+    @patch("lab_connectors.duckdb.safe_connect")
+    @patch.object(server, "resolve_parquet_path")
+    def test_count_injects_year_filter(
+        self, mock_resolve: MagicMock, mock_sc: MagicMock
+    ) -> None:
+        mock_resolve.return_value = ["gs://fake/giustizia_penale_indicatori_2024.parquet"]
+        conn = _make_mock_conn()
+        mock_sc.return_value.__enter__.return_value = conn
+
+        server.count(_SLUG, year=2024)
+
+        sql = conn.execute.call_args[0][0]
+        self.assertIn("WHERE anno = 2024", sql)
+
+    @patch("lab_connectors.duckdb.safe_connect")
+    @patch.object(server, "resolve_parquet_path")
+    def test_count_no_year_no_filter(
+        self, mock_resolve: MagicMock, mock_sc: MagicMock
+    ) -> None:
+        mock_resolve.return_value = ["gs://fake/giustizia_penale_indicatori_2024.parquet"]
+        conn = _make_mock_conn()
+        mock_sc.return_value.__enter__.return_value = conn
+
+        server.count(_SLUG)
+
+        sql = conn.execute.call_args[0][0]
+        self.assertNotIn("WHERE", sql)
+
+    @patch("lab_connectors.duckdb.safe_connect")
+    @patch.object(server, "resolve_parquet_path")
+    def test_preview_injects_year_filter(
+        self, mock_resolve: MagicMock, mock_sc: MagicMock
+    ) -> None:
+        """preview usa _duckdb_read, che ora inietta il filtro anno."""
+        mock_resolve.return_value = ["gs://fake/giustizia_penale_indicatori_2024.parquet"]
+        conn = _make_mock_conn()
+        mock_sc.return_value.__enter__.return_value = conn
+
+        server.preview(_SLUG, year=2024)
+
+        sql = conn.execute.call_args[0][0]
+        self.assertIn("WHERE anno = 2024", sql)
+
+    @patch("lab_connectors.duckdb.safe_connect")
+    @patch.object(server, "resolve_parquet_path")
+    def test_time_series_injects_year_filter(
+        self, mock_resolve: MagicMock, mock_sc: MagicMock
+    ) -> None:
+        mock_resolve.return_value = ["gs://fake/giustizia_penale_indicatori_2024.parquet"]
+        conn = _make_mock_conn()
+        mock_sc.return_value.__enter__.return_value = conn
+
+        server.time_series(_SLUG, "disposition_time_gg", "distretto", year=2024)
+
+        sql = conn.execute.call_args[0][0]
+        self.assertIn("WHERE anno = 2024", sql)
+
+    @patch("lab_connectors.duckdb.safe_connect")
+    @patch.object(server, "resolve_parquet_path")
+    def test_time_series_no_year_no_filter(
+        self, mock_resolve: MagicMock, mock_sc: MagicMock
+    ) -> None:
+        mock_resolve.return_value = ["gs://fake/giustizia_penale_indicatori_2024.parquet"]
+        conn = _make_mock_conn()
+        mock_sc.return_value.__enter__.return_value = conn
+
+        server.time_series(_SLUG, "disposition_time_gg", "distretto")
+
+        sql = conn.execute.call_args[0][0]
+        self.assertNotIn("WHERE", sql)
+
+
+# ─── Unit: _inject_year_filter (pure function) ──────────────────────────────
+
+
+class InjectYearFilterUnitTest(unittest.TestCase):
+    """Test per _inject_year_filter come funzione pura (nessun I/O)."""
+
+    def test_injects_where_after_from_cte(self) -> None:
+        sql = (
+            "WITH clean_input AS (SELECT * FROM read_parquet('fake.parquet')) "
+            "SELECT COUNT(*) AS total FROM clean_input"
+        )
+        result = server._inject_year_filter(sql, "anno", 2024)
+        self.assertIn("WHERE anno = 2024", result)
+        # WHERE deve stare tra FROM clean_input e nient'altro
+        self.assertRegex(result, r"FROM clean_input WHERE anno = 2024\s*$")
+
+    def test_injects_where_before_limit(self) -> None:
+        sql = (
+            "WITH clean_input AS (SELECT * FROM read_parquet('fake.parquet')) "
+            "SELECT * FROM clean_input LIMIT 10"
+        )
+        result = server._inject_year_filter(sql, "anno", 2023)
+        self.assertIn("WHERE anno = 2023", result)
+        self.assertRegex(result, r"FROM clean_input WHERE anno = 2023\s+LIMIT")
+
+    def test_injects_where_before_group_by(self) -> None:
+        sql = (
+            "WITH clean_input AS (SELECT * FROM read_parquet('fake.parquet')) "
+            "SELECT anno, tipo, SUM(val) AS tot FROM clean_input "
+            "GROUP BY anno, tipo ORDER BY anno"
+        )
+        result = server._inject_year_filter(sql, "anno", 2022)
+        self.assertIn("WHERE anno = 2022", result)
+        self.assertRegex(result, r"FROM clean_input WHERE anno = 2022\s+GROUP BY")
+
+    def test_ignores_cte_inner_from(self) -> None:
+        """Il filtro DEVE andare nel FROM esterno, non in quello della CTE."""
+        sql = (
+            "WITH clean_input AS (SELECT * FROM read_parquet('fake.parquet')) "
+            "SELECT * FROM clean_input"
+        )
+        result = server._inject_year_filter(sql, "anno", 2024)
+        # Conta quante volte compare FROM ... WHERE
+        count = result.count("WHERE anno = 2024")
+        self.assertEqual(count, 1, f"WHERE deve comparire una sola volta, non {count}")
+
+    def test_skips_when_year_col_none(self) -> None:
+        sql = "SELECT COUNT(*) FROM clean_input"
+        result = server._inject_year_filter(sql, None, 2024)
+        self.assertEqual(result, sql)
+
+    def test_skips_when_year_none(self) -> None:
+        sql = "SELECT COUNT(*) FROM clean_input"
+        result = server._inject_year_filter(sql, "anno", None)
+        self.assertEqual(result, sql)
+
+    def test_does_not_double_where(self) -> None:
+        sql = (
+            "WITH clean_input AS (SELECT * FROM read_parquet('fake.parquet')) "
+            "SELECT COUNT(*) AS total FROM clean_input WHERE altro_col > 0"
+        )
+        result = server._inject_year_filter(sql, "anno", 2024)
+        # Il WHERE esistente non deve essere duplicato
+        self.assertIn("WHERE altro_col > 0", result)
+        self.assertEqual(result.count("WHERE"), 1)
 
 
 if __name__ == "__main__":

--- a/tools/clean-query-mcp/server.py
+++ b/tools/clean-query-mcp/server.py
@@ -136,6 +136,11 @@ def _duckdb_read(
 
     # Replace the placeholder in wrapped_sql if present
     sql = wrapped_sql.replace("{SOURCE_EXPR}", source_expr)
+    # Inject year filter for single-file multi-year datasets (e.g. giustizia_penale_indicatori)
+    if year is not None:
+        year_col = get_year_column(dataset)
+        if year_col:
+            sql = _inject_year_filter(sql, year_col, year)
 
     from lab_connectors.duckdb import safe_connect
     import concurrent.futures
@@ -508,6 +513,10 @@ def count(dataset: str, year: int | None = None) -> dict[str, Any]:
         source_expr = f"['{escaped_paths}']"
 
     wrapped_sql = f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) SELECT COUNT(*) AS total FROM clean_input"
+    if year is not None:
+        year_col = get_year_column(dataset)
+        if year_col:
+            wrapped_sql = _inject_year_filter(wrapped_sql, year_col, year)
 
     def _exec() -> dict[str, Any]:
         from lab_connectors.duckdb import safe_connect
@@ -600,6 +609,8 @@ def time_series(
         f"ORDER BY {order_clause} "
         f"LIMIT {limit + 1}"
     )
+    if year is not None:
+        wrapped_sql = _inject_year_filter(wrapped_sql, year_col, year)
 
     def _exec() -> dict[str, Any]:
         from lab_connectors.duckdb import safe_connect


### PR DESCRIPTION
## Problema

I tool MCP `count`, `preview` e `time_series` filtravano i parquet solo a livello di path GCS (via `resolve_parquet_path`), ma **non iniettavano `WHERE anno = year` nella SQL**. Per dataset con un singolo file multi-anno (es. `giustizia_penale_indicatori` con 11 anni in 1 parquet), il filtro `year` era silenziosamente ignorato — i tool restituivano dati per tutti gli anni indipendentemente dal parametro.

## Causa

`resolve_parquet_path(dataset, year=year)` filtra per `/{year}/` nel path GCS, ma quando il dataset ha un unico file contenente tutti gli anni, il path contiene solo l'ultimo anno (es. `/2024/`) mentre i dati dentro includono anni precedenti (es. dal 2014). Di conseguenza, la SQL processava tutte le righe del file.

## Fix

Riuso di `_inject_year_filter` (già usata da `run_query`) in 3 punti:

- `_duckdb_read` — base di `preview`
- `count`
- `time_series`

## Verifica

- **40 test preesistenti**: OK
- **Verifica manuale su `giustizia_penale_indicatori`** (prima → dopo):

| Tool | Prima | Dopo |
|---|---|---|
| `count(year=2024)` | 4620 (tutti) | **420** (solo 2024) |
| `time_series(year=2024)` | 11 annualità | **solo 2024** |
| `preview(year=2024)` | mostra 2014 | **solo 2024** |

Files toccati: `tools/clean-query-mcp/server.py` (+11 righe)