### PR TITLE
chore(post-merge): aggiorna registry per PR #399

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-05-25",
+  "updated_at": "2026-05-26",
   "datasets": [
     {
       "slug": "aifa_spesa_consumo",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-25",
+  "generated_at": "2026-05-26",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -70,11 +70,13 @@
       "detail": "anno 2024 — fonte: camera_deputati_sparql — mart: sì",
       "action": "",
       "sample_run": {
-        "status": "failed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "status": "passed",
+        "run_id": "26456578571",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26456578571",
+        "checked_at": "2026-05-26",
+        "years": [
+          2024
+        ],
         "config_path": "candidates/camera-deputati-legislature/dataset.yml"
       }
     },
@@ -105,9 +107,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "26107821546",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26107821546",
-        "checked_at": "2026-05-19",
+        "run_id": "26456578571",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26456578571",
+        "checked_at": "2026-05-26",
         "years": [
           2023,
           2024,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #399 — fix: camera SPARQL URI legislatura, consip escape quote

Changed candidate/support roots:

- `camera-deputati-legislature` (candidate, `candidates/camera-deputati-legislature`)
- `consip-consumi-convenzione` (candidate, `candidates/consip-consumi-convenzione`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/camera-deputati-legislature/dataset.yml` -> artifact `sample-run-camera-deputati-legislature`
- `candidates/consip-consumi-convenzione/dataset.yml` -> artifact `sample-run-consip-consumi-convenzione`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug camera_deputati_legislature --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug consip_consumi_convenzione --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
