### PR TITLE
chore: usa mart_parquet() dal path contract lab-connectors in push_archive.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # lab-connectors — infrastruttura condivisa: HTTP client, DuckDB safe_connect,
 # GCS client/paths, MCP core. Usata da scripts/ e tools/clean-query-mcp/.
 # Extras duckdb + gcs per safe_connect() e upload su GCS.
-lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.0
+lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.1

--- a/scripts/push_archive.py
+++ b/scripts/push_archive.py
@@ -40,6 +40,7 @@ from lab_connectors.gcs.paths import (
     MART_BUCKET,
     catalog_manifest,
     gs_url,
+    mart_parquet,
     pipeline_run,
 )
 
@@ -381,7 +382,7 @@ def push_mart(bq_client, slug_filter=None, year_filter=None, dry_run=False):
 
         for year in years:
             for parq in get_parquets(slug_dir / year):
-                gcs_path = f"{slug}/{year}/{parq.name}"
+                gcs_path = mart_parquet(slug, year, parq.stem)
                 push_gcs(parq, MART_BUCKET, gcs_path, dry_run)
                 if bq_client:
                     push_bq(bq_client, parq, slug, year, dry_run)

--- a/tools/clean-query-mcp/requirements.txt
+++ b/tools/clean-query-mcp/requirements.txt
@@ -1,3 +1,3 @@
 mcp>=1.26.0
 duckdb==1.5.1
-git+https://github.com/dataciviclab/lab-connectors.git@v0.10.0
+git+https://github.com/dataciviclab/lab-connectors.git@v0.10.1


### PR DESCRIPTION
## Modifica

`scripts/push_archive.py` costruiva manualmente il path MART su GCS come `f"{slug}/{year}/{parq.name}"`. Ora usa `mart_parquet(slug, year, parq.stem)` dal path contract di `lab-connectors`.

## Perché

Il path contract `mart_parquet` è stato aggiunto in lab-connectors v0.10.1 (#26). Centralizza la convenzione `{slug}/{year}/{table}.parquet` per tutti i consumer MART.

## Dipendenza

Richiede `lab-connectors >= v0.10.1` (dichiarato in `requirements.txt` dal PR #367).

## Verifica

`mart_parquet(slug, year, parq.stem)` produce lo stesso path di `f"{slug}/{year}/{parq.name}"` perché `parq.stem` è il nome file senza estensione `.parquet`, identico a ciò che veniva usato prima.