### PR TITLE
chore(post-merge): aggiorna registry per PR #460

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -4624,6 +4624,176 @@
       "registry_source": "derive_auto"
     },
     {
+      "slug": "reparti_ricovero",
+      "name": "Reparti Ricovero",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2022,
+        "end": 2022
+      },
+      "columns": [
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_regione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "regione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_asl",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "asl",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_struttura",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "struttura",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "indirizzo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_tipo_struttura",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "sottotipo_struttura",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "tipo_struttura",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "comune",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "sigla_provincia",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_disciplina",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "disciplina",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "posti_letto_day_hospital",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "posti_letto_day_surgery",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "posti_letto_degenza_ordinaria",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "posti_letto_utilizzati",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "num_dimessi",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "giornate_degenza",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "giornate_disponibili",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "degenza_media_ordinaria",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "icm",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "tasso_utilizzo",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/reparti_ricovero/2022/reparti_ricovero_2022_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
       "slug": "strutture_asl",
       "name": "Strutture Asl",
       "description": "Strutture e attività delle ASL — medici di base, pediatri, popolazione residente, servizi territoriali e presidi per regione — Ministero della Salute 2022",
@@ -4866,6 +5036,182 @@
       "location": {
         "type": "gcs",
         "path": "gs://dataciviclab-clean/strutture_asl/2022/strutture_asl_2022_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "strutture_ricovero_asl",
+      "name": "Strutture Ricovero Asl",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2022,
+        "end": 2022
+      },
+      "columns": [
+        {
+          "name": "anno",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_struttura",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "denominazione_struttura",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "comune",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "sigla_provincia_struttura",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "posti_letto_previsti",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "posti_letto_utilizzati",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "personale_uomini",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "personale_donne",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "totale_personale",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "medici_uomini",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "medici_donne",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "medici",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "infermieri_uomini",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "infermieri_donne",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "infermieri",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "ricoveri",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "giornate_degenza",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "giornate_disponibili",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_tipo_struttura",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "sottotipo_struttura",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "tipo_struttura",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_regione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "regione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_asl",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "asl",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/strutture_ricovero_asl/2022/strutture_ricovero_asl_2022_clean.parquet",
         "multi_file": false
       },
       "stage": "published",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -4626,9 +4626,9 @@
     {
       "slug": "reparti_ricovero",
       "name": "Reparti Ricovero",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "description": "Dati di struttura e attività dei reparti di ricovero — posti letto, dimessi, discipline, degenza per struttura — Ministero della Salute 2022",
+      "source": "Ministero della Salute — Open Data Dati di struttura e attività dei reparti di ricovero",
+      "source_id": "ministero_salute",
       "period": {
         "start": 2022,
         "end": 2022
@@ -4637,152 +4637,152 @@
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di Riferimento"
         },
         {
           "name": "codice_regione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice Regione (ISTAT)"
         },
         {
           "name": "regione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione Regione"
         },
         {
           "name": "codice_asl",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice Azienda Sanitaria Locale"
         },
         {
           "name": "asl",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione ASL"
         },
         {
           "name": "codice_struttura",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice struttura di ricovero"
         },
         {
           "name": "struttura",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione struttura di ricovero"
         },
         {
           "name": "indirizzo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Indirizzo struttura"
         },
         {
           "name": "codice_tipo_struttura",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Codice tipo struttura"
         },
         {
           "name": "sottotipo_struttura",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Sottotipo struttura"
         },
         {
           "name": "tipo_struttura",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipo struttura (pubblica, IRCCS, etc.)"
         },
         {
           "name": "comune",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Comune sede struttura"
         },
         {
           "name": "sigla_provincia",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Sigla provincia sede struttura"
         },
         {
           "name": "codice_disciplina",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice disciplina"
         },
         {
           "name": "disciplina",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Disciplina / specialità"
         },
         {
           "name": "posti_letto_day_hospital",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Posti letto Day Hospital"
         },
         {
           "name": "posti_letto_day_surgery",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Posti letto Day Surgery"
         },
         {
           "name": "posti_letto_degenza_ordinaria",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Posti letto degenza ordinaria"
         },
         {
           "name": "posti_letto_utilizzati",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Posti letto utilizzati"
         },
         {
           "name": "num_dimessi",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Numero dimessi (VARCHAR — separatore migliaia)"
         },
         {
           "name": "giornate_degenza",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Giornate di degenza (VARCHAR — separatore migliaia)"
         },
         {
           "name": "giornate_disponibili",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Giornate disponibili"
         },
         {
           "name": "degenza_media_ordinaria",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Degenza media ordinaria (giorni)"
         },
         {
           "name": "icm",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Indice Case-Mix (ICM)"
         },
         {
           "name": "tasso_utilizzo",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Tasso di utilizzo posti letto"
         }
       ],
       "location": {
@@ -5044,9 +5044,9 @@
     {
       "slug": "strutture_ricovero_asl",
       "name": "Strutture Ricovero Asl",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "description": "Strutture di ricovero pubbliche presenti nel territorio della ASL — personale, posti letto, ricoveri per struttura — Ministero della Salute 2022",
+      "source": "Ministero della Salute — Open Data Strutture di ricovero per ASL",
+      "source_id": "ministero_salute",
       "period": {
         "start": 2022,
         "end": 2022
@@ -5055,158 +5055,158 @@
         {
           "name": "anno",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di Riferimento"
         },
         {
           "name": "codice_struttura",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice struttura di ricovero"
         },
         {
           "name": "denominazione_struttura",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione struttura di ricovero"
         },
         {
           "name": "comune",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Comune sede struttura"
         },
         {
           "name": "sigla_provincia_struttura",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Sigla provincia sede struttura"
         },
         {
           "name": "posti_letto_previsti",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Posti letto previsti"
         },
         {
           "name": "posti_letto_utilizzati",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Posti letto utilizzati"
         },
         {
           "name": "personale_uomini",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Personale — uomini"
         },
         {
           "name": "personale_donne",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Personale — donne"
         },
         {
           "name": "totale_personale",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Totale personale"
         },
         {
           "name": "medici_uomini",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Medici — uomini"
         },
         {
           "name": "medici_donne",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Medici — donne"
         },
         {
           "name": "medici",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Totale medici"
         },
         {
           "name": "infermieri_uomini",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Infermieri — uomini"
         },
         {
           "name": "infermieri_donne",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Infermieri — donne"
         },
         {
           "name": "infermieri",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Totale infermieri"
         },
         {
           "name": "ricoveri",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Ricoveri"
         },
         {
           "name": "giornate_degenza",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Giornate di degenza"
         },
         {
           "name": "giornate_disponibili",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Giornate disponibili"
         },
         {
           "name": "codice_tipo_struttura",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Codice tipo struttura"
         },
         {
           "name": "sottotipo_struttura",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Sottotipo struttura"
         },
         {
           "name": "tipo_struttura",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipo struttura"
         },
         {
           "name": "codice_regione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice Regione (ISTAT)"
         },
         {
           "name": "regione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione Regione"
         },
         {
           "name": "codice_asl",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Codice Azienda Sanitaria Locale"
         },
         {
           "name": "asl",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione ASL"
         }
       ],
       "location": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -4,9 +4,9 @@
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 36,
+    "total": 37,
     "by_status": {
-      "ok": 36,
+      "ok": 37,
       "warn": 0,
       "error": 0
     }
@@ -323,14 +323,6 @@
       }
     },
     {
-      "id": "malasanita-struttura-mortalita",
-      "source_id": "",
-      "status": "ok",
-      "label": "malasanita-struttura-mortalita",
-      "detail": "anno 2022 — multi-source (4 fonti) — mart: sì",
-      "action": ""
-    },
-    {
       "id": "mef-irpef-regionale",
       "source_id": "",
       "status": "ok",
@@ -539,6 +531,24 @@
       }
     },
     {
+      "id": "reparti-ricovero",
+      "source_id": "",
+      "status": "ok",
+      "label": "reparti-ricovero",
+      "detail": "anno 2022 — fonte: reparti_ricovero — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "27019783972",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27019783972",
+        "checked_at": "2026-06-05",
+        "years": [
+          2022
+        ],
+        "config_path": "candidates/reparti-ricovero/dataset.yml"
+      }
+    },
+    {
       "id": "strutture-asl",
       "source_id": "",
       "status": "ok",
@@ -554,6 +564,24 @@
           2022
         ],
         "config_path": "candidates/strutture-asl/dataset.yml"
+      }
+    },
+    {
+      "id": "strutture-ricovero-asl",
+      "source_id": "",
+      "status": "ok",
+      "label": "strutture-ricovero-asl",
+      "detail": "anno 2022 — fonte: strutture_ricovero_asl — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "27019783972",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27019783972",
+        "checked_at": "2026-06-05",
+        "years": [
+          2022
+        ],
+        "config_path": "candidates/strutture-ricovero-asl/dataset.yml"
       }
     },
     {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -532,7 +532,7 @@
     },
     {
       "id": "reparti-ricovero",
-      "source_id": "",
+      "source_id": "ministero_salute",
       "status": "ok",
       "label": "reparti-ricovero",
       "detail": "anno 2022 — fonte: reparti_ricovero — mart: sì",
@@ -568,7 +568,7 @@
     },
     {
       "id": "strutture-ricovero-asl",
-      "source_id": "",
+      "source_id": "ministero_salute",
       "status": "ok",
       "label": "strutture-ricovero-asl",
       "detail": "anno 2022 — fonte: strutture_ricovero_asl — mart: sì",


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #460 — feat: aggiunge reparti-ricovero e strutture-ricovero-asl, rimuove vecchio malasanita multi-source (completamento #455)

Changed candidate/support roots:

- `malasanita-struttura-mortalita` (candidate, `candidates/malasanita-struttura-mortalita`) — rimosso
- `reparti-ricovero` (candidate, `candidates/reparti-ricovero`)
- `strutture-ricovero-asl` (candidate, `candidates/strutture-ricovero-asl`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Compilazione dati mancanti (fix applicato)

**clean_catalog.json:**
- `reparti_ricovero`: compilati `description`, `source`, `source_id` (`ministero_salute`), descrizioni per 25 colonne, ruoli corretti
- `strutture_ricovero_asl`: compilati `description`, `source`, `source_id` (`ministero_salute`), descrizioni per 26 colonne, ruoli corretti

**pipeline_signals.json:** aggiunti `source_id` per `reparti-ricovero` e `strutture-ricovero-asl`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug reparti_ricovero --create-bq-table --update-catalog
python scripts/push_archive.py --mart --slug strutture_ricovero_asl --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.