### PR TITLE
feat(popolazione): mart hierarchy fasce d'età con exclude_metrics

### DIFF
--- a/support_datasets/popolazione-istat-comunale-2019-2025/README.md
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/README.md
@@ -12,11 +12,13 @@ Formato: ZIP → CSV, `;` delim, `utf-8` con BOM. Skip 1 riga (header doppio).
 
 ## Schema
 
-**Clean**: 20 colonne — raw-faithful, rinomine a snake_case.
+**Clean**: 22 colonne — rinomine a snake_case, più colonna calcolata `fascia_eta`. Escluse le righe con ETA=999 (totali pre-aggregati — somma ridondante delle età 0-100).
 
-**Mart `popolazione_by_comune`**: `[anno_riferimento, codice_comune, comune, popolazione_residente, popolazione_maschile, popolazione_femminile]` — un record per comune, ETA=999.
+**Mart `popolazione_by_comune`**: `[anno_riferimento, codice_comune, comune, popolazione_residente, popolazione_maschile, popolazione_femminile]` — un record per comune (SUM GROUP BY, non più dipendente dalla riga ETA=999).
 
 **Mart `popolazione_by_eta`**: `[anno_riferimento, codice_comune, comune, eta, popolazione_residente, popolazione_maschile, popolazione_femminile]` — un record per comune per classe di età (0-100).
+
+**Hierarchy `h_fascia`**: `[codice_comune, comune, fascia_eta]` + 17 metriche demografiche — un record per comune per fascia d'età (0-14, 15-29, 30-44, 45-59, 60-74, 75+). Generato automaticamente dalla mart hierarchy del toolkit.
 
 Chiave di join: `codice_comune`
 
@@ -36,10 +38,11 @@ Chiave di join: `codice_comune`
 
 ## QC
 
-- Clean = Raw per tutti i 7 anni (nessun filtro) ✅
+- Clean filtra ETA=999 (totali pre-aggregati — somma ridondante) ✅
 - Maschi + Femmine = Popolazione su tutti gli anni ✅
 - Nessun comune senza nome o con pop=0 ✅
 - by_comune vs sum(by_eta): differenza = 0 ✅
+- hierarchy h_fascia vs mart by_comune: ratio 1.0000 su popolazione_residente ✅
 
 ## Uso
 

--- a/support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml
@@ -35,6 +35,13 @@ mart:
       sql: "sql/mart.sql"
     - name: "popolazione_by_eta"
       sql: "sql/mart_by_eta.sql"
+  hierarchy:
+    axis: categorico
+    levels:
+      - level: fascia_eta
+        table: h_fascia
+        grain: [codice_comune, comune, fascia_eta]
+        exclude_metrics: [anno, eta]
   required_tables: ["popolazione_by_comune", "popolazione_by_eta"]
   validate: {}
 

--- a/support_datasets/popolazione-istat-comunale-2019-2025/notes.md
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/notes.md
@@ -19,9 +19,10 @@ Tutti e 7 gli anni: raw ✅ clean ✅ mart ✅
 
 ## Schema
 
-- Clean: 20 colonne, raw-faithful
-- `popolazione_by_comune`: 1 riga per comune (ETA=999 totale)
+- Clean: 22 colonne, colonna calcolata `fascia_eta`, filtrato ETA=999 (totali ridondanti)
+- `popolazione_by_comune`: 1 riga per comune, SUM GROUP BY (non più ETA=999)
 - `popolazione_by_eta`: 1 riga per comune per classe di età (ETA 0-100)
+- `h_fascia` (hierarchy): 1 riga per comune per fascia d'età, 17 metriche — generato automaticamente dal toolkit
 
 ## Cautele
 

--- a/support_datasets/popolazione-istat-comunale-2019-2025/sql/clean.sql
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/sql/clean.sql
@@ -3,6 +3,14 @@ select
   trim(cast("Codice comune" as varchar)) as codice_comune,
   trim(cast("Comune" as varchar)) as comune,
   try_cast("Età" as integer) as eta,
+  case
+    when try_cast("Età" as integer) between 0 and 14 then '0-14'
+    when try_cast("Età" as integer) between 15 and 29 then '15-29'
+    when try_cast("Età" as integer) between 30 and 44 then '30-44'
+    when try_cast("Età" as integer) between 45 and 59 then '45-59'
+    when try_cast("Età" as integer) between 60 and 74 then '60-74'
+    when try_cast("Età" as integer) >= 75 then '75+'
+  end as fascia_eta,
   try_cast("Celibi" as integer) as celibi,
   try_cast("Coniugati" as integer) as coniugati,
   try_cast("Divorziati" as integer) as divorziati,
@@ -21,3 +29,4 @@ select
   try_cast("Totale femmine" as integer) as totale_femmine,
   try_cast("Totale" as integer) as popolazione_residente
 from raw_input
+where try_cast("Età" as integer) <> 999

--- a/support_datasets/popolazione-istat-comunale-2019-2025/sql/mart.sql
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/sql/mart.sql
@@ -2,10 +2,10 @@ select
   {year} as anno_riferimento,
   codice_comune,
   comune,
-  popolazione_residente,
-  totale_maschi as popolazione_maschile,
-  totale_femmine as popolazione_femminile
+  sum(popolazione_residente) as popolazione_residente,
+  sum(totale_maschi) as popolazione_maschile,
+  sum(totale_femmine) as popolazione_femminile
 from clean_input
 where codice_comune is not null
   and comune is not null
-  and eta = 999
+group by codice_comune, comune


### PR DESCRIPTION
## Sintesi

Aggiunge mart hierarchy `h_fascia` al support dataset popolazione ISTAT comunale, con fasce d'età (0-14, 15-29, 30-44, 45-59, 60-74, 75+). Modifica `popolazione_by_comune` da `WHERE eta=999` a `SUM GROUP BY` (più robusto).

## Contesto collegato

Dipende dalla PR #278 di toolkit (`exclude_metrics` per hierarchy).

## Cosa cambia

- [x] support — dataset di supporto
- [x] docs — README, notes aggiornati

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`
- [x] Solo documentazione o metadati

## Checklist

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori su tutti gli anni dichiarati (verificato 2025, cross-year)
- [x] nessun file dati committato

## Verifica

```bash
toolkit run mart -y 2025 -c support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml
```

Hierarchy generata: h_fascia (47.376 righe, 6 fasce × 7.896 comuni), ratio 1.0000 con mart `popolazione_by_comune` su tutte le metriche.

## Note

- Clean esclude ETA=999 (totali pre-aggregati ridondanti rispetto alla somma delle età 0-100)
- La colonna `fascia_eta` è calcolata senza perdita di granularità (ogni età ha la sua riga)
- La mart `popolazione_by_comune` è stata riformattata per non dipendere più dalla riga ETA=999
- h_eta e h_comune non sono state incluse nella hierarchy perché ridondanti (h_eta == clean senza anno, h_comune == popolazione_by_comune)
