### PR TITLE
chore(post-merge): aggiorna registry per PR #463

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -648,7 +648,7 @@
         },
         {
           "name": "codice_ente_bdap",
-          "type": "BIGINT",
+          "type": "VARCHAR",
           "role": "dimension",
           "description": "Codice BDAP ente"
         },
@@ -678,7 +678,7 @@
         },
         {
           "name": "data_aggiornamento",
-          "type": "DATE",
+          "type": "VARCHAR",
           "role": "dimension",
           "description": "Data aggiornamento record"
         },
@@ -763,8 +763,8 @@
       ],
       "location": {
         "type": "gcs",
-        "path": "gs://dataciviclab-clean/bdap_lea/2024/bdap_lea_2024_clean.parquet",
-        "multi_file": false
+        "path": "gs://dataciviclab-clean/bdap_lea/*/bdap_lea_*_clean.parquet",
+        "multi_file": true
       },
       "stage": "published",
       "registry_source": "derive_auto"

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -59,14 +59,19 @@
       "source_id": "openbdap",
       "status": "ok",
       "label": "bdap-lea",
-      "detail": "anno 2024 — fonte: bdap_lea_csv — mart: sì",
+      "detail": "anni 2019-2024 — fonte: bdap_lea_csv — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "26397149682",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26397149682",
-        "checked_at": "2026-05-25",
+        "run_id": "27040177316",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27040177316",
+        "checked_at": "2026-06-05",
         "years": [
+          2019,
+          2020,
+          2021,
+          2022,
+          2023,
           2024
         ],
         "config_path": "candidates/bdap-lea/dataset.yml"
@@ -532,7 +537,7 @@
     },
     {
       "id": "reparti-ricovero",
-      "source_id": "ministero_salute",
+      "source_id": "",
       "status": "ok",
       "label": "reparti-ricovero",
       "detail": "anno 2022 — fonte: reparti_ricovero — mart: sì",
@@ -568,7 +573,7 @@
     },
     {
       "id": "strutture-ricovero-asl",
-      "source_id": "ministero_salute",
+      "source_id": "",
       "status": "ok",
       "label": "strutture-ricovero-asl",
       "detail": "anno 2022 — fonte: strutture_ricovero_asl — mart: sì",


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #463 — feat(bdap-lea): serie storica 2019-2024 con align_by_header

Changed candidate/support roots:

- `bdap-lea` (candidate, `candidates/bdap-lea`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/bdap-lea/dataset.yml` -> artifact `sample-run-bdap-lea`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug bdap_lea --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
