### PR TITLE
fix: aggiunta dipendenza esplicita lab-connectors in requirements.txt root

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,7 @@ jobs:
           pip install ruff mypy types-pyyaml types-requests pytest pytest-cov pytest-timeout
           pip install git+https://github.com/dataciviclab/toolkit.git@${{ env.TOOLKIT_VERSION }}
           pip install -r tools/clean-query-mcp/requirements.txt 2>/dev/null || true
+          pip install -r requirements.txt 2>/dev/null || true
 
       - name: Ruff
         run: ruff check scripts/ tools/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/**"
+      - "requirements.txt"
       - "scripts/**"
       - "tools/**"
       - "tests/**"

--- a/.github/workflows/validate-clean-catalog.yml
+++ b/.github/workflows/validate-clean-catalog.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           python -m pip install -r requirements.txt
           python -m pip install -r tools/clean-query-mcp/requirements.txt
-          python -m pip install pytest  # per test marker @pytest.mark.*
+          python -m pip install pytest pytest-timeout  # marker test + timeout da pyproject.toml
 
       - name: Validate catalog and public GCS paths
         run: python scripts/build_clean_catalog.py --check-gcs

--- a/.github/workflows/validate-clean-catalog.yml
+++ b/.github/workflows/validate-clean-catalog.yml
@@ -32,8 +32,9 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install clean-query MCP dependencies
+      - name: Install dependencies
         run: |
+          python -m pip install -r requirements.txt
           python -m pip install -r tools/clean-query-mcp/requirements.txt
           python -m pip install pytest  # per test marker @pytest.mark.*
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# lab-connectors — infrastruttura condivisa: HTTP client, DuckDB safe_connect,
+# GCS client/paths, MCP core. Usata da scripts/ e tools/clean-query-mcp/.
+# Extras duckdb + gcs per safe_connect() e upload su GCS.
+lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.0


### PR DESCRIPTION
## Problema
`dataset-incubator` importa `lab_connectors` in `scripts/` (gcs) e `tools/clean-query-mcp/` (duckdb, mcp) ma la dipendenza era soddisfatta solo indirettamente via `tools/clean-query-mcp/requirements.txt` — un tool, non il repo root.

## Causa
Nessun `requirements.txt` root dichiarava `lab-connectors`. Funzionava per effetto collaterale dell'ambiente workspace condiviso, ma si rompe in isolamento.

## Fix
- **`requirements.txt`** (nuovo): `lab-connectors[duckdb,gcs] @ git+...@v0.10.0`
- **`.github/workflows/lint.yml`**: aggiunto `pip install -r requirements.txt`
- **`.github/workflows/validate-clean-catalog.yml`**: step rinominato in "Install dependencies" con install esplicita di `requirements.txt`

## Verifica
La dipendenza ora è dichiarata a livello root. I workflow CI continuano a installare anche `tools/clean-query-mcp/requirements.txt` per le dipendenze specifiche del tool MCP.