### PR TITLE
chore(post-merge): aggiorna registry per PR #396

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3763,6 +3763,12 @@
           "description": "Classe di età (0-100, 999 = totale comunale)"
         },
         {
+          "name": "fascia_eta",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
           "name": "celibi",
           "type": "INTEGER",
           "role": "metric",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3741,7 +3741,7 @@
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
+          "role": "dimension",
           "description": "Anno di riferimento"
         },
         {
@@ -3766,7 +3766,7 @@
           "name": "fascia_eta",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Fascia d'età aggregata (0-14, 15-29, 30-44, 45-59, 60-74, 75+)"
         },
         {
           "name": "celibi",
@@ -3802,25 +3802,25 @@
           "name": "maschi_gia_unione_civile_scioglimento",
           "type": "INTEGER",
           "role": "metric",
-          "description": "Ex uniti civilmente — scioglimento (maschi)"
+          "description": "Maschi già in unione civile — scioglimento"
         },
         {
           "name": "maschi_gia_unione_civile_decesso",
           "type": "INTEGER",
           "role": "metric",
-          "description": "Ex uniti civilmente — decesso coniuge (maschi)"
+          "description": "Maschi già in unione civile — decesso del coniuge"
         },
         {
           "name": "totale_maschi",
           "type": "INTEGER",
           "role": "metric",
-          "description": "Totale popolazione maschile"
+          "description": "Totale maschi"
         },
         {
           "name": "nubili",
           "type": "INTEGER",
           "role": "metric",
-          "description": "Nubili (femmine nubili mai sposate)"
+          "description": "Nubili (femmine mai sposate)"
         },
         {
           "name": "coniugate",
@@ -3850,19 +3850,19 @@
           "name": "femmine_gia_unione_civile_scioglimento",
           "type": "INTEGER",
           "role": "metric",
-          "description": "Ex unite civilmente — scioglimento (femmine)"
+          "description": "Femmine già in unione civile — scioglimento"
         },
         {
           "name": "femmine_gia_unione_civile_decesso",
           "type": "INTEGER",
           "role": "metric",
-          "description": "Ex unite civilmente — decesso coniuge (femmine)"
+          "description": "Femmine già in unione civile — decesso del coniuge"
         },
         {
           "name": "totale_femmine",
           "type": "INTEGER",
           "role": "metric",
-          "description": "Totale popolazione femminile"
+          "description": "Totale femmine"
         },
         {
           "name": "popolazione_residente",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -577,9 +577,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "26088201871",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26088201871",
-        "checked_at": "2026-05-19",
+        "run_id": "26564952522",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26564952522",
+        "checked_at": "2026-05-28",
         "years": [
           2019,
           2020,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #396 — feat(popolazione): mart hierarchy fasce d'età con exclude_metrics

Changed candidate/support roots:

- `popolazione-istat-comunale-2019-2025` (support_dataset, `support_datasets/popolazione-istat-comunale-2019-2025`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml` -> artifact `sample-run-popolazione-istat-comunale-2019-2025`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug popolazione_istat_comunale_2019_2025 --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
