### PR TITLE
chore(post-merge): aggiorna registry per PR #416

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-05-29",
+  "updated_at": "2026-05-30",
   "datasets": [
     {
       "slug": "aifa_spesa_consumo",
@@ -376,7 +376,7 @@
       "name": "Camera Deputati Legislature",
       "description": "Deputati italiani per legislatura — Camera dei Deputati",
       "source": "Camera dei Deputati — OpenData SPARQL endpoint",
-      "source_id": "",
+      "source_id": "dati_camera",
       "period": {
         "start": 2024,
         "end": 2024

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-29",
+  "generated_at": "2026-05-30",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 33,
+    "total": 34,
     "by_status": {
-      "ok": 33,
+      "ok": 34,
       "warn": 0,
       "error": 0
     }
@@ -74,20 +74,45 @@
     },
     {
       "id": "camera-deputati-legislature",
-      "source_id": "",
+      "source_id": "dati_camera",
       "status": "ok",
       "label": "camera-deputati-legislature",
       "detail": "anno 2024 — fonte: camera_deputati_sparql — mart: sì",
       "action": "",
       "sample_run": {
-        "status": "passed",
-        "run_id": "26456578571",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26456578571",
-        "checked_at": "2026-05-26",
+        "status": "failed",
+        "run_id": "26682588914",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26682588914",
+        "checked_at": "2026-05-30",
         "years": [
           2024
         ],
         "config_path": "candidates/camera-deputati-legislature/dataset.yml"
+      }
+    },
+    {
+      "id": "camera-votazioni-sparql",
+      "source_id": "dati_camera",
+      "status": "ok",
+      "label": "camera-votazioni-sparql",
+      "detail": "anni 2018-2025 — fonte: sparql — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "failed",
+        "run_id": "26682588914",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26682588914",
+        "checked_at": "2026-05-30",
+        "years": [
+          2018,
+          2019,
+          2020,
+          2021,
+          2022,
+          2023,
+          2024,
+          2025
+        ],
+        "config_path": "candidates/camera-votazioni-sparql/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #416 — feat: candidati SPARQL (votazioni + deputati) + toolkit v1.19.0

Changed candidate/support roots:

- `camera-deputati-legislature` (candidate, `candidates/camera-deputati-legislature`)
- `camera-votazioni-sparql` (candidate, `candidates/camera-votazioni-sparql`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [ ] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/camera-deputati-legislature/dataset.yml` -> artifact `sample-run-camera-deputati-legislature`
- `candidates/camera-votazioni-sparql/dataset.yml` -> artifact `sample-run-camera-votazioni-sparql`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug camera_deputati_legislature --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug camera-votazioni-sparql --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
