### PR TITLE
fix: upload artifact path — split JSON e stderr in due step

### DIFF
--- a/.github/workflows/smoke-weekly.yml
+++ b/.github/workflows/smoke-weekly.yml
@@ -39,9 +39,14 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: probe-report
-          path: |
-            /tmp/probe_report.json
-            /tmp/probe_stderr.log
+          path: /tmp/probe_report.json
+
+      - name: Upload probe stderr
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: probe-stderr
+          path: /tmp/probe_stderr.log
 
       - name: Report summary
         if: always()


### PR DESCRIPTION
`path: |` con multi-line non è supportato da `actions/upload-artifact`.

Split in due step separati:
- `probe-report`: solo `/tmp/probe_report.json`
- `probe-stderr`: solo `/tmp/probe_stderr.log`

Test locale conferma:
- JSON valido (91 run, 91 passed)
- Stderr separato (7 righe SSL warning AIFA)
- Summary e GITHUB_OUTPUT funzionano