### PR TITLE
fix: indentazione inline script in smoke-weekly.yml

### DIFF
--- a/.github/workflows/smoke-weekly.yml
+++ b/.github/workflows/smoke-weekly.yml
@@ -51,13 +51,13 @@ jobs:
             exit 1
           fi
           python3 -c "
-import json
-data = json.load(open('registry/clean_catalog.json'))
-n = len(data.get('datasets', []))
-print(f'clean_catalog.json: {n} dataset(s)')
-assert n > 0, 'catalog vuoto'
-print('VALID')
-"
+          import json
+          data = json.load(open('registry/clean_catalog.json'))
+          n = len(data.get('datasets', []))
+          print(f'clean_catalog.json: {n} dataset(s)')
+          assert n > 0, 'catalog vuoto'
+          print('VALID')
+          "
 
       - name: Checkout data-explorer and verify catalog compatibility
         run: |
@@ -73,15 +73,15 @@ print('VALID')
           cp dataset-incubator/registry/clean_catalog.json /tmp/data-explorer/
           cd /tmp/data-explorer
           node --input-type=module -e "
-import { generateCatalogEntry } from './scripts/generate_catalog.mjs';
-import { readFileSync } from 'fs';
-const catalog = JSON.parse(readFileSync('./clean_catalog.json', 'utf-8'));
-for (const ds of catalog.datasets) {
-  const entry = generateCatalogEntry(ds);
-  console.log('  ', entry.slug || ds.slug, '-', entry.stage);
-}
-console.log('OK: tutti i dataset generano entry explorer valide');
-"
+          import { generateCatalogEntry } from './scripts/generate_catalog.mjs';
+          import { readFileSync } from 'fs';
+          const catalog = JSON.parse(readFileSync('./clean_catalog.json', 'utf-8'));
+          for (const ds of catalog.datasets) {
+            const entry = generateCatalogEntry(ds);
+            console.log('  ', entry.slug || ds.slug, '-', entry.stage);
+          }
+          console.log('OK: tutti i dataset generano entry explorer valide');
+          "
 
       - name: Report summary
         if: always()


### PR DESCRIPTION
Le righe dentro i blocchi `run: |` devono avere almeno l'indentazione della prima riga di contenuto. Sia `python3 -c` che `node -e` avevano righe a 0 spazi, causando errore YAML nel parser di GitHub Actions.

È un bug pre-esistente (anteriore a PR #370), ora che il parser lo blocca, va fixato.