### PR TITLE
chore(post-merge): aggiorna registry per PR #390

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -53,8 +53,8 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "26393993507",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26393993507",
+        "run_id": "26397149682",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26397149682",
         "checked_at": "2026-05-25",
         "years": [
           2024


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #390 — fix(bdap-lea): esclude enti 999 (regioni) dal mart — double-counting

Changed candidate/support roots:

- `bdap-lea` (candidate, `candidates/bdap-lea`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/bdap-lea/dataset.yml` -> artifact `sample-run-bdap-lea`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug bdap_lea --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
