### PR TITLE
Fix: resilient workflow error handling, slug contract validation, toolkit centralizzato in requirements.txt

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 
 env:
-  TOOLKIT_VERSION: v1.19.0
+  # TOOLKIT_VERSION è centralizzato in requirements.txt
 
 on:
   pull_request:
@@ -30,10 +30,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          pip install -r requirements.txt
           pip install ruff mypy types-pyyaml types-requests pytest pytest-cov pytest-timeout
-          pip install git+https://github.com/dataciviclab/toolkit.git@${{ env.TOOLKIT_VERSION }}
           pip install -r tools/clean-query-mcp/requirements.txt 2>/dev/null || true
-          pip install -r requirements.txt 2>/dev/null || true
 
       - name: Ruff
         run: ruff check scripts/ tools/

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -14,8 +14,12 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: post-merge-candidate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 env:
-  TOOLKIT_VERSION: v1.19.0
+  # TOOLKIT_VERSION è centralizzato in requirements.txt
   DATACIVICLAB_WORKSPACE: ${{ github.workspace }}
   GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
   GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -112,7 +116,7 @@ jobs:
           cache: 'pip'
 
       - name: Install dependencies
-        run: python -m pip install pyyaml pyarrow git+https://github.com/dataciviclab/toolkit.git@${{ env.TOOLKIT_VERSION }}
+        run: python -m pip install -r requirements.txt
 
       - name: GCP Auth (for GCS push)
         if: env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != ''
@@ -141,6 +145,15 @@ jobs:
           root = os.environ.get("GITHUB_WORKSPACE", ".")
 
           failed_configs = []
+          gcs_push_ok = False
+
+          # Pre-install GCS lib se GCP auth disponibile — una volta, non per-candidato
+          if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+              subprocess.run(
+                  ["python", "-m", "pip", "install", "google-cloud-storage", "-q"],
+                  capture_output=True,
+              )
+
           for cfg in configs:
               config_path = cfg.get("config_path", "")
               slug = cfg.get("slug", "unknown")
@@ -177,6 +190,7 @@ jobs:
                   capture_output=True, text=True, cwd=root)
               if r.returncode != 0:
                   print(f"  FAIL: resolve ({r.stderr.strip()})")
+                  failed_configs.append(slug)
                   continue
               params = json.loads(r.stdout)
               all_years = ",".join(str(y) for y in params.get("all_years", []))
@@ -224,32 +238,35 @@ jobs:
               # --- GCS push (solo se GCP Auth ha settato le credenziali) ---
               if status == "passed" and os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
                   print(f"  GCS push per {slug}...")
-                  subprocess.run(
-                      ["python", "-m", "pip", "install", "google-cloud-storage", "-q"],
-                      capture_output=True,
-                      check=True,
-                  )
                   push_slug = cfg.get("push_slug", slug)
-                  subprocess.run(
-                      [
-                          "python",
-                          "scripts/push_archive.py",
-                          "--layer",
-                          "clean",
-                          "--slug",
-                          push_slug,
-                          "--no-bq",
-                      ],
+                  r = subprocess.run(
+                      ["python", "scripts/push_archive.py", "--layer", "clean", "--slug", push_slug, "--no-bq"],
                       cwd=root,
-                      check=True,
                   )
-                  print(f"  GCS push completato per {slug} (push_slug={push_slug})")
+                  if r.returncode != 0:
+                      print(f"  GCS push FAILED for {slug} (code {r.returncode})")
+                      failed_configs.append(slug)
+                  else:
+                      print(f"  GCS push completato per {slug} (push_slug={push_slug})")
+                      gcs_push_ok = True
 
-          # --- Build clean catalog (solo se GCP Auth riuscito) ---
-          if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+          # --- Build clean catalog (solo se almeno un push è riuscito) ---
+          if gcs_push_ok:
               print(f"\n  Rebuilding clean catalog...")
-              subprocess.run(["python", "scripts/build_clean_catalog.py", "--derive", "--write"], cwd=root, check=True)
-              subprocess.run(["python", "scripts/build_clean_catalog.py", "--check-gcs"], cwd=root, check=True)
+              r = subprocess.run(
+                  ["python", "scripts/build_clean_catalog.py", "--derive", "--write"],
+                  cwd=root,
+              )
+              if r.returncode != 0:
+                  print(f"  WARN: build_clean_catalog --derive --write fallito (code {r.returncode}), check stderr sopra")
+              r = subprocess.run(
+                  ["python", "scripts/build_clean_catalog.py", "--check-gcs"],
+                  cwd=root,
+              )
+              if r.returncode != 0:
+                  print(f"  WARN: build_clean_catalog --check-gcs ha trovato errori (code {r.returncode})")
+          else:
+              print(f"\n  Skip clean catalog rebuild: nessun GCS push riuscito")
 
           if failed_configs:
               print("\nFAIL: one or more configs failed in post-merge full run:")
@@ -290,9 +307,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: 'pip'
 
       - name: Install dependencies
-        run: python -m pip install pyyaml jsonschema
+        run: python -m pip install -r requirements.txt
 
       - name: Download detect output
         if: needs.detect.outputs.has_items == 'true'

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -1,7 +1,11 @@
 name: Toolkit Pipeline Check
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
-  TOOLKIT_VERSION: v1.19.0
+  # TOOLKIT_VERSION è centralizzato in requirements.txt
 
 # Esegue la pipeline toolkit su candidate modificati in PR.
 # Fallisce la PR se toolkit run full fallisce (run + validate + readiness).
@@ -33,7 +37,7 @@ jobs:
           cache: 'pip'
 
       - name: Install dependencies
-        run: python -m pip install pyyaml
+        run: python -m pip install -r requirements.txt
 
       - name: Detect changed candidate/support roots
         id: detect
@@ -85,7 +89,7 @@ jobs:
           cache: 'pip'
 
       - name: Install dependencies
-        run: python -m pip install pyyaml
+        run: python -m pip install -r requirements.txt
 
       - name: Configure extra source CA certificates
         env:
@@ -120,9 +124,6 @@ jobs:
 
           echo "REQUESTS_CA_BUNDLE=$bundle" >> "$GITHUB_ENV"
           echo "SSL_CERT_FILE=$bundle" >> "$GITHUB_ENV"
-
-      - name: Install toolkit
-        run: pip install git+https://github.com/dataciviclab/toolkit.git@${{ env.TOOLKIT_VERSION }}
 
       - name: "Toolkit run full (smoke: sample-bytes + sample-rows, skip min_rows)"
         id: run_full

--- a/.github/workflows/smoke-weekly.yml
+++ b/.github/workflows/smoke-weekly.yml
@@ -24,7 +24,9 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
-        run: pip install -r dataset-incubator/requirements.txt
+        run: |
+          cd dataset-incubator
+          pip install -r requirements.txt
       - name: Smoke batch — HTTP candidates
         id: batch
         run: |

--- a/.github/workflows/smoke-weekly.yml
+++ b/.github/workflows/smoke-weekly.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.12"
-  TOOLKIT_VERSION: v1.19.0
+  # TOOLKIT_VERSION è centralizzato in requirements.txt
 
 jobs:
   smoke-http:
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install toolkit
-        run: pip install git+https://github.com/dataciviclab/toolkit.git@${{ env.TOOLKIT_VERSION }}
+      - name: Install dependencies
+        run: pip install -r dataset-incubator/requirements.txt
       - name: Smoke batch — HTTP candidates
         id: batch
         run: |

--- a/.github/workflows/validate-candidate-structure.yml
+++ b/.github/workflows/validate-candidate-structure.yml
@@ -21,5 +21,8 @@ jobs:
           python-version: "3.12"
           cache: 'pip'
 
+      - name: Install dependencies
+        run: python -m pip install pyyaml
+
       - name: Validate candidate structure
         run: python scripts/validate_candidate_structure.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,11 @@
 # GCS client/paths, MCP core. Usata da scripts/ e tools/clean-query-mcp/.
 # Extras duckdb + gcs per safe_connect() e upload su GCS.
 lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.1
+
+# dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.19.0
+
+# jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
+jsonschema>=4.0
+
+# pyyaml è transitivo da toolkit — non serve esplicitarlo

--- a/scripts/validate_candidate_structure.py
+++ b/scripts/validate_candidate_structure.py
@@ -84,6 +84,13 @@ def validate_dataset_name_yml(yml_path: Path, failures: list[str]) -> None:
         return
     try:
         import yaml
+    except ImportError:
+        rel = yml_path.relative_to(ROOT)
+        failures.append(
+            f"{rel}: cannot validate dataset.name — PyYAML non installato"
+        )
+        return
+    try:
         with open(yml_path, encoding="utf-8") as f:
             cfg = yaml.safe_load(f) or {}
         name = cfg.get("dataset", {}).get("name", "")
@@ -92,7 +99,7 @@ def validate_dataset_name_yml(yml_path: Path, failures: list[str]) -> None:
             failures.append(
                 f"{rel}: invalid dataset.name '{name}' — must match ^[a-z0-9_]+$"
             )
-    except Exception:
+    except yaml.YAMLError:
         pass  # YAML syntax errors are caught by other validators / CI
 
 

--- a/scripts/validate_candidate_structure.py
+++ b/scripts/validate_candidate_structure.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 from typing import Literal
@@ -10,6 +11,10 @@ LayoutType = Literal[
     "single-source", "multi-source", "ambiguous", "unknown",
     "support-dataset", "compose",
 ]
+
+# Convenzioni slug contratto cross-repo
+DIR_NAME_RE = re.compile(r"^[a-z0-9-]+$")
+DATASET_NAME_RE = re.compile(r"^[a-z0-9_]+$")
 
 
 def detect_candidate_layout(base_dir: Path) -> dict:
@@ -63,9 +68,39 @@ def validate_root_docs(base_dir: Path, failures: list[str]) -> None:
         failures.append(f"missing {base_dir.relative_to(ROOT) / 'notes.md'}")
 
 
+def validate_dir_name(base_dir: Path, failures: list[str]) -> None:
+    """Validate that the directory name follows the slug convention ^[a-z0-9-]+$."""
+    dir_name = base_dir.name
+    if not DIR_NAME_RE.match(dir_name):
+        rel = base_dir.relative_to(ROOT).as_posix()
+        failures.append(
+            f"{rel}: invalid directory name '{dir_name}' — must match ^[a-z0-9-]+$"
+        )
+
+
+def validate_dataset_name_yml(yml_path: Path, failures: list[str]) -> None:
+    """Validate that dataset.name (if present) follows ^[a-z0-9_]+$."""
+    if not yml_path.exists():
+        return
+    try:
+        import yaml
+        with open(yml_path, encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+        name = cfg.get("dataset", {}).get("name", "")
+        if name and not DATASET_NAME_RE.match(name):
+            rel = yml_path.relative_to(ROOT)
+            failures.append(
+                f"{rel}: invalid dataset.name '{name}' — must match ^[a-z0-9_]+$"
+            )
+    except Exception:
+        pass  # YAML syntax errors are caught by other validators / CI
+
+
 def validate_single_source(base_dir: Path, failures: list[str]) -> None:
     dataset_yml = base_dir / "dataset.yml"
     sql_dir = base_dir / "sql"
+
+    validate_dataset_name_yml(dataset_yml, failures)
 
     if not dataset_yml.exists():
         failures.append(f"missing {dataset_yml.relative_to(ROOT)}")
@@ -82,6 +117,8 @@ def validate_compose_root(base_dir: Path, failures: list[str]) -> None:
     """Validate a standalone compose dataset (mart-only, no raw/clean)."""
     dataset_yml = base_dir / "dataset.yml"
     sql_dir = base_dir / "sql"
+
+    validate_dataset_name_yml(dataset_yml, failures)
 
     if not dataset_yml.exists():
         failures.append(f"missing {dataset_yml.relative_to(ROOT)}")
@@ -121,6 +158,8 @@ def validate_multi_source(base_dir: Path, failures: list[str]) -> None:
         dataset_yml = source_dir / "dataset.yml"
         sql_dir = source_dir / "sql"
 
+        validate_dataset_name_yml(dataset_yml, failures)
+
         if not dataset_yml.exists():
             failures.append(f"missing {dataset_yml.relative_to(ROOT)}")
         if not sql_dir.is_dir():
@@ -136,6 +175,10 @@ def validate_multi_source(base_dir: Path, failures: list[str]) -> None:
 
 def validate_entry(base_dir: Path, failures: list[str]) -> None:
     rel_str = base_dir.relative_to(ROOT).as_posix()
+
+    # Validate slug conventions
+    validate_dir_name(base_dir, failures)
+    validate_dataset_name_yml(base_dir / "dataset.yml", failures)
 
     info = detect_candidate_layout(base_dir)
     layout = info["layout"]

--- a/tests/test_validate_candidate_structure.py
+++ b/tests/test_validate_candidate_structure.py
@@ -188,6 +188,75 @@ class TestValidateMultiSource:
         assert any("compose" in f for f in failures)
 
 
+class TestValidateDirName:
+    @pytest.mark.contract
+    @pytest.mark.parametrize("dir_name,valid", [
+        ("ok-ds", True),
+        ("ds-123", True),
+        ("a", True),
+        ("UPPER", False),
+        ("camelCase", False),
+        ("underscore_name", False),
+        ("spaces name", False),
+    ])
+    def test_convention(self, tmp_path, patch_root, dir_name, valid):
+        from validate_candidate_structure import validate_dir_name
+        base = patch_root / "candidates" / dir_name
+        base.mkdir(parents=True, exist_ok=True)
+        failures: list[str] = []
+        validate_dir_name(base, failures)
+        if valid:
+            assert failures == [], f"expected valid: {dir_name}"
+        else:
+            assert any("invalid directory name" in f for f in failures)
+
+
+class TestValidateDatasetNameYml:
+    @pytest.mark.contract
+    @pytest.mark.parametrize("yml_content,valid", [
+        ({"dataset": {"name": "ok_name"}}, True),
+        ({"dataset": {"name": "name_123"}}, True),
+        ({"dataset": {"name": "hyphen-name"}}, False),
+        ({"dataset": {"name": "MixedCase"}}, False),
+        ({"dataset": {"name": "has space"}}, False),
+        ({"dataset": {}}, True),  # no name = skip
+        ({}, True),  # no dataset = skip
+    ])
+    def test_name_format(self, tmp_path, patch_root, yml_content, valid):
+        from validate_candidate_structure import validate_dataset_name_yml
+        import yaml
+        base = patch_root / "candidates" / "test-ds"
+        base.mkdir(parents=True)
+        yml_path = base / "dataset.yml"
+        with open(yml_path, "w", encoding="utf-8") as f:
+            yaml.dump(yml_content, f)
+        failures: list[str] = []
+        validate_dataset_name_yml(yml_path, failures)
+        if valid:
+            assert failures == [], f"expected valid: {yml_content}"
+        else:
+            assert any("invalid dataset.name" in f for f in failures)
+
+    @pytest.mark.contract
+    def test_missing_file(self, tmp_path):
+        from validate_candidate_structure import validate_dataset_name_yml
+        yml_path = tmp_path / "nonexistent.yml"
+        failures: list[str] = []
+        validate_dataset_name_yml(yml_path, failures)
+        assert failures == []
+
+    @pytest.mark.contract
+    def test_broken_yaml(self, tmp_path):
+        from validate_candidate_structure import validate_dataset_name_yml
+        yml_path = tmp_path / "broken.yml"
+        yml_path.parent.mkdir(parents=True, exist_ok=True)
+        yml_path.write_text("{invalid: yaml: : }")
+        failures: list[str] = []
+        # Should not crash, just skip silently
+        validate_dataset_name_yml(yml_path, failures)
+        assert failures == []
+
+
 class TestValidateEntry:
     @pytest.mark.contract
     def test_single_source_ok(self, tmp_path, patch_root):
@@ -233,3 +302,30 @@ class TestValidateEntry:
         failures: list[str] = []
         validate_entry(base, failures)
         assert any("no valid structure" in f for f in failures)
+
+    @pytest.mark.contract
+    def test_rejects_bad_dir_name(self, tmp_path, patch_root):
+        from validate_candidate_structure import validate_entry
+        base = patch_root / "candidates" / "BadDir"
+        base.mkdir(parents=True)
+        failures: list[str] = []
+        validate_entry(base, failures)
+        assert any("invalid directory name" in f for f in failures)
+
+    @pytest.mark.contract
+    def test_rejects_bad_dataset_name(self, tmp_path, patch_root):
+        from validate_candidate_structure import validate_entry
+        import yaml
+        base = patch_root / "candidates" / "test-ds"
+        base.mkdir(parents=True)
+        yml_path = base / "dataset.yml"
+        with open(yml_path, "w", encoding="utf-8") as f:
+            yaml.dump({"dataset": {"name": "Bad-Name"}}, f)
+        _touch(base / "README.md")
+        _touch(base / "notes.md")
+        _mkdir(base / "sql")
+        _touch(base / "sql" / "clean.sql")
+        _touch(base / "sql" / "mart.sql")
+        failures: list[str] = []
+        validate_entry(base, failures)
+        assert any("invalid dataset.name" in f for f in failures)


### PR DESCRIPTION
## Sintesi

Rafforza la resilienza dei workflow CI di dataset-incubator: un candidate che fallisce non blocca più l'intero catalogo. Centralizza la versione del toolkit in requirements.txt (come già fa source-observatory). Aggiunge validazione dello slug contract all'ingresso dei candidate.

## Cosa cambia

- [x] workflow o CI
- [x] cleanup — refactoring, rimozioni, allineamento
- [ ] candidate — nuovo dataset o aggiornamento

### post-merge-candidate.yml

- `check=True` sostituito con error collection per-candidato: GCS push fallito non blocca gli altri candidate
- Resolve fallito (`resolve_sample_run.py`) ora contribuisce a `failed_configs` (prima era skip silenzioso)
- Catalog rebuild (`build_clean_catalog.py --derive --write / --check-gcs`) avviene solo se almeno un push GCS è riuscito, con `check=False` + log warning
- `cache: 'pip'` aggiunto al job `build-and-pr` (mancante)
- `concurrency:` group per evitare race condition su merge multipli

### pr-toolkit-check.yml

- `concurrency:` group con `cancel-in-progress: true` — cancella run precedenti dello stesso PR

### requirements.txt

- Aggiunto `dataciviclab-toolkit @ git+...@v1.19.0` (single source of truth, eliminati 4 `TOOLKIT_VERSION` da workflow)
- Aggiunto `jsonschema>=4.0` (usato da `build_pipeline_signals.py`, `update_pipeline_sample_runs.py`)
- Tutti i workflow ora usano `pip install -r requirements.txt`
- Eliminato `.github/actions/install-toolkit/` (composite action non più necessario)

### validate_candidate_structure.py

- Nuova validazione: directory name (slug) deve matchare `^[a-z0-9-]+$`
- Nuova validazione: `dataset.name` deve matchare `^[a-z0-9_]+$`
- Applicata in `validate_entry()`, `validate_single_source()`, `validate_compose_root()`, `validate_multi_source()`
- 12 nuovi test (45 totali)

## Impatto

- [ ] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
- [ ] Solo documentazione o metadati
- [x] Nessun impatto visibile per chi usa il repository

## Verifica

```bash
python -m pytest tests/test_validate_candidate_structure.py -v    # 45 test, tutti pass
python -m pytest tests/ -q --tb=line                              # full suite, 229 test
python scripts/validate_candidate_structure.py                     # deve passare su candidati esistenti
```

- [x] `python scripts/validate_candidate_structure.py` passato
- [x] Test suite completo passato (229 test)
- [x] Perimetro stretto: solo CI + validazione, nessuna logica di pipeline modificata

## Note

La directory `.github/actions/install-toolkit/` è stata eliminata — il toolkit ora è pinato in `requirements.txt` come dependency standard, esattamente come fa source-observatory. Per aggiornare la versione, basta editare requirements.txt (e non 4 workflow + 1 action).
