### PR TITLE
chore(post-merge): aggiorna registry per PR #414

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-05-28",
+  "updated_at": "2026-05-29",
   "datasets": [
     {
       "slug": "aifa_spesa_consumo",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-28",
+  "generated_at": "2026-05-29",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -45,10 +45,12 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "run_id": "26637016060",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26637016060",
+        "checked_at": "2026-05-29",
+        "years": [
+          2024
+        ],
         "config_path": "candidates/bdap-entrate-stato/dataset.yml"
       }
     },


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #414 — feat: time_coverage nel catalog + toolkit v1.17.0

Changed candidate/support roots:

- `bdap-entrate-stato` (candidate, `candidates/bdap-entrate-stato`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/bdap-entrate-stato/dataset.yml` -> artifact `sample-run-bdap-entrate-stato`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug bdap_entrate_stato --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
