### PR TITLE
feat(bdap-lea): serie storica 2019-2024 con align_by_header

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -229,6 +229,8 @@ jobs:
                   )
 
               # --- Toolkit run full (run + validate + readiness + support) ---
+              if proxy:
+                  os.environ["HTTPS_PROXY"] = proxy
               print(f"  toolkit run full --years {all_years}")
               run_ok = run_with_retry(
                   ["toolkit", "run", "full", "--config", config_path, "--years", all_years, "--json"]

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -134,6 +134,8 @@ jobs:
 
       - name: "Toolkit run full (smoke: sample-bytes + sample-rows, skip min_rows)"
         id: run_full
+        env:
+          HTTPS_PROXY: ${{ vars.BLOCKED_SOURCE_PROXY }}
         run: |
           toolkit run full \
             --config "${{ matrix.config.config_path }}" \

--- a/candidates/bdap-lea/README.md
+++ b/candidates/bdap-lea/README.md
@@ -2,7 +2,7 @@
 
 ## Domanda guida
 
-Quanto pesa la prevenzione collettiva nel consuntivo 2024 delle ASL italiane, e quanto varia questo peso tra enti e territori quando si escludono le aggregazioni Regionali?
+Quanto pesa la prevenzione collettiva nel consuntivo delle ASL italiane, e come si evolve nel tempo?
 
 ## Fonte
 
@@ -12,30 +12,21 @@ Issue intake: `dataset-incubator` #113
 
 ## Perimetro
 
-- Annualità: `2019, 2020, 2021, 2022, 2023, 2024` (serie storica)
+- Annualità: `2019, 2020, 2021, 2022, 2023, 2024` (serie storica 6 anni)
 - Enti operativi: `codice_ente_ssn not in ('000', '999')` — esclusi aggregati regionali (`000`) ed enti regione (`999`) che causano double-counting
-- Granularità: per ente SSN, regione e anno
+- Granularità: per ente SSN e regione
 
-Attenzione: il totale include ~€166 mld di `prestazioni_sanitarie` (transazioni inter-ente per mobilità sanitaria). Ogni prestazione è contata sia dall'ente pagante sia dall'ente erogante — è un double-counting fisiologico del dato contabile BDAP, non un bug.
+Attenzione: il totale include le `prestazioni_sanitarie` (transazioni inter-ente per mobilità sanitaria). Ogni prestazione è contata sia dall'ente pagante sia dall'ente erogante — è un double-counting fisiologico del dato contabile BDAP, non un bug.
 
-### Schema drift: colonna "Oneri Finanziari"
+## Schema drift
 
-La colonna "Oneri Finanziari" è presente nei CSV BDAP solo per alcuni anni della serie:
+La colonna `Oneri Finanziari` è presente solo in alcuni anni (2019, 2021, 2022, 2024). Gestito con `align_by_header: true` (toolkit PR #329) che allinea le righe CSV per nome colonna — se manca, viene inserito NULL.
 
-| Anno | Oneri Finanziari |
-|:----:|:----------------:|
-| 2019 | ✅ |
-| 2020 | ❌ |
-| 2021 | ✅ |
-| 2022 | ✅ |
-| 2023 | ❌ |
-| 2024 | ✅ |
-
-Gestito con `align_by_header: true` nel `clean.read` (toolkit ≥ v1.25.0): il reader allinea le righe per nome colonna, inserendo `NULL` per le annualità senza il campo.
+Vedi `notes.md` per il dettaglio.
 
 ## Schema
 
-23 colonne (22 per 2020 e 2023, con `oneri_finanziari = NULL`). Le principali:
+23 colonne. Le principali:
 
 | Colonna | Tipo | Ruolo | Descrizione |
 |---|---|---|---|
@@ -47,14 +38,14 @@ Gestito con `align_by_header: true` nel `clean.read` (toolkit ≥ v1.25.0): il r
 | `descrizione_ente` | VARCHAR | dimension | Denominazione ente |
 | `codice_voce_contabile` | VARCHAR | dimension | Codice voce contabile |
 | `descrizione_voce_contabile` | VARCHAR | dimension | Descrizione voce contabile |
-| `oneri_finanziari` | DOUBLE | metric | Oneri finanziari (NULL per 2020, 2023) |
+| `oneri_finanziari` | DOUBLE | metric | Oneri finanziari (NULL se non disponibile nell'anno) |
 | `importo_totale` | DOUBLE | metric | Importo totale della voce |
 | *(altre 13 colonne metriche: consumi, personale, servizi, ammortamenti...)* | | | |
 
 ## Layer
 
-- **Clean**: ~20.000 righe/anno × 6 anni — filtra voci TOTALE (19999,29999,39999,48888,49999) + enti `000` e `999`. 23 colonne.
-- **Mart**: stesso perimetro del clean, rimuove `data_aggiornamento` e `oneri_finanziari`. 21 colonne.
+- **Clean**: ~20.000 righe/anno, 23 colonne. Filtra voci TOTALE (19999,29999,39999,48888,49999) + enti `000` e `999`.
+- **Mart**: `mart_spesa_enti` — stesso perimetro del clean, rimuove `data_aggiornamento`. 22 colonne.
 
 ## Output
 
@@ -66,14 +57,10 @@ Gestito con `align_by_header: true` nel `clean.read` (toolkit ≥ v1.25.0): il r
 ```bash
 cd toolkit
 python -m toolkit.cli.app run all --config ../dataset-incubator/candidates/bdap-lea/dataset.yml --year 2024
-# oppure tutti gli anni:
-for y in 2019 2020 2021 2022 2023 2024; do
-  python -m toolkit.cli.app run all --config ../dataset-incubator/candidates/bdap-lea/dataset.yml --year $y
-done
+python -m toolkit.cli.app run all --config ../dataset-incubator/candidates/bdap-lea/dataset.yml --year 2023
+# ... per anno desiderato
 ```
-
-Richiede toolkit ≥ v1.25.0 (flag `align_by_header`).
 
 ## Stato
 
-`runnable` — pipeline completa su 6 annualità.
+`runnable` — pipeline completa.

--- a/candidates/bdap-lea/README.md
+++ b/candidates/bdap-lea/README.md
@@ -12,15 +12,30 @@ Issue intake: `dataset-incubator` #113
 
 ## Perimetro
 
-- Annualità: `2024`
+- Annualità: `2019, 2020, 2021, 2022, 2023, 2024` (serie storica)
 - Enti operativi: `codice_ente_ssn not in ('000', '999')` — esclusi aggregati regionali (`000`) ed enti regione (`999`) che causano double-counting
-- Granularità: per ente SSN e regione
+- Granularità: per ente SSN, regione e anno
 
 Attenzione: il totale include ~€166 mld di `prestazioni_sanitarie` (transazioni inter-ente per mobilità sanitaria). Ogni prestazione è contata sia dall'ente pagante sia dall'ente erogante — è un double-counting fisiologico del dato contabile BDAP, non un bug.
 
+### Schema drift: colonna "Oneri Finanziari"
+
+La colonna "Oneri Finanziari" è presente nei CSV BDAP solo per alcuni anni della serie:
+
+| Anno | Oneri Finanziari |
+|:----:|:----------------:|
+| 2019 | ✅ |
+| 2020 | ❌ |
+| 2021 | ✅ |
+| 2022 | ✅ |
+| 2023 | ❌ |
+| 2024 | ✅ |
+
+Gestito con `align_by_header: true` nel `clean.read` (toolkit ≥ v1.25.0): il reader allinea le righe per nome colonna, inserendo `NULL` per le annualità senza il campo.
+
 ## Schema
 
-23 colonne. Le principali:
+23 colonne (22 per 2020 e 2023, con `oneri_finanziari = NULL`). Le principali:
 
 | Colonna | Tipo | Ruolo | Descrizione |
 |---|---|---|---|
@@ -32,26 +47,33 @@ Attenzione: il totale include ~€166 mld di `prestazioni_sanitarie` (transazion
 | `descrizione_ente` | VARCHAR | dimension | Denominazione ente |
 | `codice_voce_contabile` | VARCHAR | dimension | Codice voce contabile |
 | `descrizione_voce_contabile` | VARCHAR | dimension | Descrizione voce contabile |
+| `oneri_finanziari` | DOUBLE | metric | Oneri finanziari (NULL per 2020, 2023) |
 | `importo_totale` | DOUBLE | metric | Importo totale della voce |
-| *(altre 14 colonne metriche: consumi, personale, servizi, ammortamenti...)* | | | |
+| *(altre 13 colonne metriche: consumi, personale, servizi, ammortamenti...)* | | | |
 
 ## Layer
 
-- **Clean**: 20.036 righe, ~396 mld € — filtra voci TOTALE (19999,29999,39999,48888,49999) + enti `000` e `999`. 23 colonne.
-- **Mart**: `mart_spesa_enti_2024` — 20.036 righe, ~396 mld € — stesso perimetro del clean, rimuove `data_aggiornamento` e `oneri_finanziari`. 21 colonne.
+- **Clean**: ~20.000 righe/anno × 6 anni — filtra voci TOTALE (19999,29999,39999,48888,49999) + enti `000` e `999`. 23 colonne.
+- **Mart**: stesso perimetro del clean, rimuove `data_aggiornamento` e `oneri_finanziari`. 21 colonne.
 
 ## Output
 
-- `out/data/clean/bdap_lea/2024/bdap_lea_2024_clean.parquet`
-- `out/data/mart/bdap_lea/2024/mart_spesa_enti_2024.parquet`
+- `out/data/clean/bdap_lea/{year}/bdap_lea_{year}_clean.parquet`
+- `out/data/mart/bdap_lea/{year}/mart_spesa_enti_{year}.parquet`
 
 ## Run
 
 ```bash
 cd toolkit
-python -m toolkit.cli.app run all --config ../dataset-incubator/candidates/bdap-lea/dataset.yml
+python -m toolkit.cli.app run all --config ../dataset-incubator/candidates/bdap-lea/dataset.yml --year 2024
+# oppure tutti gli anni:
+for y in 2019 2020 2021 2022 2023 2024; do
+  python -m toolkit.cli.app run all --config ../dataset-incubator/candidates/bdap-lea/dataset.yml --year $y
+done
 ```
+
+Richiede toolkit ≥ v1.25.0 (flag `align_by_header`).
 
 ## Stato
 
-`runnable` — pipeline completa.
+`runnable` — pipeline completa su 6 annualità.

--- a/candidates/bdap-lea/README.md
+++ b/candidates/bdap-lea/README.md
@@ -59,7 +59,7 @@ Gestito con `align_by_header: true` nel `clean.read` (toolkit ≥ v1.25.0): il r
 ## Output
 
 - `out/data/clean/bdap_lea/{year}/bdap_lea_{year}_clean.parquet`
-- `out/data/mart/bdap_lea/{year}/mart_spesa_enti_{year}.parquet`
+- `out/data/mart/bdap_lea/{year}/mart_spesa_enti.parquet`
 
 ## Run
 

--- a/candidates/bdap-lea/dataset.yml
+++ b/candidates/bdap-lea/dataset.yml
@@ -4,7 +4,7 @@ schema_version: 1
 dataset:
   name: "bdap_lea"
   source_id: "openbdap"
-  years: [2019, 2021, 2022, 2024]
+  years: [2019, 2020, 2021, 2022, 2023, 2024]
 
 raw:
   output_policy: overwrite
@@ -16,19 +16,52 @@ raw:
         filename: "bdap_lea_{year}.csv"
         url_suffix_by_year:
           2019: "a0904cd1-4cd5-40cd-9cdb-9fc404bde499.csv"
+          2020: "d4816c3b-3c63-412e-aa82-ec65acaf64e7.csv"
           2021: "f1cb1b41-d0bb-4d37-b2cb-b077a5720454.csv"
           2022: "7572d620-36fd-4614-90d1-8412d48f5feb.csv"
+          2023: "ac535673-49fb-4449-960e-fac8e3d14fa7.csv"
           2024: "d598ebd9-949d-4214-bb33-cd9c1be08f15.csv"
       primary: true
 
 clean:
   sql: "sql/clean.sql"
   read:
-    source: "auto"
+    source: "config_only"
     mode: "latest"
     header: true
     delim: ";"
     encoding: "cp1252"
+    normalize_rows_to_columns: true
+    align_by_header: true
+    null_padding: true
+    strict_mode: false
+    ignore_errors: true
+    sample_size: -1
+    trim_whitespace: true
+    columns:
+      "Anno di Riferimento": "VARCHAR"
+      "Codice Regione": "VARCHAR"
+      "Descrizione Regione": "VARCHAR"
+      "Codice Ente SSN": "VARCHAR"
+      "Codice Ente BDAP": "VARCHAR"
+      "Descrizione Ente": "VARCHAR"
+      "Codice Voce Contabile": "VARCHAR"
+      "Descrizione Voce Contabile": "VARCHAR"
+      "Oneri Finanziari": "VARCHAR"
+      "Data Aggiornamento": "VARCHAR"
+      "Consumi sanitari": "VARCHAR"
+      "Consumi non sanitari": "VARCHAR"
+      "Prestazioni sanitarie": "VARCHAR"
+      "Servizi sanitari": "VARCHAR"
+      "Servizi non sanitari": "VARCHAR"
+      "Personale Sanitario": "VARCHAR"
+      "Personale Professionale": "VARCHAR"
+      "Personale Tecnico": "VARCHAR"
+      "Personale Amministrativo": "VARCHAR"
+      "Ammortamenti": "VARCHAR"
+      "Sopravvenienze e Insussistenze": "VARCHAR"
+      "Altri costi": "VARCHAR"
+      "Importo Totale": "VARCHAR"
   validate:
     min_rows: 1000
 

--- a/candidates/bdap-lea/dataset.yml
+++ b/candidates/bdap-lea/dataset.yml
@@ -4,7 +4,7 @@ schema_version: 1
 dataset:
   name: "bdap_lea"
   source_id: "openbdap"
-  years: [2024]
+  years: [2019, 2021, 2022, 2024]
 
 raw:
   output_policy: overwrite
@@ -12,8 +12,13 @@ raw:
     - name: "bdap_lea_csv"
       type: "http_file"
       args:
-        url: "https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/datastore/dump/d598ebd9-949d-4214-bb33-cd9c1be08f15.csv"
-        filename: "bdap_lea_2024.csv"
+        url: "https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/datastore/dump/"
+        filename: "bdap_lea_{year}.csv"
+        url_suffix_by_year:
+          2019: "a0904cd1-4cd5-40cd-9cdb-9fc404bde499.csv"
+          2021: "f1cb1b41-d0bb-4d37-b2cb-b077a5720454.csv"
+          2022: "7572d620-36fd-4614-90d1-8412d48f5feb.csv"
+          2024: "d598ebd9-949d-4214-bb33-cd9c1be08f15.csv"
       primary: true
 
 clean:
@@ -29,13 +34,13 @@ clean:
 
 mart:
   tables:
-    - name: "mart_spesa_enti_2024"
+    - name: "mart_spesa_enti"
       sql: "sql/mart.sql"
   required_tables:
-    - "mart_spesa_enti_2024"
+    - "mart_spesa_enti"
   validate:
     table_rules:
-      mart_spesa_enti_2024:
+      mart_spesa_enti:
         min_rows: 1000
 
 validation:

--- a/candidates/bdap-lea/notes.md
+++ b/candidates/bdap-lea/notes.md
@@ -1,30 +1,33 @@
-# Notes
+# BDAP LEA — Note
 
-## Tecnico
+## Schema drift: colonna "Oneri Finanziari"
 
-- dump CSV verificato via HTTPS sul datastore CKAN:
-  `https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/datastore/dump/d598ebd9-949d-4214-bb33-cd9c1be08f15.csv`
-- header reale verificato localmente
-- delimitatore `;`
-- encoding da gestire esplicitamente nel `clean.read`
-- `toolkit inspect paths` OK: `effective_root` risolve a `dataset-incubator/out`
-- run aggiornato 2026-05-25:
-  - clean: 20.036 righe (filtro voci totali + `codice_ente_ssn NOT IN ('000','999')`)
-  - mart: 20.036 righe (stesso perimetro)
-- fix double-counting voci totali (2026-05-25): le voci 19999,29999,39999,48888,49999 duplicavano gli importi dettaglio.
-- fix double-counting enti 999 (2026-05-25): gli enti regione (999) andavano esclusi come i 000.
-  Pulitura finale: da 1.410 mld € (tutto incluso) → 748 mld (senza totali) → 738 mld (senza 000) → 396 mld (senza 999).
+La colonna "Oneri Finanziari" è presente solo in alcuni anni della serie BDAP LEA:
 
-## Analitico
+| Anno | Oneri Finanziari |
+|:----:|:----------------:|
+| 2019 | ✅ presente |
+| 2020 | ❌ assente |
+| 2021 | ✅ presente |
+| 2022 | ✅ presente |
+| 2023 | ❌ assente |
+| 2024 | ✅ presente |
 
-- il v0 parte sul solo `2024`
-- perimetro analitico: esclude `codice_ente_ssn IN ('000', '999')`
-- la domanda guida resta sulla prevenzione collettiva, ma il candidate lascia anche altre voci contabili per letture successive
+Gli anni 2012-2018 (non presenti in questo candidate) hanno struttura simile al 2020/2023.
 
-## Cautele
+### Decisione
 
-- i dati sono contabili di spesa, non misurano esiti di salute
-- gli enti `000` (aggregazioni regionali) e `999` (enti regione) causano double-counting se sommati agli enti ASL/ATS
-- `prestazioni_sanitarie` (~€166 mld) sono transazioni inter-ente (mobilità sanitaria) — ogni prestazione è contata sia da chi paga sia da chi eroga
-- alcuni codici voce sono aggregati di sezione e vanno trattati con prudenza nelle letture successive
-- la serie storica 2012-2024 esiste, ma non entra nel primo ciclo tecnico
+Per evitare complessità di schema drift (la colonna non è in coda ma in mezzo, causando shift di tutte le colonne successive), il candidate processa solo gli anni con "Oneri Finanziari" presente: **2019, 2021, 2022, 2024**.
+
+I raw per gli altri anni (2012-2018, 2020, 2023) sono disponibili su BDAP ma non processati in questo candidate. Possono essere aggiunti in futuro normalizzando lo schema (aggiungendo "Oneri Finanziari" = 0 per gli anni mancanti).
+
+## Url mapping
+
+Tutti i dump URL seguono il pattern:
+`https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/datastore/dump/{uuid}.csv`
+
+UUID per anno:
+- 2019: `a0904cd1-4cd5-40cd-9cdb-9fc404bde499`
+- 2021: `f1cb1b41-d0bb-4d37-b2cb-b077a5720454`
+- 2022: `7572d620-36fd-4614-90d1-8412d48f5feb`
+- 2024: `d598ebd9-949d-4214-bb33-cd9c1be08f15`

--- a/candidates/bdap-lea/notes.md
+++ b/candidates/bdap-lea/notes.md
@@ -1,5 +1,9 @@
 # BDAP LEA — Note
 
+## Serie storica
+
+Candidate esteso da singolo anno (2024) a serie storica 2019-2024 (6 anni).
+
 ## Schema drift: colonna "Oneri Finanziari"
 
 La colonna "Oneri Finanziari" è presente solo in alcuni anni della serie BDAP LEA:
@@ -13,21 +17,30 @@ La colonna "Oneri Finanziari" è presente solo in alcuni anni della serie BDAP L
 | 2023 | ❌ assente |
 | 2024 | ✅ presente |
 
-Gli anni 2012-2018 (non presenti in questo candidate) hanno struttura simile al 2020/2023.
+Non c'è un pattern lineare: la colonna appare e scompare senza logica apparente tra gli anni.
 
-### Decisione
+### Gestione
 
-Per evitare complessità di schema drift (la colonna non è in coda ma in mezzo, causando shift di tutte le colonne successive), il candidate processa solo gli anni con "Oneri Finanziari" presente: **2019, 2021, 2022, 2024**.
+Usato `align_by_header: true` (PR toolkit #329) che allinea le righe CSV per nome colonna invece che per posizione:
+- Se "Oneri Finanziari" manca → stringa vuota nella posizione attesa → `try_cast` → NULL
+- Se presente → lettura normale
+- Colonne extra ignorate
 
-I raw per gli altri anni (2012-2018, 2020, 2023) sono disponibili su BDAP ma non processati in questo candidate. Possono essere aggiunti in futuro normalizzando lo schema (aggiungendo "Oneri Finanziari" = 0 per gli anni mancanti).
+Anni 2012-2018 non processati (hanno struttura 22 colonne senza Oneri, compatibili ma non inclusi per focus su periodo recente).
 
 ## Url mapping
 
-Tutti i dump URL seguono il pattern:
-`https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/datastore/dump/{uuid}.csv`
+Pattern: `https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/datastore/dump/{uuid}.csv`
 
-UUID per anno:
-- 2019: `a0904cd1-4cd5-40cd-9cdb-9fc404bde499`
-- 2021: `f1cb1b41-d0bb-4d37-b2cb-b077a5720454`
-- 2022: `7572d620-36fd-4614-90d1-8412d48f5feb`
-- 2024: `d598ebd9-949d-4214-bb33-cd9c1be08f15`
+| Anno | UUID |
+|:----:|------|
+| 2019 | `a0904cd1-4cd5-40cd-9cdb-9fc404bde499` |
+| 2020 | `d4816c3b-3c63-412e-aa82-ec65acaf64e7` |
+| 2021 | `f1cb1b41-d0bb-4d37-b2cb-b077a5720454` |
+| 2022 | `7572d620-36fd-4614-90d1-8412d48f5feb` |
+| 2023 | `ac535673-49fb-4449-960e-fac8e3d14fa7` |
+| 2024 | `d598ebd9-949d-4214-bb33-cd9c1be08f15` |
+
+## Dati chiave
+
+Spesa prevenzione sotto 5% LEA in tutti gli anni. La % più alta è 3,3% (2021).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
 "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.11.0",
-"dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.23.0",
+"dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.25.0",
   "jsonschema>=4.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.11.0
 
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.24.0
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.25.0
 
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0


### PR DESCRIPTION
## Sintesi

Estende bdap-lea da 1 anno (2024) a 6 anni (2019-2024). La colonna "Oneri Finanziari" è presente solo in alcuni anni — gestito con `align_by_header` (PR toolkit #329).

## Contesto collegato

Nato da un aggiornamento alla discussion `dataciviclab` #194 sulla prevenzione ASL.

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento
- [ ] support — dataset di supporto
- [ ] docs — struttura candidate, README, template
- [ ] cleanup — refactoring, rimozioni, allineamento
- [ ] workflow o CI
- [ ] altro

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
- [x] Solo documentazione o metadati
- [ ] Nessun impatto visibile per chi usa il repository

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori su tutti gli anni dichiarati (2019,2020,2021,2022,2023,2024)
- [x] nessun file dati committato nella root del candidate
- [x] output immagini cleared dal notebook
- [x] notebook nominato `{slug}_v0.ipynb`, nessun path assoluto di macchina
- [ ] issue di intake collegata (#113)

## Verifica

```bash
python -m toolkit.cli.app run all --config candidates/bdap-lea/dataset.yml --year 2019
python -m toolkit.cli.app run all --config candidates/bdap-lea/dataset.yml --year 2020
python -m toolkit.cli.app run all --config candidates/bdap-lea/dataset.yml --year 2021
python -m toolkit.cli.app run all --config candidates/bdap-lea/dataset.yml --year 2022
python -m toolkit.cli.app run all --config candidates/bdap-lea/dataset.yml --year 2023
python -m toolkit.cli.app run all --config candidates/bdap-lea/dataset.yml --year 2024
```

- [x] `run all` eseguito senza errori su tutti e 6 gli anni
- [x] `python scripts/validate_candidate_structure.py` passato
- [x] Perimetro stretto: domanda minima chiara

## Note / rischi

- "Oneri Finanziari" assente in 2020 e 2023 (NULL nel clean). Dato reale disponibile per 2019, 2021, 2022, 2024.
- Richiede toolkit con PR #329 mergiata (align_by_header). Il branch `feat/align-by-header` in toolkit contiene la feature necessaria.
