### PR TITLE
fix: allinea stage 4 dataset in clean_catalog — bdap_entrate/inps→published, camera/mim→incubating

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -210,7 +210,7 @@
         "path": "gs://dataciviclab-clean/bdap_entrate_stato/2024/bdap_entrate_stato_2024_clean.parquet",
         "multi_file": false
       },
-      "stage": "incubating",
+      "stage": "published",
       "registry_source": "derive_auto"
     },
     {
@@ -418,7 +418,7 @@
         "path": "gs://dataciviclab-clean/camera_deputati_legislature/2024/camera_deputati_legislature_2024_clean.parquet",
         "multi_file": false
       },
-      "stage": "published",
+      "stage": "incubating",
       "registry_source": "derive_auto"
     },
     {
@@ -908,7 +908,7 @@
         "path": "gs://dataciviclab-clean/inps_pensioni_trimestrale/2024/inps_pensioni_trimestrale_2024_clean.parquet",
         "multi_file": false
       },
-      "stage": "incubating",
+      "stage": "published",
       "registry_source": "derive_auto"
     },
     {
@@ -3044,7 +3044,7 @@
         "path": "gs://dataciviclab-clean/mim_anagrafica_scuole_statali/2024/mim_anagrafica_scuole_statali_2024_clean.parquet",
         "multi_file": false
       },
-      "stage": "published",
+      "stage": "incubating",
       "registry_source": "derive_auto"
     },
     {


### PR DESCRIPTION
## Sintesi

Allineamento stage in `registry/clean_catalog.json` per risolvere il mismatch Explorer vs catalogo reale emerso nell'audit pubblicazione.

## Cosa cambia

- [x] cleanup — allineamento metadati

## Impatto

- [x] Cambia il contratto con consumatori downstream (explorer, analisi)

## Cambiamenti

| Slug | Prima | Dopo |
|---|---|---|
| `bdap_entrate_stato` | incubating | **published** |
| `inps_pensioni_trimestrale` | incubating | **published** |
| `camera_deputati_legislature` | published | **incubating** |
| `mim_anagrafica_scuole_statali` | published | **incubating** |

**Effetto netto**: published restano 13. Le 2 pagine Explorer che usavano dataset incubating ora sono su published.

## Verifica

```bash
python3 -c "
import json
cat = json.load(open('registry/clean_catalog.json'))
for ds in cat['datasets']:
    if ds['slug'] in ('bdap_entrate_stato','camera_deputati_legislature','inps_pensioni_trimestrale','mim_anagrafica_scuole_statali'):
        print(f\"{ds['slug']}: {ds['stage']}\")
"
```

- [x] Solo metadati, nessuna struttura candidate toccata

## Note

Nessun rischio tecnico. L'Explorer userà `bdap_entrate_stato` e `inps_pensioni_trimestrale` come published. Le pagine per `camera_deputati` e `mim_scuole` non saranno attese finché ri-promosse.
