### PR TITLE
chore(post-merge): aggiorna registry per PR #360

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-05-26",
+  "updated_at": "2026-05-27",
   "datasets": [
     {
       "slug": "aifa_spesa_consumo",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-26",
+  "generated_at": "2026-05-27",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -361,9 +361,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "26091471735",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26091471735",
-        "checked_at": "2026-05-19",
+        "run_id": "26505556706",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26505556706",
+        "checked_at": "2026-05-27",
         "years": [
           2001
         ],


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #360 — chore: aggiunta directory figures per candidate MIT

Changed candidate/support roots:

- `mit-incidentalita-mensile-2001-2018` (candidate, `candidates/mit-incidentalita-mensile-2001-2018`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/mit-incidentalita-mensile-2001-2018/dataset.yml` -> artifact `sample-run-mit-incidentalita-mensile-2001-2018`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug mit_incidentalita_mensile --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
