### PR TITLE
fix(dipendenti-pubblici): aggiunge quote e strict_mode per nuovo formato BDAP

### DIFF
--- a/candidates/dipendenti-pubblici/dataset.yml
+++ b/candidates/dipendenti-pubblici/dataset.yml
@@ -24,6 +24,8 @@ clean:
     header: true
     delim: ";"
     encoding: "cp1252"
+    quote: "\""
+    strict_mode: false
   validate:
     min_rows: 1000
 


### PR DESCRIPTION
BDAP ha cambiato formato CSV: header e valori ora sono tra doppi apici. 

Il weekly smoke falliva con `"Anno Rilevazione" not found`.

Fix: `quote: '"'` + `strict_mode: false`. Testato su 2018-2023, tutti ok.