### PR TITLE
fix(bdap-lea): esclude enti 999 (regioni) dal mart — double-counting

### DIFF
--- a/candidates/bdap-lea/README.md
+++ b/candidates/bdap-lea/README.md
@@ -13,27 +13,32 @@ Issue intake: `dataset-incubator` #113
 ## Perimetro
 
 - Annualità: `2024`
-- Enti operativi: `codice_ente_ssn != '000'` (esclusi aggregati Regionali)
+- Enti operativi: `codice_ente_ssn not in ('000', '999')` — esclusi aggregati regionali (`000`) ed enti regione (`999`) che causano double-counting
 - Granularità: per ente SSN e regione
+
+Attenzione: il totale include ~€166 mld di `prestazioni_sanitarie` (transazioni inter-ente per mobilità sanitaria). Ogni prestazione è contata sia dall'ente pagante sia dall'ente erogante — è un double-counting fisiologico del dato contabile BDAP, non un bug.
 
 ## Schema
 
-| Colonna | Tipo | Descrizione |
-|---|---|---|
-| `anno_riferimento` | INTEGER | Anno di riferimento |
-| `codice_regione` | VARCHAR | Codice regione |
-| `denominazione_regione` | VARCHAR | Denominazione regione |
-| `codice_ente_ssn` | VARCHAR | Codice ente SSN |
-| `denominazione_ente` | VARCHAR | Denominazione ente |
-| `codice_modello_lea` | VARCHAR | Codice modello LEA |
-| `descrizione_modello_lea` | VARCHAR | Descrizione modello LEA |
-| `importo_totale` | DOUBLE | Importo totale |
-| `flag_aggregazione` | VARCHAR | Flag aggregazione |
+23 colonne. Le principali:
+
+| Colonna | Tipo | Ruolo | Descrizione |
+|---|---|---|---|
+| `anno_riferimento` | INTEGER | dimension | Anno di riferimento |
+| `codice_regione` | VARCHAR | dimension | Codice regione |
+| `descrizione_regione` | VARCHAR | dimension | Denominazione regione |
+| `codice_ente_ssn` | VARCHAR | dimension | Codice ente SSN |
+| `codice_ente_bdap` | BIGINT | dimension | Codice BDAP ente |
+| `descrizione_ente` | VARCHAR | dimension | Denominazione ente |
+| `codice_voce_contabile` | VARCHAR | dimension | Codice voce contabile |
+| `descrizione_voce_contabile` | VARCHAR | dimension | Descrizione voce contabile |
+| `importo_totale` | DOUBLE | metric | Importo totale della voce |
+| *(altre 14 colonne metriche: consumi, personale, servizi, ammortamenti...)* | | | |
 
 ## Layer
 
-- **Clean**: 23.595 righe — filtra voci di totale contabile (codici 19999, 29999, 39999, 48888, 49999) che duplicavano gli importi di dettaglio. SUM importo_totale: 748 mld €
-- **Mart**: `mart_spesa_enti_2024` — 22.180 righe — filtro `codice_ente_ssn != '000'` + eredita filtro voci totali dal clean. SUM importo_totale: 738 mld €
+- **Clean**: 20.036 righe, ~396 mld € — filtra voci TOTALE (19999,29999,39999,48888,49999) + enti `000` e `999`. 23 colonne.
+- **Mart**: `mart_spesa_enti_2024` — 20.036 righe, ~396 mld € — stesso perimetro del clean, rimuove `data_aggiornamento` e `oneri_finanziari`. 21 colonne.
 
 ## Output
 

--- a/candidates/bdap-lea/notes.md
+++ b/candidates/bdap-lea/notes.md
@@ -9,20 +9,22 @@
 - encoding da gestire esplicitamente nel `clean.read`
 - `toolkit inspect paths` OK: `effective_root` risolve a `dataset-incubator/out`
 - run aggiornato 2026-05-25:
-  - clean: 23.595 righe (filtro voci totali `codice_voce_contabile NOT IN ('19999','29999','39999','48888','49999')`)
-  - mart: 22.180 righe (filtro voci totali + `codice_ente_ssn <> '000'`)
-- fix double-counting 2026-05-25: le voci di totale (19999,29999,39999,48888,49999) duplicavano gli importi delle voci di dettaglio.
-  SUM importo_totale pulito da 1.410 mld € a 748 mld € (-47%).
+  - clean: 20.036 righe (filtro voci totali + `codice_ente_ssn NOT IN ('000','999')`)
+  - mart: 20.036 righe (stesso perimetro)
+- fix double-counting voci totali (2026-05-25): le voci 19999,29999,39999,48888,49999 duplicavano gli importi dettaglio.
+- fix double-counting enti 999 (2026-05-25): gli enti regione (999) andavano esclusi come i 000.
+  Pulitura finale: da 1.410 mld € (tutto incluso) → 748 mld (senza totali) → 738 mld (senza 000) → 396 mld (senza 999).
 
 ## Analitico
 
 - il v0 parte sul solo `2024`
-- perimetro analitico: esclude `codice_ente_ssn = '000'` (filtro in mart)
+- perimetro analitico: esclude `codice_ente_ssn IN ('000', '999')`
 - la domanda guida resta sulla prevenzione collettiva, ma il candidate lascia anche altre voci contabili per letture successive
 
 ## Cautele
 
 - i dati sono contabili di spesa, non misurano esiti di salute
-- gli enti `000` sono aggregazioni regionali e causano double-counting se sommati ai singoli enti
+- gli enti `000` (aggregazioni regionali) e `999` (enti regione) causano double-counting se sommati agli enti ASL/ATS
+- `prestazioni_sanitarie` (~€166 mld) sono transazioni inter-ente (mobilità sanitaria) — ogni prestazione è contata sia da chi paga sia da chi eroga
 - alcuni codici voce sono aggregati di sezione e vanno trattati con prudenza nelle letture successive
 - la serie storica 2012-2024 esiste, ma non entra nel primo ciclo tecnico

--- a/candidates/bdap-lea/sql/clean.sql
+++ b/candidates/bdap-lea/sql/clean.sql
@@ -24,3 +24,4 @@ select
   try_cast("Importo Totale" as double) as importo_totale
 from raw_input
 where "Codice Voce Contabile" not in ('19999', '29999', '39999', '48888', '49999')
+  and "Codice Ente SSN" not in ('000', '999')

--- a/candidates/bdap-lea/sql/mart.sql
+++ b/candidates/bdap-lea/sql/mart.sql
@@ -21,4 +21,4 @@ select
   altri_costi,
   importo_totale
 from clean_input
-where codice_ente_ssn <> '000'
+where codice_ente_ssn not in ('000', '999')


### PR DESCRIPTION
## Problema

Gli enti con `codice_ente_ssn = '999'` rappresentano le **regioni stesse** come entità contabili. Sommati agli enti ASL/ATS, duplicano la spesa: la regione stanzia fondi alle ASL, le ASL li spendono, ma entrambe registrano gli stessi importi.

Prima: 
- `mart.sql` filtrava solo `codice_ente_ssn <> '000'`  (aggregati regionali)
- Manca `'999'`, quindi spesa totale €738 mld (doppio conteggio)

## Fix

- `clean.sql`: `"Codice Ente SSN" not in ('000', '999')`
- `mart.sql`: `codice_ente_ssn not in ('000', '999')`

Dopo: spesa ASL/ATS ~€396 mld, che include le transazioni inter-ente (mobilità sanitaria), contabilmente corretto per il dato BDAP.

## Note

Il totale include ~€166 mld di `prestazioni_sanitarie` (servizi acquistati da altri enti SSN). È un double-counting fisiologico del dato contabile: ogni prestazione è contata sia dall'ente pagante sia dall'ente erogante. Per la dashboard, in futuro si potrà separare.