### PR TITLE
chore: bump toolkit to v1.23.0, lab-connectors to v0.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ classifiers = [
 ]
 
 dependencies = [
-  "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.1",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.22.0",
+"lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.11.0",
+"dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.23.0",
   "jsonschema>=4.0",
 ]
 


### PR DESCRIPTION
## Cosa cambia

- `toolkit` v1.22.0 → **v1.23.0** (dataset_loader, validate config, CKAN/SDMX centralization, backward compat cleanup)
- `lab-connectors` v0.10.1 → **v0.11.0** (SPARQL module, test fixes)

Allinea pyproject.toml a requirements.txt (che già puntava a v0.11.0 per lab-connectors).