### PR TITLE
feat: aggiunge compose malasanita (v1/v2/v3)

### DIFF
--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -112,16 +112,22 @@ jobs:
           python scripts/prefetch_blocked_sources.py \
             "${{ matrix.config.config_path }}"
         env:
-          BLOCKED_SOURCE_PROXY: ${{ vars.BLOCKED_SOURCE_PROXY }}
+          BLOCKED_SOURCE_PROXY: ${{ secrets.BLOCKED_SOURCE_PROXY }}
 
       - name: "Toolkit run full (smoke: sample-bytes + sample-rows, skip min_rows) [retry x2]"
         id: run_full
         env:
           HTTPS_PROXY: ${{ vars.BLOCKED_SOURCE_PROXY }}
         run: |
+          # Determina se è un compose (solo mart, senza raw/clean)
+          if grep -q '^support:' "${{ matrix.config.config_path }}" 2>/dev/null; then
+            cmd="toolkit run mart"
+          else
+            cmd="toolkit run full"
+          fi
           MAX_ATTEMPTS=2
           for i in $(seq 1 $MAX_ATTEMPTS); do
-            toolkit run full \
+            $cmd \
               --config "${{ matrix.config.config_path }}" \
               --json \
               --sample-rows 1000 \
@@ -142,6 +148,11 @@ jobs:
           done
           echo "exit_code=$ec" >> "$GITHUB_OUTPUT"
           cat run_full.json 2>/dev/null || echo "No JSON output"
+          if [ -s run_full_err.log ]; then
+            echo "--- stderr ---"
+            cat run_full_err.log
+            echo "---"
+          fi
           exit $ec
 
       - name: Upload artifacts

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -119,16 +119,9 @@ jobs:
         env:
           HTTPS_PROXY: ${{ vars.BLOCKED_SOURCE_PROXY }}
         run: |
-          # Determina se è un compose (solo mart, senza raw/clean)
-          if grep -q '^support:' "${{ matrix.config.config_path }}" 2>/dev/null; then
-            cmd="toolkit run mart"
-            extra_opts=""
-            out_file="run_mart.json"
-          else
-            cmd="toolkit run full"
-            extra_opts="--json --sample-rows 1000 --sample-bytes 5242880"
-            out_file="run_full.json"
-          fi
+          cmd="toolkit run full"
+          extra_opts="--json --sample-rows 1000 --sample-bytes 5242880"
+          out_file="run_full.json"
           MAX_ATTEMPTS=2
           for i in $(seq 1 $MAX_ATTEMPTS); do
             $cmd \

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -119,13 +119,44 @@ jobs:
         env:
           HTTPS_PROXY: ${{ vars.BLOCKED_SOURCE_PROXY }}
         run: |
+          cfg="${{ matrix.config.config_path }}"
           cmd="toolkit run full"
           extra_opts="--json --sample-rows 1000 --sample-bytes 5242880"
           out_file="run_full.json"
+
+          # Se è un compose con support, esegue support in sequenza
+          if grep -q '^support:' "$cfg" 2>/dev/null; then
+            echo "📦 Compose rilevato — eseguo support dataset..."
+            python scripts/run_compose_with_support.py "$cfg" \
+              --json --sample-rows 1000 --sample-bytes 5242880 > run_full.json 2>run_err.log; ec=$?
+          else
+            # Candidate standard: run full
+            MAX_ATTEMPTS=2
+            for i in $(seq 1 $MAX_ATTEMPTS); do
+              toolkit run full \
+                --config "$cfg" \
+                $extra_opts \
+                > run_full.json 2>run_err.log; ec=$?
+              if [ $ec -eq 0 ]; then
+                echo "exit_code=0" >> "$GITHUB_OUTPUT"
+                cat run_full.json
+                exit 0
+              fi
+              echo "Attempt $i/$MAX_ATTEMPTS failed (exit=$ec). Stderr:"
+              cat run_err.log
+              if [ $i -lt $MAX_ATTEMPTS ]; then
+                WAIT=$(( i * 15 ))
+                echo "Retrying in ${WAIT}s..."
+                sleep $WAIT
+              fi
+            done
+          fi
+
+          # Run principale (compose o candidate)
           MAX_ATTEMPTS=2
           for i in $(seq 1 $MAX_ATTEMPTS); do
             $cmd \
-              --config "${{ matrix.config.config_path }}" \
+              --config "$cfg" \
               $extra_opts \
               > "$out_file" 2>run_err.log; ec=$?
             if [ $ec -eq 0 ]; then

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -129,7 +129,6 @@ jobs:
             extra_opts="--json --sample-rows 1000 --sample-bytes 5242880"
             out_file="run_full.json"
           fi
-<<<<<<< HEAD
           MAX_ATTEMPTS=2
           for i in $(seq 1 $MAX_ATTEMPTS); do
             $cmd \
@@ -152,20 +151,6 @@ jobs:
           echo "exit_code=$ec" >> "$GITHUB_OUTPUT"
           cat "$out_file" 2>/dev/null || echo "No JSON output"
           if [ -s run_err.log ]; then
-            echo "--- stderr ---"
-            cat run_err.log
-            echo "---"
-          fi
-          exit $ec
-=======
-          $cmd \
-            --config "${{ matrix.config.config_path }}" \
-            $extra_opts \
-            > "$out_file" 2>run_err.log; ec=$?
-          echo "exit_code=$ec" >> "$GITHUB_OUTPUT"
-          cat "$out_file" 2>/dev/null || echo "JSON output non disponibile"
-          if [ -s run_err.log ]; then
->>>>>>> d25ff6e (fix(CI): toolkit run mart senza flag incompatibili (--json, --sample-*))
             echo "--- stderr ---"
             cat run_err.log
             echo "---"

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -122,24 +122,27 @@ jobs:
           # Determina se è un compose (solo mart, senza raw/clean)
           if grep -q '^support:' "${{ matrix.config.config_path }}" 2>/dev/null; then
             cmd="toolkit run mart"
+            extra_opts=""
+            out_file="run_mart.json"
           else
             cmd="toolkit run full"
+            extra_opts="--json --sample-rows 1000 --sample-bytes 5242880"
+            out_file="run_full.json"
           fi
+<<<<<<< HEAD
           MAX_ATTEMPTS=2
           for i in $(seq 1 $MAX_ATTEMPTS); do
             $cmd \
               --config "${{ matrix.config.config_path }}" \
-              --json \
-              --sample-rows 1000 \
-              --sample-bytes 5242880 \
-              > run_full.json 2>run_full_err.log; ec=$?
+              $extra_opts \
+              > "$out_file" 2>run_err.log; ec=$?
             if [ $ec -eq 0 ]; then
               echo "exit_code=0" >> "$GITHUB_OUTPUT"
-              cat run_full.json
+              cat "$out_file"
               exit 0
             fi
             echo "Attempt $i/$MAX_ATTEMPTS failed (exit=$ec). Stderr:"
-            cat run_full_err.log
+            cat run_err.log
             if [ $i -lt $MAX_ATTEMPTS ]; then
               WAIT=$(( i * 15 ))
               echo "Retrying in ${WAIT}s..."
@@ -147,10 +150,24 @@ jobs:
             fi
           done
           echo "exit_code=$ec" >> "$GITHUB_OUTPUT"
-          cat run_full.json 2>/dev/null || echo "No JSON output"
-          if [ -s run_full_err.log ]; then
+          cat "$out_file" 2>/dev/null || echo "No JSON output"
+          if [ -s run_err.log ]; then
             echo "--- stderr ---"
-            cat run_full_err.log
+            cat run_err.log
+            echo "---"
+          fi
+          exit $ec
+=======
+          $cmd \
+            --config "${{ matrix.config.config_path }}" \
+            $extra_opts \
+            > "$out_file" 2>run_err.log; ec=$?
+          echo "exit_code=$ec" >> "$GITHUB_OUTPUT"
+          cat "$out_file" 2>/dev/null || echo "JSON output non disponibile"
+          if [ -s run_err.log ]; then
+>>>>>>> d25ff6e (fix(CI): toolkit run mart senza flag incompatibili (--json, --sample-*))
+            echo "--- stderr ---"
+            cat run_err.log
             echo "---"
           fi
           exit $ec
@@ -162,7 +179,8 @@ jobs:
           name: pr-toolkit-${{ matrix.config.artifact_name }}
           path: |
             run_full.json
-            run_full_err.log
+            run_mart.json
+            run_err.log
           retention-days: 7
 
   report:

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -112,7 +112,7 @@ jobs:
           python scripts/prefetch_blocked_sources.py \
             "${{ matrix.config.config_path }}"
         env:
-          BLOCKED_SOURCE_PROXY: ${{ secrets.BLOCKED_SOURCE_PROXY }}
+          BLOCKED_SOURCE_PROXY: ${{ vars.BLOCKED_SOURCE_PROXY }}
 
       - name: "Toolkit run full (smoke: sample-bytes + sample-rows, skip min_rows) [retry x2]"
         id: run_full

--- a/compose/malasanita-compose/README.md
+++ b/compose/malasanita-compose/README.md
@@ -1,0 +1,48 @@
+# malasanita-compose
+
+Compose puro del filone **malasanita**. Mette insieme i 4 candidate flat regionali e produce 3 mart con diversa metodologia di mortalità.
+
+## Domanda
+
+Le regioni con meno personale sanitario hanno livelli più alti di mortalità evitabile?
+
+## Fonti
+
+| ID | Candidate | Fonte | Output |
+|---|---|---|---|
+| A | `candidates/strutture-asl` | Ministero della Salute — Strutture e attività ASL | `mart_regioni` (medici, pediatri, residenti per regione) |
+| C | `candidates/strutture-ricovero-asl` | Ministero della Salute — Strutture di ricovero per ASL | `mart_regioni` (personale, posti letto, ricoveri per regione) |
+| D | `candidates/mortalita-istat-evitabile` | ISTAT — Mortalità per causa | `mart_regioni_v1/v2/v3` (3 metriche di mortalità) |
+
+**B** (reparti-ricovero) è escluso dal compose: ridondante con C sui posti letto aggregati (differenza di 6 unità sul totale nazionale). Il suo valore distintivo è il dettaglio per disciplina, utilizzabile in analisi separate.
+
+## Output
+
+Il compose produce 3 mart regionali (21 righe, una per regione/PA):
+
+| Mart | Mortalità | Metodologia |
+|---|---|---|
+| `mart_compose_regioni_v1` | `decessi_30plus` — mortalità totale 30+ | Baseline storica (`cod_causa=25`) |
+| `mart_compose_regioni_v2` | `decessi_evitabili_30plus` — 12 cause Euro-2013 | Proxy grezzo 30+, tasso non age-standardized |
+| `mart_compose_regioni_v3` | `tasso_std_broad_evitabile_100k_30plus` | **Baseline raccomandata** — broad age-standardization 30+ |
+
+Tutti i mart hanno join A+C+D verificato: 21/21 unità territoriali.
+
+## Esecuzione
+
+```bash
+# Prerequisito: i 3 candidate support devono avere i mart generati
+python -m toolkit.cli.app run mart --config compose/malasanita-compose/dataset.yml
+```
+
+Il comando esegue automaticamente raw+clean+mart sui support (se necessario), poi genera i 3 compose mart.
+
+## Dipendenze
+
+- Toolkit **>= v1.24.0** (supporto parametro `thousands` per CSV con separatore migliaia)
+
+## Note tecniche
+
+- Il join regionale usa il mapping `codice_regione` (3 cifre, Ministero) → `cod_territorio` (2 cifre, ISTAT): `LEFT(codice_regione, 2)` con eccezioni `041→21` (Bolzano) e `042→22` (Trento)
+- Fonte D ha 3 mart separati (v1/v2/v3) con diverse metodologie — il compose li legge tutti con `union_by_name=true` e filtra per versione
+- La v3 è la baseline raccomandata per confronti inter-regionali (decisione issue #24)

--- a/compose/malasanita-compose/dataset.yml
+++ b/compose/malasanita-compose/dataset.yml
@@ -9,9 +9,6 @@ support:
   - name: a
     config: "../../candidates/strutture-asl/dataset.yml"
     years: [2022]
-  - name: b
-    config: "../../candidates/reparti-ricovero/dataset.yml"
-    years: [2022]
   - name: c
     config: "../../candidates/strutture-ricovero-asl/dataset.yml"
     years: [2022]

--- a/compose/malasanita-compose/dataset.yml
+++ b/compose/malasanita-compose/dataset.yml
@@ -1,0 +1,37 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "malasanita_compose"
+  years: [2022]
+
+support:
+  - name: a
+    config: "../../candidates/strutture-asl/dataset.yml"
+    years: [2022]
+  - name: b
+    config: "../../candidates/reparti-ricovero/dataset.yml"
+    years: [2022]
+  - name: c
+    config: "../../candidates/strutture-ricovero-asl/dataset.yml"
+    years: [2022]
+  - name: d
+    config: "../../candidates/mortalita-istat-evitabile/dataset.yml"
+    years: [2022]
+
+mart:
+  tables:
+    - name: "mart_compose_regioni_v1"
+      sql: "sql/mart_compose_regioni_v1.sql"
+    - name: "mart_compose_regioni_v2"
+      sql: "sql/mart_compose_regioni_v2.sql"
+    - name: "mart_compose_regioni_v3"
+      sql: "sql/mart_compose_regioni_v3.sql"
+  validate:
+    table_rules:
+      mart_compose_regioni_v1: { min_rows: 21 }
+      mart_compose_regioni_v2: { min_rows: 21 }
+      mart_compose_regioni_v3: { min_rows: 21 }
+
+validation:
+  fail_on_error: true

--- a/compose/malasanita-compose/notes.md
+++ b/compose/malasanita-compose/notes.md
@@ -1,162 +1,28 @@
-# Notes - malasanita-struttura-mortalita
+# Note — malasanita-compose
 
 ## Stato tecnico
 
-Nel branch `feat/malasanita-mart-hardening` il candidato ha una prima base eseguibile e verificata:
+Compose puro standalone (non più annidato in candidate A come nella vecchia architettura).
+Join A+C+D verificato: 21/21 regioni per tutte e 3 le versioni (v1/v2/v3).
 
-- `A` raw/clean/mart ok
-- `C` raw/clean/mart ok
-- `D` raw/clean/mart ok
-- compose finale `A + C + D` ok
+## Fonte D — metodologia
 
-Join finale verificato:
-- `join_c_ok = 21/21`
-- `join_d_ok = 21/21`
+La fonte D è il punto metodologicamente più delicato:
 
-## Architettura adottata
+- **v1**: mortalità totale 30+ (`cod_causa=25`) — baseline storica
+- **v2**: 12 cause Euro-2013 (amenable + preventable), tasso grezzo 30+ — proxy di supporto
+- **v3**: stesse 12 cause, ma con age-standardizzazione broad su 3 bande (30-69, 70-84, 85+) con pesi ESP2013 aggregati — **baseline raccomandata**
 
-Pattern multi-fonte:
-
-- un source dataset per ogni fonte
-- un mart regionale minimo per fonte
-- un compose finale che legge solo output gia aggregati
-
-Implementazione attuale (branch `feat/malasanita-v2-euro2013`):
-
-- `sources/a_strutture_asl/sql/mart.sql`
-- `sources/c_strutture_ricovero_asl/sql/mart.sql`
-- `sources/d_mortalita_istat/sql/mart_regioni_v1.sql` (v1 — baseline `cod_causa=25`)
-- `sources/d_mortalita_istat/sql/mart_regioni_v2.sql` (v2 — Euro-2013, 12 cause)
-- `sources/d_mortalita_istat/sql/mart_regioni_v3.sql` (v3 — broad age-standardization 30+)
-- `sources/a_strutture_asl/sql/mart_compose_regioni_v1.sql`
-- `sources/a_strutture_asl/sql/mart_compose_regioni_v2.sql`
-- `sources/a_strutture_asl/sql/mart_compose_regioni_v3.sql`
-
-File legacy (non eseguiti dal dataset.yml, mantenuti come riferimento storico):
-
-- `sources/d_mortalita_istat/sql/mart.sql`
-- `sources/a_strutture_asl/sql/mart_compose_regioni.sql`
-
-Il compose finale e` agganciato al dataset di `A` per un vincolo del toolkit: il file SQL del mart deve stare sotto la base dir del dataset che lo esegue.
-
-## Fonte D
-
-La fonte `D` e` il punto metodologicamente piu delicato.
-
-Problema verificato:
-- sommare tutte le righe del clean sovraconta i decessi
-
-Scelta adottata nella v1 (main):
-- `cod_sesso = 3`, `cod_classe_eta = 9`, `cod_titolo_studio = 9`, `cod_causa = 25`
-- produce una riga per territorio: mortalita totale 30+
-
-Scelta adottata nella v2 (branch `feat/malasanita-v2-euro2013`):
-- stessi filtri su sesso/eta/studio
-- `cod_causa IN (2,5,6,7,9,15,16,17,19,20,22,24)` — 12 cause Euro-2013 proxy
-- aggregazione: `SUM(decessi)`, `MAX(pop_media)`, tasso grezzo 30+
-- `MAX(pop_media)` verificato: e` identico per tutte le cause dello stesso territorio/anno
-  (e` la popolazione 30+ di riferimento, non specifica per causa)
-
-Nota denominatore ibrido (documentata in mart.sql e notebook v2):
-- il campo `decessi_evitabili_30plus_per_100k_pop_totale` nel compose finale
-  usa numeratore 30+ e denominatore pop totale regionale (da fonte A)
-- non e` un tasso grezzo canonico, e` un indicatore proxy comparativo inter-regionale
-
-Causa cod_territorio=4 esclusa nel clean:
-- cod 4 = Trentino-Alto Adige aggregato
-- cod 21 (Bolzano) e 22 (Trento) gia presenti come righe separate
-- escludere 4 evita doppio conteggio nel join
+Il ranking regionale cambia tra v2 e v3 per via dell'artefatto demografico (es. Liguria #1 in v2 → #9 in v3).
 
 ## Join regionale
 
-Fonte A e C:
-- `codice_regione` a 3 cifre Ministero
+- Fonte A e C: `codice_regione` a 3 cifre Ministero (es. `"010"`)
+- Fonte D: `cod_territorio` ISTAT a 2 cifre (es. `"01"`)
+- Mapping: `LEFT(codice_regione, 2)` per regioni ordinarie, `041→21` (Bolzano), `042→22` (Trento)
 
-Fonte D:
-- `cod_territorio` ISTAT a 2 cifre
+## Rischi noti
 
-Mapping usato nel compose:
-- `LEFT(codice_regione, 2)` per le regioni ordinarie
-- eccezioni:
-  - `041 -> 21` Bolzano
-  - `042 -> 22` Trento
-
-Nota: nel dataset ISTAT 2022 i codici territoriali sono gia presenti come stringhe a due cifre (`01`-`22`), quindi il join regge senza padding extra. Questa assunzione va comunque ricontrollata se cambia la sorgente.
-
-## Fonte B
-
-Spike chiuso su issue #22. Esito tecnico:
-
-- 6.989 righe, 21 regioni/PA complete, 504 strutture, 65 discipline
-- `sources/b_reparti_ricovero/sql/mart.sql` definito; output: `mart_regioni`
-- join regionale compatibile: B e C hanno lo stesso formato `codice_regione` a 3 cifre
-- a livello regionale B e` tendenzialmente ridondante rispetto a C sui posti letto
-  (`posti_letto_utilizzati` B/C differiscono di sole 6 unita sul totale nazionale)
-- il valore distintivo di B e` il dettaglio per `codice_disciplina` / `disciplina`, assente in C
-
-**Decisione:** B non entra nel compose regionale principale. Resta fonte separata con `mart_regioni` proprio, utile per analisi su specializzazione/offerta disciplinare in un follow-up dedicato.
-
-## Limiti residui
-
-- `B` ha un mart regionale ma non entra nel compose principale (vedi sezione Fonte B)
-- `D` e` ancora un proxy regionale, non la metrica finale desiderata
-- i tassi `30+` di `D` non vanno confusi con un denominatore generale di popolazione residente
-- il campo `decessi_30plus_per_100k_pop_totale` usa un numeratore `30+` e un denominatore di popolazione totale: e` un indicatore proxy, non un tasso grezzo canonico
-
-## v3 - age-standardizzazione broad 30+
-
-Esito tecnico:
-
-- la fonte `D` espone tre classi età utili per il 30+: `30-69`, `70-84`, `85+`
-- questo non consente una standardizzazione piena a bande quinquennali
-- consente pero una standardizzazione esplicita broad, aggregando i pesi ESP2013 sulle tre classi disponibili
-
-Pesi usati:
-
-- `30-69` -> `52.500`
-- `70-84` -> `11.500`
-- `85+` -> `2.500`
-- totale `30+` -> `66.500`
-
-Validazione interna:
-
-- applicata al totale cause (`cod_causa=25`), la broad-standardization replica bene il `tasso_std_10000` della fonte su 30+
-- correlazione broad vs tasso standardizzato fonte: `~0,99`
-- correlazione tasso grezzo vs tasso standardizzato fonte: molto piu bassa (`~0,41`)
-
-Decisione (issue #24 — chiusa):
-
-- **`v3` e` la baseline raccomandata per il confronto inter-regionale**
-- `v2` resta proxy grezzo 30+ di supporto — documentato, non eliminato
-- `v3` non sostituisce una age-standardization piena a 5 anni, che la fonte non consente
-- il ranking v2 era distorto dall'artefatto demografico (es. Liguria anziana: #1 in v2, #9 in v3); v3 corregge questo confond
-- `medici_osp_per_100k` a -0.43 e` l'unica correlazione direzionalmente coerente con l'ipotesi; mmg (+0.49) e personale (+0.21) riflettono confond noti (Molise, demografia) — documentare onestamente nel notebook
-
-## v2 — stato (branch `feat/malasanita-v2-euro2013`, PR #16)
-
-### Decisione naming (Opzione A — rinomina esplicita)
-
-Adottata Opzione A: nomi espliciti v1/v2 su tutti gli artifact.
-
-| Layer | v1 | v2 | v3 |
-|---|---|---|---|
-| D mart | `mart_regioni_v1.sql` / `.parquet` | `mart_regioni_v2.sql` / `.parquet` | `mart_regioni_v3.sql` / `.parquet` |
-| A compose | `mart_compose_regioni_v1.sql` / `.parquet` | `mart_compose_regioni_v2.sql` / `.parquet` | `mart_compose_regioni_v3.sql` / `.parquet` |
-| Analisi pubblica | `v1` | `v2` | `v3` |
-| Metrica | `decessi_30plus_per_100k_pop_totale` | `decessi_evitabili_30plus_per_100k_pop_totale` | `tasso_std_broad_evitabile_100k_30plus` |
-
-I file `mart.sql` (D) e `mart_compose_regioni.sql` (A) sono marcati LEGACY nel commento di testa.
-
-### Checklist
-
-- [x] definizione esplicita mortalita evitabile da `D` (Euro-2013 proxy, 12 cause)
-- [x] artifact v1 e v2 separati — nessuna competizione sullo stesso parquet
-- [x] notebook v1 legge `mart_compose_regioni_v1.parquet`
-- [x] notebook v2 legge `mart_compose_regioni_v2.parquet`
-- [x] placeholder campo mancante chiuso in notebook v2 (cella nota metodologica)
-- [x] caveat Molise/Valle d'Aosta su `personale_osp_per_100k` in notebook v2 e README
-- [x] smoke test: run mart D (v1+v2) + run mart A (compose v1+v2), verifica parquet e schema
-- [x] smoke test colonne: v1 ha `decessi_30plus_per_100k_pop_totale`, v2 ha `decessi_evitabili_30plus_per_100k_pop_totale`, nessuna contaminazione incrociata
-- [x] join_c_ok e join_d_ok = 21/21 su entrambi gli artifact
-- [x] age-standardizzazione broad 30+ implementata come v3 (`mart_regioni_v3` + `mart_compose_regioni_v3`)
-- [x] fonte B: definito `mart_regioni` minimo, join verificato, decisione presa — fuori dal compose principale (vedi sezione Fonte B e issue #22)
+- **Fonte D**: i 3 mart (v1/v2/v3) sono letti con `union_by_name=true`. La v3 viene filtrata per presenza di `tasso_std_broad_evitabile_10000_30plus`. Se in futuro D cambiasse schema, il filtro potrebbe non funzionare.
+- **Separatore migliaia**: i CSV di C usano `.` come separatore migliaia — gestito dal toolkit v1.24.0+ con `decimal: ","` + `thousands: "."`
+- **URL fonte A e C**: puntano a `dati.salute.gov.it`, bloccato in CI senza proxy

--- a/compose/malasanita-compose/notes.md
+++ b/compose/malasanita-compose/notes.md
@@ -1,0 +1,162 @@
+# Notes - malasanita-struttura-mortalita
+
+## Stato tecnico
+
+Nel branch `feat/malasanita-mart-hardening` il candidato ha una prima base eseguibile e verificata:
+
+- `A` raw/clean/mart ok
+- `C` raw/clean/mart ok
+- `D` raw/clean/mart ok
+- compose finale `A + C + D` ok
+
+Join finale verificato:
+- `join_c_ok = 21/21`
+- `join_d_ok = 21/21`
+
+## Architettura adottata
+
+Pattern multi-fonte:
+
+- un source dataset per ogni fonte
+- un mart regionale minimo per fonte
+- un compose finale che legge solo output gia aggregati
+
+Implementazione attuale (branch `feat/malasanita-v2-euro2013`):
+
+- `sources/a_strutture_asl/sql/mart.sql`
+- `sources/c_strutture_ricovero_asl/sql/mart.sql`
+- `sources/d_mortalita_istat/sql/mart_regioni_v1.sql` (v1 — baseline `cod_causa=25`)
+- `sources/d_mortalita_istat/sql/mart_regioni_v2.sql` (v2 — Euro-2013, 12 cause)
+- `sources/d_mortalita_istat/sql/mart_regioni_v3.sql` (v3 — broad age-standardization 30+)
+- `sources/a_strutture_asl/sql/mart_compose_regioni_v1.sql`
+- `sources/a_strutture_asl/sql/mart_compose_regioni_v2.sql`
+- `sources/a_strutture_asl/sql/mart_compose_regioni_v3.sql`
+
+File legacy (non eseguiti dal dataset.yml, mantenuti come riferimento storico):
+
+- `sources/d_mortalita_istat/sql/mart.sql`
+- `sources/a_strutture_asl/sql/mart_compose_regioni.sql`
+
+Il compose finale e` agganciato al dataset di `A` per un vincolo del toolkit: il file SQL del mart deve stare sotto la base dir del dataset che lo esegue.
+
+## Fonte D
+
+La fonte `D` e` il punto metodologicamente piu delicato.
+
+Problema verificato:
+- sommare tutte le righe del clean sovraconta i decessi
+
+Scelta adottata nella v1 (main):
+- `cod_sesso = 3`, `cod_classe_eta = 9`, `cod_titolo_studio = 9`, `cod_causa = 25`
+- produce una riga per territorio: mortalita totale 30+
+
+Scelta adottata nella v2 (branch `feat/malasanita-v2-euro2013`):
+- stessi filtri su sesso/eta/studio
+- `cod_causa IN (2,5,6,7,9,15,16,17,19,20,22,24)` — 12 cause Euro-2013 proxy
+- aggregazione: `SUM(decessi)`, `MAX(pop_media)`, tasso grezzo 30+
+- `MAX(pop_media)` verificato: e` identico per tutte le cause dello stesso territorio/anno
+  (e` la popolazione 30+ di riferimento, non specifica per causa)
+
+Nota denominatore ibrido (documentata in mart.sql e notebook v2):
+- il campo `decessi_evitabili_30plus_per_100k_pop_totale` nel compose finale
+  usa numeratore 30+ e denominatore pop totale regionale (da fonte A)
+- non e` un tasso grezzo canonico, e` un indicatore proxy comparativo inter-regionale
+
+Causa cod_territorio=4 esclusa nel clean:
+- cod 4 = Trentino-Alto Adige aggregato
+- cod 21 (Bolzano) e 22 (Trento) gia presenti come righe separate
+- escludere 4 evita doppio conteggio nel join
+
+## Join regionale
+
+Fonte A e C:
+- `codice_regione` a 3 cifre Ministero
+
+Fonte D:
+- `cod_territorio` ISTAT a 2 cifre
+
+Mapping usato nel compose:
+- `LEFT(codice_regione, 2)` per le regioni ordinarie
+- eccezioni:
+  - `041 -> 21` Bolzano
+  - `042 -> 22` Trento
+
+Nota: nel dataset ISTAT 2022 i codici territoriali sono gia presenti come stringhe a due cifre (`01`-`22`), quindi il join regge senza padding extra. Questa assunzione va comunque ricontrollata se cambia la sorgente.
+
+## Fonte B
+
+Spike chiuso su issue #22. Esito tecnico:
+
+- 6.989 righe, 21 regioni/PA complete, 504 strutture, 65 discipline
+- `sources/b_reparti_ricovero/sql/mart.sql` definito; output: `mart_regioni`
+- join regionale compatibile: B e C hanno lo stesso formato `codice_regione` a 3 cifre
+- a livello regionale B e` tendenzialmente ridondante rispetto a C sui posti letto
+  (`posti_letto_utilizzati` B/C differiscono di sole 6 unita sul totale nazionale)
+- il valore distintivo di B e` il dettaglio per `codice_disciplina` / `disciplina`, assente in C
+
+**Decisione:** B non entra nel compose regionale principale. Resta fonte separata con `mart_regioni` proprio, utile per analisi su specializzazione/offerta disciplinare in un follow-up dedicato.
+
+## Limiti residui
+
+- `B` ha un mart regionale ma non entra nel compose principale (vedi sezione Fonte B)
+- `D` e` ancora un proxy regionale, non la metrica finale desiderata
+- i tassi `30+` di `D` non vanno confusi con un denominatore generale di popolazione residente
+- il campo `decessi_30plus_per_100k_pop_totale` usa un numeratore `30+` e un denominatore di popolazione totale: e` un indicatore proxy, non un tasso grezzo canonico
+
+## v3 - age-standardizzazione broad 30+
+
+Esito tecnico:
+
+- la fonte `D` espone tre classi età utili per il 30+: `30-69`, `70-84`, `85+`
+- questo non consente una standardizzazione piena a bande quinquennali
+- consente pero una standardizzazione esplicita broad, aggregando i pesi ESP2013 sulle tre classi disponibili
+
+Pesi usati:
+
+- `30-69` -> `52.500`
+- `70-84` -> `11.500`
+- `85+` -> `2.500`
+- totale `30+` -> `66.500`
+
+Validazione interna:
+
+- applicata al totale cause (`cod_causa=25`), la broad-standardization replica bene il `tasso_std_10000` della fonte su 30+
+- correlazione broad vs tasso standardizzato fonte: `~0,99`
+- correlazione tasso grezzo vs tasso standardizzato fonte: molto piu bassa (`~0,41`)
+
+Decisione (issue #24 — chiusa):
+
+- **`v3` e` la baseline raccomandata per il confronto inter-regionale**
+- `v2` resta proxy grezzo 30+ di supporto — documentato, non eliminato
+- `v3` non sostituisce una age-standardization piena a 5 anni, che la fonte non consente
+- il ranking v2 era distorto dall'artefatto demografico (es. Liguria anziana: #1 in v2, #9 in v3); v3 corregge questo confond
+- `medici_osp_per_100k` a -0.43 e` l'unica correlazione direzionalmente coerente con l'ipotesi; mmg (+0.49) e personale (+0.21) riflettono confond noti (Molise, demografia) — documentare onestamente nel notebook
+
+## v2 — stato (branch `feat/malasanita-v2-euro2013`, PR #16)
+
+### Decisione naming (Opzione A — rinomina esplicita)
+
+Adottata Opzione A: nomi espliciti v1/v2 su tutti gli artifact.
+
+| Layer | v1 | v2 | v3 |
+|---|---|---|---|
+| D mart | `mart_regioni_v1.sql` / `.parquet` | `mart_regioni_v2.sql` / `.parquet` | `mart_regioni_v3.sql` / `.parquet` |
+| A compose | `mart_compose_regioni_v1.sql` / `.parquet` | `mart_compose_regioni_v2.sql` / `.parquet` | `mart_compose_regioni_v3.sql` / `.parquet` |
+| Analisi pubblica | `v1` | `v2` | `v3` |
+| Metrica | `decessi_30plus_per_100k_pop_totale` | `decessi_evitabili_30plus_per_100k_pop_totale` | `tasso_std_broad_evitabile_100k_30plus` |
+
+I file `mart.sql` (D) e `mart_compose_regioni.sql` (A) sono marcati LEGACY nel commento di testa.
+
+### Checklist
+
+- [x] definizione esplicita mortalita evitabile da `D` (Euro-2013 proxy, 12 cause)
+- [x] artifact v1 e v2 separati — nessuna competizione sullo stesso parquet
+- [x] notebook v1 legge `mart_compose_regioni_v1.parquet`
+- [x] notebook v2 legge `mart_compose_regioni_v2.parquet`
+- [x] placeholder campo mancante chiuso in notebook v2 (cella nota metodologica)
+- [x] caveat Molise/Valle d'Aosta su `personale_osp_per_100k` in notebook v2 e README
+- [x] smoke test: run mart D (v1+v2) + run mart A (compose v1+v2), verifica parquet e schema
+- [x] smoke test colonne: v1 ha `decessi_30plus_per_100k_pop_totale`, v2 ha `decessi_evitabili_30plus_per_100k_pop_totale`, nessuna contaminazione incrociata
+- [x] join_c_ok e join_d_ok = 21/21 su entrambi gli artifact
+- [x] age-standardizzazione broad 30+ implementata come v3 (`mart_regioni_v3` + `mart_compose_regioni_v3`)
+- [x] fonte B: definito `mart_regioni` minimo, join verificato, decisione presa — fuori dal compose principale (vedi sezione Fonte B e issue #22)

--- a/compose/malasanita-compose/sql/mart_compose_regioni_v1.sql
+++ b/compose/malasanita-compose/sql/mart_compose_regioni_v1.sql
@@ -1,21 +1,17 @@
--- mart_compose_regioni_v1.sql - compose puro malasanita
--- Input: mart regionali di A (strutture-asl), C (strutture-ricovero-asl), D (mortalita-istat-evitabile)
--- Output: una riga per regione / PA con indicatori di struttura + mortalita totale 30+
---
+-- mart_compose_regioni_v1.sql — compose puro malasanita
 -- Baseline v1: mortalita totale 30+ (cod_causa=25) da D v1
+-- {support.d.mart} si risolve in mart_regioni_v1.parquet (primo mart di D).
+--
 -- Fonte B (reparti-ricovero) resta fuori dal compose principale.
 
 WITH a AS (
-    SELECT *
-    FROM read_parquet('{support.a.mart}')
+    SELECT * FROM read_parquet('{support.a.mart}')
 ),
 c AS (
-    SELECT *
-    FROM read_parquet('{support.c.mart}')
+    SELECT * FROM read_parquet('{support.c.mart}')
 ),
 d AS (
-    SELECT *
-    FROM read_parquet('out/data/mart/mortalita_istat_evitabile/{year}/mart_regioni_v1.parquet')
+    SELECT * FROM read_parquet('{support.d.mart}')
 ),
 a_lookup AS (
     SELECT

--- a/compose/malasanita-compose/sql/mart_compose_regioni_v1.sql
+++ b/compose/malasanita-compose/sql/mart_compose_regioni_v1.sql
@@ -1,0 +1,68 @@
+-- mart_compose_regioni_v1.sql - compose puro malasanita
+-- Input: mart regionali di A (strutture-asl), C (strutture-ricovero-asl), D (mortalita-istat-evitabile)
+-- Output: una riga per regione / PA con indicatori di struttura + mortalita totale 30+
+--
+-- Baseline v1: mortalita totale 30+ (cod_causa=25) da D v1
+-- Fonte B (reparti-ricovero) resta fuori dal compose principale.
+
+WITH a AS (
+    SELECT *
+    FROM read_parquet('{support.a.mart}')
+),
+c AS (
+    SELECT *
+    FROM read_parquet('{support.c.mart}')
+),
+d AS (
+    SELECT *
+    FROM read_parquet('out/data/mart/mortalita_istat_evitabile/{year}/mart_regioni_v1.parquet')
+),
+a_lookup AS (
+    SELECT
+        *,
+        CASE codice_regione
+            WHEN '041' THEN '21'
+            WHEN '042' THEN '22'
+            ELSE LEFT(codice_regione, 2)
+        END AS cod_territorio_istat
+    FROM a
+)
+SELECT
+    a.anno,
+    a.codice_regione,
+    a.cod_territorio_istat AS cod_territorio,
+    a.regione,
+    d.territorio AS territorio_istat,
+
+    a.pop_residente,
+    a.medici_mmg,
+    a.pediatri,
+    c.personale_ospedaliero,
+    c.medici_ospedalieri,
+    c.infermieri,
+    c.posti_letto_previsti,
+    c.posti_letto_utilizzati,
+
+    d.decessi_30plus AS decessi_regionali,
+    d.pop_media_30plus,
+    d.tasso_grezzo_10000_30plus,
+
+    a.medici_mmg_per_100k,
+    a.pediatri_per_100k,
+    ROUND(c.medici_ospedalieri * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS medici_osp_per_100k,
+    ROUND(c.infermieri * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS infermieri_per_100k,
+    ROUND(c.personale_ospedaliero * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS personale_osp_per_100k,
+    ROUND(c.posti_letto_previsti * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS posti_letto_previsti_per_100k,
+    ROUND(c.posti_letto_utilizzati * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS posti_letto_utilizzati_per_100k,
+    ROUND(d.decessi_30plus * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS decessi_30plus_per_100k_pop_totale,
+
+    CASE WHEN c.codice_regione IS NOT NULL THEN true ELSE false END AS join_c_ok,
+    CASE WHEN d.cod_territorio IS NOT NULL THEN true ELSE false END AS join_d_ok
+FROM a_lookup a
+LEFT JOIN c
+    ON a.anno = c.anno
+   AND a.codice_regione = c.codice_regione
+LEFT JOIN d
+    ON a.anno = d.anno
+   AND a.cod_territorio_istat = d.cod_territorio
+ORDER BY a.codice_regione

--- a/compose/malasanita-compose/sql/mart_compose_regioni_v2.sql
+++ b/compose/malasanita-compose/sql/mart_compose_regioni_v2.sql
@@ -1,0 +1,67 @@
+-- mart_compose_regioni_v2.sql - compose puro malasanita
+-- Input: mart regionali di A, C, D
+-- Output: una riga per regione / PA con indicatori + mortalita evitabile
+--
+-- Baseline v2: Euro-2013 proxy (12 cause amenable/preventable) da D v2
+
+WITH a AS (
+    SELECT *
+    FROM read_parquet('{support.a.mart}')
+),
+c AS (
+    SELECT *
+    FROM read_parquet('{support.c.mart}')
+),
+d AS (
+    SELECT *
+    FROM read_parquet('out/data/mart/mortalita_istat_evitabile/{year}/mart_regioni_v2.parquet')
+),
+a_lookup AS (
+    SELECT
+        *,
+        CASE codice_regione
+            WHEN '041' THEN '21'
+            WHEN '042' THEN '22'
+            ELSE LEFT(codice_regione, 2)
+        END AS cod_territorio_istat
+    FROM a
+)
+SELECT
+    a.anno,
+    a.codice_regione,
+    a.cod_territorio_istat AS cod_territorio,
+    a.regione,
+    d.territorio AS territorio_istat,
+
+    a.pop_residente,
+    a.medici_mmg,
+    a.pediatri,
+    c.personale_ospedaliero,
+    c.medici_ospedalieri,
+    c.infermieri,
+    c.posti_letto_previsti,
+    c.posti_letto_utilizzati,
+
+    d.decessi_evitabili_30plus AS decessi_evitabili_regionali,
+    d.pop_media_30plus,
+    d.tasso_grezzo_evitabile_10000_30plus,
+
+    a.medici_mmg_per_100k,
+    a.pediatri_per_100k,
+    ROUND(c.medici_ospedalieri * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS medici_osp_per_100k,
+    ROUND(c.infermieri * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS infermieri_per_100k,
+    ROUND(c.personale_ospedaliero * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS personale_osp_per_100k,
+    ROUND(c.posti_letto_previsti * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS posti_letto_previsti_per_100k,
+    ROUND(c.posti_letto_utilizzati * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS posti_letto_utilizzati_per_100k,
+    ROUND(d.decessi_evitabili_30plus * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS decessi_evitabili_30plus_per_100k_pop_totale,
+
+    CASE WHEN c.codice_regione IS NOT NULL THEN true ELSE false END AS join_c_ok,
+    CASE WHEN d.cod_territorio IS NOT NULL THEN true ELSE false END AS join_d_ok
+FROM a_lookup a
+LEFT JOIN c
+    ON a.anno = c.anno
+   AND a.codice_regione = c.codice_regione
+LEFT JOIN d
+    ON a.anno = d.anno
+   AND a.cod_territorio_istat = d.cod_territorio
+ORDER BY a.codice_regione

--- a/compose/malasanita-compose/sql/mart_compose_regioni_v2.sql
+++ b/compose/malasanita-compose/sql/mart_compose_regioni_v2.sql
@@ -1,20 +1,18 @@
--- mart_compose_regioni_v2.sql - compose puro malasanita
--- Input: mart regionali di A, C, D
--- Output: una riga per regione / PA con indicatori + mortalita evitabile
---
+-- mart_compose_regioni_v2.sql — compose puro malasanita
 -- Baseline v2: Euro-2013 proxy (12 cause amenable/preventable) da D v2
+-- Legge tutti e 3 i mart di D via {support.d.outputs} e filtra per la v2
+-- (decessi_evitabili_30plus presente, tasso_std_broad assente).
 
 WITH a AS (
-    SELECT *
-    FROM read_parquet('{support.a.mart}')
+    SELECT * FROM read_parquet('{support.a.mart}')
 ),
 c AS (
-    SELECT *
-    FROM read_parquet('{support.c.mart}')
+    SELECT * FROM read_parquet('{support.c.mart}')
 ),
 d AS (
-    SELECT *
-    FROM read_parquet('out/data/mart/mortalita_istat_evitabile/{year}/mart_regioni_v2.parquet')
+    SELECT * FROM read_parquet({support.d.outputs}, union_by_name=true)
+    WHERE decessi_evitabili_30plus IS NOT NULL
+      AND tasso_std_broad_evitabile_10000_30plus IS NULL
 ),
 a_lookup AS (
     SELECT

--- a/compose/malasanita-compose/sql/mart_compose_regioni_v3.sql
+++ b/compose/malasanita-compose/sql/mart_compose_regioni_v3.sql
@@ -1,0 +1,69 @@
+-- mart_compose_regioni_v3.sql - compose puro malasanita
+-- Input: mart regionali di A, C, D
+-- Output: una riga per regione / PA con indicatori + mortalita evitabile v3
+--
+-- Baseline v3: broad age-standardization 30+ su 3 bande (D v3)
+-- Baseline raccomandata per confronto inter-regionale.
+
+WITH a AS (
+    SELECT *
+    FROM read_parquet('{support.a.mart}')
+),
+c AS (
+    SELECT *
+    FROM read_parquet('{support.c.mart}')
+),
+d AS (
+    SELECT *
+    FROM read_parquet('out/data/mart/mortalita_istat_evitabile/{year}/mart_regioni_v3.parquet')
+),
+a_lookup AS (
+    SELECT
+        *,
+        CASE codice_regione
+            WHEN '041' THEN '21'
+            WHEN '042' THEN '22'
+            ELSE LEFT(codice_regione, 2)
+        END AS cod_territorio_istat
+    FROM a
+)
+SELECT
+    a.anno,
+    a.codice_regione,
+    a.cod_territorio_istat AS cod_territorio,
+    a.regione,
+    d.territorio AS territorio_istat,
+
+    a.pop_residente,
+    a.medici_mmg,
+    a.pediatri,
+    c.personale_ospedaliero,
+    c.medici_ospedalieri,
+    c.infermieri,
+    c.posti_letto_previsti,
+    c.posti_letto_utilizzati,
+
+    d.decessi_evitabili_30plus AS decessi_evitabili_regionali,
+    d.pop_media_30plus,
+    d.tasso_grezzo_evitabile_10000_30plus,
+    d.tasso_std_broad_evitabile_10000_30plus,
+    ROUND(d.tasso_std_broad_evitabile_10000_30plus * 10, 2) AS tasso_std_broad_evitabile_100k_30plus,
+
+    a.medici_mmg_per_100k,
+    a.pediatri_per_100k,
+    ROUND(c.medici_ospedalieri * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS medici_osp_per_100k,
+    ROUND(c.infermieri * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS infermieri_per_100k,
+    ROUND(c.personale_ospedaliero * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS personale_osp_per_100k,
+    ROUND(c.posti_letto_previsti * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS posti_letto_previsti_per_100k,
+    ROUND(c.posti_letto_utilizzati * 100000.0 / NULLIF(a.pop_residente, 0), 2) AS posti_letto_utilizzati_per_100k,
+
+    CASE WHEN c.codice_regione IS NOT NULL THEN true ELSE false END AS join_c_ok,
+    CASE WHEN d.cod_territorio IS NOT NULL THEN true ELSE false END AS join_d_ok
+FROM a_lookup a
+LEFT JOIN c
+    ON a.anno = c.anno
+   AND a.codice_regione = c.codice_regione
+LEFT JOIN d
+    ON a.anno = d.anno
+   AND a.cod_territorio_istat = d.cod_territorio
+ORDER BY a.codice_regione

--- a/compose/malasanita-compose/sql/mart_compose_regioni_v3.sql
+++ b/compose/malasanita-compose/sql/mart_compose_regioni_v3.sql
@@ -1,21 +1,18 @@
--- mart_compose_regioni_v3.sql - compose puro malasanita
--- Input: mart regionali di A, C, D
--- Output: una riga per regione / PA con indicatori + mortalita evitabile v3
---
+-- mart_compose_regioni_v3.sql — compose puro malasanita
 -- Baseline v3: broad age-standardization 30+ su 3 bande (D v3)
 -- Baseline raccomandata per confronto inter-regionale.
+-- Legge tutti e 3 i mart di D via {support.d.outputs} e filtra per la v3
+-- (tasso_std_broad_evitabile_10000_30plus presente solo in v3).
 
 WITH a AS (
-    SELECT *
-    FROM read_parquet('{support.a.mart}')
+    SELECT * FROM read_parquet('{support.a.mart}')
 ),
 c AS (
-    SELECT *
-    FROM read_parquet('{support.c.mart}')
+    SELECT * FROM read_parquet('{support.c.mart}')
 ),
 d AS (
-    SELECT *
-    FROM read_parquet('out/data/mart/mortalita_istat_evitabile/{year}/mart_regioni_v3.parquet')
+    SELECT * FROM read_parquet({support.d.outputs}, union_by_name=true)
+    WHERE tasso_std_broad_evitabile_10000_30plus IS NOT NULL
 ),
 a_lookup AS (
     SELECT

--- a/scripts/prefetch_blocked_sources.py
+++ b/scripts/prefetch_blocked_sources.py
@@ -139,8 +139,10 @@ def main(config_args: list[str] | None = None) -> None:
             for s in support_list:
                 scfg = s.get("config", "")
                 if scfg:
-                    print(f"  ↪️ Compose support: {scfg}")
-                    main([scfg])
+                    # Risolve path relativo rispetto alla directory del compose
+                    scfg_resolved = str((config_path.parent / scfg).resolve())
+                    print(f"  ↪️ Compose support: {scfg_resolved}")
+                    main([scfg_resolved])
 
         # Cerca raw.sources con http_file
         raw_sources = (cfg or {}).get("raw", {}).get("sources", [])

--- a/scripts/prefetch_blocked_sources.py
+++ b/scripts/prefetch_blocked_sources.py
@@ -111,8 +111,10 @@ def _patch_config(config_path: Path, raw_path: Path, blocked_url: str = "") -> N
     print("  ✅ dataset.yml aggiornato: http_file → local_file")
 
 
-def main() -> None:
-    if len(sys.argv) < 2:
+def main(config_args: list[str] | None = None) -> None:
+    if config_args is None:
+        config_args = sys.argv[1:]
+    if len(config_args) < 1:
         print(f"Uso: {sys.argv[0]} <dataset.yml> [dataset.yml ...]")
         sys.exit(1)
 
@@ -121,7 +123,7 @@ def main() -> None:
         print("Nessun proxy configurato (HTTPS_PROXY / BLOCKED_SOURCE_PROXY). Skipping.")
         return
 
-    config_paths = [Path(a) for a in sys.argv[1:]]
+    config_paths = [Path(a) for a in config_args]
 
     for config_path in config_paths:
         if not config_path.exists():
@@ -130,6 +132,15 @@ def main() -> None:
 
         with open(config_path) as f:
             cfg = yaml.safe_load(f)
+
+        # Se è un compose (ha support:), prefetch ricorsivo per ogni support
+        support_list = (cfg or {}).get("support", [])
+        if support_list:
+            for s in support_list:
+                scfg = s.get("config", "")
+                if scfg:
+                    print(f"  ↪️ Compose support: {scfg}")
+                    main([scfg])
 
         # Cerca raw.sources con http_file
         raw_sources = (cfg or {}).get("raw", {}).get("sources", [])

--- a/scripts/run_compose_with_support.py
+++ b/scripts/run_compose_with_support.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Esegue toolkit run full per un compose, prima i support dataset in sequenza.
+
+Uso:
+    python scripts/run_compose_with_support.py <dataset.yml> [extra_opts...]
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Uso: run_compose_with_support.py <dataset.yml> [extra_opts...]")
+        sys.exit(1)
+
+    config_path = Path(sys.argv[1])
+    extra_opts = sys.argv[2:]
+
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f)
+
+    # Esegue i support dataset in sequenza
+    supports = cfg.get("support", [])
+    if supports:
+        print(f"📦 Compose: eseguo {len(supports)} support dataset in sequenza...")
+        for s in supports:
+            scfg = s.get("config", "")
+            syears = s.get("years", [])
+            if not scfg or not Path(scfg).exists():
+                print(f"  ⏭️  Support config non trovata: {scfg}")
+                continue
+            print(f"  ▶ Support: {scfg} years={syears}")
+            for y in syears:
+                cmd = ["toolkit", "run", "full", "--config", scfg, "--year", str(y)] + extra_opts
+                print(f"    toolkit run full --year {y}...")
+                r = subprocess.run(cmd, capture_output=True, text=True)
+                if r.returncode != 0:
+                    print(f"    ❌ Support {scfg} year {y} FAILED")
+                    print(r.stderr)
+                    sys.exit(1)
+                print("    ✅ OK")
+        print("  ✅ Support completati")
+
+    # Esegue il compose stesso
+    print(f"📦 Eseguo compose: {config_path}")
+    cmd = ["toolkit", "run", "full", "--config", str(config_path)] + extra_opts
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        print("❌ Compose FAILED")
+        print(r.stderr)
+    else:
+        print("✅ Compose OK")
+    # Stampa stdout del compose (contiene JSON)
+    print(r.stdout)
+    sys.exit(r.returncode)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Sintesi

Aggiunge il compose puro `compose/malasanita-compose/` — mancante dalla PR #455. Mette insieme i 4 candidate flat regionali (A+B+C+D) e produce 3 mart con diversa metodologia di mortalità.

## Contesto

Closes #455 (completion)

## Cosa cambia

- [x] compose — dataset di supporto multi-fonte

## Impatto

- [x] Aggiunge un compose in `compose/`

## Verifica locale

```bash
python -m toolkit.cli.app run mart --config compose/malasanita-compose/dataset.yml
```

**Risultati:**
- Compose v1: 21/21 regioni, join_c=21, join_d=21 ✅
- Compose v2: 21/21 regioni ✅
- Compose v3: 21/21 regioni ✅

Da verificare in CI.

## Note

- B (reparti-ricovero) è nel compose come support ma non entra nelle query SQL (ridondante con C sui posti letto — decisione PR #455)
- Toolkit v1.24.0 richiesto (supporto `thousands`)
