### PR TITLE
feat(build_clean_catalog): flag --derive da GCS (P2)

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -238,7 +238,6 @@ jobs:
                           "clean",
                           "--slug",
                           push_slug,
-                          "--update-catalog",
                           "--no-bq",
                       ],
                       cwd=root,
@@ -249,7 +248,7 @@ jobs:
           # --- Build clean catalog (solo se GCP Auth riuscito) ---
           if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
               print(f"\n  Rebuilding clean catalog...")
-              subprocess.run(["python", "scripts/build_clean_catalog.py", "--write"], cwd=root)
+              subprocess.run(["python", "scripts/build_clean_catalog.py", "--derive", "--write"], cwd=root)
               subprocess.run(["python", "scripts/build_clean_catalog.py", "--check-gcs"], cwd=root)
 
           if failed_configs:

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -248,8 +248,8 @@ jobs:
           # --- Build clean catalog (solo se GCP Auth riuscito) ---
           if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
               print(f"\n  Rebuilding clean catalog...")
-              subprocess.run(["python", "scripts/build_clean_catalog.py", "--derive", "--write"], cwd=root)
-              subprocess.run(["python", "scripts/build_clean_catalog.py", "--check-gcs"], cwd=root)
+              subprocess.run(["python", "scripts/build_clean_catalog.py", "--derive", "--write"], cwd=root, check=True)
+              subprocess.run(["python", "scripts/build_clean_catalog.py", "--check-gcs"], cwd=root, check=True)
 
           if failed_configs:
               print("\nFAIL: one or more configs failed in post-merge full run:")

--- a/scripts/build_clean_catalog.py
+++ b/scripts/build_clean_catalog.py
@@ -213,10 +213,10 @@ def derive_catalog_from_gcs(
 
     # 2. Filtra slug con pipeline_run.json (gate: solo da pipeline)
     piped_slug_years: dict[str, set[str]] = {}
-    for slug, years in slug_index.items():
-        for y in years:
+    for slug, slug_years in slug_index.items():
+        for y in slug_years:
             if object_exists(bucket, f"{slug}/{y}/pipeline_run.json"):
-                piped_slug_years[slug] = years
+                piped_slug_years[slug] = slug_years
                 break
     skipped = len(slug_index) - len(piped_slug_years)
     if skipped:

--- a/scripts/build_clean_catalog.py
+++ b/scripts/build_clean_catalog.py
@@ -10,16 +10,26 @@ from pathlib import Path
 from typing import Any
 
 from lab_connectors.gcs import list_objects, object_exists
+from lab_connectors.gcs.paths import gs_url
 
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CATALOG = ROOT / "registry" / "clean_catalog.json"
 DEFAULT_SCHEMA = ROOT / "registry" / "clean_catalog.schema.json"
 
+_PARQUET_TYPE_MAP = {
+    "int8": "INTEGER", "int16": "INTEGER", "int32": "INTEGER", "int64": "INTEGER",
+    "uint8": "INTEGER", "uint16": "INTEGER", "uint32": "INTEGER", "uint64": "INTEGER",
+    "float": "DOUBLE", "double": "DOUBLE", "float32": "DOUBLE", "float64": "DOUBLE",
+    "bool": "BOOLEAN", "boolean": "BOOLEAN",
+    "date32[day]": "DATE", "date64[us]": "TIMESTAMP",
+    "timestamp[us]": "TIMESTAMP", "timestamp[ms]": "TIMESTAMP",
+}
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Normalize and optionally verify the Lab Clean Registry."
+        description="Normalize, derive, and optionally verify the Lab Clean Registry."
     )
     parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
     parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
@@ -32,14 +42,34 @@ def main() -> int:
         help="Set updated_at to today's date when writing.",
     )
     parser.add_argument(
+        "--derive",
+        action="store_true",
+        help="Derive catalog from GCS: scan bucket, read parquet schemas, merge with editorial metadata. "
+        "Usa --write per salvare (--derive senza --write è dry-run).",
+    )
+    parser.add_argument(
         "--check-gcs",
         action="store_true",
         help="Verify that public GCS paths resolve to at least one parquet.",
     )
     args = parser.parse_args()
 
-    original_text = args.catalog.read_text(encoding="utf-8")
-    catalog = json.loads(original_text)
+    # Il catalogo di partenza: vuoto se --derive, altrimenti da file
+    if args.derive:
+        raw: dict[str, Any] = {"datasets": []}
+        # Carica editorial metadata dal catalogo esistente (se presente)
+        if args.catalog.exists():
+            try:
+                existing = json.loads(args.catalog.read_text(encoding="utf-8"))
+                raw = existing
+                print(f"[derive] Caricati metadata editoriali da {args.catalog}", file=sys.stderr)
+            except Exception:
+                print(f"[derive] WARN: cannot read {args.catalog}, starting fresh", file=sys.stderr)
+        catalog = derive_catalog_from_gcs(raw, args.refresh_date)
+    else:
+        original_text = args.catalog.read_text(encoding="utf-8")
+        catalog = json.loads(original_text)
+
     schema = json.loads(args.schema.read_text(encoding="utf-8"))
     normalized = normalize_catalog(catalog, refresh_date=args.refresh_date)
 
@@ -138,6 +168,157 @@ def _enrich_source_ids(catalog: dict[str, Any], root: Path) -> None:
 
     if updated:
         print(f"[enrich] source_id aggiunto a {updated} dataset da dataset.yml")
+
+
+def derive_catalog_from_gcs(
+    existing: dict[str, Any], refresh_date: bool = False
+) -> dict[str, Any]:
+    """Deriva il catalogo scansionando GCS e leggendo schemi parquet.
+
+    1. Scansiona ``gs://dataciviclab-clean/`` per scoprire slug + anni
+    2. Per ogni slug, legge lo schema del parquet più recente
+    3. Costruisce location usando il path contract
+    4. Fonde con metadata editoriali dal catalogo esistente
+    5. Ritorna il catalogo completo
+    """
+    import duckdb
+
+    from lab_connectors.gcs.paths import https_url as _https
+
+    errors: list[str] = []
+    slug_index: dict[str, set[str]] = {}
+    bucket = "dataciviclab-clean"
+
+    print(f"[derive] Scansione GCS bucket {bucket}...", file=sys.stderr)
+
+    # 1. Scansiona bucket per scoprire slug + anni
+    try:
+        objects = list_objects(bucket, auth=False)
+    except Exception as exc:
+        print(f"[derive] ERRORE: impossibile leggere GCS: {exc}", file=sys.stderr)
+        return existing
+
+    for obj in objects:
+        name: str = obj["name"]
+        parts = name.split("/")
+        if len(parts) == 3 and parts[2].endswith("_clean.parquet"):
+            slug, year = parts[0], parts[1]
+            slug_index.setdefault(slug, set()).add(year)
+
+    if not slug_index:
+        print(f"[derive] Nessun parquet pulito trovato in {bucket}", file=sys.stderr)
+        return existing
+
+    print(f"[derive] Trovati {len(slug_index)} slug su GCS", file=sys.stderr)
+
+    # 2. Filtra slug con pipeline_run.json (gate: solo da pipeline)
+    piped_slug_years: dict[str, set[str]] = {}
+    for slug, years in slug_index.items():
+        for y in years:
+            if object_exists(bucket, f"{slug}/{y}/pipeline_run.json"):
+                piped_slug_years[slug] = years
+                break
+    skipped = len(slug_index) - len(piped_slug_years)
+    if skipped:
+        print(f"[derive] Esclusi {skipped} slug senza pipeline_run.json", file=sys.stderr)
+
+    if not piped_slug_years:
+        print(f"[derive] Nessun slug con pipeline_run.json in {bucket}", file=sys.stderr)
+        return existing
+
+    # 3. Costruisci indice editoriali per merge
+    editorial = {}
+    for ds in existing.get("datasets", []):
+        editorial[ds["slug"]] = ds
+
+    # 4. Per ogni slug, deriva entry
+    datasets: list[dict[str, Any]] = []
+    for slug in sorted(piped_slug_years):
+        years = sorted(piped_slug_years[slug])
+        if not years:
+            continue
+
+        multi_file = len(years) > 1
+        gcs_path = (
+            gs_url("clean", "clean_parquet", slug=slug, year="*")
+            if multi_file
+            else gs_url("clean", "clean_parquet", slug=slug, year=years[0])
+        )
+
+        # Leggi schema dal parquet più recente su GCS (via DuckDB read_parquet)
+        columns: list[dict[str, str]] = []
+        latest_year = years[-1]
+        parquet_url = _https("clean", "clean_parquet", slug=slug, year=latest_year)
+        try:
+            with duckdb.connect() as con:
+                rows = con.sql(f"DESCRIBE SELECT * FROM read_parquet('{parquet_url}')").fetchall()
+            for row in rows:
+                col_name = row[0]
+                raw_type = str(row[1]).lower()
+                # Mappa tipo parquet generico
+                if "int" in raw_type:
+                    bq_type = "INTEGER"
+                elif "float" in raw_type or "double" in raw_type:
+                    bq_type = "DOUBLE"
+                elif "decimal" in raw_type:
+                    bq_type = "DOUBLE"
+                elif "date" in raw_type or "timestamp" in raw_type:
+                    bq_type = "DATE" if "date" in raw_type else "TIMESTAMP"
+                elif "bool" in raw_type:
+                    bq_type = "BOOLEAN"
+                else:
+                    bq_type = "VARCHAR"
+                role = "dimension" if bq_type == "VARCHAR" else "metric"
+                columns.append({"name": col_name, "type": bq_type, "role": role, "description": ""})
+        except Exception as exc:
+            errors.append(f"{slug}: cannot read schema from {parquet_url}: {exc}")
+            continue
+
+        # Entry derivata
+        entry: dict[str, Any] = {
+            "slug": slug,
+            "name": slug.replace("_", " ").title(),
+            "description": "",
+            "source": "",
+            "source_id": "",
+            "period": {"start": int(years[0]), "end": int(years[-1])},
+            "columns": columns,
+            "location": {"type": "gcs", "path": gcs_path, "multi_file": multi_file},
+            "stage": "published",
+            "registry_source": "derive_auto",
+        }
+
+        # Merge con editoriali: preserva campi umani
+        old = editorial.get(slug)
+        if old:
+            for field in ("name", "description", "source", "source_id", "stage"):
+                if old.get(field):
+                    entry[field] = old[field]
+            # Se lo slug esisteva già con source_id, preservalo
+            if old.get("source_id"):
+                entry["source_id"] = old["source_id"]
+
+        datasets.append(entry)
+
+    if errors:
+        for err in errors:
+            print(f"[derive] ERROR: {err}", file=sys.stderr)
+
+    # 4. Assembla catalogo
+    catalog: dict[str, Any] = {
+        "schema_version": 1,
+        "name": "Lab Clean Registry",
+        "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
+        "source_repo": "dataciviclab/dataset-incubator",
+        "updated_at": str(date.today()),
+        "datasets": sorted(datasets, key=lambda d: d["slug"]),
+    }
+
+    nuovi = sum(1 for d in datasets if d["slug"] not in editorial)
+    agg = sum(1 for d in datasets if d["slug"] in editorial)
+    print(f"[derive] Catalogo: {len(datasets)} dataset ({nuovi} nuovi, {agg} aggiornati)", file=sys.stderr)
+
+    return catalog
 
 
 def validate_catalog(catalog: dict[str, Any], schema: dict[str, Any]) -> list[str]:

--- a/scripts/build_clean_catalog.py
+++ b/scripts/build_clean_catalog.py
@@ -57,23 +57,23 @@ def main() -> int:
     # Il catalogo di partenza: vuoto se --derive, altrimenti da file
     if args.derive:
         raw: dict[str, Any] = {"datasets": []}
-        # Carica editorial metadata dal catalogo esistente (se presente)
         if args.catalog.exists():
             try:
-                existing = json.loads(args.catalog.read_text(encoding="utf-8"))
-                raw = existing
+                raw = json.loads(args.catalog.read_text(encoding="utf-8"))
                 print(f"[derive] Caricati metadata editoriali da {args.catalog}", file=sys.stderr)
             except Exception:
                 print(f"[derive] WARN: cannot read {args.catalog}, starting fresh", file=sys.stderr)
-        catalog = derive_catalog_from_gcs(raw, args.refresh_date)
+        catalog, derive_errors = derive_catalog_from_gcs(raw, args.refresh_date)
     else:
         original_text = args.catalog.read_text(encoding="utf-8")
         catalog = json.loads(original_text)
+        derive_errors = []
 
     schema = json.loads(args.schema.read_text(encoding="utf-8"))
     normalized = normalize_catalog(catalog, refresh_date=args.refresh_date)
 
     errors = validate_catalog(normalized, schema)
+    errors.extend(derive_errors)
     if args.check_gcs:
         errors.extend(validate_gcs_locations(normalized))
 
@@ -86,6 +86,11 @@ def main() -> int:
     if args.write:
         args.catalog.write_text(output_text, encoding="utf-8")
         print(f"wrote {args.catalog}")
+        return 0
+
+    # Dry-run: --derive senza --write
+    if args.derive:
+        print(f"ok (dry-run, {len(normalized['datasets'])} datasets)")
         return 0
 
     if output_text != original_text:
@@ -172,14 +177,19 @@ def _enrich_source_ids(catalog: dict[str, Any], root: Path) -> None:
 
 def derive_catalog_from_gcs(
     existing: dict[str, Any], refresh_date: bool = False
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], list[str]]:
     """Deriva il catalogo scansionando GCS e leggendo schemi parquet.
 
     1. Scansiona ``gs://dataciviclab-clean/`` per scoprire slug + anni
     2. Per ogni slug, legge lo schema del parquet più recente
     3. Costruisce location usando il path contract
     4. Fonde con metadata editoriali dal catalogo esistente
-    5. Ritorna il catalogo completo
+    5. Ritorna (catalogo, errori)
+
+    Gli errori di lettura schema fanno fallire lo script: meglio catalogo
+    bloccante che parziale.
+    Returns:
+        Tuple (catalogo_dict, lista_errori).
     """
     import duckdb
 
@@ -196,7 +206,7 @@ def derive_catalog_from_gcs(
         objects = list_objects(bucket, auth=False)
     except Exception as exc:
         print(f"[derive] ERRORE: impossibile leggere GCS: {exc}", file=sys.stderr)
-        return existing
+        return existing, [f"GCS unreachable: {exc}"]
 
     for obj in objects:
         name: str = obj["name"]
@@ -207,7 +217,7 @@ def derive_catalog_from_gcs(
 
     if not slug_index:
         print(f"[derive] Nessun parquet pulito trovato in {bucket}", file=sys.stderr)
-        return existing
+        return existing, []
 
     print(f"[derive] Trovati {len(slug_index)} slug su GCS", file=sys.stderr)
 
@@ -224,7 +234,7 @@ def derive_catalog_from_gcs(
 
     if not piped_slug_years:
         print(f"[derive] Nessun slug con pipeline_run.json in {bucket}", file=sys.stderr)
-        return existing
+        return existing, []
 
     # 3. Costruisci indice editoriali per merge
     editorial = {}
@@ -300,10 +310,6 @@ def derive_catalog_from_gcs(
 
         datasets.append(entry)
 
-    if errors:
-        for err in errors:
-            print(f"[derive] ERROR: {err}", file=sys.stderr)
-
     # 4. Assembla catalogo
     catalog: dict[str, Any] = {
         "schema_version": 1,
@@ -317,8 +323,11 @@ def derive_catalog_from_gcs(
     nuovi = sum(1 for d in datasets if d["slug"] not in editorial)
     agg = sum(1 for d in datasets if d["slug"] in editorial)
     print(f"[derive] Catalogo: {len(datasets)} dataset ({nuovi} nuovi, {agg} aggiornati)", file=sys.stderr)
+    if errors:
+        for e in errors:
+            print(f"[derive] ERROR: {e}", file=sys.stderr)
 
-    return catalog
+    return catalog, errors
 
 
 def validate_catalog(catalog: dict[str, Any], schema: dict[str, Any]) -> list[str]:

--- a/tests/test_build_clean_catalog_derive.py
+++ b/tests/test_build_clean_catalog_derive.py
@@ -1,0 +1,195 @@
+"""Tests per build_clean_catalog.py --derive.
+
+Mocka list_objects, object_exists e DuckDB per testare la
+logica di derivazione senza dipendere da GCS reale.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+FAKE_PARQUET_OBJECTS = [
+    {"name": "test_slug_a/2023/test_slug_a_2023_clean.parquet"},
+    {"name": "test_slug_a/2024/test_slug_a_2024_clean.parquet"},
+    {"name": "test_slug_b/2024/test_slug_b_2024_clean.parquet"},
+    {"name": "test_slug_c/2024/test_slug_c_2024_clean.parquet"},  # no pipeline_run
+]
+
+def fake_list_objects(bucket, **kw):
+    return FAKE_PARQUET_OBJECTS
+
+def fake_object_exists(bucket, key):
+    # Solo test_slug_a e test_slug_b hanno pipeline_run.json
+    if "pipeline_run" in key:
+        return key.startswith("test_slug_a/") or key.startswith("test_slug_b/")
+    return True  # per i parquet, esistono tutti
+
+# DuckDB mock che ritorna schema prevedibile
+MOCK_DESCRIBE_ROWS = [
+    ("anno", "INTEGER", "YES", None, None, None),
+    ("nome", "VARCHAR", "YES", None, None, None),
+    ("valore", "DOUBLE", "YES", None, None, None),
+]
+
+
+class FakeDuckDBConnection:
+    def sql(self, query):
+        return self
+    def fetchall(self):
+        return MOCK_DESCRIBE_ROWS
+    def close(self):
+        pass
+    def __enter__(self):
+        return self
+    def __exit__(self, *args):
+        pass
+
+
+class TestBuildCleanCatalogDerive(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.maxDiff = None
+        # Usa un catalogo editoriale fittizio per testare il merge
+        self.existing_catalog = {
+            "schema_version": 1,
+            "updated_at": "2026-01-01",
+            "datasets": [
+                {
+                    "slug": "test_slug_a",
+                    "name": "Nome Umano",
+                    "description": "Descrizione esistente",
+                    "source": "Fonte Manuale",
+                    "source_id": "manual-id",
+                    "period": {"start": 2023, "end": 2024},
+                    "columns": [],
+                    "location": {"type": "gcs", "path": "gs://bucket/test_slug_a/*/test_slug_a_*_clean.parquet", "multi_file": True},
+                    "stage": "published",
+                    "registry_source": "manual",
+                }
+            ],
+        }
+        self.tmpdir = Path("/tmp/test_build_clean_catalog_derive")
+
+    def _run_derive(self, args: list[str], expect_zero: bool = True) -> int:
+        """Helper: esegui build_clean_catalog.py --derive con mock."""
+        # The function is in __main__ context, call main() directly
+        # Actually we need to mock at module level before import
+        # Better: call derive_catalog_from_gcs directly
+        pass
+
+    # ── Test derive_catalog_from_gcs ────────────────────────────────────────
+
+    @patch("duckdb.connect")
+    @patch("scripts.build_clean_catalog.list_objects", side_effect=fake_list_objects)
+    @patch("scripts.build_clean_catalog.object_exists", side_effect=fake_object_exists)
+    def test_derive_filters_without_pipeline_run(self, mock_exists, mock_list, mock_connect):
+        """Slug senza pipeline_run.json devono essere esclusi."""
+        mock_connect.return_value = FakeDuckDBConnection()
+
+        from scripts.build_clean_catalog import derive_catalog_from_gcs
+
+        catalog, errors = derive_catalog_from_gcs({"datasets": []}, refresh_date=False)
+
+        slugs = [d["slug"] for d in catalog["datasets"]]
+        self.assertIn("test_slug_a", slugs)
+        self.assertIn("test_slug_b", slugs)
+        self.assertNotIn("test_slug_c", slugs)  # no pipeline_run
+        self.assertEqual(errors, [])
+
+    @patch("duckdb.connect")
+    @patch("scripts.build_clean_catalog.list_objects", side_effect=fake_list_objects)
+    @patch("scripts.build_clean_catalog.object_exists", side_effect=fake_object_exists)
+    def test_derive_merges_editorial_metadata(self, mock_exists, mock_list, mock_connect):
+        """Name, description, source, stage devono venire dal catalogo esistente."""
+        mock_connect.return_value = FakeDuckDBConnection()
+
+        from scripts.build_clean_catalog import derive_catalog_from_gcs
+
+        catalog, _ = derive_catalog_from_gcs(self.existing_catalog, refresh_date=False)
+        ds = {d["slug"]: d for d in catalog["datasets"]}
+
+        # test_slug_a esiste → preserva name, description, source, source_id, stage
+        a = ds["test_slug_a"]
+        self.assertEqual(a["name"], "Nome Umano")
+        self.assertEqual(a["description"], "Descrizione esistente")
+        self.assertEqual(a["source"], "Fonte Manuale")
+        self.assertEqual(a["source_id"], "manual-id")
+        self.assertEqual(a["stage"], "published")
+
+        # test_slug_b è nuovo → defaults
+        b = ds["test_slug_b"]
+        self.assertEqual(b["name"], "Test Slug B")  # title()
+        self.assertEqual(b["stage"], "published")
+
+    @patch("duckdb.connect")
+    @patch("scripts.build_clean_catalog.list_objects", side_effect=fake_list_objects)
+    @patch("scripts.build_clean_catalog.object_exists", side_effect=fake_object_exists)
+    def test_derive_preserves_columns(self, mock_exists, mock_list, mock_connect):
+        """Le colonne devono essere derivate dal parquet."""
+        mock_connect.return_value = FakeDuckDBConnection()
+
+        from scripts.build_clean_catalog import derive_catalog_from_gcs
+
+        catalog, _ = derive_catalog_from_gcs({"datasets": []}, refresh_date=False)
+        a = catalog["datasets"][0]
+        col_names = [c["name"] for c in a["columns"]]
+        self.assertEqual(col_names, ["anno", "nome", "valore"])
+
+    @patch("duckdb.connect")
+    @patch("scripts.build_clean_catalog.list_objects", side_effect=fake_list_objects)
+    @patch("scripts.build_clean_catalog.object_exists", side_effect=fake_object_exists)
+    def test_derive_multi_file_vs_single(self, mock_exists, mock_list, mock_connect):
+        """Multi-file se ha più anni, single se un anno solo."""
+        mock_connect.return_value = FakeDuckDBConnection()
+
+        from scripts.build_clean_catalog import derive_catalog_from_gcs
+
+        catalog, _ = derive_catalog_from_gcs({"datasets": []}, refresh_date=False)
+        ds = {d["slug"]: d for d in catalog["datasets"]}
+        self.assertTrue(ds["test_slug_a"]["location"]["multi_file"])  # 2 years
+        self.assertFalse(ds["test_slug_b"]["location"]["multi_file"])  # 1 year
+
+    @patch("duckdb.connect")
+    @patch("scripts.build_clean_catalog.list_objects", side_effect=fake_list_objects)
+    @patch("scripts.build_clean_catalog.object_exists", side_effect=fake_object_exists)
+    def test_derive_schema_error_returns_errors(self, mock_exists, mock_list, mock_connect):
+        """Se DuckDB fallisce, l'errore deve essere ritornato."""
+        mock_conn = MagicMock()
+        mock_conn.sql.side_effect = Exception("DuckDB exploded")
+        mock_conn.__enter__.return_value = mock_conn  # context manager → stesso oggetto
+        mock_connect.return_value = mock_conn
+
+        from scripts.build_clean_catalog import derive_catalog_from_gcs
+
+        catalog, errors = derive_catalog_from_gcs({"datasets": []}, refresh_date=False)
+        self.assertEqual(len(catalog["datasets"]), 0)  # tutti falliti
+        self.assertGreater(len(errors), 0)
+        self.assertIn("DuckDB exploded", errors[0])
+
+    # ── Test CLI dry-run (--derive senza --write) ───────────────────────────
+
+    @patch("duckdb.connect")
+    @patch("scripts.build_clean_catalog.list_objects", side_effect=fake_list_objects)
+    @patch("scripts.build_clean_catalog.object_exists", side_effect=fake_object_exists)
+    def test_main_derive_dry_run_exits_zero(self, mock_exists, mock_list, mock_connect):
+        """--derive senza --write non deve crashare."""
+        mock_connect.return_value = FakeDuckDBConnection()
+
+        from scripts.build_clean_catalog import main
+        import sys
+
+        test_args = ["--derive", "--catalog", str(self.tmpdir / "catalog.json")]
+        with patch.object(sys, "argv", ["build_clean_catalog.py"] + test_args):
+            rc = main()
+            self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/clean-query-mcp/requirements.txt
+++ b/tools/clean-query-mcp/requirements.txt
@@ -1,3 +1,3 @@
 mcp>=1.26.0
 duckdb==1.5.1
-git+https://github.com/dataciviclab/lab-connectors.git@v0.8.0
+git+https://github.com/dataciviclab/lab-connectors.git@v0.9.0


### PR DESCRIPTION
## P2 — Catalogo derivato dalla pipeline

**Problema**: `clean_catalog.json` veniva aggiornato manualmente via `push_archive.py --update-catalog` per ogni singolo slug. Il catalogo e la pipeline erano scollegati: se dimenticavi `--update-catalog`, il catalogo non rifletteva la realtà.

**Soluzione**: nuovo flag `--derive` in `build_clean_catalog.py` che deriva il catalogo dai dati effettivamente su GCS.

### Come funziona `--derive`

```bash
python scripts/build_clean_catalog.py --derive --write
```

1. **Scansiona** `gs://dataciviclab-clean/` via `list_objects` → scopre tutti gli slug presenti
2. **Filtra** per `pipeline_run.json` (gate: solo dataset passati dalla pipeline)
3. **Legge schema** del parquet più recente per ogni slug (via DuckDB `DESCRIBE SELECT * FROM read_parquet(...)`)
4. **Costruisce location** usando `gs_url("clean", "clean_parquet", ...)` dal contratto P1
5. **Fonde** con metadata editoriali dal catalogo esistente (preserva name, description, source, stage)
6. **Output**: catalogo allineato alla realtà di GCS

### Cosa cambia nel workflow CI

Prima (per ogni config in `post-merge-candidate.yml`):
```yaml
push_archive.py --slug X --update-catalog --no-bq   # aggiornava per-slug
build_clean_catalog.py --write                        # normalizzava
```

Dopo:
```yaml
push_archive.py --slug X --no-bq                      # solo push, no catalog
build_clean_catalog.py --derive --write               # deriva tutto da GCS
```

`--update-catalog` in `push_archive.py` esiste ancora per uso manuale ma non serve più in CI.

### Test locale

- `ruff check`: ✅
- `python build_clean_catalog.py --derive --write` → **31 dataset** (filtrati 40→31: 9 slug orfani senza `pipeline_run.json`)
- Validazione catalogo: ✅ ok
