### PR TITLE
chore(post-merge): aggiorna registry per PR #431

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-30",
+  "generated_at": "2026-06-02",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -552,10 +552,12 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "run_id": "26845334383",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26845334383",
+        "checked_at": "2026-06-02",
+        "years": [
+          2024
+        ],
         "config_path": "support_datasets/bdap-anagrafe-enti/dataset.yml"
       }
     },


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #431 — feat(bdap-anagrafe-enti): run stats e documentazione bridge columns

Changed candidate/support roots:

- `bdap-anagrafe-enti` (support_dataset, `support_datasets/bdap-anagrafe-enti`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [ ] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `support_datasets/bdap-anagrafe-enti/dataset.yml` -> artifact `sample-run-bdap-anagrafe-enti`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug bdap_anagrafe_enti --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
