### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -96,7 +96,24 @@
       "status": "ok",
       "label": "camera-votazioni-sparql",
       "detail": "anni 2018-2025 — fonte: sparql — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "26683224488",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26683224488",
+        "checked_at": "2026-05-30",
+        "years": [
+          2018,
+          2019,
+          2020,
+          2021,
+          2022,
+          2023,
+          2024,
+          2025
+        ],
+        "config_path": "candidates/camera-votazioni-sparql/dataset.yml"
+      }
     },
     {
       "id": "civile-flussi",


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `camera-votazioni-sparql` (candidate, `candidates/camera-votazioni-sparql`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [ ] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/camera-votazioni-sparql/dataset.yml` -> artifact `sample-run-camera-votazioni-sparql`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug camera-votazioni-sparql --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
