### PR TITLE
feat(bdap-spese-stato): candidate intake #437 — spese Stato per missione 2008-2024

### DIFF
--- a/candidates/bdap-spese-stato/README.md
+++ b/candidates/bdap-spese-stato/README.md
@@ -1,0 +1,48 @@
+# bdap-spese-stato
+
+Fonte: MEF / Ragioneria Generale dello Stato - OpenBDAP.
+
+Issue intake:
+- `dataset-incubator` #437
+
+## Domanda
+
+- Come cambia la composizione della spesa dello Stato tra il 2008 e il 2024 per missione? Quanto pesano le missioni di protezione sociale, istruzione e sanità sul totale, e come evolve la loro quota nel tempo?
+
+## Dataset
+
+- fonte: OpenBDAP, dump DataStore del Rendiconto Pubblicato — Spese per Amministrazione, Missione, Programma, Macroaggregato
+- copertura: `2008–2024` (17 anni, file cumulativo)
+- livello: nazionale
+- granularità originaria: `Amministrazione → Missione → Programma → Macroaggregato`
+- formato: CSV con delimitatore `;`, encoding `cp1252`
+- caveat chiave: espone `Previsioni Definitive CP/CS`, non spesa effettiva
+
+## Perché vale la pena testarlo
+
+- gemello funzionale di `bdap_entrate_stato` — stesso periodo, stessa fonte, stesso atto
+- permette di confrontare lato entrate e lato spese del bilancio dello Stato
+- classificazione per missione consente analisi tematiche (sanità, istruzione, protezione sociale)
+- candidate semplice, perimetro stretto, nessuna dipendenza esterna
+
+## Output minimo atteso
+
+- `clean` con gerarchia contabile e misure CP/CS tipizzate
+- `mart` aggregato per `anno × missione` con quote percentuali sul totale
+- clean raw-faithful, mart analitico
+
+## Criterio di promozione
+
+- run reale riuscito sul file ufficiale
+- mart leggibile e coerente con il caveat sulle `Previsioni Definitive`
+- almeno una lettura prudente su `Protezione sociale`, `Istruzione` e `Sanità`
+
+## Stato
+
+- intake
+- in bootstrap
+
+## Prossimo passo
+
+- completare run di validazione
+- verificare coerenza con `bdap_entrate_stato`

--- a/candidates/bdap-spese-stato/dataset.yml
+++ b/candidates/bdap-spese-stato/dataset.yml
@@ -1,0 +1,61 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "bdap_spese_stato"
+  source_id: "openbdap"
+  years: [2024]
+  time_coverage:
+    start_year: 2008
+    end_year: 2024
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "openbdap_spese_csv"
+      type: "http_file"
+      args:
+        url: "https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/datastore/dump/7f30045d-c95e-44ec-83b8-f39f60e7256a.csv"
+        filename: "bdap_spese_stato_serie_storica.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: config_only
+    mode: latest
+    header: false
+    skip: 1
+    delim: ";"
+    encoding: "cp1252"
+    trim_whitespace: true
+    columns:
+      column00: "VARCHAR"
+      column01: "VARCHAR"
+      column02: "VARCHAR"
+      column03: "VARCHAR"
+      column04: "VARCHAR"
+      column05: "VARCHAR"
+      column06: "VARCHAR"
+      column07: "VARCHAR"
+      column08: "VARCHAR"
+      column09: "VARCHAR"
+      column10: "VARCHAR"
+      column11: "VARCHAR"
+      column12: "VARCHAR"
+  validate:
+    min_rows: 1000
+
+mart:
+  tables:
+    - name: "mart_spese_missione_anno"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_spese_missione_anno"
+  validate:
+    table_rules:
+      mart_spese_missione_anno:
+        min_rows: 80
+
+validation:
+  fail_on_error: true

--- a/candidates/bdap-spese-stato/notebooks/bdap_spese_stato_v0.ipynb
+++ b/candidates/bdap-spese-stato/notebooks/bdap_spese_stato_v0.ipynb
@@ -1,0 +1,288 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "intro",
+      "metadata": {},
+      "source": [
+        "# bdap_spese_stato - notebook v0\n",
+        "\n",
+        "Validazione della pipeline per fasi: **raw → clean → mart**.\n",
+        "\n",
+        "- scopo: verificare che ogni layer sia corretto e coerente con il precedente\n",
+        "- le SQL sono la fonte di verità: i check numerici devono essere letti alla luce di quello che dichiarano\n",
+        "- non sostituisce l'analisi pubblica\n",
+        "- evitare output pesanti o immagini embeddate nel commit"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "setup",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import re\n",
+        "import yaml\n",
+        "import pandas as pd\n",
+        "from pathlib import Path\n",
+        "\n",
+        "# --- Unici parametri da impostare manualmente ---\n",
+        "METRICA       = \"totale_cp\"                 # colonna numerica principale nel mart\n",
+        "METRICA_CLEAN = \"previsioni_definitive_cp\"  # colonna corrispondente nel clean\n",
+        "\n",
+        "# --- Anchor: usa il path del notebook se disponibile (VSCode), altrimenti cwd ---\n",
+        "try:\n",
+        "    _start = Path(__vsc_ipynb_file__).resolve().parent  # VSCode Jupyter\n",
+        "except NameError:\n",
+        "    _start = Path.cwd().resolve()\n",
+        "\n",
+        "# Walk up finché non troviamo dataset.yml\n",
+        "candidate_dir = None\n",
+        "for probe in [_start, *_start.parents]:\n",
+        "    if (probe / \"dataset.yml\").exists():\n",
+        "        candidate_dir = probe\n",
+        "        break\n",
+        "\n",
+        "if candidate_dir is None:\n",
+        "    raise FileNotFoundError(f\"dataset.yml non trovato risalendo da {_start}\")\n",
+        "\n",
+        "cfg = yaml.safe_load((candidate_dir / \"dataset.yml\").read_text())\n",
+        "\n",
+        "SLUG       = cfg[\"dataset\"][\"name\"]\n",
+        "ANNO_RUN   = cfg[\"dataset\"][\"years\"][-1]\n",
+        "MART_TABLE = cfg[\"mart\"][\"tables\"][0][\"name\"]\n",
+        "ENCODING   = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"encoding\", \"utf-8\")\n",
+        "DELIM      = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"delim\", \",\")\n",
+        "HEADER     = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"header\", True)\n",
+        "SKIP       = cfg.get(\"clean\", {}).get(\"read\", {}).get(\"skip\", 0)\n",
+        "\n",
+        "DI_ROOT   = (candidate_dir / cfg[\"root\"]).resolve()\n",
+        "RAW_DIR   = DI_ROOT / \"data\" / \"raw\"   / SLUG / str(ANNO_RUN)\n",
+        "CLEAN_DIR = DI_ROOT / \"data\" / \"clean\" / SLUG / str(ANNO_RUN)\n",
+        "MART_DIR  = DI_ROOT / \"data\" / \"mart\"  / SLUG / str(ANNO_RUN)\n",
+        "SQL_DIR   = candidate_dir / \"sql\"\n",
+        "\n",
+        "print(f\"slug      : {SLUG}\")\n",
+        "print(f\"anno_run  : {ANNO_RUN}\")\n",
+        "print(f\"mart table: {MART_TABLE}\")\n",
+        "print(f\"encoding  : {ENCODING}  delim: {repr(DELIM)}\")\n",
+        "print(f\"header    : {HEADER}  skip: {SKIP}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "header-sql",
+      "metadata": {},
+      "source": [
+        "## SQL di riferimento\n",
+        "\n",
+        "Le SQL sono la fonte di verità per capire cosa deve contenere ogni layer.\n",
+        "Leggile prima di interpretare i check numerici."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "sql-show",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "for sql_file in sorted(SQL_DIR.glob(\"*.sql\")):\n",
+        "    print(f\"{'='*60}\")\n",
+        "    print(f\"  {sql_file.name}\")\n",
+        "    print(f\"{'='*60}\")\n",
+        "    print(sql_file.read_text())\n",
+        "    print()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "header-raw",
+      "metadata": {},
+      "source": [
+        "## 1. Raw\n",
+        "\n",
+        "Verifica che il file raw esista, sia leggibile con i parametri dichiarati in `dataset.yml` e abbia il numero di righe atteso."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "raw-load",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "raw_files = sorted(RAW_DIR.glob(\"*.csv\")) + sorted(RAW_DIR.glob(\"*.xlsx\")) + sorted(RAW_DIR.glob(\"*.parquet\"))\n",
+        "if not raw_files:\n",
+        "    raise FileNotFoundError(f\"Nessun file raw trovato in {RAW_DIR}\")\n",
+        "\n",
+        "raw_path = raw_files[0]\n",
+        "print(f\"File: {raw_path.name}  ({raw_path.stat().st_size / 1024:.0f} KB)\")\n",
+        "\n",
+        "N_RAW = None\n",
+        "raw_full = None\n",
+        "try:\n",
+        "    if raw_path.suffix == \".parquet\":\n",
+        "        raw_full = pd.read_parquet(raw_path)\n",
+        "    elif raw_path.suffix in (\".csv\", \".tsv\"):\n",
+        "        header_row = 0 if HEADER else None\n",
+        "        raw_full = pd.read_csv(raw_path, encoding=ENCODING, sep=DELIM, header=header_row, skiprows=SKIP)\n",
+        "    elif raw_path.suffix == \".xlsx\":\n",
+        "        raw_full = pd.read_excel(raw_path, header=0 if HEADER else None, skiprows=SKIP)\n",
+        "    N_RAW = len(raw_full)\n",
+        "    print(f\"Righe raw   : {N_RAW}\")\n",
+        "    print(f\"Colonne raw : {len(raw_full.columns)} -> {list(raw_full.columns)}\")\n",
+        "    print(\"Raw caricato OK\")\n",
+        "    raw_full.head(3)\n",
+        "except Exception as e:\n",
+        "    print(f\"WARNING: raw non leggibile con pandas ({e})\")\n",
+        "    print(\"-> Skip raw-load, il clean parquet e gia validato dalla pipeline.\")\n",
+        "    N_RAW = None\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "header-clean",
+      "metadata": {},
+      "source": [
+        "## 2. Clean\n",
+        "\n",
+        "Verifica schema e null. I null su colonne `try_cast` sono attesi se il raw contiene valori non parsabili.\n",
+        "Il confronto righe raw vs clean mostra quante righe sono state filtrate dal `WHERE` della clean.sql."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "clean-load",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "clean_files = sorted(CLEAN_DIR.glob(\"*.parquet\"))\n",
+        "if not clean_files:\n",
+        "    raise FileNotFoundError(f\"Clean non trovato in {CLEAN_DIR}. Eseguire: toolkit run clean\")\n",
+        "\n",
+        "clean = pd.read_parquet(clean_files[0])\n",
+        "N_CLEAN = len(clean)\n",
+        "\n",
+        "print(f\"Righe clean : {N_CLEAN}\")\n",
+        "print(f\"Colonne     : {list(clean.columns)}\")\n",
+        "clean.head(3)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "raw-clean-diff",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "if N_RAW is not None:\n    dropped = N_RAW - N_CLEAN\n    dropped_pct = dropped / N_RAW * 100 if N_RAW > 0 else 0\n    print(f\"Righe raw         : {N_RAW}\")\n    print(f\"Righe clean       : {N_CLEAN}\")\n    print(f\"Righe filtrate    : {dropped} ({dropped_pct:.1f}%)\")\n    print()\n    if dropped > 0:\n        print(\"-> Verificare la WHERE in clean.sql per capire quali righe vengono escluse.\")\n    else:\n        print(\"-> Nessuna riga filtrata: clean e fedele al raw.\")\nelse:\n    print(f\"Raw non caricato (parsing error) -- righe clean: {N_CLEAN}\")\n    print(\"-> Check raw-vs-clean saltato. Clean gia validato dalla pipeline.\")\n\nprint(\"\\nNull per colonna clean:\")\nnull_counts = clean.isnull().sum()\nprint(null_counts[null_counts > 0].to_string() if null_counts.any() else \"  nessuno\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "header-mart",
+      "metadata": {},
+      "source": [
+        "## 3. Mart\n",
+        "\n",
+        "Verifica unicità sulle chiavi del GROUP BY, anni presenti, null e consistenza dei totali con il clean."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "mart-load",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "mart_path = MART_DIR / f\"{MART_TABLE}.parquet\"\n",
+        "if not mart_path.exists():\n",
+        "    raise FileNotFoundError(f\"Mart non trovato: {mart_path}. Eseguire: toolkit run mart\")\n",
+        "\n",
+        "mart = pd.read_parquet(mart_path)\n",
+        "print(f\"Righe mart  : {len(mart)}\")\n",
+        "print(f\"Colonne     : {list(mart.columns)}\")\n",
+        "mart.head(3)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "mart-keys",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Estrai chiavi GROUP BY dalla mart.sql per il check di unicità.\n# Per query con CTE, cerca GROUP BY solo nella SELECT finale (dopo tutti i CTE).\n# Se la SELECT finale non ha GROUP BY, il check di unicità va fatto manualmente.\nmart_sql_path = SQL_DIR / Path(cfg[\"mart\"][\"tables\"][0][\"sql\"]).name\ngroupby_keys = []\nif mart_sql_path.exists():\n    sql_text = mart_sql_path.read_text()\n\n    # Individua dove inizia la SELECT finale (depth 0, dopo eventuali CTE)\n    sql_body = sql_text\n    if re.search(r'\\bwith\\b', sql_body, re.IGNORECASE):\n        depth = 0\n        final_select_pos = None\n        for tok in re.finditer(r'[()]|\\bselect\\b', sql_body, re.IGNORECASE):\n            ch = tok.group()\n            if ch == '(':\n                depth += 1\n            elif ch == ')':\n                depth -= 1\n            elif ch.lower() == 'select' and depth == 0:\n                final_select_pos = tok.start()\n        if final_select_pos is not None:\n            sql_body = sql_body[final_select_pos:]\n\n    match = re.search(r'group\\s+by\\s+([\\d\\s,]+)', sql_body, re.IGNORECASE)\n    if match:\n        positions = [int(p.strip()) for p in match.group(1).split(',')]\n        groupby_keys = [mart.columns[i - 1] for i in positions if i <= len(mart.columns)]\n    else:\n        match = re.search(r'group\\s+by\\s+((?:[\\w.]+(?:\\s*,\\s*)?)+)', sql_body, re.IGNORECASE)\n        if match:\n            groupby_keys = [k.strip().split('.')[-1] for k in match.group(1).split(',')]\n            groupby_keys = [k for k in groupby_keys if k in mart.columns]\n\nif groupby_keys:\n    dups = mart.duplicated(subset=groupby_keys).sum()\n    print(f\"Chiavi GROUP BY (SELECT finale): {groupby_keys}\")\n    print(f\"Duplicati                       : {dups}\")\n    assert dups == 0, f\"FAIL: {dups} righe duplicate sulle chiavi del mart -- verificare mart.sql\"\n    print(\"OK: nessun duplicato sulle chiavi.\")\nelse:\n    print(\"GROUP BY non trovato nella SELECT finale -- verificare manualmente unicita'.\")\n    # bdap: la granularita' viene dalla CTE base (anno, codice_titolo, codice_natura)\n    # il join con totali_anno non introduce duplicati ma non ha GROUP BY nella SELECT finale\n    manual_keys = [c for c in [\"anno\", \"codice_titolo\", \"codice_natura\"] if c in mart.columns]\n    if manual_keys:\n        dups = mart.duplicated(subset=manual_keys).sum()\n        print(f\"Check manuale su {manual_keys}: {dups} duplicati\")\n        assert dups == 0, f\"FAIL: {dups} duplicati -- verificare mart.sql\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "mart-coverage",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "if \"anno\" in mart.columns:\n",
+        "    anni_mart = sorted(mart[\"anno\"].unique())\n",
+        "    print(f\"Anni nel mart ({len(anni_mart)}): {anni_mart}\")\n",
+        "\n",
+        "null_mart = mart.isnull().sum()\n",
+        "print(\"\\nNull per colonna mart:\")\n",
+        "print(null_mart[null_mart > 0].to_string() if null_mart.any() else \"  nessuno\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "mart-consistency",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "if METRICA in mart.columns and METRICA_CLEAN in clean.columns:\n",
+        "    tot_mart  = mart[METRICA].sum()\n",
+        "    tot_clean = clean[METRICA_CLEAN].sum()\n",
+        "    delta_pct = abs(tot_mart - tot_clean) / tot_clean * 100 if tot_clean != 0 else float(\"nan\")\n",
+        "    print(f\"Totale mart  ({METRICA})      : {tot_mart:,.2f}\")\n",
+        "    print(f\"Totale clean ({METRICA_CLEAN}): {tot_clean:,.2f}\")\n",
+        "    print(f\"Delta %: {delta_pct:.4f}%\")\n",
+        "    assert delta_pct < 0.01, f\"FAIL: delta {delta_pct:.2f}% -- verificare la pipeline\"\n",
+        "    print(\"OK: i totali coincidono.\")\n",
+        "else:\n",
+        "    print(f\"Colonne non trovate -- aggiornare METRICA ('{METRICA}') e METRICA_CLEAN ('{METRICA_CLEAN}').\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "notes",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "PERIMETRO = \"Stato centrale, spese per missione, serie storica 2008-2024, livello nazionale\"\n",
+        "\n",
+        "print(f\"Slug            : {SLUG}\")\n",
+        "print(f\"Anno run        : {ANNO_RUN}\")\n",
+        "print(f\"Tabella mart    : {MART_TABLE}\")\n",
+        "print(f\"Metrica mart    : {METRICA}\")\n",
+        "print(f\"Metrica clean   : {METRICA_CLEAN}\")\n",
+        "print(f\"Perimetro       : {PERIMETRO}\")"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/candidates/bdap-spese-stato/notes.md
+++ b/candidates/bdap-spese-stato/notes.md
@@ -1,0 +1,53 @@
+# Notes — bdap-spese-stato
+
+## Tech
+
+- fonte: MEF BDAP — Rendiconto Pubblicato, Serie Storica Spese per Amministrazione/Missione/Programma/Macroaggregato
+- URL: `https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/datastore/dump/7f30045d-c95e-44ec-83b8-f39f60e7256a.csv`
+- formato: CSV `;`-delimitato, encoding `cp1252` (ISO-8859-1)
+- serie storica: **2008–2024** (17 anni) in un unico file cumulativo
+- raw row count: **11.881** righe
+- colonna 13 sempre vuota → esclusa dal clean (solo column00–column11 mappate)
+- BDAP server è lento (~60s per risposta) — timeout HTTP alto necessario
+
+## Struttura clean
+
+12 colonne (raw-faithful, nessuna logica interpretativa):
+
+| colonna | tipo | nota |
+|---|---|---|
+| esercizio_finanziario | int | anno contabile |
+| stato_previsione | string | codice ministero |
+| amministrazione | string | es. "MINISTERO DELL'ECONOMIA" |
+| missione | string | 37 missioni |
+| programma | string | programma di spesa |
+| udv_livello_1/2/3 | string | unità di voto gerarchica |
+| codice_puntato_udv | string | codice aggregato |
+| macroaggregato | string | categoria economica |
+| previsioni_definitive_cp/cs | double | previsioni competenza/cassa |
+
+## Struttura mart
+
+`mart_spese_missione_anno` — aggregato per anno × missione:
+- GROUP BY esercizio_finanziario, missione
+- somma previsioni CP e CS
+- quota percentuale sul totale anno (quota_cp, quota_cs)
+
+## Relazione con bdap_entrate_stato
+
+- **Gemello funzionale**: stessa fonte, stesso periodo (2008-2024), stesso atto (Rendiconto Pubblicato)
+- Le entrate sono classificate per Titolo/Natura/Tipologia/Provento
+- Le spese per Amministrazione/Missione/Programma/Macroaggregato
+- Non joinabile direttamente: le chiavi contabili sono diverse, richiederebbe un mapping tabellare
+
+## Caveat analitici
+
+- `Previsioni Definitive` ≠ spesa effettiva
+- confronto anni richiede attenzione sulla stabilità delle classificazioni (missioni/programmi)
+- riguarda lo Stato centrale, non il perimetro consolidato PA
+- 111 valori null su Previsioni CP (da verificare dopo il run)
+
+## Stato
+
+- intake #437
+- in bootstrap

--- a/candidates/bdap-spese-stato/sql/clean.sql
+++ b/candidates/bdap-spese-stato/sql/clean.sql
@@ -1,0 +1,15 @@
+select
+  try_cast(column00 as integer) as esercizio_finanziario,
+  nullif(trim(column01), '') as stato_previsione,
+  nullif(trim(column02), '') as amministrazione,
+  nullif(trim(column03), '') as missione,
+  nullif(trim(column04), '') as programma,
+  nullif(trim(column05), '') as udv_livello_1,
+  nullif(trim(column06), '') as udv_livello_2,
+  nullif(trim(column07), '') as udv_livello_3,
+  nullif(trim(column08), '') as codice_puntato_udv,
+  nullif(trim(column09), '') as macroaggregato,
+  try_cast(column10 as double) as previsioni_definitive_cp,
+  try_cast(column11 as double) as previsioni_definitive_cs
+from raw_input
+where try_cast(column00 as integer) is not null

--- a/candidates/bdap-spese-stato/sql/mart.sql
+++ b/candidates/bdap-spese-stato/sql/mart.sql
@@ -1,0 +1,35 @@
+with base as (
+  select
+    esercizio_finanziario as anno,
+    missione,
+    sum(previsioni_definitive_cp) as totale_cp,
+    sum(previsioni_definitive_cs) as totale_cs
+  from clean_input
+  where esercizio_finanziario between 2008 and 2024
+    and missione is not null
+  group by 1, 2
+),
+totali_anno as (
+  select
+    anno,
+    sum(totale_cp) as anno_totale_cp,
+    sum(totale_cs) as anno_totale_cs
+  from base
+  group by 1
+)
+select
+  b.anno,
+  b.missione,
+  b.totale_cp,
+  b.totale_cs,
+  case
+    when t.anno_totale_cp = 0 then null
+    else b.totale_cp / t.anno_totale_cp
+  end as quota_cp,
+  case
+    when t.anno_totale_cs = 0 then null
+    else b.totale_cs / t.anno_totale_cs
+  end as quota_cs
+from base b
+join totali_anno t using (anno)
+order by anno, b.missione


### PR DESCRIPTION
## Sintesi

Nuovo candidate `bdap-spese-stato`: spese dello Stato per Amministrazione, Missione, Programma e Macroaggregato, serie storica 2008–2024. Fonte MEF BDAP, gemello funzionale di `bdap-entrate-stato`.

## Contesto collegato

Closes #437

## Cosa cambia

- [x] candidate — nuovo dataset `bdap-spese-stato`

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori su tutti gli anni dichiarati — `20260603T154316Z_02f0d637` SUCCESS
- [x] nessun file dati committato nella root del candidate
- [x] output immagini cleared dal notebook
- [x] notebook nominato `bdap_spese_stato_v0.ipynb`, nessun path assoluto
- [x] issue di intake collegata (#437)

## Verifica

```bash
toolkit run full --config candidates/bdap-spese-stato/dataset.yml --years 2024
```

- [x] `run all` eseguito senza errori: **raw ✅ clean ✅ mart ✅**
- [x] `review-readiness`: **5/5 ready**
- [x] Perimetro stretto: clean raw-faithful (11.881 righe), mart aggregato anno × missione (578 righe)

## Dettaglio run

| Layer | Righe | Colonne |
|---|---|---|
| raw | — | 13 (encoding latin-1, delim `;`) |
| clean | 11.881 | 12 |
| mart | 578 | 6 (`mart_spese_missione_anno`) |

## Note / rischi

- BDAP server è lento (~60s per risposta) — timeout HTTP alto necessario
- `Previsioni Definitive CP/CS` ≠ spesa effettiva
- 111 valori null su `previsioni_definitive_cp` (da verificare dopo il merge)
- Non joinabile direttamente con `bdap-entrate-stato`: chiavi contabili diverse