### PR TITLE
fix(bdap-anagrafe-enti): anno 2024→2026 e pyarrow in requirements.txt

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -290,7 +290,7 @@ jobs:
     needs:
       - detect
       - sample_run
-    if: always() && needs.detect.outputs.has_items == 'true'
+    if: needs.sample_run.result == 'success' && needs.detect.outputs.has_items == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,7 @@ dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.19.0
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0
 
+# pyarrow — per push_archive.py (GCS push post-merge)
+pyarrow>=24.0.0
+
 # pyyaml è transitivo da toolkit — non serve esplicitarlo

--- a/support_datasets/bdap-anagrafe-enti/dataset.yml
+++ b/support_datasets/bdap-anagrafe-enti/dataset.yml
@@ -4,7 +4,7 @@ schema_version: 1
 dataset:
   name: "bdap_anagrafe_enti"
   source_id: "openbdap"
-  years: [2024]
+  years: [2026]
 
 raw:
   output_policy: overwrite


### PR DESCRIPTION
## Sintesi

Due fix post-merge per far funzionare il GCS push di `bdap-anagrafe-enti`:

1. **Anno sbagliato**: `years: [2024]` → `[2026]` (il dato arriva a febbraio 2026)
2. **pyarrow mancante**: `push_archive.py` importa pyarrow ma non era in `requirements.txt` → GCS push falliva

## Cosa cambia

- [ ] candidate — nuovo dataset o aggiornamento
- [x] support — dataset di supporto
- [ ] docs — struttura candidate, README, template
- [ ] cleanup — refactoring, rimozioni, allineamento
- [x] workflow o CI
- [ ] altro

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
- [ ] Solo documentazione o metadati
- [ ] Nessun impatto visibile per chi usa il repository

## Verifica

- Post-merge CI #431 falliva su `push_archive.py` per `ModuleNotFoundError: No module named 'pyarrow'`
- Con pyarrow in requirements.txt, il GCS push del prossimo merge dovrebbe funzionare

## Note / rischi

- L'anno `2026` è l'anno del dump più recente. Se il dataset viene aggiornato ogni anno, `years` va aumentato di conseguenza.
- Il dataset non è multi-anno (singolo dump live), quindi un solo anno è corretto.
