### PR TITLE
chore: allinea PR template alla struttura org

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,34 @@
-## Summary
-- 
+## Sintesi
 
-## Tipo
-- [ ] candidate
-- [ ] support
-- [ ] docs
-- [ ] cleanup
+Descrivi in poche righe cosa cambia e perché.
+
+## Contesto collegato
+
+Closes #
+
+## Cosa cambia
+
+- [ ] candidate — nuovo dataset o aggiornamento
+- [ ] support — dataset di supporto
+- [ ] docs — struttura candidate, README, template
+- [ ] cleanup — refactoring, rimozioni, allineamento
+- [ ] workflow o CI
 - [ ] altro
 
-## Checklist (solo se tocchi `candidates/`)
+## Impatto
+
+Segna solo quello che si applica.
+
+- [ ] Aggiunge o modifica un candidate / support in `candidates/`
+- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
+- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
+- [ ] Solo documentazione o metadati
+- [ ] Nessun impatto visibile per chi usa il repository
+
+## Checklist candidate
+
+Se tocchi `candidates/`:
+
 - [ ] `dataset.yml` presente con `name` e `years`
 - [ ] toolkit run eseguito senza errori su tutti gli anni dichiarati
 - [ ] nessun file dati committato nella root del candidate (`*.csv`, `*.parquet`, `*.xlsx`)
@@ -16,8 +36,20 @@
 - [ ] notebook nominato `{slug}_v0.ipynb`, nessun path assoluto di macchina
 - [ ] issue di intake collegata
 
-## Issue collegata
-Closes #
+## Verifica
+
+Spiega come hai verificato il cambiamento.
+
+```bash
+# Esempi
+python -m toolkit.cli.app run all --config candidates/{slug}/dataset.yml
+python scripts/validate_candidate_structure.py
+```
+
+- [ ] `run all` o `dry-run` eseguito senza errori (candidate/support)
+- [ ] `python scripts/validate_candidate_structure.py` passato
+- [ ] Perimetro stretto: candidate con domanda minima chiara
 
 ## Note / rischi
--
+
+Rischi, limiti, punti da controllare con attenzione.


### PR DESCRIPTION
## Sintesi

Allinea il PR template di dataset-incubator alla struttura dell'org `.github` template, preservando la checklist candidate specifica del repo.

## Cosa cambia

Il PR template passa da 23 righe (inglese misto, solo checklist candidate) a 56 righe (italiano, sezioni strutturate):

| Sezione nuova | Cosa aggiunge |
|---|---|
| **Cosa cambia** | Tipo di cambiamento (candidate/support/docs/cleanup/workflow/altro) |
| **Impatto** | Classifica l'impatto: candidate, struttura, contratti downstream, docs |
| **Verifica** | Comandi specifici: `run all`/`dry-run` + `validate_candidate_structure.py` |
| **Checklist candidate** | Preservata invariata dal template precedente |

## Perché

- Il template precedente era in inglese misto, non allineato con la policy Lab (PR in italiano)
- Mancavano le sezioni "Impatto" e "Verifica" presenti nell'org template
- Il CONTRIBUTING.md richiede `validate_candidate_structure.py` e `dry-run` — ora sono nel template

## Verifica

- Template statico, nessun codice modificato
