### PR TITLE
chore(post-merge): aggiorna registry per PR #456

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -4637,7 +4637,7 @@
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
+          "role": "dimension",
           "description": "Anno di Riferimento"
         },
         {
@@ -4649,7 +4649,7 @@
         {
           "name": "codice_asl",
           "type": "INTEGER",
-          "role": "metric",
+          "role": "dimension",
           "description": "Codice Azienda Sanitaria Locale"
         },
         {
@@ -4848,13 +4848,13 @@
           "name": "adi_casi_trattati",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": "Assistenza Domiciliare Integrata — Casi Trattati (VARCHAR)"
+          "description": "Assistenza Domiciliare Integrata — Casi Trattati"
         },
         {
           "name": "adi_casi_trattati_anziani",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": "Assistenza Domiciliare Integrata — Casi Trattati Anziani (VARCHAR)"
+          "description": "Assistenza Domiciliare Integrata — Casi Trattati Anziani"
         },
         {
           "name": "adi_casi_trattati_terminali",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-06-04",
+  "updated_at": "2026-06-05",
   "datasets": [
     {
       "slug": "aifa_spesa_consumo",
@@ -4619,6 +4619,254 @@
         "type": "gcs",
         "path": "gs://dataciviclab-clean/popolazione_istat_comunale_2019_2025/*/popolazione_istat_comunale_2019_2025_*_clean.parquet",
         "multi_file": true
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "strutture_asl",
+      "name": "Strutture Asl",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2022,
+        "end": 2022
+      },
+      "columns": [
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_regione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_asl",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "regione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "denominazione_asl",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "indirizzo_asl",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cap_asl",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "comune_asl",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "sigla_provincia_asl",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "residenti_eta_infantile",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "residenti_eta_adulta",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "residenti_anziani",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "totale_residenti",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "cup_tipo_1",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "cup_tipo_2",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "dipartimento_prevenzione",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "dipartimento_materno_infantile",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "dipartimento_salute_mentale",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "servizio_trasporto_dialisi",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "servizio_adi",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "unita_mobile_rianimazione",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "ambulanze_emergenza_neonato",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "totale_medici",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "medici_indennita_associativa",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "totale_scelte",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "totale_pediatri",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pediatri_indennita_associativa",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "totale_scelte_pediatri",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "ambulatori_laboratori",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "ambulatori_laboratori_convenzionati",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "num_medio_punti_guardia_medica",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "num_medio_medici_titolari",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "ore_totali_guardia_medica",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "num_ricette_specialita_medicinali",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "euro_importo_ricette",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "adi_casi_trattati",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "adi_casi_trattati_anziani",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "adi_casi_trattati_terminali",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/strutture_asl/2022/strutture_asl_2022_clean.parquet",
+        "multi_file": false
       },
       "stage": "published",
       "registry_source": "derive_auto"

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -4626,9 +4626,9 @@
     {
       "slug": "strutture_asl",
       "name": "Strutture Asl",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "description": "Strutture e attività delle ASL — medici di base, pediatri, popolazione residente, servizi territoriali e presidi per regione — Ministero della Salute 2022",
+      "source": "Ministero della Salute — Open Data Strutture e attività ASL",
+      "source_id": "ministero_salute",
       "period": {
         "start": 2022,
         "end": 2022
@@ -4638,229 +4638,229 @@
           "name": "anno",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Anno di Riferimento"
         },
         {
           "name": "codice_regione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice Regione (ISTAT)"
         },
         {
           "name": "codice_asl",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Codice Azienda Sanitaria Locale"
         },
         {
           "name": "regione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione Regione"
         },
         {
           "name": "denominazione_asl",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione ASL"
         },
         {
           "name": "indirizzo_asl",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Indirizzo sede ASL"
         },
         {
           "name": "cap_asl",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "C.A.P. sede ASL"
         },
         {
           "name": "comune_asl",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Comune sede ASL"
         },
         {
           "name": "sigla_provincia_asl",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Sigla provincia sede ASL"
         },
         {
           "name": "residenti_eta_infantile",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Residenti in età infantile (0-14 anni)"
         },
         {
           "name": "residenti_eta_adulta",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Residenti in età adulta (15-64 anni)"
         },
         {
           "name": "residenti_anziani",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Residenti anziani (65+ anni)"
         },
         {
           "name": "totale_residenti",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Totale residenti nell'ASL"
         },
         {
           "name": "cup_tipo_1",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Centro Unificato di Prenotazione Tipo 1 (CUP aziendale)"
         },
         {
           "name": "cup_tipo_2",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Centro Unificato di Prenotazione Tipo 2 (CUP integrato/presso ASL)"
         },
         {
           "name": "dipartimento_prevenzione",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Presenza Dipartimento di Prevenzione (1/0)"
         },
         {
           "name": "dipartimento_materno_infantile",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Presenza Dipartimento Materno-Infantile (1/0)"
         },
         {
           "name": "dipartimento_salute_mentale",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Presenza Dipartimento di Salute Mentale (1/0)"
         },
         {
           "name": "servizio_trasporto_dialisi",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Servizio Trasporto per Centro Dialisi (1/0)"
         },
         {
           "name": "servizio_adi",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Servizio di Assistenza Domiciliare Integrata (1/0)"
         },
         {
           "name": "unita_mobile_rianimazione",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Unità Mobile di Rianimazione (1/0)"
         },
         {
           "name": "ambulanze_emergenza_neonato",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Ambulanze Trasporto Emergenza Neonato (1/0)"
         },
         {
           "name": "totale_medici",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Totale medici di medicina generale"
         },
         {
           "name": "medici_indennita_associativa",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Medici con indennità per attività in forma associativa"
         },
         {
           "name": "totale_scelte",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Totale scelte per classe di scelte (medici MG)"
         },
         {
           "name": "totale_pediatri",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Totale pediatri di libera scelta"
         },
         {
           "name": "pediatri_indennita_associativa",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Pediatri con indennità per attività in forma associativa"
         },
         {
           "name": "totale_scelte_pediatri",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Totale scelte per classe di scelte (pediatri)"
         },
         {
           "name": "ambulatori_laboratori",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Ambulatori e Laboratori"
         },
         {
           "name": "ambulatori_laboratori_convenzionati",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Ambulatori e Laboratori convenzionati"
         },
         {
           "name": "num_medio_punti_guardia_medica",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero medio punti di guardia medica"
         },
         {
           "name": "num_medio_medici_titolari",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero medio medici titolari (guardia medica)"
         },
         {
           "name": "ore_totali_guardia_medica",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Ore totali guardia medica"
         },
         {
           "name": "num_ricette_specialita_medicinali",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Numero ricette di specialità medicinali e galenici"
         },
         {
           "name": "euro_importo_ricette",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "EURO Importo ricette di specialità medicinali e galenici"
         },
         {
           "name": "adi_casi_trattati",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Assistenza Domiciliare Integrata — Casi Trattati (VARCHAR)"
         },
         {
           "name": "adi_casi_trattati_anziani",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Assistenza Domiciliare Integrata — Casi Trattati Anziani (VARCHAR)"
         },
         {
           "name": "adi_casi_trattati_terminali",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Assistenza Domiciliare Integrata — Casi Trattati Pazienti Terminali"
         }
       ],
       "location": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -432,7 +432,7 @@
     },
     {
       "id": "mortalita-istat-evitabile",
-      "source_id": "istat",
+      "source_id": "",
       "status": "ok",
       "label": "mortalita-istat-evitabile",
       "detail": "anno 2022 — fonte: mortalita_causa_istat — mart: sì",
@@ -540,7 +540,7 @@
     },
     {
       "id": "strutture-asl",
-      "source_id": "ministero_salute",
+      "source_id": "",
       "status": "ok",
       "label": "strutture-asl",
       "detail": "anno 2022 — fonte: strutture_asl — mart: sì",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -432,7 +432,7 @@
     },
     {
       "id": "mortalita-istat-evitabile",
-      "source_id": "",
+      "source_id": "istat",
       "status": "ok",
       "label": "mortalita-istat-evitabile",
       "detail": "anno 2022 — fonte: mortalita_causa_istat — mart: sì",
@@ -540,7 +540,7 @@
     },
     {
       "id": "strutture-asl",
-      "source_id": "",
+      "source_id": "ministero_salute",
       "status": "ok",
       "label": "strutture-asl",
       "detail": "anno 2022 — fonte: strutture_asl — mart: sì",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-04",
+  "generated_at": "2026-06-05",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 34,
+    "total": 36,
     "by_status": {
-      "ok": 34,
+      "ok": 36,
       "warn": 0,
       "error": 0
     }
@@ -431,6 +431,14 @@
       }
     },
     {
+      "id": "mortalita-istat-evitabile",
+      "source_id": "",
+      "status": "ok",
+      "label": "mortalita-istat-evitabile",
+      "detail": "anno 2022 — fonte: mortalita_causa_istat — mart: sì",
+      "action": ""
+    },
+    {
       "id": "mur-contribuzione-universitaria",
       "source_id": "mur_ustat",
       "status": "ok",
@@ -528,6 +536,24 @@
           2024
         ],
         "config_path": "candidates/pensioni-pa-dag/dataset.yml"
+      }
+    },
+    {
+      "id": "strutture-asl",
+      "source_id": "",
+      "status": "ok",
+      "label": "strutture-asl",
+      "detail": "anno 2022 — fonte: strutture_asl — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "27014606312",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27014606312",
+        "checked_at": "2026-06-05",
+        "years": [
+          2022
+        ],
+        "config_path": "candidates/strutture-asl/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #456 — feat: pre-download fonti bloccate via proxy + candidate pilota (strutture-asl)

Changed candidate/support roots:

- `strutture-asl` (candidate, `candidates/strutture-asl`)
- `mortalita-istat-evitabile` (candidate, `candidates/mortalita-istat-evitabile`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/strutture-asl/dataset.yml` -> artifact `sample-run-strutture-asl`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug strutture_asl --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.

## Compilazione dati mancanti (fix applicato)

- `clean_catalog.json`: aggiunti `description`, `source` ("Ministero della Salute — Open Data Strutture e attività ASL"), `source_id` ("ministero_salute") e descrizioni per tutte le 38 colonne
- `pipeline_signals.json`: aggiunto `source_id` per `strutture-asl` e `mortalita-istat-evitabile`