### PR TITLE
chore(post-merge): aggiorna registry per PR #402

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -21,10 +21,18 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "run_id": "26462812456",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26462812456",
+        "checked_at": "2026-05-26",
+        "years": [
+          2018,
+          2019,
+          2020,
+          2021,
+          2022,
+          2023,
+          2024
+        ],
         "config_path": "candidates/aifa-spesa-consumo/dataset.yml"
       }
     },
@@ -161,9 +169,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25862718345",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25862718345",
-        "checked_at": "2026-05-14",
+        "run_id": "26462812456",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26462812456",
+        "checked_at": "2026-05-26",
         "years": [
           2024
         ],
@@ -245,9 +253,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "26088201871",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26088201871",
-        "checked_at": "2026-05-19",
+        "run_id": "26462812456",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26462812456",
+        "checked_at": "2026-05-26",
         "years": [
           2024
         ],
@@ -438,9 +446,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "26414714733",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26414714733",
-        "checked_at": "2026-05-25",
+        "run_id": "26462812456",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26462812456",
+        "checked_at": "2026-05-26",
         "years": [
           2023,
           2024,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #402 — fix: clean.sql dry-run — quote colonne raw in 4 candidate

Changed candidate/support roots:

- `aifa-spesa-consumo` (candidate, `candidates/aifa-spesa-consumo`)
- `inps-pensioni` (candidate, `candidates/inps-pensioni`)
- `istat-housing-crowding` (candidate, `candidates/istat-housing-crowding`)
- `openga-ricorsi-cds` (candidate, `candidates/openga-ricorsi-cds`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/aifa-spesa-consumo/dataset.yml` -> artifact `sample-run-aifa-spesa-consumo`
- `candidates/inps-pensioni/dataset.yml` -> artifact `sample-run-inps-pensioni`
- `candidates/istat-housing-crowding/dataset.yml` -> artifact `sample-run-istat-housing-crowding`
- `candidates/openga-ricorsi-cds/dataset.yml` -> artifact `sample-run-openga-ricorsi-cds`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug aifa_spesa_consumo --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug inps_pensioni_trimestrale --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug istat_housing_crowding --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug openga_ricorsi_cds --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
