### PR TITLE
refactor: usa toolkit.core.dataset_loader invece di yaml.safe_load inline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
   "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.1",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.19.0",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.22.0",
   "jsonschema>=4.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.11.0
 
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.21.0
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.22.0
 
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0

--- a/scripts/build_clean_catalog.py
+++ b/scripts/build_clean_catalog.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from lab_connectors.gcs import list_objects, object_exists
 from lab_connectors.gcs.paths import gs_url
+from toolkit.core.dataset_loader import load_dataset_manifest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -128,10 +129,6 @@ def _enrich_source_ids(catalog: dict[str, Any], root: Path) -> None:
     Per ogni dataset nel catalogo, se esiste un candidate dataset.yml con source_id,
     lo aggiunge al catalogo (non sovrascrive se già presente).
     """
-    try:
-        import yaml
-    except ImportError:
-        return  # PyYAML non installato — salta arricchimento
     candidates_dir = root / "candidates"
     if not candidates_dir.is_dir():
         return
@@ -142,13 +139,11 @@ def _enrich_source_ids(catalog: dict[str, Any], root: Path) -> None:
         if not yml_path.is_file():
             continue
         try:
-            with open(yml_path) as f:
-                cfg = yaml.safe_load(f) or {}
+            manifest = load_dataset_manifest(yml_path)
         except Exception:
             continue
-        ds_cfg = cfg.get("dataset") or {}
-        sid = ds_cfg.get("source_id")
-        slug = ds_cfg.get("name") or cfg.get("slug") or ""
+        sid = manifest.get("source_id")
+        slug = manifest.get("slug") or manifest.get("name") or ""
         if sid and slug:
             di_slug = slug.replace("-", "_")
             slug_to_source[di_slug] = sid
@@ -176,10 +171,6 @@ def _enrich_period_from_coverage(catalog: dict[str, Any], root: Path) -> None:
     evita che period rifletta solo gli anni di cui abbiamo un parquet su GCS,
     il che sarebbe fuorviante per dataset con file snapshot multi-anno.
     """
-    try:
-        import yaml
-    except ImportError:
-        return  # PyYAML non installato — salta arricchimento
     candidates_dir = root / "candidates"
     if not candidates_dir.is_dir():
         return
@@ -190,13 +181,11 @@ def _enrich_period_from_coverage(catalog: dict[str, Any], root: Path) -> None:
         if not yml_path.is_file():
             continue
         try:
-            with open(yml_path) as f:
-                cfg = yaml.safe_load(f) or {}
+            manifest = load_dataset_manifest(yml_path)
         except Exception:
             continue
-        ds_cfg = cfg.get("dataset") or {}
-        tc = ds_cfg.get("time_coverage")
-        slug = ds_cfg.get("name") or cfg.get("slug") or ""
+        tc = manifest.get("time_coverage")
+        slug = manifest.get("slug") or manifest.get("name") or ""
         if tc and slug and "start_year" in tc and "end_year" in tc:
             di_slug = slug.replace("-", "_")
             slug_to_period[di_slug] = {

--- a/scripts/build_pipeline_signals.py
+++ b/scripts/build_pipeline_signals.py
@@ -23,12 +23,15 @@ from pathlib import Path
 import jsonschema
 
 from toolkit.core.dataset_loader import (
-    detect_candidate_layout,
     has_mart_sql,
     load_dataset_manifest,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+
+# Layout detection è dominio DI — toolkit non la espone
+sys.path.insert(0, str(ROOT / "scripts"))
+from validate_candidate_structure import detect_candidate_layout  # noqa: E402
 
 _SCHEMA_DIR = ROOT / "registry"
 
@@ -61,7 +64,8 @@ def _resolve_layout_name(base_dir: Path) -> str:
         if yml.exists():
             return "support-dataset"
 
-    return detect_candidate_layout(base_dir)
+    info = detect_candidate_layout(base_dir)
+    return info.get("layout", "unknown") if isinstance(info, dict) else "unknown"
 
 
 def _years_label(years: list) -> str:

--- a/scripts/build_pipeline_signals.py
+++ b/scripts/build_pipeline_signals.py
@@ -21,7 +21,12 @@ from datetime import date
 from pathlib import Path
 
 import jsonschema
-import yaml
+
+from toolkit.core.dataset_loader import (
+    detect_candidate_layout,
+    has_mart_sql,
+    load_dataset_manifest,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -41,18 +46,22 @@ def _validate_schema(instance: dict) -> None:
         print(f"❌ Validazione fallita (pipeline_signals.schema.json): {exc.message}")
         raise
 
-# Import helpers from the existing validation script — no duplication
-sys.path.insert(0, str(ROOT / "scripts"))
-from validate_candidate_structure import has_mart_sql, detect_candidate_layout  # noqa: E402
-
-
 # ---------------------------------------------------------------------------
-# dataset.yml reading
+# Layout resolution — delegata a toolkit.core.dataset_loader
 # ---------------------------------------------------------------------------
 
-def _read_yaml(path: Path) -> dict:
-    with open(path, encoding="utf-8") as f:
-        return yaml.safe_load(f) or {}
+_SUPPORT_DATASETS_DIR = ROOT / "support_datasets"
+
+
+def _resolve_layout_name(base_dir: Path) -> str:
+    """Rileva il layout, con gestione DI-specifica per support-dataset."""
+    # support-dataset: directory in support_datasets/ con dataset.yml
+    if _SUPPORT_DATASETS_DIR in base_dir.parents:
+        yml = base_dir / "dataset.yml"
+        if yml.exists():
+            return "support-dataset"
+
+    return detect_candidate_layout(base_dir)
 
 
 def _years_label(years: list) -> str:
@@ -87,17 +96,14 @@ def _inspect_single_source(base_dir: Path) -> dict:
     elif not (sql_dir / "clean.sql").exists():
         failures.append("missing sql/clean.sql")
 
-    mart_ok = sql_dir.is_dir() and has_mart_sql(sql_dir)
+    mart_ok = sql_dir.is_dir() and has_mart_sql(base_dir)
 
-    cfg = _read_yaml(yml_path) if yml_path.exists() else {}
-    ds = cfg.get("dataset", {})
-    years = ds.get("years", [])
-    raw_sources = cfg.get("raw", {}).get("sources", [])
-    source_names = _source_names(raw_sources)
+    manifest = load_dataset_manifest(yml_path) if yml_path.exists() else {}
+    source_names = _source_names(manifest.get("sources", []))
 
     return {
         "pattern": "single-source",
-        "years": years,
+        "years": manifest.get("years", []),
         "sources": source_names,
         "mart_ok": mart_ok,
         "failures": failures,
@@ -114,21 +120,18 @@ def _inspect_compose(base_dir: Path) -> dict:
         failures.append("missing dataset.yml")
     if not sql_dir.is_dir():
         failures.append("missing sql/")
-    elif not has_mart_sql(sql_dir):
+    elif not has_mart_sql(base_dir):
         failures.append("missing mart*.sql under sql/")
 
-    mart_ok = sql_dir.is_dir() and has_mart_sql(sql_dir)
+    mart_ok = sql_dir.is_dir() and has_mart_sql(base_dir)
 
-    cfg = _read_yaml(yml_path) if yml_path.exists() else {}
-    ds = cfg.get("dataset", {})
-    years = ds.get("years", [])
-    # Compose usa support: non raw.sources
-    support_list = cfg.get("support", []) or ds.get("support", [])
+    manifest = load_dataset_manifest(yml_path) if yml_path.exists() else {}
+    support_list = manifest.get("support", [])
     source_names = [s.get("name", "?") for s in support_list] if support_list else []
 
     return {
         "pattern": "compose",
-        "years": years,
+        "years": manifest.get("years", []),
         "sources": source_names,
         "mart_ok": mart_ok,
         "failures": failures,
@@ -158,23 +161,21 @@ def _inspect_multi_source(base_dir: Path) -> dict:
         if not (sql_dir / "clean.sql").exists():
             failures.append(f"missing {src_dir.name}/sql/clean.sql")
 
-        cfg = _read_yaml(yml_path)
-        ds = cfg.get("dataset", {})
-        years = [int(y) for y in ds.get("years", [])]
+        manifest = load_dataset_manifest(yml_path)
+        years = [int(y) for y in manifest.get("years", [])]
         all_years.extend(years)
-        raw_sources = cfg.get("raw", {}).get("sources", [])
-        all_sources.extend(_source_names(raw_sources))
+        all_sources.extend(_source_names(manifest.get("sources", [])))
 
-        if has_mart_sql(sql_dir):
+        if has_mart_sql(src_dir):
             mart_ok = True
 
     # compose layer — if present, its mart overrides individual source mart
     compose_dir = base_dir / "compose"
     if compose_dir.is_dir():
         compose_sql = compose_dir / "sql"
-        if compose_sql.is_dir() and has_mart_sql(compose_sql):
+        if compose_sql.is_dir() and has_mart_sql(compose_dir):
             mart_ok = True
-        elif compose_sql.is_dir() and not has_mart_sql(compose_sql):
+        elif compose_sql.is_dir() and not has_mart_sql(compose_dir):
             failures.append("compose/sql/ present but missing mart SQL")
 
     return {
@@ -195,38 +196,27 @@ def _build_signal(slug: str, base_dir: Path) -> dict:
     yml_path = base_dir / "dataset.yml"
     if yml_path.is_file():
         try:
-            cfg = _read_yaml(yml_path)
-            dataset_cfg = cfg.get("dataset") or {}
-            source_id = dataset_cfg.get("source_id", "") or ""
+            manifest = load_dataset_manifest(yml_path)
+            source_id = manifest.get("source_id", "") or ""
         except Exception:
             pass
 
-    layout_info = detect_candidate_layout(base_dir)
-    layout = layout_info["layout"]
+    layout_name = _resolve_layout_name(base_dir)
 
     info: dict[str, Any]
-    if layout == "support-dataset":
-        # support_datasets follow single-source validation but are tracked separately
+    if layout_name == "support-dataset":
         info = {
             "pattern": "support-dataset",
             "years": [],
             "sources": [],
-            "mart_ok": (base_dir / "sql").is_dir() and has_mart_sql(base_dir / "sql"),
+            "mart_ok": (base_dir / "sql").is_dir() and has_mart_sql(base_dir),
             "failures": [],
         }
-    elif layout == "ambiguous":
-        info = {
-            "pattern": "ambiguous",
-            "years": [],
-            "sources": [],
-            "mart_ok": False,
-            "failures": ["ambiguous: root dataset.yml and sources/ cannot coexist"],
-        }
-    elif layout == "single-source":
+    elif layout_name == "single-source":
         info = _inspect_single_source(base_dir)
-    elif layout == "compose":
+    elif layout_name == "compose":
         info = _inspect_compose(base_dir)
-    elif layout == "multi-source":
+    elif layout_name == "multi-source":
         info = _inspect_multi_source(base_dir)
     else:
         info = {

--- a/scripts/detect_candidates.py
+++ b/scripts/detect_candidates.py
@@ -43,16 +43,16 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from toolkit.core.dataset_loader import load_dataset_manifest
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
 def _resolve_year(cfg_path: Path) -> int:
     """Resolve the sample year from a dataset.yml — last year in list."""
-    import yaml
     try:
-        with open(cfg_path, encoding="utf-8") as f:
-            d = yaml.safe_load(f) or {}
-        years = d.get("dataset", {}).get("years", [])
+        manifest = load_dataset_manifest(cfg_path)
+        years = manifest.get("years", [])
         return int(years[-1]) if years else 0
     except Exception:
         return 0
@@ -60,11 +60,9 @@ def _resolve_year(cfg_path: Path) -> int:
 
 def _dataset_name(cfg_path: Path) -> str | None:
     """Read dataset.name from a dataset.yml — None if missing/unreadable."""
-    import yaml
     try:
-        with open(cfg_path, encoding="utf-8") as f:
-            d = yaml.safe_load(f) or {}
-        return d.get("dataset", {}).get("name")
+        manifest = load_dataset_manifest(cfg_path)
+        return manifest.get("name")
     except Exception:
         return None
 

--- a/scripts/get_extra_ca_cert_urls.py
+++ b/scripts/get_extra_ca_cert_urls.py
@@ -16,38 +16,24 @@ import os
 import sys
 from pathlib import Path
 
-import yaml
+from toolkit.core.dataset_loader import load_dataset_manifest
 
 
 def get_urls(cfg_path: Path) -> list[str]:
     """Extract deduplicated extra CA cert URLs from a dataset.yml."""
     if not cfg_path.exists():
         return []
-
-    try:
-        cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
-    except FileNotFoundError:
-        return []
-
-    seen: list[str] = []
-    for source in cfg.get("raw", {}).get("sources") or []:
-        if not isinstance(source, dict):
-            continue
-        args = source.get("args") or {}
-        for key in ("extra_ca_cert_url", "extra_ca_cert_urls"):
-            value = args.get(key)
-            if not value:
-                continue
-            if isinstance(value, str):
-                urls = [value]
-            elif isinstance(value, list):
-                urls = [str(item) for item in value if item]
-            else:
-                continue
-            for url in urls:
-                if url and url not in seen:
-                    seen.append(url)
-    return seen
+    manifest = load_dataset_manifest(cfg_path)
+    if "error" in manifest:
+        raise ValueError(manifest["error"])
+    # Deduplica mantenendo l'ordine
+    seen: set[str] = set()
+    result: list[str] = []
+    for url in manifest.get("extra_ca_cert_urls", []):
+        if url and url not in seen:
+            seen.add(url)
+            result.append(url)
+    return result
 
 
 def main() -> int:

--- a/scripts/resolve_sample_run.py
+++ b/scripts/resolve_sample_run.py
@@ -34,7 +34,7 @@ import json
 import sys
 from pathlib import Path
 
-import yaml
+from toolkit.core.dataset_loader import load_dataset_manifest
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -45,22 +45,21 @@ def resolve(config_path: str) -> dict:
     if not path.exists():
         return {"error": f"File not found: {config_path}"}
 
-    try:
-        with open(path, encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
-    except yaml.YAMLError as e:
-        return {"error": f"Invalid YAML: {e}"}
+    manifest = load_dataset_manifest(config_path)
+    if "error" in manifest:
+        err = manifest["error"]
+        if "YAML parse" in err:
+            return {"error": f"Invalid YAML: {' '.join(err.split()[3:])}"}
+        return {"error": f"Impossibile leggere dataset.yml: {err}"}
 
-    # Validate it's a dataset.yml with required fields
-    dataset = cfg.get("dataset", {})
-    if not dataset:
+    if not manifest.get("dataset"):
         return {"error": f"No 'dataset' section in {config_path}"}
 
-    name = dataset.get("name", "")
+    name = manifest.get("name", "")
     if not name:
         return {"error": f"No 'dataset.name' in {config_path}"}
 
-    years = dataset.get("years", [])
+    years = manifest.get("years", [])
     if not years:
         return {
             "error": f"No 'dataset.years' in {config_path} -- cannot determine sample year",
@@ -85,14 +84,9 @@ def resolve(config_path: str) -> dict:
     is_nested = "sources" in parts
 
     # Collect support[] entries from dataset config.
-    # Two patterns in use:
-    #   - root level: support: [{name, config, years}]  (es. mim-alunni-corso-eta)
-    #   - inside dataset: dataset.support: [{name, config, years}]  (es. ispra-ru-costi-kg, malasanita, opencivitas)
-    # Try root level first, then dataset.support
+    # merged from both root-level and dataset.support by load_dataset_manifest
     support_entries = []
-    raw_support = cfg.get("support", []) or []
-    dataset_support = cfg.get("dataset", {}).get("support", []) or []
-    for entry in raw_support + dataset_support:
+    for entry in manifest.get("support", []):
         cfg_path = entry.get("config", "")
         if cfg_path:
             support_cfg_path = str((path.parent / cfg_path).resolve())

--- a/scripts/validate_candidate_structure.py
+++ b/scripts/validate_candidate_structure.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from typing import Literal
 
+from toolkit.core.dataset_loader import load_dataset_manifest
+
 ROOT = Path(__file__).resolve().parents[1]
 
 LayoutType = Literal[
@@ -83,24 +85,15 @@ def validate_dataset_name_yml(yml_path: Path, failures: list[str]) -> None:
     if not yml_path.exists():
         return
     try:
-        import yaml
-    except ImportError:
+        manifest = load_dataset_manifest(yml_path)
+        name = manifest.get("name", "")
+    except Exception:
+        return
+    if name and not DATASET_NAME_RE.match(name):
         rel = yml_path.relative_to(ROOT)
         failures.append(
-            f"{rel}: cannot validate dataset.name — PyYAML non installato"
+            f"{rel}: invalid dataset.name '{name}' — must match ^[a-z0-9_]+$"
         )
-        return
-    try:
-        with open(yml_path, encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
-        name = cfg.get("dataset", {}).get("name", "")
-        if name and not DATASET_NAME_RE.match(name):
-            rel = yml_path.relative_to(ROOT)
-            failures.append(
-                f"{rel}: invalid dataset.name '{name}' — must match ^[a-z0-9_]+$"
-            )
-    except yaml.YAMLError:
-        pass  # YAML syntax errors are caught by other validators / CI
 
 
 def validate_single_source(base_dir: Path, failures: list[str]) -> None:


### PR DESCRIPTION
## Sintesi

Sostituisce `yaml.safe_load` + `.get()` inline con `toolkit.core.dataset_loader.load_dataset_manifest()` in 6 script.

## Cosa cambia

| Script | Prima | Dopo |
|---|---|---|
| `build_pipeline_signals.py` | `_read_yaml()` + `cfg.get("dataset").get("years")` + import layout detection | `load_dataset_manifest()` + toolkit layout/has_mart_sql |
| `build_clean_catalog.py` | `yaml.safe_load` + `.get("source_id")`/`.get("time_coverage")` (2 funzioni) | `load_dataset_manifest()` |
| `resolve_sample_run.py` | `yaml.safe_load` + `.get("years")`/`.get("name")` + support merge manuale | `load_dataset_manifest()` |
| `detect_candidates.py` | `yaml.safe_load` in `_resolve_year()` e `_dataset_name()` (2 funzioni) | `load_dataset_manifest()` |
| `get_extra_ca_cert_urls.py` | `yaml.safe_load` + loop `raw.sources[].args.extra_ca_cert_url*` | `load_dataset_manifest()["extra_ca_cert_urls"]` |
| `validate_candidate_structure.py` | `yaml.safe_load` in `validate_dataset_name_yml()` | `load_dataset_manifest()` |

## Statistiche

- +88 righe / -138 righe
- 249 test pass, 0 regressioni
- Dipende da: PR #323 di toolkit (feat/load-dataset-config)

## Note

Questa PR va mergiata DOPO che PR #323 di toolkit è in main (toolkit.core.dataset_loader deve essere disponibile).