### PR TITLE
fix: promote mim_alunni_corso_eta e popolazione_istat a published

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3116,7 +3116,7 @@
         "path": "gs://dataciviclab-clean/mim_alunni_corso_eta/*/mim_alunni_corso_eta_*_clean.parquet",
         "multi_file": true
       },
-      "stage": "incubating",
+      "stage": "published",
       "registry_source": "derive_auto"
     },
     {
@@ -4052,7 +4052,7 @@
         "path": "gs://dataciviclab-clean/popolazione_istat_comunale_2019_2025/*/popolazione_istat_comunale_2019_2025_*_clean.parquet",
         "multi_file": true
       },
-      "stage": "incubating",
+      "stage": "published",
       "registry_source": "derive_auto"
     },
     {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2136,7 +2136,7 @@
         "path": "gs://dataciviclab-clean/istat_housing_crowding/2024/istat_housing_crowding_2024_clean.parquet",
         "multi_file": false
       },
-      "stage": "incubating",
+      "stage": "published",
       "registry_source": "derive_auto"
     },
     {


### PR DESCRIPTION
## Cosa

Promozione a published di 2 dataset che hanno già pagina Explorer live.

| Slug | Stage prima | Stage dopo |
|---|---|---|
| `mim_alunni_corso_eta` | incubating | published |
| `popolazione_istat_comunale_2019_2025` | incubating | published |

Entrambi hanno pagina in data-explorer da PR #127 e #129 mergiate.