### PR TITLE
chore: aggiorna skills e template dopo rimozione 'toolkit init'

### DIFF
--- a/skills/intake-candidate.md
+++ b/skills/intake-candidate.md
@@ -61,7 +61,7 @@ Se vuoi anche eseguire subito il run raw dopo lo scaffold, aggiungi `--run` (ali
 
 **Candidate strutturato già esistente, vuoi rigenerare lo scaffold:**
 ```bash
-toolkit init --config candidates/{slug}/dataset.yml --years 2024
+toolkit run raw -c candidates/{slug}/dataset.yml -y 2024
 ```
 
 ### 3. Struttura

--- a/skills/run-candidate.md
+++ b/skills/run-candidate.md
@@ -42,7 +42,7 @@ Se il candidate è nuovo, manca `sql/clean.sql`, oppure lo scaffold non è ancor
 Bootstrap:
 
 ```bash
-toolkit init --config candidates/{slug}/dataset.yml --years 2024
+toolkit run raw -c candidates/{slug}/dataset.yml -y 2024
 ```
 
 Poi revisiona prima di proseguire:

--- a/templates/candidate/README.md
+++ b/templates/candidate/README.md
@@ -16,7 +16,7 @@ Ogni nuovo ingresso in `dataset-incubator` dovrebbe partire da questa cartella, 
 Per un candidate nuovo, usa il bootstrap prima del run completo:
 
 ```bash
-toolkit init --config candidates/<slug>/dataset.yml --years 2024
+toolkit run raw -c candidates/<slug>/dataset.yml -y 2024
 ```
 
 Questo scarica RAW, produce profiling e può scaffoldare/aiutare `sql/clean.sql` e `clean.read`.

--- a/templates/candidate/dataset.yml
+++ b/templates/candidate/dataset.yml
@@ -16,7 +16,7 @@ raw:
       primary: true
 
 # --- CLEAN LAYER ---
-# Bootstrap: toolkit init --config candidates/<slug>/dataset.yml --years 2024
+# Bootstrap: toolkit run raw -c candidates/<slug>/dataset.yml -y 2024
 # Poi revisiona sql/clean.sql e clean.read prima del run completo.
 clean:
   sql: "sql/clean.sql"


### PR DESCRIPTION
## Sintesi

`toolkit init` è stato rimosso da toolkit (PR #285): `init --url` era alias di `scout --scaffold`, `init --config` era wrapper di `run raw -c`.

Skills e template aggiornati ai comandi canonici.

## Cosa cambia

- [ ] cleanup — refactoring, rimozioni, allineamento

## Impatto

- [ ] Solo documentazione o metadati

## Verifica

```bash
grep -r "toolkit init" .  →  0 matches
```

## Note / rischi

Nessuno — solo documentazione.
