### PR TITLE
fix: preserva colonne descrizione/role nel derive del catalogo

### DIFF
--- a/scripts/build_clean_catalog.py
+++ b/scripts/build_clean_catalog.py
@@ -304,9 +304,6 @@ def derive_catalog_from_gcs(
             for field in ("name", "description", "source", "source_id", "stage"):
                 if old.get(field):
                     entry[field] = old[field]
-            # Se lo slug esisteva già con source_id, preservalo
-            if old.get("source_id"):
-                entry["source_id"] = old["source_id"]
             # Preserva descrizione e role delle colonne dall'editoriale
             old_cols = {c["name"]: c for c in old.get("columns", [])}
             for col in entry["columns"]:

--- a/scripts/build_clean_catalog.py
+++ b/scripts/build_clean_catalog.py
@@ -307,6 +307,15 @@ def derive_catalog_from_gcs(
             # Se lo slug esisteva già con source_id, preservalo
             if old.get("source_id"):
                 entry["source_id"] = old["source_id"]
+            # Preserva descrizione e role delle colonne dall'editoriale
+            old_cols = {c["name"]: c for c in old.get("columns", [])}
+            for col in entry["columns"]:
+                oc = old_cols.get(col["name"])
+                if oc:
+                    if oc.get("description"):
+                        col["description"] = oc["description"]
+                    if oc.get("role"):
+                        col["role"] = oc["role"]
 
         datasets.append(entry)
 

--- a/tests/test_build_clean_catalog_derive.py
+++ b/tests/test_build_clean_catalog_derive.py
@@ -74,7 +74,10 @@ class TestBuildCleanCatalogDerive(unittest.TestCase):
                     "source": "Fonte Manuale",
                     "source_id": "manual-id",
                     "period": {"start": 2023, "end": 2024},
-                    "columns": [],
+                    "columns": [
+                        {"name": "anno", "type": "INTEGER", "role": "dimension", "description": "Anno di riferimento"},
+                        {"name": "nome", "type": "VARCHAR", "role": "dimension", "description": "Nome del dataset"},
+                    ],
                     "location": {"type": "gcs", "path": "gs://bucket/test_slug_a/*/test_slug_a_*_clean.parquet", "multi_file": True},
                     "stage": "published",
                     "registry_source": "manual",
@@ -133,6 +136,37 @@ class TestBuildCleanCatalogDerive(unittest.TestCase):
         b = ds["test_slug_b"]
         self.assertEqual(b["name"], "Test Slug B")  # title()
         self.assertEqual(b["stage"], "published")
+
+    @patch("duckdb.connect")
+    @patch("scripts.build_clean_catalog.list_objects", side_effect=fake_list_objects)
+    @patch("scripts.build_clean_catalog.object_exists", side_effect=fake_object_exists)
+    def test_derive_preserves_column_metadata(self, mock_exists, mock_list, mock_connect):
+        """description e role delle colonne devono venire dall'editoriale, type dal parquet."""
+        mock_connect.return_value = FakeDuckDBConnection()
+
+        from scripts.build_clean_catalog import derive_catalog_from_gcs
+
+        catalog, _ = derive_catalog_from_gcs(self.existing_catalog, refresh_date=False)
+        ds = {d["slug"]: d for d in catalog["datasets"]}
+
+        # test_slug_a ha colonne editoriali → preserve description e role
+        a = ds["test_slug_a"]
+        cols = {c["name"]: c for c in a["columns"]}
+
+        # anno: role diverso tra editoriale (dimension) e derive (metric → INTEGER)
+        self.assertEqual(cols["anno"]["role"], "dimension")        # da editoriale
+        self.assertEqual(cols["anno"]["description"], "Anno di riferimento")  # da editoriale
+        self.assertEqual(cols["anno"]["type"], "INTEGER")          # dal parquet
+
+        # nome: uguale in editoriale e derive
+        self.assertEqual(cols["nome"]["role"], "dimension")
+        self.assertEqual(cols["nome"]["description"], "Nome del dataset")
+        self.assertEqual(cols["nome"]["type"], "VARCHAR")
+
+        # valore: colonna nuova (solo parquet) → defaults derive
+        self.assertEqual(cols["valore"]["role"], "metric")
+        self.assertEqual(cols["valore"]["description"], "")
+        self.assertEqual(cols["valore"]["type"], "DOUBLE")
 
     @patch("duckdb.connect")
     @patch("scripts.build_clean_catalog.list_objects", side_effect=fake_list_objects)

--- a/tests/test_build_clean_catalog_derive.py
+++ b/tests/test_build_clean_catalog_derive.py
@@ -140,6 +140,7 @@ class TestBuildCleanCatalogDerive(unittest.TestCase):
     @patch("duckdb.connect")
     @patch("scripts.build_clean_catalog.list_objects", side_effect=fake_list_objects)
     @patch("scripts.build_clean_catalog.object_exists", side_effect=fake_object_exists)
+    @pytest.mark.regression
     def test_derive_preserves_column_metadata(self, mock_exists, mock_list, mock_connect):
         """description e role delle colonne devono venire dall'editoriale, type dal parquet."""
         mock_connect.return_value = FakeDuckDBConnection()

--- a/tests/test_build_clean_catalog_derive.py
+++ b/tests/test_build_clean_catalog_derive.py
@@ -98,6 +98,7 @@ class TestBuildCleanCatalogDerive(unittest.TestCase):
     @patch("duckdb.connect")
     @patch("scripts.build_clean_catalog.list_objects", side_effect=fake_list_objects)
     @patch("scripts.build_clean_catalog.object_exists", side_effect=fake_object_exists)
+    @pytest.mark.contract
     def test_derive_filters_without_pipeline_run(self, mock_exists, mock_list, mock_connect):
         """Slug senza pipeline_run.json devono essere esclusi."""
         mock_connect.return_value = FakeDuckDBConnection()
@@ -115,6 +116,7 @@ class TestBuildCleanCatalogDerive(unittest.TestCase):
     @patch("duckdb.connect")
     @patch("scripts.build_clean_catalog.list_objects", side_effect=fake_list_objects)
     @patch("scripts.build_clean_catalog.object_exists", side_effect=fake_object_exists)
+    @pytest.mark.contract
     def test_derive_merges_editorial_metadata(self, mock_exists, mock_list, mock_connect):
         """Name, description, source, stage devono venire dal catalogo esistente."""
         mock_connect.return_value = FakeDuckDBConnection()
@@ -172,6 +174,7 @@ class TestBuildCleanCatalogDerive(unittest.TestCase):
     @patch("duckdb.connect")
     @patch("scripts.build_clean_catalog.list_objects", side_effect=fake_list_objects)
     @patch("scripts.build_clean_catalog.object_exists", side_effect=fake_object_exists)
+    @pytest.mark.contract
     def test_derive_preserves_columns(self, mock_exists, mock_list, mock_connect):
         """Le colonne devono essere derivate dal parquet."""
         mock_connect.return_value = FakeDuckDBConnection()
@@ -186,6 +189,7 @@ class TestBuildCleanCatalogDerive(unittest.TestCase):
     @patch("duckdb.connect")
     @patch("scripts.build_clean_catalog.list_objects", side_effect=fake_list_objects)
     @patch("scripts.build_clean_catalog.object_exists", side_effect=fake_object_exists)
+    @pytest.mark.contract
     def test_derive_multi_file_vs_single(self, mock_exists, mock_list, mock_connect):
         """Multi-file se ha più anni, single se un anno solo."""
         mock_connect.return_value = FakeDuckDBConnection()
@@ -200,6 +204,7 @@ class TestBuildCleanCatalogDerive(unittest.TestCase):
     @patch("duckdb.connect")
     @patch("scripts.build_clean_catalog.list_objects", side_effect=fake_list_objects)
     @patch("scripts.build_clean_catalog.object_exists", side_effect=fake_object_exists)
+    @pytest.mark.contract
     def test_derive_schema_error_returns_errors(self, mock_exists, mock_list, mock_connect):
         """Se DuckDB fallisce, l'errore deve essere ritornato."""
         mock_conn = MagicMock()
@@ -219,6 +224,7 @@ class TestBuildCleanCatalogDerive(unittest.TestCase):
     @patch("duckdb.connect")
     @patch("scripts.build_clean_catalog.list_objects", side_effect=fake_list_objects)
     @patch("scripts.build_clean_catalog.object_exists", side_effect=fake_object_exists)
+    @pytest.mark.contract
     def test_main_derive_dry_run_exits_zero(self, mock_exists, mock_list, mock_connect):
         """--derive senza --write non deve crashare."""
         mock_connect.return_value = FakeDuckDBConnection()


### PR DESCRIPTION
## Problema

`build_clean_catalog.py --derive` ricostruisce le colonne da zero leggendo lo schema dal parquet su GCS. Le colonne vengono create con `description: ""` e `role` euristico (`VARCHAR → dimension`, tutto il resto → `metric`). Questo **sovrascrive** le descrizioni e i role curati a mano nel catalogo esistente.

Vedi PR #387 per l'impatto: dopo il post-merge di bdap-lea, il rebuild automatico ha azzerato tutte le descrizioni e cambiato i role di tutti i dataset nel catalogo, non solo di bdap-lea.

## Fix

Nel merge con l'editoriale esistente (`derive_catalog_from_gcs`, blocco `if old:`), ora preserva anche i metadati delle singole colonne:

```python
old_cols = {c["name"]: c for c in old.get("columns", [])}
for col in entry["columns"]:
    oc = old_cols.get(col["name"])
    if oc:
        if oc.get("description"):
            col["description"] = oc["description"]
        if oc.get("role"):
            col["role"] = oc["role"]
```

Se la colonna non esisteva nell'editoriale (es. colonna aggiunta da un cambio di schema), il valore derivato dal parquet rimane — corretto per colonne nuove.

## Test

- `build_clean_catalog.py --derive --write` ora preserva descrizioni e role esistenti
- La prossima rigenerazione del catalogo non azzererà più i metadati editoriali

## Note

Dopo il merge di questo fix, la PR #387 va rigenerata (o chiusa e riaperta) con `--derive --write` per ripristinare le descrizioni e i role persi.