### PR TITLE
chore(post-merge): aggiorna registry per PR #444

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-06-02",
+  "updated_at": "2026-06-03",
   "datasets": [
     {
       "slug": "aifa_spesa_consumo",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-02",
+  "generated_at": "2026-06-03",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -162,10 +162,25 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "25509412527",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25509412527",
-        "checked_at": "2026-05-07",
-        "year": 2023,
+        "run_id": "26909765054",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26909765054",
+        "checked_at": "2026-06-03",
+        "years": [
+          2010,
+          2011,
+          2012,
+          2013,
+          2014,
+          2015,
+          2016,
+          2017,
+          2018,
+          2019,
+          2020,
+          2021,
+          2022,
+          2023
+        ],
         "config_path": "candidates/dipendenti-pubblici/dataset.yml"
       }
     },


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #444 — fix(dipendenti-pubblici): aggiunge quote e strict_mode per nuovo formato BDAP

Changed candidate/support roots:

- `dipendenti-pubblici` (candidate, `candidates/dipendenti-pubblici`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/dipendenti-pubblici/dataset.yml` -> artifact `sample-run-dipendenti-pubblici`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug dipendenti_pubblici --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
