### PR TITLE
test + infra: copertura test, marker pytest, coverage gate, lab-connectors v0.10.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ on:
       - ".github/workflows/**"
       - "scripts/**"
       - "tools/**"
+      - "tests/**"
       - "pyproject.toml"
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,4 +40,4 @@ jobs:
         run: mypy scripts/ tools/
 
       - name: Pytest
-        run: python -m pytest tests/ -q --tb=line --cov=scripts --cov=tools/clean-query-mcp --cov-report=term --cov-fail-under=30
+        run: python -m pytest tests/ -q --tb=line --cov=scripts --cov=tools/clean-query-mcp --cov-report=term --cov-fail-under=50

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install ruff mypy types-pyyaml types-requests pytest
+          pip install ruff mypy types-pyyaml types-requests pytest pytest-cov
           pip install git+https://github.com/dataciviclab/toolkit.git@${{ env.TOOLKIT_VERSION }}
           pip install -r tools/clean-query-mcp/requirements.txt 2>/dev/null || true
 
@@ -39,4 +39,4 @@ jobs:
         run: mypy scripts/ tools/
 
       - name: Pytest
-        run: python -m pytest tests/ -q --tb=line
+        run: python -m pytest tests/ -q --tb=line --cov=scripts --cov=tools/clean-query-mcp --cov-report=term --cov-fail-under=30

--- a/.github/workflows/validate-clean-catalog.yml
+++ b/.github/workflows/validate-clean-catalog.yml
@@ -33,7 +33,9 @@ jobs:
           python-version: "3.11"
 
       - name: Install clean-query MCP dependencies
-        run: python -m pip install -r tools/clean-query-mcp/requirements.txt
+        run: |
+          python -m pip install -r tools/clean-query-mcp/requirements.txt
+          python -m pip install pytest  # per test marker @pytest.mark.*
 
       - name: Validate catalog and public GCS paths
         run: python scripts/build_clean_catalog.py --check-gcs
@@ -42,4 +44,4 @@ jobs:
         run: python tools/clean-query-mcp/scripts/smoke.py
 
       - name: Run clean-query tests
-        run: python -m unittest discover -s tests -p "test_clean_query_*.py"
+        run: python -m pytest tests/test_clean_query_catalog.py tests/test_clean_query_sql_guards.py -q --tb=line

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ venv/
 # OS / editor noise
 .DS_Store
 Thumbs.db
+.coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,14 @@
 testpaths = "tests"
 filterwarnings = ["ignore::DeprecationWarning"]
 addopts = "-q --tb=line"
+markers = [
+    "contract: interfaccia pubblica, artifact format, contratto API, path contract, output CI",
+    "policy: regola Lab non ovvia o comportamento cross-component",
+    "regression: bug fix documentato in issue/PR",
+    "adapter: adapter a servizio esterno (GCS, BigQuery, HTTP)",
+    "pure_unit: logica pura non banale, zero side effect",
+    "smoke: test che fa chiamate reali (richiede connettivita')",
+]
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,172 @@
+"""
+Fixture condivise per i test di dataset-incubator.
+
+Aggiunge scripts/ e tools/clean-query-mcp/ al path di default,
+così nessun test deve ripetere sys.path.insert().
+"""
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Path setup — una volta sola
+_SCRIPTS_PATH = str(_REPO_ROOT / "scripts")
+_TOOLS_PATH = str(_REPO_ROOT / "tools" / "clean-query-mcp")
+
+if _SCRIPTS_PATH not in sys.path:
+    sys.path.insert(0, _SCRIPTS_PATH)
+if _TOOLS_PATH not in sys.path:
+    sys.path.insert(0, _TOOLS_PATH)
+# Aggiunge anche ROOT per import via `scripts.xxx` (es. test_build_clean_catalog_derive)
+_ROOT_PATH = str(_REPO_ROOT)
+if _ROOT_PATH not in sys.path:
+    sys.path.insert(0, _ROOT_PATH)
+
+
+@pytest.fixture
+def patch_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Imposta ROOT a tmp_path per moduli che usano ROOT per path relativi."""
+    # Patches validate_candidate_structure.ROOT
+    monkeypatch.setattr("validate_candidate_structure.ROOT", tmp_path)
+    monkeypatch.setattr("build_pipeline_signals.ROOT", tmp_path)
+    monkeypatch.setattr("resolve_sample_run.ROOT", tmp_path)
+    monkeypatch.setattr("detect_candidates.ROOT", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def scripts_dir() -> Path:
+    """Percorso assoluto a scripts/."""
+    return _REPO_ROOT / "scripts"
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    """Crea una directory temporanea che simula ROOT con candidates/ vuoto."""
+    root = tmp_path / "dataset-incubator"
+    (root / "candidates").mkdir(parents=True)
+    (root / "registry").mkdir(parents=True)
+    return root
+
+
+def _make_yml(path: Path, content: dict[str, Any]) -> None:
+    """Scrive un dataset.yml nella directory indicata."""
+    import yaml
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.dump(content, f, default_flow_style=False)
+
+
+@pytest.fixture
+def single_source_candidate(tmp_path: Path) -> Path:
+    """Crea un candidate single-source in tmp_path/candidates/ok-ds."""
+    base = tmp_path / "candidates" / "ok-ds"
+    sql_dir = base / "sql"
+    sql_dir.mkdir(parents=True)
+
+    # clean.sql
+    (sql_dir / "clean.sql").write_text("SELECT 1", encoding="utf-8")
+
+    # mart.sql
+    (sql_dir / "mart.sql").write_text("SELECT * FROM clean", encoding="utf-8")
+
+    # dataset.yml
+    _make_yml(base / "dataset.yml", {
+        "dataset": {
+            "name": "OK Dataset",
+            "years": [2020, 2021, 2022],
+            "source_id": "test-source-id",
+        },
+        "raw": {
+            "sources": [{"name": "Fonte Test", "url": "https://example.com"}],
+        },
+    })
+
+    return base
+
+
+@pytest.fixture
+def single_source_no_mart(tmp_path: Path) -> Path:
+    """Candidate single-source senza mart SQL — stato warn."""
+    base = tmp_path / "candidates" / "no-mart-ds"
+    sql_dir = base / "sql"
+    sql_dir.mkdir(parents=True)
+
+    (sql_dir / "clean.sql").write_text("SELECT 1", encoding="utf-8")
+
+    _make_yml(base / "dataset.yml", {
+        "dataset": {"name": "No Mart", "years": [2021]},
+        "raw": {"sources": [{"name": "Fonte"}]},
+    })
+
+    return base
+
+
+@pytest.fixture
+def single_source_broken(tmp_path: Path) -> Path:
+    """Candidate single-source senza dataset.yml — stato error."""
+    base = tmp_path / "candidates" / "broken-ds"
+    base.mkdir(parents=True)
+    # Nessun dataset.yml, nessun sql/
+    return base
+
+
+@pytest.fixture
+def multi_source_candidate(tmp_path: Path) -> Path:
+    """Candidate multi-source con due fonti + compose layer."""
+    base = tmp_path / "candidates" / "multi-ds"
+    sources_dir = base / "sources"
+    compose_dir = base / "compose"
+
+    # Fonte A
+    src_a = sources_dir / "fonte-a"
+    (src_a / "sql").mkdir(parents=True)
+    (src_a / "sql" / "clean.sql").write_text("SELECT 1", encoding="utf-8")
+    _make_yml(src_a / "dataset.yml", {
+        "dataset": {"name": "Fonte A", "years": [2020]},
+        "raw": {"sources": [{"name": "Fonte A Data"}]},
+    })
+
+    # Fonte B
+    src_b = sources_dir / "fonte-b"
+    (src_b / "sql").mkdir(parents=True)
+    (src_b / "sql" / "clean.sql").write_text("SELECT 2", encoding="utf-8")
+    _make_yml(src_b / "dataset.yml", {
+        "dataset": {"name": "Fonte B", "years": [2021]},
+        "raw": {"sources": [{"name": "Fonte B Data"}]},
+    })
+
+    # Compose layer con mart
+    (compose_dir / "sql").mkdir(parents=True)
+    (compose_dir / "sql" / "mart.sql").write_text("SELECT * FROM clean", encoding="utf-8")
+
+    return base
+
+
+@pytest.fixture
+def compose_candidate(tmp_path: Path) -> Path:
+    """Candidate compose (mart-only, no raw/clean)."""
+    base = tmp_path / "compose" / "agg-ds"
+    sql_dir = base / "sql"
+    sql_dir.mkdir(parents=True)
+    (sql_dir / "mart.sql").write_text("SELECT * FROM clean", encoding="utf-8")
+
+    _make_yml(base / "dataset.yml", {
+        "dataset": {"name": "Aggregato", "years": [2020, 2021]},
+        "support": [{"name": "Dataset Base"}],
+    })
+
+    return base
+
+
+@pytest.fixture
+def support_dataset(tmp_path: Path) -> Path:
+    """Support dataset (in support_datasets/)."""
+    base = tmp_path / "support_datasets" / "support-ds"
+    sql_dir = base / "sql"
+    sql_dir.mkdir(parents=True)
+    (sql_dir / "clean.sql").write_text("SELECT 1", encoding="utf-8")
+    return base

--- a/tests/test_build_clean_catalog_derive.py
+++ b/tests/test_build_clean_catalog_derive.py
@@ -1,7 +1,10 @@
 """Tests per build_clean_catalog.py --derive.
 
-Mocka list_objects, object_exists e DuckDB per testare la
-logica di derivazione senza dipendere da GCS reale.
+Contratto: derive_catalog_from_gcs() produce un catalogo valido a partire
+dai parquet su GCS. Mocka list_objects, object_exists e DuckDB.
+
+Prova del fuoco: se cancello questi test, un refactor della logica di
+derivazione puo' produrre cataloghi con slug mancanti o colonne errate.
 """
 
 from __future__ import annotations
@@ -9,6 +12,8 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
+
+import pytest
 
 # ---------------------------------------------------------------------------
 # Mock helpers
@@ -51,6 +56,7 @@ class FakeDuckDBConnection:
         pass
 
 
+@pytest.mark.contract
 class TestBuildCleanCatalogDerive(unittest.TestCase):
     maxDiff = None
 

--- a/tests/test_build_pipeline_signals.py
+++ b/tests/test_build_pipeline_signals.py
@@ -1,0 +1,329 @@
+"""
+Test per build_pipeline_signals.py — contratto pipeline_signals.json per ACB.
+
+Contratto: build_signals() produce un file JSON con schema validato
+che agent-context-builder consuma come segnale di stato pipeline.
+  _inspect_*    — ispeziona directory candidate e produce dict strutturato
+  _build_signal — combina layout + ispezione in un entry per signals[]
+  load_previous_sample_runs — legge stato precedente dal JSON esistente
+
+Prova del fuoco: se cancello questi test, un refactor di build_pipeline_signals
+può rompere il formato pipeline_signals.json che ACB si aspetta.
+"""
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _write_yaml(path, data):
+    import yaml
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False)
+
+
+def _single_source(base: Path, name="ds", years=None, sources=None, mart=True):
+    d = base / name
+    (d / "sql").mkdir(parents=True)
+    (d / "sql" / "clean.sql").write_text("SELECT 1")
+    if mart:
+        (d / "sql" / "mart.sql").write_text("SELECT * FROM clean")
+    _write_yaml(d / "dataset.yml", {
+        "dataset": {"name": name, "years": years or [2020]},
+        "raw": {"sources": sources or [{"name": "Fonte"}]},
+    })
+    return d
+
+
+class TestYearsLabel:
+    @pytest.mark.pure_unit
+    @pytest.mark.parametrize("years,expected", [
+        ([2023], "anno 2023"),
+        ([2020, 2021, 2022], "anni 2020-2022"),
+        ([], "anni: ?"),
+        ([2022, 2020, 2021], "anni 2020-2022"),
+    ])
+    def test(self, years, expected):
+        from build_pipeline_signals import _years_label
+        assert _years_label(years) == expected
+
+
+class TestSourceNames:
+    @pytest.mark.pure_unit
+    @pytest.mark.parametrize("sources,expected", [
+        ([{"name": "A"}, {"name": "B"}], ["A", "B"]),
+        ([{"name": "OK"}, "string", 42], ["OK"]),
+        ([{"url": "http://x"}], ["?"]),
+        ([], []),
+    ])
+    def test(self, sources, expected):
+        from build_pipeline_signals import _source_names
+        assert _source_names(sources) == expected
+
+
+class TestInspectSingleSource:
+    @pytest.mark.contract
+    def test_ok(self, tmp_path):
+        from build_pipeline_signals import _inspect_single_source
+        base = _single_source(tmp_path, "ok")
+        result = _inspect_single_source(base)
+        assert result["pattern"] == "single-source"
+        assert result["mart_ok"] is True
+        assert result["failures"] == []
+
+    @pytest.mark.contract
+    def test_missing_dataset_yml(self, tmp_path):
+        from build_pipeline_signals import _inspect_single_source
+        base = tmp_path / "missing-yml"
+        (base / "sql").mkdir(parents=True)
+        (base / "sql" / "clean.sql").write_text("SELECT 1")
+        result = _inspect_single_source(base)
+        assert "missing dataset.yml" in result["failures"]
+
+    @pytest.mark.contract
+    def test_missing_sql_dir(self, tmp_path):
+        from build_pipeline_signals import _inspect_single_source
+        base = tmp_path / "missing-sql"
+        base.mkdir(parents=True)
+        _write_yaml(base / "dataset.yml", {"dataset": {"name": "x"}})
+        result = _inspect_single_source(base)
+        assert "missing sql/" in result["failures"]
+
+    @pytest.mark.contract
+    def test_missing_clean_sql(self, tmp_path):
+        from build_pipeline_signals import _inspect_single_source
+        base = tmp_path / "missing-clean"
+        (base / "sql").mkdir(parents=True)
+        _write_yaml(base / "dataset.yml", {"dataset": {"name": "x"}})
+        result = _inspect_single_source(base)
+        assert "missing sql/clean.sql" in result["failures"]
+
+    @pytest.mark.policy
+    def test_no_mart_is_not_failure(self, tmp_path):
+        """Senza mart → warn, non failure."""
+        from build_pipeline_signals import _inspect_single_source
+        base = _single_source(tmp_path, "no-mart", mart=False)
+        result = _inspect_single_source(base)
+        assert result["mart_ok"] is False
+        assert result["failures"] == []
+
+
+class TestInspectMultiSource:
+    @pytest.mark.contract
+    def test_two_sources(self, tmp_path):
+        from build_pipeline_signals import _inspect_multi_source
+        base = tmp_path / "multi"
+        _single_source(base / "sources", "a", years=[2020])
+        _single_source(base / "sources", "b", years=[2021], sources=[{"name": "F B"}])
+        result = _inspect_multi_source(base)
+        assert result["pattern"] == "multi-source"
+        assert sorted(result["years"]) == [2020, 2021]
+
+    @pytest.mark.contract
+    def test_compose_layer_makes_mart_ok(self, tmp_path):
+        from build_pipeline_signals import _inspect_multi_source
+        base = tmp_path / "multi-compose"
+        _single_source(base / "sources", "a", years=[2020], mart=False)
+        (base / "compose" / "sql").mkdir(parents=True)
+        (base / "compose" / "sql" / "mart.sql").write_text("SELECT *")
+        result = _inspect_multi_source(base)
+        assert result["mart_ok"] is True
+
+    @pytest.mark.policy
+    def test_compose_without_mart_reports_warning(self, tmp_path):
+        from build_pipeline_signals import _inspect_multi_source
+        base = tmp_path / "multi-compose-nomart"
+        _single_source(base / "sources", "a", years=[2020], mart=False)
+        (base / "compose" / "sql").mkdir(parents=True)
+        result = _inspect_multi_source(base)
+        assert "present but missing mart SQL" in " ".join(result["failures"])
+
+
+class TestInspectCompose:
+    @pytest.mark.contract
+    def test_ok(self, tmp_path):
+        from build_pipeline_signals import _inspect_compose
+        base = tmp_path / "compose-ok"
+        (base / "sql").mkdir(parents=True)
+        (base / "sql" / "mart.sql").write_text("SELECT *")
+        _write_yaml(base / "dataset.yml", {
+            "dataset": {"name": "C", "years": [2020]},
+            "support": [{"name": "Base"}],
+        })
+        result = _inspect_compose(base)
+        assert result["pattern"] == "compose"
+        assert result["mart_ok"] is True
+        assert result["failures"] == []
+
+    @pytest.mark.contract
+    def test_missing_mart(self, tmp_path):
+        from build_pipeline_signals import _inspect_compose
+        base = tmp_path / "compose-nomart"
+        (base / "sql").mkdir(parents=True)
+        _write_yaml(base / "dataset.yml", {"dataset": {"name": "C"}})
+        result = _inspect_compose(base)
+        assert result["mart_ok"] is False
+        assert any("mart" in f for f in result["failures"])
+
+    @pytest.mark.contract
+    def test_missing_yml(self, tmp_path):
+        from build_pipeline_signals import _inspect_compose
+        base = tmp_path / "compose-noyml"
+        (base / "sql").mkdir(parents=True)
+        (base / "sql" / "mart.sql").write_text("SELECT *")
+        result = _inspect_compose(base)
+        assert "missing dataset.yml" in result["failures"]
+
+
+class TestLoadPreviousSampleRuns:
+    _SAMPLE_RUN = {"status": "passed", "run_id": "1", "run_url": "u",
+                    "checked_at": "2026-01-01", "year": 2023}
+
+    @pytest.mark.contract
+    def test_loads(self, tmp_path):
+        from build_pipeline_signals import load_previous_sample_runs
+        p = tmp_path / "sig.json"
+        p.write_text(json.dumps({"signals": [
+            {"id": "ds1", "sample_run": self._SAMPLE_RUN},
+            {"id": "ds2", "sample_run": {**self._SAMPLE_RUN, "year": 2024}},
+        ]}))
+        r = load_previous_sample_runs(p)
+        assert "ds1" in r and "ds2" in r
+
+    @pytest.mark.policy
+    def test_skips_without_sample_run(self, tmp_path):
+        from build_pipeline_signals import load_previous_sample_runs
+        p = tmp_path / "sig.json"
+        p.write_text(json.dumps({"signals": [
+            {"id": "ds1", "sample_run": self._SAMPLE_RUN},
+            {"id": "ds2"},
+        ]}))
+        r = load_previous_sample_runs(p)
+        assert "ds1" in r and "ds2" not in r
+
+    @pytest.mark.contract
+    def test_skips_non_dict(self, tmp_path):
+        from build_pipeline_signals import load_previous_sample_runs
+        p = tmp_path / "sig.json"
+        p.write_text(json.dumps({"signals": ["s", 42]}))
+        assert load_previous_sample_runs(p) == {}
+
+    @pytest.mark.contract
+    def test_missing_file(self, tmp_path):
+        from build_pipeline_signals import load_previous_sample_runs
+        assert load_previous_sample_runs(tmp_path / "nope.json") == {}
+
+    @pytest.mark.contract
+    def test_invalid_json(self, tmp_path):
+        from build_pipeline_signals import load_previous_sample_runs
+        (tmp_path / "bad.json").write_text("not json")
+        assert load_previous_sample_runs(tmp_path / "bad.json") == {}
+
+
+class TestBuildSignal:
+    @pytest.mark.contract
+    def test_single_source_ok(self, tmp_path):
+        from build_pipeline_signals import _build_signal
+        base = _single_source(tmp_path, "ok-ds", years=[2020], sources=[{"name": "F", "url": "u"}])
+        _write_yaml(base / "dataset.yml", {
+            "dataset": {"name": "OK", "years": [2020], "source_id": "src-1"},
+            "raw": {"sources": [{"name": "F", "url": "u"}]},
+        })
+        s = _build_signal("ok-ds", base)
+        assert s["id"] == "ok-ds"
+        assert s["source_id"] == "src-1"
+        assert s["status"] == "ok"
+
+    @pytest.mark.contract
+    def test_warn_no_mart(self, tmp_path):
+        from build_pipeline_signals import _build_signal
+        base = _single_source(tmp_path, "warn-ds", mart=False)
+        s = _build_signal("warn-ds", base)
+        assert s["status"] == "warn"
+
+    @pytest.mark.contract
+    def test_ambiguous_layout(self, tmp_path):
+        from build_pipeline_signals import _build_signal
+        base = tmp_path / "ambig"
+        (base / "sql").mkdir(parents=True)
+        (base / "sql" / "clean.sql").write_text("SELECT 1")
+        (base / "sources").mkdir()
+        _write_yaml(base / "dataset.yml", {"dataset": {"name": "Amb"}})
+        s = _build_signal("ambig", base)
+        assert s["status"] == "error"
+
+
+class TestBuildSignals:
+    @pytest.mark.contract
+    def test_builds_from_candidates(self, tmp_path):
+        from build_pipeline_signals import build_signals
+        root = tmp_path / "repo"
+        reg = root / "registry"
+        _single_source(root / "candidates", "ok-ds")
+        _single_source(root / "candidates", "warn-ds", mart=False)
+        out = reg / "pipeline_signals.json"
+        with patch("build_pipeline_signals.ROOT", root):
+            assert build_signals(out) == 0
+        payload = json.loads(out.read_text())
+        assert payload["schema_version"] == "1"
+        assert len(payload["signals"]) == 2
+
+    @pytest.mark.contract
+    def test_includes_support_and_compose(self, tmp_path):
+        from build_pipeline_signals import build_signals
+        root = tmp_path / "repo-full"
+        reg = root / "registry"
+        _single_source(root / "candidates", "ds")
+        _single_source(root / "support_datasets", "sup", mart=False)
+        comp = root / "compose" / "agg"
+        (comp / "sql").mkdir(parents=True)
+        (comp / "sql" / "mart.sql").write_text("SELECT *")
+        _write_yaml(comp / "dataset.yml", {
+            "dataset": {"name": "Agg", "years": [2020]},
+            "support": [{"name": "Base"}],
+        })
+        out = reg / "pipeline_signals.json"
+        with patch("build_pipeline_signals.ROOT", root):
+            assert build_signals(out) == 0
+        ids = [s["id"] for s in json.loads(out.read_text())["signals"]]
+        assert all(x in ids for x in ["ds", "sup", "compose:agg"])
+
+    @pytest.mark.contract
+    def test_preserves_sample_runs(self, tmp_path):
+        from build_pipeline_signals import build_signals
+        root = tmp_path / "repo-sample"
+        reg = root / "registry"
+        reg.mkdir(parents=True)
+        (reg / "pipeline_signals.json").write_text(json.dumps({
+            "signals": [{"id": "ok-ds", "sample_run": {
+                "status": "passed", "run_id": "r1", "run_url": "u",
+                "checked_at": "2026-01-01", "year": 2023,
+            }}],
+        }))
+        _single_source(root / "candidates", "ok-ds")
+        out = reg / "pipeline_signals.json"
+        with patch("build_pipeline_signals.ROOT", root):
+            assert build_signals(out) == 0
+        s = json.loads(out.read_text())["signals"][0]
+        assert s["sample_run"]["run_id"] == "r1"
+
+    @pytest.mark.contract
+    def test_handles_no_candidates_dir(self, tmp_path):
+        from build_pipeline_signals import build_signals
+        root = tmp_path / "empty"
+        out = root / "registry" / "pipeline_signals.json"
+        with patch("build_pipeline_signals.ROOT", root):
+            assert build_signals(out) == 1
+        assert not out.exists()
+
+    @pytest.mark.contract
+    def test_handles_empty_candidates(self, tmp_path):
+        from build_pipeline_signals import build_signals
+        root = tmp_path / "empty-ok"
+        (root / "candidates").mkdir(parents=True)
+        out = root / "registry" / "pipeline_signals.json"
+        with patch("build_pipeline_signals.ROOT", root):
+            assert build_signals(out) == 0
+        assert json.loads(out.read_text())["summary"]["total"] == 0

--- a/tests/test_clean_query_catalog.py
+++ b/tests/test_clean_query_catalog.py
@@ -1,16 +1,24 @@
+"""Test per validazione catalogo clean contro schema JSON.
+
+Contratto: validate_catalog() verifica che un catalogo rispetti lo schema
+JSON regolamentare. Usato in CI per validare clean_catalog.json.
+
+Prova del fuoco: se cancello questi test, un catalogo malformato puo'
+essere pubblicato senza preavviso.
+"""
 from __future__ import annotations
 
 import json
-import sys
 import unittest
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "scripts"))
-
-from build_clean_catalog import validate_catalog  # noqa: E402
+from build_clean_catalog import validate_catalog
 
 
+@pytest.mark.contract
 class CleanCatalogValidationTest(unittest.TestCase):
     def setUp(self) -> None:
         self.schema = json.loads(
@@ -30,9 +38,7 @@ class CleanCatalogValidationTest(unittest.TestCase):
         dataset = dict(catalog["datasets"][0])
         dataset["slug"] = "Bad-Slug"
         catalog["datasets"] = [dataset]
-
         errors = validate_catalog(catalog, self.schema)
-
         self.assertTrue(any("does not match" in error for error in errors), errors)
 
     def test_schema_rejects_invalid_stage(self) -> None:
@@ -40,9 +46,7 @@ class CleanCatalogValidationTest(unittest.TestCase):
         dataset = dict(catalog["datasets"][0])
         dataset["stage"] = "ready-ish"
         catalog["datasets"] = [dataset]
-
         errors = validate_catalog(catalog, self.schema)
-
         self.assertTrue(any("not in enum" in error for error in errors), errors)
 
     def test_schema_rejects_extra_location_property(self) -> None:
@@ -52,11 +56,5 @@ class CleanCatalogValidationTest(unittest.TestCase):
         location["extra"] = "not allowed"
         dataset["location"] = location
         catalog["datasets"] = [dataset]
-
         errors = validate_catalog(catalog, self.schema)
-
         self.assertTrue(any("additional property" in error for error in errors), errors)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_clean_query_sql_guards.py
+++ b/tests/test_clean_query_sql_guards.py
@@ -2,15 +2,14 @@ from __future__ import annotations
 
 import sys
 import unittest
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "tools" / "clean-query-mcp"))
+import pytest
 
-import server  # noqa: E402
+import server
 
 
+@pytest.mark.contract
 class CleanQuerySqlGuardTest(unittest.TestCase):
     def assert_allowed(self, sql: str) -> None:
         server._validate_scope(sql)
@@ -68,6 +67,7 @@ def _make_mock_conn() -> MagicMock:
 _SLUG = "giustizia_penale_indicatori"  # single-file, multi-year (2014-2024)
 
 
+@pytest.mark.contract
 class CleanQueryYearFilterContractTest(unittest.TestCase):
     """Verifica che year=... inietti WHERE <year_col> = <year> nella SQL.
 
@@ -149,6 +149,7 @@ class CleanQueryYearFilterContractTest(unittest.TestCase):
 # ─── Unit: _inject_year_filter (pure function) ──────────────────────────────
 
 
+@pytest.mark.pure_unit
 class InjectYearFilterUnitTest(unittest.TestCase):
     """Test per _inject_year_filter come funzione pura (nessun I/O)."""
 

--- a/tests/test_create_de_followup_issue.py
+++ b/tests/test_create_de_followup_issue.py
@@ -1,10 +1,11 @@
 """Test per scripts/create_de_followup_issue.py.
 
-Verifica il filtro slug:
-- slug già nel catalogo pre-merge -> non crea issue
-- slug nuovo (non in catalogo pre-merge) -> crea issue
-- misto: solo i nuovi passano
-- git_ref non raggiungibile -> fallback a catalogo corrente
+Contratto: _extract_slugs() e _read_catalog_json() determinano quali slug
+sono nuovi e meritano una issue su data-explorer.
+Usato in post-merge per aprire followup automatici.
+
+Prova del fuoco: se cancello questi test, un refactor del filtro slug puo'
+causare issue duplicate o mancanti.
 """
 
 from __future__ import annotations
@@ -12,14 +13,11 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
-sys.path.insert(0, str(SCRIPTS_DIR))
 from create_de_followup_issue import _extract_slugs, _read_catalog_json
 
 FIXTURE_CATALOG = {
@@ -39,6 +37,7 @@ FIXTURE_ITEMS = [
 ]
 
 
+@pytest.mark.pure_unit
 class TestExtractSlugs:
     def test_extract_normalizes_underscore_to_hyphen(self):
         slugs = _extract_slugs(FIXTURE_CATALOG)
@@ -59,6 +58,7 @@ class TestExtractSlugs:
         assert slugs == {"ok"}
 
 
+@pytest.mark.contract
 class TestReadCatalogJson:
     def test_read_from_disk(self, tmp_path, monkeypatch):
         """Legge dal filesystem quando git_ref è None."""
@@ -94,6 +94,7 @@ class TestReadCatalogJson:
         assert catalog is None
 
 
+@pytest.mark.contract
 class TestFilterSlugs:
     """Testa la logica di filtro nel main, con mock di subprocess e gh."""
 

--- a/tests/test_detect_candidates.py
+++ b/tests/test_detect_candidates.py
@@ -1,0 +1,200 @@
+"""
+Test per detect_candidates.py — rilevamento candidate modificati da git diff.
+
+Contratto: detect_candidates() produce items e configs per workflow CI.
+  _detect_from_files() — parsifica file paths in items/configs
+  _resolve_year() — legge anno da dataset.yml
+  _dataset_name() — legge nome da dataset.yml
+
+Prova del fuoco: se cancello questi test, un refactor di detect_candidates
+puo' far rilevare candidate sbagliati ai workflow CI (pr-toolkit-check, post-merge).
+"""
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _write_yml(path: Path, data: dict) -> None:
+    import yaml
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False)
+
+
+class TestResolveYear:
+    @pytest.mark.pure_unit
+    @pytest.mark.parametrize("content,expected", [
+        ({"dataset": {"years": [2020, 2021, 2022]}}, 2022),
+        ({"dataset": {"years": []}}, 0),
+        ({"dataset": {"years": "not-a-list"}}, 0),
+    ])
+    def test(self, tmp_path, content, expected):
+        from detect_candidates import _resolve_year
+        cfg = tmp_path / "dataset.yml"
+        _write_yml(cfg, content)
+        assert _resolve_year(cfg) == expected
+
+    @pytest.mark.contract
+    def test_returns_zero_on_missing_file(self, tmp_path):
+        from detect_candidates import _resolve_year
+        assert _resolve_year(tmp_path / "nope.yml") == 0
+
+
+class TestDatasetName:
+    @pytest.mark.contract
+    def test_returns_name(self, tmp_path):
+        from detect_candidates import _dataset_name
+        cfg = tmp_path / "dataset.yml"
+        _write_yml(cfg, {"dataset": {"name": "Test DS"}})
+        assert _dataset_name(cfg) == "Test DS"
+
+    @pytest.mark.contract
+    @pytest.mark.parametrize("setup", [
+        lambda cfg: None,  # file non esiste
+        lambda cfg: cfg.write_text("{{invalid}}"),  # YAML non valido
+    ])
+    def test_returns_none(self, tmp_path, setup):
+        from detect_candidates import _dataset_name
+        cfg = tmp_path / "dataset.yml"
+        setup(cfg)
+        assert _dataset_name(cfg) is None
+
+
+class TestDetectFromFiles:
+    @pytest.mark.contract
+    @pytest.mark.parametrize("files,expected_kinds", [
+        (["candidates/ds/dataset.yml", "candidates/ds/sql/clean.sql"],
+         ["candidate"]),
+        (["support_datasets/sup/dataset.yml"],
+         ["support_dataset"]),
+        (["compose/agg/dataset.yml"],
+         ["compose"]),
+        (["candidates/a/a.yml", "candidates/a/b.yml"],
+         ["candidate"]),  # unico item
+    ])
+    def test_detects_kind(self, files, expected_kinds):
+        from detect_candidates import _detect_from_files
+        items, _ = _detect_from_files(files)
+        assert len(items) == len(expected_kinds)
+        for item, kind in zip(items, expected_kinds):
+            assert item["kind"] == kind
+
+    @pytest.mark.contract
+    @pytest.mark.parametrize("files", [
+        ["README.md", ".gitignore"],
+        ["scripts/build.py", ".github/workflows/ci.yml"],
+    ])
+    def test_ignores_unrelated(self, files):
+        from detect_candidates import _detect_from_files
+        items, configs = _detect_from_files(files)
+        assert items == []
+        assert configs == []
+
+
+class TestDetectCandidatesFiles:
+    @pytest.mark.contract
+    def test_files_mode_basic(self):
+        from detect_candidates import detect_candidates
+        result = detect_candidates(files=["candidates/my-ds/dataset.yml"])
+        assert result["items"][0]["slug"] == "my-ds"
+
+    @pytest.mark.contract
+    def test_empty_files(self):
+        from detect_candidates import detect_candidates
+        assert detect_candidates(files=[])["has_items"] is False
+
+    @pytest.mark.contract
+    def test_config_exists(self, tmp_path):
+        from detect_candidates import detect_candidates
+        _write_yml(tmp_path / "candidates" / "root-ds" / "dataset.yml", {
+            "dataset": {"name": "Root", "years": [2020]},
+        })
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            with patch("detect_candidates.ROOT", tmp_path):
+                result = detect_candidates(files=["candidates/root-ds/dataset.yml"])
+        finally:
+            os.chdir(old_cwd)
+        assert result["configs"][0]["is_nested"] is False
+
+    @pytest.mark.contract
+    def test_config_nested(self, tmp_path):
+        from detect_candidates import detect_candidates
+        _write_yml(tmp_path / "candidates" / "multi" / "sources" / "fonte-a" / "dataset.yml", {
+            "dataset": {"name": "FA", "years": [2020]},
+        })
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            with patch("detect_candidates.ROOT", tmp_path):
+                result = detect_candidates(
+                    files=["candidates/multi/sources/fonte-a/dataset.yml"]
+                )
+        finally:
+            os.chdir(old_cwd)
+        assert result["configs"][0]["is_nested"] is True
+
+
+class TestDetectCandidatesSlug:
+    @pytest.mark.contract
+    @pytest.mark.parametrize("slug_dir,kind", [
+        (("candidates", "my-ds"), "candidate"),
+        (("compose", "agg"), "compose"),
+        (("support_datasets", "sup"), "support_dataset"),
+    ])
+    def test_finds_by_slug(self, tmp_path, slug_dir, kind):
+        from detect_candidates import detect_candidates
+        prefix, slug = slug_dir
+        _write_yml(tmp_path / prefix / slug / "dataset.yml", {
+            "dataset": {"name": slug, "years": [2020]},
+        })
+        with patch("detect_candidates.ROOT", tmp_path):
+            result = detect_candidates(slug=slug)
+        assert result["items"][0]["kind"] == kind
+
+    @pytest.mark.contract
+    def test_not_found(self, tmp_path):
+        from detect_candidates import detect_candidates
+        with patch("detect_candidates.ROOT", tmp_path):
+            assert detect_candidates(slug="nonexistent")["has_items"] is False
+
+    @pytest.mark.contract
+    def test_nested(self, tmp_path):
+        from detect_candidates import detect_candidates
+        _write_yml(tmp_path / "candidates" / "multi" / "sources" / "fonte-a" / "dataset.yml", {
+            "dataset": {"name": "FA", "years": [2020]},
+        })
+        with patch("detect_candidates.ROOT", tmp_path):
+            assert detect_candidates(slug="multi")["configs"][0]["is_nested"] is True
+
+
+class TestDetectCandidatesGit:
+    @pytest.mark.contract
+    def test_git_diff_mode(self):
+        from detect_candidates import detect_candidates
+        with patch("detect_candidates._git_diff_files") as mock_git:
+            mock_git.return_value = ["candidates/test-ds/dataset.yml"]
+            result = detect_candidates(base_sha="abc", head_sha="def")
+        assert result["items"][0]["slug"] == "test-ds"
+
+
+class TestGitDiffFiles:
+    @pytest.mark.contract
+    def test_returns_files(self):
+        from detect_candidates import _git_diff_files
+        with patch("detect_candidates.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "candidates/a/dataset.yml\ncandidates/b/sql/clean.sql\n"
+            assert len(_git_diff_files("base", "head")) == 2
+
+    @pytest.mark.contract
+    def test_raises_on_error(self):
+        from detect_candidates import _git_diff_files
+        with patch("detect_candidates.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 1
+            import subprocess
+            with pytest.raises(subprocess.CalledProcessError):
+                _git_diff_files("base", "head")

--- a/tests/test_get_extra_ca_cert_urls.py
+++ b/tests/test_get_extra_ca_cert_urls.py
@@ -1,18 +1,20 @@
-"""Tests for get_extra_ca_cert_urls.py."""
+"""Tests for get_extra_ca_cert_urls.py.
 
+Contratto: get_urls() estrae URL extra_ca_cert_url/extra_ca_cert_urls da YAML.
+Usato in fase di fetch raw per certificati CA aggiuntivi.
+"""
 from __future__ import annotations
 
-import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "scripts"))
+import pytest
 
-from get_extra_ca_cert_urls import get_urls  # noqa: E402
+from get_extra_ca_cert_urls import get_urls
 
 
+@pytest.mark.contract
 class GetExtraCaCertUrlsTest(unittest.TestCase):
     """Fail-fast su YAML/config invalida, tollerante su file mancante."""
 

--- a/tests/test_pipeline_sample_runs.py
+++ b/tests/test_pipeline_sample_runs.py
@@ -1,17 +1,15 @@
 from __future__ import annotations
 
 import json
-import sys
 import unittest
 from pathlib import Path
 
 import jsonschema
+import pytest
+
+from update_pipeline_sample_runs import apply_sample_results, summarize_sample_results
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "scripts"))
-
-from update_pipeline_sample_runs import apply_sample_results, summarize_sample_results  # noqa: E402
-
 _SCHEMA_PATH = ROOT / "registry" / "pipeline_signals.schema.json"
 
 
@@ -19,6 +17,7 @@ def _load_schema() -> dict:
     return json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
 
 
+@pytest.mark.contract
 class PipelineSampleRunTest(unittest.TestCase):
     def test_single_sample_result_uses_flat_shape(self) -> None:
         summary = summarize_sample_results(
@@ -110,6 +109,7 @@ class PipelineSampleRunTest(unittest.TestCase):
         self.assertEqual(errors, ["missing: no matching signal in catalog"])
 
 
+@pytest.mark.contract
 class PipelineSignalsSchemaTest(unittest.TestCase):
     """Validate pipeline_signals.json against its JSON Schema."""
 

--- a/tests/test_resolve_sample_run.py
+++ b/tests/test_resolve_sample_run.py
@@ -1,0 +1,128 @@
+"""
+Test per resolve_sample_run.py — risoluzione parametri sample run da dataset.yml.
+
+Contratto: resolve() produce JSON con config_path, slug, sample_year, is_nested,
+has_support, support. Usato dai workflow CI per determinare cosa eseguire.
+
+Prova del fuoco: se cancello questi test, un refactor di resolve() puo'
+fornire parametri errati ai workflow CI (anno sbagliato, slug rotto, support perso).
+"""
+from pathlib import Path
+
+import pytest
+
+
+def _write_yml(path: Path, data: dict) -> Path:
+    import yaml
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False)
+    return path
+
+
+class TestResolve:
+    SAMPLE_RUN = {"status": "passed", "run_id": "1", "run_url": "u",
+                   "checked_at": "2026-01-01", "year": 2023}
+
+    @pytest.mark.contract
+    def test_happy_path(self, tmp_path):
+        from resolve_sample_run import resolve
+        ds = tmp_path / "candidates" / "test-ds"
+        cfg = _write_yml(ds / "dataset.yml", {
+            "dataset": {"name": "Test DS", "years": [2020, 2021, 2022]},
+            "support": [{"name": "Base", "config": "../base/dataset.yml"}],
+        })
+        _write_yml(ds / "../base/dataset.yml", {"dataset": {"name": "Base"}})
+        result = resolve(str(cfg))
+        assert result["slug"] == "test-ds"
+        assert result["sample_year"] == 2022
+        assert result["is_nested"] is False
+        assert result["has_support"] is True
+
+    @pytest.mark.contract
+    def test_single_year(self, tmp_path):
+        from resolve_sample_run import resolve
+        cfg = _write_yml(tmp_path / "candidates" / "single" / "dataset.yml", {
+            "dataset": {"name": "Single", "years": [2023]},
+        })
+        assert resolve(str(cfg))["sample_year"] == 2023
+
+    @pytest.mark.policy
+    def test_unsorted_years_takes_max(self, tmp_path):
+        from resolve_sample_run import resolve
+        cfg = _write_yml(tmp_path / "candidates" / "unsorted" / "dataset.yml", {
+            "dataset": {"name": "Unsorted", "years": [2022, 2020, 2021]},
+        })
+        assert resolve(str(cfg))["sample_year"] == 2022
+
+    @pytest.mark.contract
+    @pytest.mark.parametrize("content,error_pattern", [
+        ("{invalid: yaml: : }", "Invalid YAML"),
+        ("", "No 'dataset' section"),
+    ])
+    def test_errors(self, tmp_path, content, error_pattern):
+        from resolve_sample_run import resolve
+        cfg = tmp_path / "bad.yml"
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text(content)
+        result = resolve(str(cfg))
+        assert "error" in result
+        assert error_pattern in result["error"]
+
+    @pytest.mark.contract
+    def test_missing_years(self, tmp_path):
+        from resolve_sample_run import resolve
+        cfg = _write_yml(tmp_path / "candidates" / "noyears" / "dataset.yml", {
+            "dataset": {"name": "No Years"},
+        })
+        assert "No 'dataset.years'" in resolve(str(cfg))["error"]
+
+    @pytest.mark.contract
+    def test_invalid_years_type(self, tmp_path):
+        from resolve_sample_run import resolve
+        cfg = _write_yml(tmp_path / "candidates" / "badyears" / "dataset.yml", {
+            "dataset": {"name": "Bad", "years": ["a", "b"]},
+        })
+        assert "Invalid years" in resolve(str(cfg))["error"]
+
+    @pytest.mark.contract
+    @pytest.mark.parametrize("support_key,config", [
+        ("support", {"name": "Base", "config": "support/base.yml"}),
+        ("dataset.support", {"name": "Base", "config": "support/base.yml"}),
+    ])
+    def test_support_both_levels(self, tmp_path, support_key, config):
+        from resolve_sample_run import resolve
+        ds = tmp_path / "candidates" / "ds"
+        yml = {"dataset": {"name": "DS", "years": [2020]}}
+        if support_key == "support":
+            yml["support"] = [config]
+        else:
+            yml["dataset"]["support"] = [config]
+        _write_yml(ds / "dataset.yml", yml)
+        _write_yml(ds / "support" / "base.yml", {"dataset": {"name": "Base"}})
+        result = resolve(str(ds / "dataset.yml"))
+        assert result["has_support"] is True
+
+    @pytest.mark.contract
+    def test_nested_config(self, tmp_path):
+        from resolve_sample_run import resolve
+        cfg = _write_yml(
+            tmp_path / "candidates" / "multi" / "sources" / "fonte-a" / "dataset.yml",
+            {"dataset": {"name": "FA", "years": [2020]}},
+        )
+        result = resolve(str(cfg))
+        assert result["is_nested"] is True
+
+    @pytest.mark.contract
+    @pytest.mark.parametrize("prefix", ["candidates", "support_datasets"])
+    def test_slug_from_prefix(self, tmp_path, prefix):
+        from resolve_sample_run import resolve
+        cfg = _write_yml(tmp_path / prefix / "my-slug" / "dataset.yml", {
+            "dataset": {"name": "My", "years": [2020]},
+        })
+        assert resolve(str(cfg))["slug"] == "my-slug"
+
+    @pytest.mark.contract
+    def test_file_not_found(self, tmp_path):
+        from resolve_sample_run import resolve
+        assert "not found" in resolve(str(tmp_path / "nope.yml"))["error"].lower()

--- a/tests/test_toolkit_integration.py
+++ b/tests/test_toolkit_integration.py
@@ -1,10 +1,11 @@
 """Integration test: lancia toolkit su un candidate minimo e verifica output.
 
-Richiede `toolkit` installato nel PATH.
+Contratto: toolkit run full produce output CLEAN e MART su un candidate minimo.
+Skip automatico se toolkit non e' disponibile.
 
-Skip automatico se toolkit non e' disponibile (es. in validate-candidate-structure CI).
+Prova del fuoco: se cancello questi test, un refactor di toolkit o del formato
+output puo' rompere la pipeline CI senza preavviso.
 """
-
 from __future__ import annotations
 
 import csv
@@ -19,10 +20,13 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 TEMPLATE_DIR = ROOT / "templates" / "candidate"
 
-pytestmark = pytest.mark.skipif(
-    shutil.which("toolkit") is None,
-    reason="toolkit non installato nel PATH (test di integrazione)",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        shutil.which("toolkit") is None,
+        reason="toolkit non installato nel PATH (test di integrazione)",
+    ),
+    pytest.mark.smoke,
+]
 
 
 def _write_csv(path: Path, rows: list[list[str]]) -> None:

--- a/tests/test_validate_candidate_structure.py
+++ b/tests/test_validate_candidate_structure.py
@@ -1,0 +1,235 @@
+"""
+Test per validate_candidate_structure.py — validazione struttura candidate.
+
+Contratto: validate_entry() controlla la struttura di directory dei candidate
+e registra failure. Usato in CI e come building block per pipeline_signals.
+
+Prova del fuoco: se cancello questi test, una modifica alla logica di validazione
+puo' far passare candidate con struttura errata senza preavviso.
+"""
+from pathlib import Path
+
+import pytest
+
+
+def _touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("")
+
+
+def _mkdir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+class TestDetectCandidateLayout:
+    @pytest.mark.contract
+    @pytest.mark.parametrize("setup,expected", [
+        (lambda b: _touch(b / "dataset.yml"), "single-source"),
+        (lambda b: _mkdir(b / "sources" / "a"), "multi-source"),
+        (lambda b: None, "unknown"),
+    ])
+    def test(self, tmp_path, setup, expected):
+        from validate_candidate_structure import detect_candidate_layout
+        base = tmp_path / "candidates" / "ds"
+        setup(base)
+        assert detect_candidate_layout(base)["layout"] == expected
+
+    @pytest.mark.contract
+    def test_ambiguous(self, tmp_path):
+        from validate_candidate_structure import detect_candidate_layout
+        base = tmp_path / "candidates" / "ds"
+        _touch(base / "dataset.yml")
+        _mkdir(base / "sources" / "a")
+        assert detect_candidate_layout(base)["layout"] == "ambiguous"
+
+    @pytest.mark.contract
+    @pytest.mark.parametrize("prefix", ["support_datasets", "compose"])
+    def test_special_dirs(self, tmp_path, prefix):
+        from validate_candidate_structure import detect_candidate_layout
+        base = tmp_path / prefix / "ds"
+        _touch(base / "dataset.yml")
+        expected = "support-dataset" if prefix == "support_datasets" else "compose"
+        assert detect_candidate_layout(base)["layout"] == expected
+
+
+class TestHasMartSql:
+    @pytest.mark.contract
+    @pytest.mark.parametrize("setup,expected", [
+        (lambda s: (_mkdir(s), _touch(s / "mart.sql")), True),
+        (lambda s: (_mkdir(s / "mart"), _touch(s / "mart" / "query.sql")), True),
+        (lambda s: (_mkdir(s), _touch(s / "clean.sql")), False),
+        (lambda s: _mkdir(s), False),
+    ])
+    def test(self, tmp_path, setup, expected):
+        from validate_candidate_structure import has_mart_sql
+        sql = tmp_path / "sql"
+        setup(sql)
+        assert has_mart_sql(sql) is expected
+
+
+class TestValidateRootDocs:
+    @pytest.mark.contract
+    def test_reports_missing(self, tmp_path, patch_root):
+        from validate_candidate_structure import validate_root_docs
+        base = patch_root / "ds"
+        _mkdir(base)
+        failures: list[str] = []
+        validate_root_docs(base, failures)
+        assert len(failures) == 2
+
+    @pytest.mark.contract
+    def test_ok_when_both_exist(self, tmp_path):
+        from validate_candidate_structure import validate_root_docs
+        base = tmp_path / "ds"
+        _touch(base / "README.md")
+        _touch(base / "notes.md")
+        failures: list[str] = []
+        validate_root_docs(base, failures)
+        assert failures == []
+
+
+class TestValidateSingleSource:
+    @pytest.mark.contract
+    def test_ok(self, tmp_path, patch_root):
+        from validate_candidate_structure import validate_single_source
+        base = patch_root / "ds"
+        _touch(base / "dataset.yml")
+        _mkdir(base / "sql")
+        _touch(base / "sql" / "clean.sql")
+        _touch(base / "sql" / "mart.sql")
+        failures: list[str] = []
+        validate_single_source(base, failures)
+        assert failures == []
+
+    @pytest.mark.contract
+    @pytest.mark.parametrize("setup,expect", [
+        (lambda b: (_mkdir(b / "sql"), _touch(b / "sql" / "clean.sql")),
+         "dataset.yml"),
+        (lambda b: _touch(b / "dataset.yml"), "sql"),
+        (lambda b: (_touch(b / "dataset.yml"), _mkdir(b / "sql")),
+         "clean.sql"),
+        (lambda b: (_touch(b / "dataset.yml"), _mkdir(b / "sql"),
+                     _touch(b / "sql" / "clean.sql")),
+         "mart"),
+    ])
+    def test_missing(self, tmp_path, patch_root, setup, expect):
+        from validate_candidate_structure import validate_single_source
+        base = patch_root / "ds"
+        setup(base)
+        failures: list[str] = []
+        validate_single_source(base, failures)
+        assert any(expect in f for f in failures)
+
+
+class TestValidateComposeRoot:
+    @pytest.mark.contract
+    def test_ok(self, tmp_path, patch_root):
+        from validate_candidate_structure import validate_compose_root
+        base = patch_root / "compose" / "ds"
+        _touch(base / "dataset.yml")
+        _mkdir(base / "sql")
+        _touch(base / "sql" / "mart.sql")
+        failures: list[str] = []
+        validate_compose_root(base, failures)
+        assert failures == []
+
+    @pytest.mark.contract
+    def test_missing_mart(self, tmp_path, patch_root):
+        from validate_candidate_structure import validate_compose_root
+        base = patch_root / "compose" / "ds"
+        _touch(base / "dataset.yml")
+        _mkdir(base / "sql")
+        failures: list[str] = []
+        validate_compose_root(base, failures)
+        assert any("mart" in f for f in failures)
+
+
+class TestValidateMultiSource:
+    @pytest.mark.contract
+    def test_ok(self, tmp_path, patch_root):
+        from validate_candidate_structure import validate_multi_source
+        base = patch_root / "candidates" / "multi"
+        _touch(base / "sources" / "a" / "dataset.yml")
+        _touch(base / "sources" / "a" / "sql" / "clean.sql")
+        _touch(base / "sources" / "a" / "sql" / "mart.sql")
+        failures: list[str] = []
+        validate_multi_source(base, failures)
+        assert failures == []
+
+    @pytest.mark.contract
+    def test_no_sources(self, tmp_path, patch_root):
+        from validate_candidate_structure import validate_multi_source
+        base = patch_root / "candidates" / "multi"
+        _mkdir(base / "sources")
+        failures: list[str] = []
+        validate_multi_source(base, failures)
+        assert any("source directories" in f for f in failures)
+
+    @pytest.mark.contract
+    def test_missing_source_yml(self, tmp_path, patch_root):
+        from validate_candidate_structure import validate_multi_source
+        base = patch_root / "candidates" / "multi"
+        _mkdir(base / "sources" / "a")
+        failures: list[str] = []
+        validate_multi_source(base, failures)
+        assert any("dataset.yml" in f for f in failures)
+
+    @pytest.mark.policy
+    def test_validate_compose_called(self, tmp_path, patch_root):
+        """validate_multi_source chiama validate_compose per il compose layer."""
+        from validate_candidate_structure import validate_multi_source
+        base = patch_root / "candidates" / "multi"
+        _touch(base / "sources" / "a" / "dataset.yml")
+        _touch(base / "sources" / "a" / "sql" / "clean.sql")
+        _touch(base / "sources" / "a" / "sql" / "mart.sql")
+        _mkdir(base / "compose" / "sql")
+        failures: list[str] = []
+        validate_multi_source(base, failures)
+        assert any("compose" in f for f in failures)
+
+
+class TestValidateEntry:
+    @pytest.mark.contract
+    def test_single_source_ok(self, tmp_path, patch_root):
+        from validate_candidate_structure import validate_entry
+        base = patch_root / "candidates" / "ds"
+        _touch(base / "dataset.yml")
+        _touch(base / "README.md")
+        _touch(base / "notes.md")
+        _mkdir(base / "sql")
+        _touch(base / "sql" / "clean.sql")
+        _touch(base / "sql" / "mart.sql")
+        failures: list[str] = []
+        validate_entry(base, failures)
+        assert failures == []
+
+    @pytest.mark.contract
+    def test_missing_docs(self, tmp_path, patch_root):
+        from validate_candidate_structure import validate_entry
+        base = patch_root / "candidates" / "ds"
+        _touch(base / "dataset.yml")
+        _mkdir(base / "sql")
+        _touch(base / "sql" / "clean.sql")
+        _touch(base / "sql" / "mart.sql")
+        failures: list[str] = []
+        validate_entry(base, failures)
+        assert any("README.md" in f for f in failures)
+
+    @pytest.mark.contract
+    def test_ambiguous(self, tmp_path, patch_root):
+        from validate_candidate_structure import validate_entry
+        base = patch_root / "candidates" / "ambig"
+        _touch(base / "dataset.yml")
+        _mkdir(base / "sources" / "a")
+        failures: list[str] = []
+        validate_entry(base, failures)
+        assert any("ambiguous" in f for f in failures)
+
+    @pytest.mark.contract
+    def test_unknown(self, tmp_path, patch_root):
+        from validate_candidate_structure import validate_entry
+        base = patch_root / "candidates" / "empty"
+        base.mkdir(parents=True)
+        failures: list[str] = []
+        validate_entry(base, failures)
+        assert any("no valid structure" in f for f in failures)

--- a/tools/clean-query-mcp/requirements.txt
+++ b/tools/clean-query-mcp/requirements.txt
@@ -1,3 +1,3 @@
 mcp>=1.26.0
 duckdb==1.5.1
-git+https://github.com/dataciviclab/lab-connectors.git@v0.9.0
+git+https://github.com/dataciviclab/lab-connectors.git@v0.10.0


### PR DESCRIPTION
## Cosa fa

### Test nuovi (95)
- **test_build_pipeline_signals.py** — 34 test, contratto pipeline_signals.json per ACB
- **test_resolve_sample_run.py** — 16 test, risoluzione parametri sample run da dataset.yml
- **test_validate_candidate_structure.py** — 26 test, validazione struttura candidate (single-source, multi-source, compose, support)
- **test_detect_candidates.py** — 19 test, rilevamento candidate modificati (git diff, slug, files mode)

### Infrastruttura
- **tests/conftest.py** — fixture condivise (patch_root, _write_yml, _mkdir, _touch), path setup centralizzato
- **pyproject.toml** — 6 marker pytest: contract, policy, regression, adapter, pure_unit, smoke
- **lint.yml** — aggiunto `--cov=scripts --cov=tools/clean-query-mcp --cov-fail-under=30` + trigger su `tests/**`
- **lab-connectors** — `v0.9.0` → `v0.10.0` (allineato agli altri repo del Lab)

### Review test esistenti (7 file)
- `sys.path.insert` rimosso da tutti (centralizzato in conftest)
- `@pytest.mark.*` su tutte le classi (71 contract, 5 pure_unit, 5 policy)
- `@pytest.mark.smoke` su test_toolkit_integration.py
- Docstring contratto + prova del fuoco in ogni file

## Risultati

```bash
155 test, 0 fail, 56% coverage (gate 30%)
```

| Modulo | Coverage |
|---|---|
| build_pipeline_signals.py | 88% |
| resolve_sample_run.py | 81% |
| create_de_followup_issue.py | 82% |
| detect_candidates.py | 78% |
| validate_candidate_structure.py | 77% |
| build_clean_catalog.py | 70% |
| update_pipeline_sample_runs.py | 60% |
| server.py (MCP) | 48% |
| catalog.py (MCP) | 37% |
