### PR TITLE
chore(post-merge): aggiorna registry per PR #381

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3404,8 +3404,8 @@
     {
       "slug": "openga_ricorsi_cds",
       "name": "Openga Ricorsi Cds",
-      "description": "",
-      "source": "",
+      "description": "Ricorsi pendenti presso il Consiglio di Stato — dati mensili per sede giudiziaria",
+      "source": "OpenGA — Giustizia Amministrativa",
       "source_id": "openga",
       "period": {
         "start": 2023,
@@ -3415,38 +3415,38 @@
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di riferimento"
         },
         {
           "name": "anno_mese_riferimento",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Periodo di riferimento in formato AAAAMM"
         },
         {
           "name": "mese",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Mese di riferimento (1-12)"
         },
         {
           "name": "codice_sede",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Codice identificativo della sede giudiziaria"
         },
         {
           "name": "nome_sede",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione della sede giudiziaria"
         },
         {
           "name": "numero_ricorsi_pendenti",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Numero di ricorsi pendenti"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3402,6 +3402,62 @@
       "registry_source": "derive_auto"
     },
     {
+      "slug": "openga_ricorsi_cds",
+      "name": "Openga Ricorsi Cds",
+      "description": "",
+      "source": "",
+      "source_id": "openga",
+      "period": {
+        "start": 2023,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "anno_mese_riferimento",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "mese",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_sede",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "nome_sede",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "numero_ricorsi_pendenti",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/openga_ricorsi_cds/*/openga_ricorsi_cds_*_clean.parquet",
+        "multi_file": true
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
       "slug": "pensioni_pa_dag",
       "name": "Pensioni Pa Dag",
       "description": "Pensioni PA: importi pensionistici per gestione, categoria e caratteristiche pensionato",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -4,9 +4,9 @@
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 32,
+    "total": 33,
     "by_status": {
-      "ok": 32,
+      "ok": 33,
       "warn": 0,
       "error": 0
     }
@@ -426,6 +426,27 @@
       "label": "opencoesione-pagamenti-ue-2014-2020",
       "detail": "anno 2020 — fonte: opencoesione_progetti_esteso_zip — mart: sì",
       "action": ""
+    },
+    {
+      "id": "openga-ricorsi-cds",
+      "source_id": "openga",
+      "status": "ok",
+      "label": "openga-ricorsi-cds",
+      "detail": "anni 2023-2026 — fonte: cds_ricorsi_pendenti — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "26414714733",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26414714733",
+        "checked_at": "2026-05-25",
+        "years": [
+          2023,
+          2024,
+          2025,
+          2026
+        ],
+        "config_path": "candidates/openga-ricorsi-cds/dataset.yml"
+      }
     },
     {
       "id": "pensioni-pa-dag",


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #381 — feat: candidate openga-ricorsi-cds — Ricorsi Pendenti Consiglio di Stato

Changed candidate/support roots:

- `openga-ricorsi-cds` (candidate, `candidates/openga-ricorsi-cds`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/openga-ricorsi-cds/dataset.yml` -> artifact `sample-run-openga-ricorsi-cds`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug openga_ricorsi_cds --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
