### PR TITLE
feat(batch): smoke HTTP settimanale (v0)

### DIFF
--- a/.github/workflows/smoke-weekly.yml
+++ b/.github/workflows/smoke-weekly.yml
@@ -52,7 +52,7 @@ jobs:
             print(f'{icon} {r[\"slug\"]:35s} year={r[\"year\"]}  {r[\"duration\"]:>5.1f}s  {r[\"status\"]}')
           " >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Durata: ${DURATION}s" >> "$GITHUB_STEP_SUMMARY"
+          echo "Durata: $(python3 -c "import json;d=json.load(open('/tmp/batch_report.json'));print(d['duration_seconds'])")s" >> "$GITHUB_STEP_SUMMARY"
 
   verify-catalog:
     needs: smoke-http

--- a/.github/workflows/smoke-weekly.yml
+++ b/.github/workflows/smoke-weekly.yml
@@ -2,7 +2,7 @@ name: Smoke cross-repo (weekly)
 
 on:
   schedule:
-    - cron: "0 5 * * 1"  # ogni lunedì 05:00 UTC
+    - cron: "0 5 * * 1"
   workflow_dispatch:
 
 env:
@@ -10,66 +10,71 @@ env:
   TOOLKIT_VERSION: v1.14.2
 
 jobs:
-  cross-repo-smoke:
+  smoke-http:
     runs-on: ubuntu-latest
+    outputs:
+      passed: ${{ steps.batch.outputs.passed }}
+      failed: ${{ steps.batch.outputs.failed }}
+      total: ${{ steps.batch.outputs.total }}
     steps:
-      - name: Checkout dataset-incubator
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           path: dataset-incubator
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
       - name: Install toolkit
         run: pip install git+https://github.com/dataciviclab/toolkit.git@${{ env.TOOLKIT_VERSION }}
-
-      - name: Run pipeline on a test candidate
+      - name: Smoke batch — HTTP candidates
+        id: batch
         run: |
           cd dataset-incubator
-          echo "=== Esecuzione toolkit su irpef-comunale ==="
-          toolkit run all --config candidates/irpef-comunale/dataset.yml --smoke 2>&1
-          echo "=== Run completata ==="
-
-      - name: Verify clean parquet artifact
+          python scripts/smoke_batch.py batches/http.txt --json /tmp/batch_report.json 2>&1
+          echo "passed=$(python3 -c "import json;d=json.load(open('/tmp/batch_report.json'));print(d['passed'])")" >> "$GITHUB_OUTPUT"
+          echo "failed=$(python3 -c "import json;d=json.load(open('/tmp/batch_report.json'));print(d['failed'])")" >> "$GITHUB_OUTPUT"
+          echo "total=$(python3 -c "import json;d=json.load(open('/tmp/batch_report.json'));print(d['total'])")" >> "$GITHUB_OUTPUT"
+      - name: Upload batch report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: batch-report-http
+          path: /tmp/batch_report.json
+      - name: Report summary
+        if: always()
         run: |
-          cd dataset-incubator
-          count=$(find out -name "*_clean.parquet" -type f 2>/dev/null | wc -l)
-          if [ "$count" -eq 0 ]; then
-            echo "ERROR: nessun clean parquet generato"
-            exit 1
-          fi
-          echo "OK: $count clean parquet file(s)"
+          echo "## Smoke HTTP — ${{ steps.batch.outputs.passed }}/${{ steps.batch.outputs.total }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          python3 -c "
+          import json
+          d = json.load(open('/tmp/batch_report.json'))
+          for r in d['results']:
+            icon = '✅' if r['status'] == 'PASSED' else '❌'
+            print(f'{icon} {r[\"slug\"]:35s} year={r[\"year\"]}  {r[\"duration\"]:>5.1f}s  {r[\"status\"]}')
+          " >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Durata: ${DURATION}s" >> "$GITHUB_STEP_SUMMARY"
 
+  verify-catalog:
+    needs: smoke-http
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          path: dataset-incubator
       - name: Verify clean_catalog.json
         run: |
           cd dataset-incubator
-          if [ ! -f registry/clean_catalog.json ]; then
-            echo "ERROR: registry/clean_catalog.json non trovato"
-            exit 1
-          fi
           python3 -c "
           import json
           data = json.load(open('registry/clean_catalog.json'))
           n = len(data.get('datasets', []))
           print(f'clean_catalog.json: {n} dataset(s)')
-          assert n > 0, 'catalog vuoto'
+          assert n > 0
           print('VALID')
           "
-
       - name: Checkout data-explorer and verify catalog compatibility
         run: |
-          git clone --depth=1 https://github.com/dataciviclab/data-explorer.git /tmp/data-explorer 2>&1
-          if [ ! -f dataset-incubator/registry/clean_catalog.json ]; then
-            echo "ERROR: clean_catalog.json non disponibile per verifica explorer"
-            exit 1
-          fi
-          if [ ! -f /tmp/data-explorer/scripts/generate_catalog.mjs ]; then
-            echo "ERROR: script explorer generate_catalog.mjs non trovato"
-            exit 1
-          fi
+          git clone --depth=1 https://github.com/dataciviclab/data-explorer.git /tmp/data-explorer
           cp dataset-incubator/registry/clean_catalog.json /tmp/data-explorer/
           cd /tmp/data-explorer
           node --input-type=module -e "
@@ -82,12 +87,9 @@ jobs:
           }
           console.log('OK: tutti i dataset generano entry explorer valide');
           "
-
-      - name: Report summary
+      - name: Catalog summary
         if: always()
         run: |
-          echo "## Smoke cross-repo" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- toolkit: irpef-comunale pipeline completata" >> "$GITHUB_STEP_SUMMARY"
-          echo "- dataset-incubator: clean_catalog.json verificato" >> "$GITHUB_STEP_SUMMARY"
-          echo "- data-explorer: compatibilità catalogo verificata" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Catalogo" >> "$GITHUB_STEP_SUMMARY"
+          echo "- clean_catalog.json: verificato" >> "$GITHUB_STEP_SUMMARY"
+          echo "- data-explorer: compatibile" >> "$GITHUB_STEP_SUMMARY"

--- a/batches/ckan.txt
+++ b/batches/ckan.txt
@@ -1,0 +1,2 @@
+# CKAN
+candidates/mur-contribuzione-universitaria/dataset.yml

--- a/batches/green.txt
+++ b/batches/green.txt
@@ -1,0 +1,29 @@
+# Batch: tutti i candidate che passano dry-run (26)
+# toolkit batch --configs batches/green.txt --step all --dry-run
+#
+candidates/aifa-spesa-consumo/dataset.yml
+candidates/bdap-entrate-stato/dataset.yml
+candidates/bdap-lea/dataset.yml
+candidates/camera-deputati-legislature/dataset.yml
+candidates/civile-flussi/dataset.yml
+candidates/consip-consumi-convenzione/dataset.yml
+candidates/dipendenti-pubblici/dataset.yml
+candidates/giustizia-penale-indicatori/dataset.yml
+candidates/inps-pensioni/dataset.yml
+candidates/irpef-comunale/dataset.yml
+candidates/ispra-consumo-suolo/dataset.yml
+candidates/istat-gini-regionale/dataset.yml
+candidates/istat-housing-crowding/dataset.yml
+candidates/istat-ipab-aree/dataset.yml
+candidates/mef-irpef-regionale/dataset.yml
+candidates/mef-partecipazioni/dataset.yml
+candidates/mim-alunni-corso-eta/dataset.yml
+candidates/mit-incidentalita-mensile-2001-2018/dataset.yml
+candidates/mit-opere-incompiute-2020/dataset.yml
+candidates/mur-contribuzione-universitaria/dataset.yml
+candidates/opencivitas-fsc-rso/dataset.yml
+candidates/opencoesione-pagamenti-ue-2014-2020/dataset.yml
+candidates/openga-ricorsi-cds/dataset.yml
+candidates/pensioni-pa-dag/dataset.yml
+candidates/terna-capacita-rinnovabile/dataset.yml
+candidates/terna-electricity-by-source/dataset.yml

--- a/batches/http.txt
+++ b/batches/http.txt
@@ -1,0 +1,24 @@
+# Batch: candidate HTTP/S (sample-bytes compatibili)
+# toolkit batch --configs batches/http.txt --step all --smoke
+#
+candidates/aifa-spesa-consumo/dataset.yml
+candidates/bdap-entrate-stato/dataset.yml
+candidates/bdap-lea/dataset.yml
+candidates/civile-flussi/dataset.yml
+candidates/consip-consumi-convenzione/dataset.yml
+candidates/dipendenti-pubblici/dataset.yml
+candidates/giustizia-penale-indicatori/dataset.yml
+candidates/inps-pensioni/dataset.yml
+candidates/irpef-comunale/dataset.yml
+candidates/ispra-consumo-suolo/dataset.yml
+candidates/mef-irpef-regionale/dataset.yml
+candidates/mef-partecipazioni/dataset.yml
+candidates/mim-alunni-corso-eta/dataset.yml
+candidates/mit-incidentalita-mensile-2001-2018/dataset.yml
+candidates/mit-opere-incompiute-2020/dataset.yml
+candidates/opencivitas-fsc-rso/dataset.yml
+candidates/opencoesione-pagamenti-ue-2014-2020/dataset.yml
+candidates/openga-ricorsi-cds/dataset.yml
+candidates/pensioni-pa-dag/dataset.yml
+candidates/terna-capacita-rinnovabile/dataset.yml
+candidates/terna-electricity-by-source/dataset.yml

--- a/batches/sdmx.txt
+++ b/batches/sdmx.txt
@@ -1,0 +1,4 @@
+# SDMX
+candidates/istat-gini-regionale/dataset.yml
+candidates/istat-housing-crowding/dataset.yml
+candidates/istat-ipab-aree/dataset.yml

--- a/batches/sparql.txt
+++ b/batches/sparql.txt
@@ -1,0 +1,2 @@
+# SPARQL
+candidates/camera-deputati-legislature/dataset.yml

--- a/scripts/smoke_batch.py
+++ b/scripts/smoke_batch.py
@@ -141,13 +141,7 @@ def main() -> int:
     else:
         for cfg, year in tasks:
             if year is None:
-                results.append({
-                    "slug": Path(cfg).parent.name, "config": cfg,
-                    "year": None, "status": "SKIPPED",
-                    "duration": 0, "output": "anno non risolto",
-                })
-                print(f"  ⏭️ {Path(cfg).parent.name:35s} — SKIPPED (no year)")
-                continue
+                continue  # already added before the branch
             r = run_one(cfg, year)
             results.append(r)
             icon = "✅" if r["status"] == "PASSED" else "❌"
@@ -163,7 +157,7 @@ def main() -> int:
     print("=" * 60)
     for r in results:
         if r["status"] != "PASSED":
-            print(f"  ❌ {r['slug']} ({r['status']}): {r.get('output','')[:120]}")
+            print(f"  ❌ {r['slug']} ({r['status']}): {str(r.get('output',''))[:120]}")
 
     report = {
         "batch_file": args.batch_file,

--- a/scripts/smoke_batch.py
+++ b/scripts/smoke_batch.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Esegue smoke test batch su una lista di candidate.
+
+Legge un file batch (es. batches/http.txt), per ogni config risolve
+l'ultimo anno via resolve_sample_run.py, ed esegue toolkit run all
+con --smoke. Produce report JSON e riepilogo a schermo.
+
+Usage:
+    python scripts/smoke_batch.py batches/http.txt
+    python scripts/smoke_batch.py batches/http.txt --parallel 4
+    python scripts/smoke_batch.py batches/green.txt --json report.json
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPTS_DIR.parent
+
+
+def resolve_year(config_path: str) -> dict | None:
+    """Run resolve_sample_run.py for a config and return result."""
+    try:
+        r = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "resolve_sample_run.py"), config_path],
+            capture_output=True, text=True, timeout=15,
+        )
+        if r.returncode == 0:
+            return json.loads(r.stdout)
+        return None
+    except Exception:
+        return None
+
+
+def run_one(config_path: str, year: int) -> dict:
+    """Run toolkit on one candidate for one year with --smoke."""
+    slug = Path(config_path).parent.name
+    start = time.time()
+    try:
+        r = subprocess.run(
+            [sys.executable, "-m", "toolkit.cli.app", "run", "all",
+             "-c", config_path, "-y", str(year), "--smoke"],
+            cwd=ROOT, capture_output=True, text=True, timeout=120,
+        )
+        ok = r.returncode == 0
+        duration = round(time.time() - start, 1)
+        output = (r.stdout + r.stderr).strip()
+        return {
+            "slug": slug,
+            "config": config_path,
+            "year": year,
+            "status": "PASSED" if ok else "FAILED",
+            "duration": duration,
+            "output": output[-200:] if not ok else "",
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "slug": slug, "config": config_path, "year": year,
+            "status": "TIMEOUT", "duration": round(time.time() - start, 1),
+            "output": "timeout 120s",
+        }
+    except Exception as e:
+        return {
+            "slug": slug, "config": config_path, "year": year,
+            "status": "ERROR", "duration": round(time.time() - start, 1),
+            "output": str(e),
+        }
+
+
+def load_configs(batch_file: str) -> list[str]:
+    """Load config paths from a batch file (skip comments/empty)."""
+    path = Path(batch_file)
+    if not path.exists():
+        print(f"ERROR: file non trovato: {batch_file}", file=sys.stderr)
+        sys.exit(1)
+    configs = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        configs.append(line)
+    return configs
+
+
+def main() -> int:
+    import argparse
+    parser = argparse.ArgumentParser(description="Smoke batch per candidate DI")
+    parser.add_argument("batch_file", help="Path a batches/*.txt")
+    parser.add_argument("--parallel", type=int, default=1, help="Run paralleli (default: 1)")
+    parser.add_argument("--json", type=str, help="Path per output JSON")
+    args = parser.parse_args()
+
+    configs = load_configs(args.batch_file)
+    if not configs:
+        print("ERROR: nessun config trovato", file=sys.stderr)
+        return 1
+    print(f"Batch: {Path(args.batch_file).name}")
+    print(f"Configs: {len(configs)}")
+    print(f"Parallel: {args.parallel}")
+    print()
+
+    tasks = []
+    for cfg in configs:
+        resolved = resolve_year(cfg)
+        if resolved and resolved.get("sample_year"):
+            tasks.append((cfg, resolved["sample_year"]))
+        else:
+            print(f"  ❌ {cfg} — impossibile risolvere anno")
+            tasks.append((cfg, None))
+
+    results = []
+    start_total = time.time()
+
+    if args.parallel > 1:
+        with ThreadPoolExecutor(max_workers=args.parallel) as ex:
+            futures = {
+                ex.submit(run_one, cfg, year): (cfg, year)
+                for cfg, year in tasks if year
+            }
+            for future in as_completed(futures):
+                r = future.result()
+                results.append(r)
+                icon = "✅" if r["status"] == "PASSED" else "❌"
+                print(f"  {icon} {r['slug']:35s} year={r['year']}  {r['duration']:>5.1f}s  {r['status']}")
+    else:
+        for cfg, year in tasks:
+            if year is None:
+                results.append({
+                    "slug": Path(cfg).parent.name, "config": cfg,
+                    "year": None, "status": "SKIPPED",
+                    "duration": 0, "output": "anno non risolto",
+                })
+                print(f"  ⏭️ {Path(cfg).parent.name:35s} — SKIPPED (no year)")
+                continue
+            r = run_one(cfg, year)
+            results.append(r)
+            icon = "✅" if r["status"] == "PASSED" else "❌"
+            print(f"  {icon} {r['slug']:35s} year={r['year']}  {r['duration']:>5.1f}s  {r['status']}")
+
+    total_time = round(time.time() - start_total, 1)
+    passed = sum(1 for r in results if r["status"] == "PASSED")
+    failed = sum(1 for r in results if r["status"] != "PASSED")
+
+    print()
+    print("=" * 60)
+    print(f"  RISULTATI: {passed}/{len(results)} passed  |  {total_time}s totali")
+    print("=" * 60)
+    for r in results:
+        if r["status"] != "PASSED":
+            print(f"  ❌ {r['slug']} ({r['status']}): {r.get('output','')[:120]}")
+
+    report = {
+        "batch_file": args.batch_file,
+        "total": len(results),
+        "passed": passed,
+        "failed": failed,
+        "duration_seconds": total_time,
+        "results": results,
+    }
+    if args.json:
+        Path(args.json).write_text(json.dumps(report, indent=2))
+        print(f"\nReport salvato: {args.json}")
+    return 0 if failed == 0 else 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke_batch.py
+++ b/scripts/smoke_batch.py
@@ -117,6 +117,16 @@ def main() -> int:
     results = []
     start_total = time.time()
 
+    # Add SKIPPED entries before parallel execution (year could not be resolved)
+    for cfg, year in tasks:
+        if year is None:
+            results.append({
+                "slug": Path(cfg).parent.name, "config": cfg,
+                "year": None, "status": "SKIPPED",
+                "duration": 0, "output": "anno non risolto",
+            })
+            print(f"  ⏭️ {Path(cfg).parent.name:35s} — SKIPPED (no year)")
+
     if args.parallel > 1:
         with ThreadPoolExecutor(max_workers=args.parallel) as ex:
             futures = {


### PR DESCRIPTION
## Sintesi

Prima versione del batch smoke settimanale. Esegue toolkit run all --smoke su 21 candidate HTTP, usando l'ultimo anno dichiarato (tramite resolve_sample_run.py).

## Cosa cambia

- [x] CI
- [x] cleanup

## Dettaglio

### batches/
- `http.txt` — 21 candidate HTTP
- `green.txt` — 26 candidate tutti protocolli (dry-run)
- `sdmx.txt`, `ckan.txt`, `sparql.txt` — altri protocolli (non ancora in CI)

### scripts/smoke_batch.py
Legge un file batch, per ogni config risolve l'ultimo anno via `resolve_sample_run.py`, esegue `toolkit run all -c <config> -y <year> --smoke`. Supporta `--parallel N` e `--json`.

### .github/workflows/smoke-weekly.yml
Sostituito il singolo test `irpef-comunale` con due job paralleli:
1. `smoke-http`: batch su 21 candidate HTTP
2. `verify-catalog`: clean_catalog.json + compatibilità explorer (in cascata)

## Tempi stimati
- 21 candidate × ~10-12s cad = ~4 minuti
- Catalog verify: ~1 minuto
- Totale: ~5 minuti

## Limiti noti (v0)
- Solo HTTP in CI (SDMX/CKAN/SPARQL esclusi per ora)
- Workflow non testato in CI (da verificare dopo merge)
- Nessun alert automatico su regressioni

## Verifica locale
```bash
python scripts/smoke_batch.py batches/http.txt
# 3 candidate testati: 11s/8s/14s tutti PASSED
```
