### PR TITLE
chore(post-merge): aggiorna registry per PR #419

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -344,9 +344,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "26106467223",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26106467223",
-        "checked_at": "2026-05-19",
+        "run_id": "26683614225",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26683614225",
+        "checked_at": "2026-05-30",
         "years": [
           2016,
           2017,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #419 — feat: clean arricchito con join anagrafica + gerarchia automatica

Changed candidate/support roots:

- `mim-alunni-corso-eta` (candidate, `candidates/mim-alunni-corso-eta`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/mim-alunni-corso-eta/dataset.yml` -> artifact `sample-run-mim-alunni-corso-eta`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug mim_alunni_corso_eta --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
