### PR TITLE
chore(post-merge): aggiorna registry per PR #433

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-05-30",
+  "updated_at": "2026-06-02",
   "datasets": [
     {
       "slug": "aifa_spesa_consumo",
@@ -123,6 +123,404 @@
         "type": "gcs",
         "path": "gs://dataciviclab-clean/aifa_spesa_consumo/*/aifa_spesa_consumo_*_clean.parquet",
         "multi_file": true
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "bdap_anagrafe_enti",
+      "name": "Bdap Anagrafe Enti",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2026,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "id_ente",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "denominazione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cf",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "piva",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "data_istituzione",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_cessazione",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_ateco",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "descr_codice_ateco",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_forma_giuridica",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "descr_forma_giuridica",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "telefono",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "fax",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "url",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "nome_resp",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cogn_resp",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "titolo_resp",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "indirizzo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cap",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_istat_comune",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_comune",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "dizione_comune",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_catastale",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_provincia",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "dizione_provincia",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "sigla_provincia",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_regione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "dizione_regione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_zona",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "dizione_zona",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "stato_partecipazione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_ente_siope",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "id_tipologia_siope",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_tipologia_siope",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "descr_tipologia_siope",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "data_inclusione_siope",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_esclusione_siope",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_ente_ipa",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "id_categoria_ipa",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_categoria_ipa",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "descr_categoria_ipa",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_tipologia_ipa",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "descr_tipologia_ipa",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "data_inclusione_ipa",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_esclusione_ipa",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_ente_miur",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "id_tipologia_miur",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_tipologia_miur",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "descr_tipologia_miur",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "id_tipologia_dt",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_tipologia_dt",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "descr_tipologia_dt",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_ente_ssn",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_ente_istat_s13",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "id_tipologia_istat_s13",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_tipologia_istat_s13",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "descr_tipologia_istat_s13",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "data_inclusione_istat_s13",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_esclusione_istat_s13",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "id_tipologia_dlgs_118_2011",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_tipologia_dlgs_118_2011",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "descr_tipologia_dlgs_118_2011",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "data_inclusione_dlgs_118_2011",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_esclusione_dlgs_118_2011",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/bdap_anagrafe_enti/2026/bdap_anagrafe_enti_2026_clean.parquet",
+        "multi_file": false
       },
       "stage": "published",
       "registry_source": "derive_auto"

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -129,10 +129,10 @@
     },
     {
       "slug": "bdap_anagrafe_enti",
-      "name": "Bdap Anagrafe Enti",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "name": "BDAP Anagrafe Enti Pubblici",
+      "description": "Anagrafe completa degli enti pubblici italiani. 63 colonne, ~38k enti. Mappa codici IPA, SIOPE, ISTAT, MIUR, SSN, catastale. Usata come bridge table per join cross-dataset nel joinability scan.",
+      "source": "MEF — Ragioneria Generale dello Stato / OpenBDAP",
+      "source_id": "openbdap",
       "period": {
         "start": 2026,
         "end": 2026
@@ -141,380 +141,380 @@
         {
           "name": "id_ente",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Identificativo univoco ente (chiave primaria)"
         },
         {
           "name": "denominazione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione ufficiale ente"
         },
         {
           "name": "cf",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice fiscale ente"
         },
         {
           "name": "piva",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Partita IVA ente"
         },
         {
           "name": "data_istituzione",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data istituzione ente"
         },
         {
           "name": "data_cessazione",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data cessazione ente (null se attivo)"
         },
         {
           "name": "codice_ateco",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ATECO attività economica"
         },
         {
           "name": "descr_codice_ateco",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione codice ATECO"
         },
         {
           "name": "codice_forma_giuridica",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Codice forma giuridica"
         },
         {
           "name": "descr_forma_giuridica",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione forma giuridica"
         },
         {
           "name": "telefono",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Numero telefono"
         },
         {
           "name": "fax",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Numero fax"
         },
         {
           "name": "url",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Sito web"
         },
         {
           "name": "nome_resp",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Nome responsabile"
         },
         {
           "name": "cogn_resp",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Cognome responsabile"
         },
         {
           "name": "titolo_resp",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Titolo responsabile"
         },
         {
           "name": "indirizzo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Indirizzo sede"
         },
         {
           "name": "cap",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "CAP sede"
         },
         {
           "name": "codice_istat_comune",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT comune (chiave join)"
         },
         {
           "name": "codice_comune",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice comune interno BDAP"
         },
         {
           "name": "dizione_comune",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione comune"
         },
         {
           "name": "codice_catastale",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice catastale comune (chiave join IRPEF)"
         },
         {
           "name": "codice_provincia",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice provincia"
         },
         {
           "name": "dizione_provincia",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione provincia"
         },
         {
           "name": "sigla_provincia",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Sigla provincia (chiave join)"
         },
         {
           "name": "codice_regione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT regione (chiave join)"
         },
         {
           "name": "dizione_regione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione regione"
         },
         {
           "name": "codice_zona",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Codice zona geografica"
         },
         {
           "name": "dizione_zona",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione zona geografica"
         },
         {
           "name": "stato_partecipazione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Stato partecipazione (S/N)"
         },
         {
           "name": "codice_ente_siope",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice SIOPE ente (chiave join BDAP)"
         },
         {
           "name": "id_tipologia_siope",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "ID tipologia SIOPE"
         },
         {
           "name": "codice_tipologia_siope",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice tipologia SIOPE"
         },
         {
           "name": "descr_tipologia_siope",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione tipologia SIOPE"
         },
         {
           "name": "data_inclusione_siope",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data inclusione registro SIOPE"
         },
         {
           "name": "data_esclusione_siope",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data esclusione registro SIOPE"
         },
         {
           "name": "codice_ente_ipa",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice IPA ente (chiave join PA)"
         },
         {
           "name": "id_categoria_ipa",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "ID categoria IPA"
         },
         {
           "name": "codice_categoria_ipa",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice categoria IPA"
         },
         {
           "name": "descr_categoria_ipa",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione categoria IPA"
         },
         {
           "name": "codice_tipologia_ipa",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice tipologia IPA (PA/GPS)"
         },
         {
           "name": "descr_tipologia_ipa",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione tipologia IPA"
         },
         {
           "name": "data_inclusione_ipa",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data inclusione IPA"
         },
         {
           "name": "data_esclusione_ipa",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data esclusione IPA"
         },
         {
           "name": "codice_ente_miur",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice MIUR ente (chiave join MIM scuola)"
         },
         {
           "name": "id_tipologia_miur",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "ID tipologia MIUR"
         },
         {
           "name": "codice_tipologia_miur",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice tipologia MIUR (IC, DD, ecc.)"
         },
         {
           "name": "descr_tipologia_miur",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione tipologia MIUR"
         },
         {
           "name": "id_tipologia_dt",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "ID tipologia DT"
         },
         {
           "name": "codice_tipologia_dt",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Codice tipologia DT"
         },
         {
           "name": "descr_tipologia_dt",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione tipologia DT"
         },
         {
           "name": "codice_ente_ssn",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice SSN ente (chiave join sanità)"
         },
         {
           "name": "codice_ente_istat_s13",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Codice ISTAT S13 ente"
         },
         {
           "name": "id_tipologia_istat_s13",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "ID tipologia ISTAT S13"
         },
         {
           "name": "codice_tipologia_istat_s13",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Codice tipologia ISTAT S13"
         },
         {
           "name": "descr_tipologia_istat_s13",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione tipologia ISTAT S13"
         },
         {
           "name": "data_inclusione_istat_s13",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data inclusione ISTAT S13"
         },
         {
           "name": "data_esclusione_istat_s13",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data esclusione ISTAT S13"
         },
         {
           "name": "id_tipologia_dlgs_118_2011",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "ID tipologia DLGS 118/2011"
         },
         {
           "name": "codice_tipologia_dlgs_118_2011",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice tipologia DLGS 118/2011"
         },
         {
           "name": "descr_tipologia_dlgs_118_2011",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione tipologia DLGS 118/2011"
         },
         {
           "name": "data_inclusione_dlgs_118_2011",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data inclusione DLGS 118/2011"
         },
         {
           "name": "data_esclusione_dlgs_118_2011",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data esclusione DLGS 118/2011"
         }
       ],
       "location": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-30",
+  "generated_at": "2026-06-02",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -552,10 +552,12 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2024,
+        "run_id": "26845796510",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26845796510",
+        "checked_at": "2026-06-02",
+        "years": [
+          2026
+        ],
         "config_path": "support_datasets/bdap-anagrafe-enti/dataset.yml"
       }
     },


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #433 — fix(bdap-anagrafe-enti): anno 2024→2026 e pyarrow in requirements.txt

Changed candidate/support roots:

- `bdap-anagrafe-enti` (support_dataset, `support_datasets/bdap-anagrafe-enti`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `support_datasets/bdap-anagrafe-enti/dataset.yml` -> artifact `sample-run-bdap-anagrafe-enti`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug bdap_anagrafe_enti --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
