### PR TITLE
chore(post-merge): aggiorna registry per PR #371

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-19",
+  "generated_at": "2026-05-23",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #371 — refactor: migra irpef-comunale da cross_year a mart multi-year

Changed candidate/support roots:

- `irpef-comunale` (candidate, `candidates/irpef-comunale`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [ ] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/irpef-comunale/dataset.yml` -> artifact `sample-run-irpef-comunale`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug irpef_comunale --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
