### PR TITLE
chore(post-merge): aggiorna registry per PR #385

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-19",
+  "generated_at": "2026-05-25",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -53,9 +53,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25958889635",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25958889635",
-        "checked_at": "2026-05-16",
+        "run_id": "26392665826",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26392665826",
+        "checked_at": "2026-05-25",
         "years": [
           2024
         ],


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #385 — fix(bdap-lea): esclude voci di totale contabile dal clean (double-counting -47%)

Changed candidate/support roots:

- `bdap-lea` (candidate, `candidates/bdap-lea`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [ ] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/bdap-lea/dataset.yml` -> artifact `sample-run-bdap-lea`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug bdap_lea --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
