### PR TITLE
refactor(ci): composite action python-setup, estrazione logica post-merge, retry toolkit-check

### DIFF
--- a/.github/actions/python-setup/action.yml
+++ b/.github/actions/python-setup/action.yml
@@ -1,0 +1,52 @@
+name: 'Python Setup'
+description: |
+  Setup Python 3.12 con pip cache e installa requirements.txt +
+  pacchetti extra opzionali.
+
+  NOTA: Il checkout deve essere fatto PRIMA di chiamare questa action
+  (le composite action locali non possono contenere actions/checkout).
+
+inputs:
+  python-version:
+    description: Versione Python
+    default: "3.12"
+    required: false
+  extra-packages:
+    description: |
+      Pacchetti pip extra separati da spazio
+      (es. "ruff mypy pytest-cov")
+    default: ""
+    required: false
+  extra-requirements:
+    description: |
+      Path a requirements.txt extra separati da spazio
+      (es. "tools/clean-query-mcp/requirements.txt")
+    default: ""
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: 'pip'
+
+    - name: Install core dependencies
+      shell: bash
+      run: python -m pip install -r requirements.txt
+
+    - name: Install extra requirements files
+      if: inputs.extra-requirements != ''
+      shell: bash
+      run: |
+        for req in ${{ inputs.extra-requirements }}; do
+          if [ -f "$req" ]; then
+            python -m pip install -r "$req"
+          fi
+        done
+
+    - name: Install extra packages
+      if: inputs.extra-packages != ''
+      shell: bash
+      run: python -m pip install ${{ inputs.extra-packages }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/**"
+      - ".github/actions/**"
       - "requirements.txt"
       - "scripts/**"
       - "tools/**"
@@ -19,20 +20,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout dataset-incubator
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - uses: actions/checkout@v6
+      - name: Python setup
+        uses: ./.github/actions/python-setup
         with:
-          python-version: "3.12"
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
-          pip install ruff mypy types-pyyaml types-requests pytest pytest-cov pytest-timeout
-          pip install -r tools/clean-query-mcp/requirements.txt 2>/dev/null || true
+          extra-packages: ruff mypy types-pyyaml types-requests pytest pytest-cov pytest-timeout
+          extra-requirements: tools/clean-query-mcp/requirements.txt
 
       - name: Ruff
         run: ruff check scripts/ tools/

--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -106,26 +106,18 @@ jobs:
         shell: bash
 
     steps:
-      - name: Checkout merge commit
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || github.ref }}
           fetch-depth: 0
+      - name: Python setup
+        uses: ./.github/actions/python-setup
 
       - name: Download detect output
         uses: actions/download-artifact@v8
         with:
           name: detect-output
           path: .
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: python -m pip install -r requirements.txt
 
       - name: GCP Auth (for GCS push)
         if: env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != ''
@@ -139,162 +131,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v3
 
       - name: Process each detected config
-        run: |
-          python - <<'PY'
-          import json, os, subprocess, sys, glob, time
-
-          with open("detect_output.json") as f:
-              detect = json.load(f)
-
-          configs = detect.get("configs", [])
-          if not configs:
-              print("Nessun config da processare")
-              sys.exit(0)
-
-          root = os.environ.get("GITHUB_WORKSPACE", ".")
-
-          failed_configs = []
-          gcs_push_ok = False
-
-          # Pre-install GCS lib se GCP auth disponibile — una volta, non per-candidato
-          if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
-              subprocess.run(
-                  ["python", "-m", "pip", "install", "google-cloud-storage", "-q"],
-                  capture_output=True,
-              )
-
-          for cfg in configs:
-              config_path = cfg.get("config_path", "")
-              slug = cfg.get("slug", "unknown")
-              artifact_name = cfg.get("artifact_name", slug)
-              config_exists = cfg.get("config_exists", False)
-
-              print(f"\n=== Processing {slug} ({config_path}) ===")
-
-              if not config_exists:
-                  print(f"  SKIP: config_path non esiste")
-                  continue
-
-              # --- CA certs ---
-              r = subprocess.run(["python", "scripts/get_extra_ca_cert_urls.py", config_path],
-                  capture_output=True, text=True, cwd=root)
-              urls = [u.strip() for u in r.stdout.strip().split('\n') if u.strip()]
-              if urls:
-                  bundle = f"/tmp/extra-ca-{artifact_name}.pem"
-                  with open("/etc/ssl/certs/ca-certificates.crt") as src, open(bundle, "w") as dst:
-                      dst.write(src.read())
-                  for url in urls:
-                      try:
-                          import urllib.request
-                          data = urllib.request.urlopen(url).read()
-                          with open(bundle, "a") as dst:
-                              dst.write(data.decode() if isinstance(data, bytes) else data)
-                      except Exception as e:
-                          print(f"  WARN CA cert {url}: {e}")
-                  os.environ["REQUESTS_CA_BUNDLE"] = bundle
-                  os.environ["SSL_CERT_FILE"] = bundle
-
-              # --- Resolve ---
-              r = subprocess.run(["python", "scripts/resolve_sample_run.py", config_path],
-                  capture_output=True, text=True, cwd=root)
-              if r.returncode != 0:
-                  print(f"  FAIL: resolve ({r.stderr.strip()})")
-                  failed_configs.append(slug)
-                  continue
-              params = json.loads(r.stdout)
-              all_years = ",".join(str(y) for y in params.get("all_years", []))
-
-              # Support datasets gestiti nativamente da toolkit run full.
-              # Non serve eseguirli separatamente.
-
-              def run_with_retry(cmd, attempts=3):
-                  for i in range(1, attempts + 1):
-                      r = subprocess.run(cmd, cwd=root)
-                      if r.returncode == 0:
-                          return True
-                      if i < attempts:
-                          wait = 20 * i
-                          print(f"    attempt {i}/{attempts} failed, retry in {wait}s...")
-                          time.sleep(wait)
-                  return False
-
-              # --- Pre-download blocked sources via proxy (dati.salute.gov.it) ---
-              proxy = os.environ.get("BLOCKED_SOURCE_PROXY") or ""
-              if proxy:
-                  subprocess.run(
-                      ["python", "scripts/prefetch_blocked_sources.py", config_path],
-                      cwd=root,
-                      env={**os.environ, "BLOCKED_SOURCE_PROXY": proxy},
-                      check=True,
-                  )
-
-              # --- Toolkit run full (run + validate + readiness + support) ---
-              if proxy:
-                  os.environ["HTTPS_PROXY"] = proxy
-              print(f"  toolkit run full --years {all_years}")
-              run_ok = run_with_retry(
-                  ["toolkit", "run", "full", "--config", config_path, "--years", all_years, "--json"]
-              )
-              validate_ok = run_ok  # run full include gia validate
-
-              status = "passed" if (run_ok and validate_ok) else "failed"
-              if status == "failed":
-                  failed_configs.append(slug)
-              run_id = os.environ.get("GITHUB_RUN_ID", "0")
-              repo = os.environ.get("GITHUB_REPOSITORY", "")
-              payload = {
-                  "id": slug, "status": status,
-                  "years": params.get("all_years", []),
-                  "config_path": config_path, "config_exists": config_exists,
-                  "run_id": run_id,
-                  "run_url": f"https://github.com/{repo}/actions/runs/{run_id}",
-                  "checked_at": __import__("datetime").datetime.now().astimezone().date().isoformat(),
-              }
-              out_dir = f"sample_run_artifacts/{artifact_name}"
-              os.makedirs(out_dir, exist_ok=True)
-              with open(f"{out_dir}/sample_run_result.json", "w") as pf:
-                  json.dump(payload, pf, indent=2)
-              print(f"  {status}")
-
-              # --- GCS push (solo se GCP Auth ha settato le credenziali) ---
-              if status == "passed" and os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
-                  print(f"  GCS push per {slug}...")
-                  push_slug = cfg.get("push_slug", slug)
-                  r = subprocess.run(
-                      ["python", "scripts/push_archive.py", "--layer", "clean", "--slug", push_slug, "--no-bq"],
-                      cwd=root,
-                  )
-                  if r.returncode != 0:
-                      print(f"  GCS push FAILED for {slug} (code {r.returncode})")
-                      failed_configs.append(slug)
-                  else:
-                      print(f"  GCS push completato per {slug} (push_slug={push_slug})")
-                      gcs_push_ok = True
-
-          # --- Build clean catalog (solo se almeno un push è riuscito) ---
-          if gcs_push_ok:
-              print(f"\n  Rebuilding clean catalog...")
-              r = subprocess.run(
-                  ["python", "scripts/build_clean_catalog.py", "--derive", "--write"],
-                  cwd=root,
-              )
-              if r.returncode != 0:
-                  print(f"  WARN: build_clean_catalog --derive --write fallito (code {r.returncode}), check stderr sopra")
-              r = subprocess.run(
-                  ["python", "scripts/build_clean_catalog.py", "--check-gcs"],
-                  cwd=root,
-              )
-              if r.returncode != 0:
-                  print(f"  WARN: build_clean_catalog --check-gcs ha trovato errori (code {r.returncode})")
-          else:
-              print(f"\n  Skip clean catalog rebuild: nessun GCS push riuscito")
-
-          if failed_configs:
-              print("\nFAIL: one or more configs failed in post-merge full run:")
-              for slug in failed_configs:
-                  print(f" - {slug}")
-              sys.exit(1)
-          PY
+        run: python scripts/post_merge_runner.py sample-run --retry 3
 
       - name: Upload sample-run artifacts
         uses: actions/upload-artifact@v7
@@ -318,20 +155,12 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout merge commit
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || github.ref }}
           fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: python -m pip install -r requirements.txt
+      - name: Python setup
+        uses: ./.github/actions/python-setup
 
       - name: Download detect output
         if: needs.detect.outputs.has_items == 'true'
@@ -382,71 +211,16 @@ jobs:
 
       - name: Build draft PR body
         env:
-          SAMPLE_RESULT: ${{ needs.sample_run.result }}
-          PIPELINE_SIGNALS_CHANGED: ${{ steps.diff.outputs.changed }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SAMPLE_RESULT: ${{ needs.sample_run.result }}
+          SIGNALS_CHANGED: ${{ steps.diff.outputs.changed }}
         run: |
-          python - <<'PY'
-          import json, os
-
-          with open("detect_output.json") as f:
-              detect = json.load(f)
-          items = detect.get("items", [])
-          configs = detect.get("configs", [])
-          sample_result = os.environ.get("SAMPLE_RESULT", "skipped")
-          sample_passed = sample_result == "success"
-          signals_changed = os.environ.get("PIPELINE_SIGNALS_CHANGED", "false") == "true"
-          pr_number = os.environ.get("PR_NUMBER", "?")
-          pr_title = os.environ.get("PR_TITLE", "?")
-          gcp_available = os.environ.get("GCP_WORKLOAD_IDENTITY_PROVIDER", "") != "" and os.environ.get("GCP_SERVICE_ACCOUNT", "") != ""
-
-          item_list = "\n".join(f'- `{i["slug"]}` ({i["kind"]}, `{i["root"]}`)' for i in items)
-          sample_list = "\n".join(
-              f'- `{c["config_path"]}` -> artifact `sample-run-{c["artifact_name"]}`'
-              for c in configs
-          ) or "- No sample-run config detected"
-
-          commands = []
-          for c in configs:
-              commands.append(
-                  f"python scripts/push_archive.py --mart --slug {c['push_slug']} "
-                  f"--create-bq-table --update-catalog"
-              )
-
-          body = "\n".join([
-              "## Post-merge registry handoff",
-              "",
-              f"Source PR: #{pr_number} — {pr_title}",
-              "",
-              "Changed candidate/support roots:",
-              "",
-              item_list,
-              "",
-              "## Automatic updates",
-              "",
-              f"- [x] Rebuilt `registry/pipeline_signals.json`{' (no diff)' if not signals_changed else ''}",
-              f"- [{'x' if sample_passed else ' '}] CI: full run completato (tutti gli anni)",
-              f"- [{'x' if gcp_available else ' '}] CI: clean parquet pushato su GCS",
-              f"- [{'x' if gcp_available else ' '}] CI: `registry/clean_catalog.json` aggiornato",
-              "- [ ] Maintainer: push mart + BQ (se serve)",
-              "",
-              "## Sample-run artifacts",
-              "",
-              sample_list,
-              "",
-              "## Maintainer commands",
-              "",
-              "```bash",
-              "\n".join(commands),
-              "```",
-              "",
-              "CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.",
-          ])
-
-          with open("post_merge_pr_body.md", "w", encoding="utf-8") as f:
-              f.write(body + "\n")
-          PY
+          python scripts/post_merge_runner.py build-pr-body \
+            --pr-number "$PR_NUMBER" \
+            --pr-title "$PR_TITLE" \
+            --sample-result "$SAMPLE_RESULT" \
+            --signals-changed "$SIGNALS_CHANGED"
 
       - name: Create draft registry PR
         env:

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -24,20 +24,11 @@ jobs:
       has_configs: ${{ steps.detect.outputs.has_configs }}
       configs: ${{ steps.detect.outputs.configs }}
     steps:
-      - name: Checkout PR commit
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: python -m pip install -r requirements.txt
+      - name: Python setup
+        uses: ./.github/actions/python-setup
 
       - name: Detect changed candidate/support roots
         id: detect
@@ -76,20 +67,11 @@ jobs:
         shell: bash
 
     steps:
-      - name: Checkout PR commit
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: python -m pip install -r requirements.txt
+      - name: Python setup
+        uses: ./.github/actions/python-setup
 
       - name: Configure extra source CA certificates
         env:
@@ -132,19 +114,34 @@ jobs:
         env:
           BLOCKED_SOURCE_PROXY: ${{ vars.BLOCKED_SOURCE_PROXY }}
 
-      - name: "Toolkit run full (smoke: sample-bytes + sample-rows, skip min_rows)"
+      - name: "Toolkit run full (smoke: sample-bytes + sample-rows, skip min_rows) [retry x2]"
         id: run_full
         env:
           HTTPS_PROXY: ${{ vars.BLOCKED_SOURCE_PROXY }}
         run: |
-          toolkit run full \
-            --config "${{ matrix.config.config_path }}" \
-            --json \
-            --sample-rows 1000 \
-            --sample-bytes 5242880 \
-            > run_full.json 2>run_full_err.log; ec=$?
+          MAX_ATTEMPTS=2
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            toolkit run full \
+              --config "${{ matrix.config.config_path }}" \
+              --json \
+              --sample-rows 1000 \
+              --sample-bytes 5242880 \
+              > run_full.json 2>run_full_err.log; ec=$?
+            if [ $ec -eq 0 ]; then
+              echo "exit_code=0" >> "$GITHUB_OUTPUT"
+              cat run_full.json
+              exit 0
+            fi
+            echo "Attempt $i/$MAX_ATTEMPTS failed (exit=$ec). Stderr:"
+            cat run_full_err.log
+            if [ $i -lt $MAX_ATTEMPTS ]; then
+              WAIT=$(( i * 15 ))
+              echo "Retrying in ${WAIT}s..."
+              sleep $WAIT
+            fi
+          done
           echo "exit_code=$ec" >> "$GITHUB_OUTPUT"
-          cat run_full.json 2>/dev/null || echo "JSON output non disponibile"
+          cat run_full.json 2>/dev/null || echo "No JSON output"
           exit $ec
 
       - name: Upload artifacts
@@ -162,14 +159,33 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Set summary
+      - name: Aggregated toolkit check report
         run: |
-          echo "## Toolkit Pipeline Check" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Toolkit Pipeline Check"
+            echo ""
+            echo "### Configs changed"
+            echo '```json'
+            echo '${{ needs.detect.outputs.configs }}'
+            echo '```'
+            echo ""
+            echo "### Results by candidate"
+            echo ""
+            echo "| Candidate | Result |"
+            echo "|-----------|--------|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # toolkit-check è una matrix job — needs.toolkit-check è un
+          # aggregato. Mostriamo il risultato complessivo.
+          RESULT="${{ needs.toolkit-check.result }}"
+          echo "| **Overall** | **$RESULT** |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Configs changed: ${{ needs.detect.outputs.configs }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${{ needs.toolkit-check.result }}" = "success" ]; then
+
+          if [ "$RESULT" = "success" ]; then
             echo "✅ All candidates passed toolkit run + validate" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "❌ Some candidates failed — see job details" >> "$GITHUB_STEP_SUMMARY"
+            echo "❌ Some candidates failed — individual artifacts in 'pr-toolkit-*' above" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> I fallimenti possono essere dovuti a fonte irraggiungibile (retry automatico x2)." >> "$GITHUB_STEP_SUMMARY"
+            echo "> Se il fallimento persiste, controlla l'artifact 'pr-toolkit-{slug}/run_full_err.log'." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/smoke-weekly.yml
+++ b/.github/workflows/smoke-weekly.yml
@@ -17,14 +17,8 @@ jobs:
       total: ${{ steps.probe.outputs.total }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
+      - name: Python setup
+        uses: ./.github/actions/python-setup
 
       - name: Weekly probe — raggiungibilità fonti
         id: probe

--- a/.github/workflows/validate-candidate-structure.yml
+++ b/.github/workflows/validate-candidate-structure.yml
@@ -12,17 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout dataset-incubator
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: python -m pip install -r requirements.txt
+      - uses: actions/checkout@v6
+      - name: Python setup
+        uses: ./.github/actions/python-setup
 
       - name: Validate candidate structure
         run: python scripts/validate_candidate_structure.py

--- a/.github/workflows/validate-clean-catalog.yml
+++ b/.github/workflows/validate-clean-catalog.yml
@@ -27,17 +27,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2  # serve per git diff HEAD~1 nei passaggi notify
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Python setup
+        uses: ./.github/actions/python-setup
         with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install -r requirements.txt
-          python -m pip install -r tools/clean-query-mcp/requirements.txt
-          python -m pip install pytest pytest-timeout
+          extra-requirements: tools/clean-query-mcp/requirements.txt
+          extra-packages: pytest pytest-timeout
 
       - name: Validate catalog and public GCS paths
         run: python scripts/build_clean_catalog.py --check-gcs

--- a/scripts/post_merge_runner.py
+++ b/scripts/post_merge_runner.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Runner per il workflow post-merge-candidate.yml.
+
+Estratto dalla logica inline Python nei job sample_run e build-and-pr
+del workflow GHA post-merge-candidate.yml.
+
+Subcommands:
+    sample-run    Esegue toolkit run full + GCS push + catalog rebuild
+                  per ogni config rilevato in detect_output.json.
+                  Sostituisce il blocco inline 'Process each detected config'.
+
+    build-pr-body  Genera il body markdown della PR registry.
+                   Sostituisce il blocco inline 'Build draft PR body'.
+
+Usage:
+    python scripts/post_merge_runner.py sample-run [--detect-json PATH]
+    python scripts/post_merge_runner.py build-pr-body [--detect-json PATH] \\
+        --pr-number NUM --pr-title TITLE [--sample-result success|skipped] \\
+        [--signals-changed true|false]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# sample-run
+# ---------------------------------------------------------------------------
+
+
+def _read_detect_json(path: str) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+def _ca_cert_setup(config_path: str, artifact_name: str, root: str) -> None:
+    """Configure extra CA certificates if the config requires them."""
+    r = subprocess.run(
+        ["python", "scripts/get_extra_ca_cert_urls.py", config_path],
+        capture_output=True, text=True, cwd=root,
+    )
+    urls = [u.strip() for u in r.stdout.strip().split("\n") if u.strip()]
+    if not urls:
+        return
+
+    bundle = f"/tmp/extra-ca-{artifact_name}.pem"
+    with open("/etc/ssl/certs/ca-certificates.crt") as src, open(bundle, "w") as dst:
+        dst.write(src.read())
+
+    for url in urls:
+        try:
+            data = urllib.request.urlopen(url).read()
+            with open(bundle, "a") as dst:
+                dst.write(data.decode() if isinstance(data, bytes) else data)
+        except Exception as e:
+            print(f"  WARN CA cert {url}: {e}")
+
+    os.environ["REQUESTS_CA_BUNDLE"] = bundle
+    os.environ["SSL_CERT_FILE"] = bundle
+
+
+def _resolve_years(config_path: str, root: str) -> list[int]:
+    """Resolve all_years from resolve_sample_run.py."""
+    r = subprocess.run(
+        ["python", "scripts/resolve_sample_run.py", config_path],
+        capture_output=True, text=True, cwd=root,
+    )
+    if r.returncode != 0:
+        raise RuntimeError(f"resolve fallito ({r.stderr.strip()})")
+    params = json.loads(r.stdout)
+    return params.get("all_years", [])
+
+
+def _run_with_retry(cmd: list[str], cwd: str, attempts: int = 3) -> bool:
+    for i in range(1, attempts + 1):
+        r = subprocess.run(cmd, cwd=cwd)
+        if r.returncode == 0:
+            return True
+        if i < attempts:
+            wait = 20 * i
+            print(f"    tentativo {i}/{attempts} fallito, riprovo tra {wait}s...")
+            time.sleep(wait)
+    return False
+
+
+def _prefetch_blocked_sources(config_path: str, root: str) -> None:
+    """Pre-download blocked sources via proxy."""
+    proxy = os.environ.get("BLOCKED_SOURCE_PROXY") or ""
+    if not proxy:
+        return
+    subprocess.run(
+        ["python", "scripts/prefetch_blocked_sources.py", config_path],
+        cwd=root,
+        env={**os.environ, "BLOCKED_SOURCE_PROXY": proxy},
+        check=True,
+    )
+
+
+def _push_clean_to_gcs(slug: str, root: str) -> bool:
+    """Push clean parquet to GCS. Returns True on success."""
+    r = subprocess.run(
+        ["python", "scripts/push_archive.py", "--layer", "clean", "--slug", slug, "--no-bq"],
+        cwd=root,
+    )
+    return r.returncode == 0
+
+
+def _rebuild_clean_catalog(root: str) -> None:
+    """Rebuild clean_catalog.json after GCS push."""
+    r = subprocess.run(
+        ["python", "scripts/build_clean_catalog.py", "--derive", "--write"],
+        cwd=root,
+    )
+    if r.returncode != 0:
+        print(f"  WARN: build_clean_catalog --derive --write fallito (code {r.returncode})")
+
+    r = subprocess.run(
+        ["python", "scripts/build_clean_catalog.py", "--check-gcs"],
+        cwd=root,
+    )
+    if r.returncode != 0:
+        print(f"  WARN: build_clean_catalog --check-gcs ha trovato errori (code {r.returncode})")
+
+
+def cmd_sample_run(args: argparse.Namespace) -> None:
+    """Process each detected config: toolkit run, GCS push, catalog."""
+    detect = _read_detect_json(args.detect_json)
+    configs = detect.get("configs", [])
+    if not configs:
+        print("Nessun config da processare")
+        return
+
+    root = os.environ.get("GITHUB_WORKSPACE", ".")
+    failed_configs: list[str] = []
+    gcs_push_ok = False
+
+    # Pre-install GCS lib se GCP auth disponibile
+    if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+        subprocess.run(
+            ["python", "-m", "pip", "install", "google-cloud-storage", "-q"],
+            capture_output=True,
+        )
+
+    for cfg in configs:
+        config_path = cfg.get("config_path", "")
+        slug = cfg.get("slug", "unknown")
+        artifact_name = cfg.get("artifact_name", slug)
+        config_exists = cfg.get("config_exists", False)
+
+        print(f"\n=== Processing {slug} ({config_path}) ===")
+
+        if not config_exists:
+            print("  SKIP: config_path non esiste")
+            continue
+
+        # --- CA certs ---
+        _ca_cert_setup(config_path, artifact_name, root)
+
+        # --- Resolve ---
+        try:
+            all_years = _resolve_years(config_path, root)
+        except RuntimeError as e:
+            print(f"  FAIL: {e}")
+            failed_configs.append(slug)
+            continue
+
+        years_str = ",".join(str(y) for y in all_years)
+
+        # --- Pre-download blocked sources ---
+        _prefetch_blocked_sources(config_path, root)
+
+        # --- Toolkit run full (run + validate + readiness + support) ---
+        proxy = os.environ.get("BLOCKED_SOURCE_PROXY") or ""
+        if proxy:
+            os.environ["HTTPS_PROXY"] = proxy
+
+        print(f"  toolkit run full --years {years_str}")
+        run_ok = _run_with_retry(
+            ["toolkit", "run", "full", "--config", config_path, "--years", years_str, "--json"],
+            cwd=root,
+            attempts=args.retry,
+        )
+
+        status = "passed" if run_ok else "failed"
+        if status == "failed":
+            failed_configs.append(slug)
+
+        run_id = os.environ.get("GITHUB_RUN_ID", "0")
+        repo = os.environ.get("GITHUB_REPOSITORY", "")
+        payload = {
+            "id": slug,
+            "status": status,
+            "years": all_years,
+            "config_path": config_path,
+            "config_exists": config_exists,
+            "run_id": run_id,
+            "run_url": f"https://github.com/{repo}/actions/runs/{run_id}",
+            "checked_at": datetime.now(timezone.utc).date().isoformat(),
+        }
+        out_dir = f"sample_run_artifacts/{artifact_name}"
+        Path(out_dir).mkdir(parents=True, exist_ok=True)
+        with open(f"{out_dir}/sample_run_result.json", "w") as pf:
+            json.dump(payload, pf, indent=2)
+        print(f"  {status}")
+
+        # --- GCS push ---
+        if status == "passed" and os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+            print(f"  GCS push per {slug}...")
+            push_slug = cfg.get("push_slug", slug)
+            if _push_clean_to_gcs(push_slug, root):
+                print(f"  GCS push completato per {slug} (push_slug={push_slug})")
+                gcs_push_ok = True
+            else:
+                print(f"  GCS push FAILED for {slug}")
+                failed_configs.append(slug)
+
+    # --- Clean catalog rebuild ---
+    if gcs_push_ok:
+        print("\n  Rebuilding clean catalog...")
+        _rebuild_clean_catalog(root)
+    else:
+        print("\n  Skip clean catalog rebuild: nessun GCS push riuscito")
+
+    if failed_configs:
+        print("\nFAIL: one or more configs failed in post-merge full run:")
+        for slug in failed_configs:
+            print(f" - {slug}")
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# build-pr-body
+# ---------------------------------------------------------------------------
+
+
+def cmd_build_pr_body(args: argparse.Namespace) -> None:
+    """Generate the PR body markdown for the registry PR."""
+    detect = _read_detect_json(args.detect_json)
+    items = detect.get("items", [])
+    configs = detect.get("configs", [])
+
+    sample_passed = args.sample_result == "success"
+    signals_changed = args.signals_changed == "true"
+
+    gcp_available = (
+        os.environ.get("GCP_WORKLOAD_IDENTITY_PROVIDER", "") != ""
+        and os.environ.get("GCP_SERVICE_ACCOUNT", "") != ""
+    )
+
+    item_list = "\n".join(
+        f'- `{i["slug"]}` ({i["kind"]}, `{i["root"]}`)' for i in items
+    )
+    sample_list = "\n".join(
+        f'- `{c["config_path"]}` -> artifact `sample-run-{c["artifact_name"]}`'
+        for c in configs
+    ) or "- No sample-run config detected"
+
+    commands = [
+        f"python scripts/push_archive.py --mart --slug {c['push_slug']} "
+        f"--create-bq-table --update-catalog"
+        for c in configs
+    ]
+
+    body = "\n".join([
+        "## Post-merge registry handoff",
+        "",
+        f"Source PR: #{args.pr_number} — {args.pr_title}",
+        "",
+        "Changed candidate/support roots:",
+        "",
+        item_list,
+        "",
+        "## Automatic updates",
+        "",
+        f"- [x] Rebuilt `registry/pipeline_signals.json`{' (no diff)' if not signals_changed else ''}",
+        f"- [{'x' if sample_passed else ' '}] CI: full run completato (tutti gli anni)",
+        f"- [{'x' if gcp_available else ' '}] CI: clean parquet pushato su GCS",
+        f"- [{'x' if gcp_available else ' '}] CI: `registry/clean_catalog.json` aggiornato",
+        "- [ ] Maintainer: push mart + BQ (se serve)",
+        "",
+        "## Sample-run artifacts",
+        "",
+        sample_list,
+        "",
+        "## Maintainer commands",
+        "",
+        "```bash",
+        "\n".join(commands),
+        "```",
+        "",
+        "CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.",
+    ])
+
+    out_path = args.output
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(body + "\n")
+    print(f"PR body scritto in {out_path}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Post-merge runner per dataset-incubator"
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # sample-run
+    p_sample = sub.add_parser("sample-run", help="Esegui toolkit run full + GCS push per ogni config")
+    p_sample.add_argument(
+        "--detect-json",
+        default="detect_output.json",
+        help="Path a detect_output.json (default: detect_output.json)",
+    )
+    p_sample.add_argument(
+        "--retry",
+        type=int,
+        default=3,
+        help="Numero di tentativi per toolkit run (default: 3)",
+    )
+
+    # build-pr-body
+    p_body = sub.add_parser("build-pr-body", help="Genera il body della PR registry")
+    p_body.add_argument(
+        "--detect-json",
+        default="detect_output.json",
+        help="Path a detect_output.json (default: detect_output.json)",
+    )
+    p_body.add_argument("--pr-number", required=True, help="Numero della PR sorgente")
+    p_body.add_argument("--pr-title", required=True, help="Titolo della PR sorgente")
+    p_body.add_argument(
+        "--sample-result",
+        default="skipped",
+        choices=["success", "skipped", "failure"],
+        help="Risultato del job sample_run (default: skipped)",
+    )
+    p_body.add_argument(
+        "--signals-changed",
+        default="false",
+        choices=["true", "false"],
+        help="Se pipeline_signals.json è cambiato (default: false)",
+    )
+    p_body.add_argument(
+        "--output",
+        default="post_merge_pr_body.md",
+        help="Path di output per il body markdown (default: post_merge_pr_body.md)",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "sample-run":
+        cmd_sample_run(args)
+    elif args.command == "build-pr-body":
+        cmd_build_pr_body(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_post_merge_runner.py
+++ b/tests/test_post_merge_runner.py
@@ -1,0 +1,309 @@
+"""
+Test per post_merge_runner.py — contratto PR body + sample-run early exit.
+
+Contratto:
+  cmd_build_pr_body  genera il body markdown della PR registry da detect_output.json
+  cmd_sample_run     processa config rilevati; con input vuoto deve uscire senza errori
+  main()             CLI arg parsing
+
+I test chiamano le funzioni direttamente (non via subprocess) per copertura reale.
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts import post_merge_runner as pmr
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_detect_json(tmp_path: Path) -> Path:
+    """Crea un detect_output.json con due config finti."""
+    data = {
+        "has_items": True,
+        "has_configs": True,
+        "items": [
+            {"slug": "test-ds-1", "kind": "candidate", "root": "candidates/test-ds-1"},
+            {"slug": "test-ds-2", "kind": "candidate", "root": "candidates/test-ds-2"},
+        ],
+        "configs": [
+            {
+                "kind": "candidate",
+                "slug": "test-ds-1",
+                "config_path": "candidates/test-ds-1/dataset.yml",
+                "config_exists": True,
+                "artifact_name": "test-ds-1",
+                "is_nested": False,
+                "push_slug": "test-ds-1",
+            },
+            {
+                "kind": "candidate",
+                "slug": "test-ds-2",
+                "config_path": "candidates/test-ds-2/dataset.yml",
+                "config_exists": True,
+                "artifact_name": "test-ds-2",
+                "is_nested": False,
+                "push_slug": "test-ds-2",
+            },
+        ],
+    }
+    path = tmp_path / "detect_output.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+@pytest.fixture
+def empty_detect_json(tmp_path: Path) -> Path:
+    """Crea un detect_output.json senza config ne items."""
+    data = {
+        "has_items": False,
+        "has_configs": False,
+        "items": [],
+        "configs": [],
+    }
+    path = tmp_path / "detect_output_empty.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def _run_build_pr_body(detect_json: Path, tmp_path: Path, **overrides) -> str:
+    """Helper: chiama cmd_build_pr_body e restituisce il body generato."""
+    out = tmp_path / "body.md"
+    kwargs = dict(
+        detect_json=str(detect_json),
+        pr_number="1",
+        pr_title="test",
+        sample_result="success",
+        signals_changed="true",
+        output=str(out),
+    )
+    kwargs.update(overrides)
+    args = argparse.Namespace(**kwargs)
+    pmr.cmd_build_pr_body(args)
+    return out.read_text()
+
+
+# ---------------------------------------------------------------------------
+# build-pr-body
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPrBody:
+    @pytest.mark.pure_unit
+    def test_generates_markdown(self, sample_detect_json: Path, tmp_path: Path):
+        """build-pr-body produce markdown valido con i placeholder giusti."""
+        body = _run_build_pr_body(
+            sample_detect_json, tmp_path,
+            pr_number="42",
+            pr_title="feat: test dataset",
+        )
+        assert "## Post-merge registry handoff" in body
+        assert "Source PR: #42" in body
+        assert "feat: test dataset" in body
+        assert "test-ds-1" in body
+        assert "test-ds-2" in body
+        assert "- [x] CI: full run completato" in body
+        assert "Maintainer: push mart + BQ" in body
+        assert "push_archive.py --mart --slug" in body
+        # GCP env non settato in test → check vuoto
+        assert "[ ] CI: clean parquet" in body
+
+    @pytest.mark.pure_unit
+    def test_no_diff_when_signals_unchanged(self, sample_detect_json: Path, tmp_path: Path):
+        """(no diff) appare nel body quando signals_changed=false."""
+        body = _run_build_pr_body(sample_detect_json, tmp_path, signals_changed="false")
+        assert "(no diff)" in body
+
+    @pytest.mark.pure_unit
+    def test_sample_not_passed(self, sample_detect_json: Path, tmp_path: Path):
+        """Check vuoto se sample fallisce."""
+        body = _run_build_pr_body(sample_detect_json, tmp_path, sample_result="failure")
+        assert "[ ] CI: full run" in body
+        assert "[ ] CI: clean parquet" in body
+
+    @pytest.mark.pure_unit
+    def test_empty_items(self, empty_detect_json: Path, tmp_path: Path):
+        """Con detect vuoto, il body segnala 'No sample-run config'."""
+        body = _run_build_pr_body(empty_detect_json, tmp_path, sample_result="skipped")
+        assert "No sample-run config detected" in body
+        assert "push_archive.py" not in body
+
+    @pytest.mark.pure_unit
+    def test_gcp_available_shows_x(self, sample_detect_json: Path, tmp_path: Path, monkeypatch):
+        """Con GCP env settati, i check GCS appaiono come [x]."""
+        monkeypatch.setenv("GCP_WORKLOAD_IDENTITY_PROVIDER", "projects/p/...")
+        monkeypatch.setenv("GCP_SERVICE_ACCOUNT", "sa@project.iam.gserviceaccount.com")
+        body = _run_build_pr_body(sample_detect_json, tmp_path)
+        assert "- [x] CI: clean parquet pushato su GCS" in body
+        assert "- [x] CI: `registry/clean_catalog.json` aggiornato" in body
+
+
+# ---------------------------------------------------------------------------
+# sample-run — early exit
+# ---------------------------------------------------------------------------
+
+
+class TestSampleRun:
+    @pytest.mark.smoke
+    def test_empty_config_exits_cleanly(self, empty_detect_json: Path, capsys):
+        """sample-run con detect vuoto deve uscire senza errori."""
+        args = argparse.Namespace(
+            detect_json=str(empty_detect_json),
+            retry=3,
+        )
+        # Non deve sollevare SystemExit
+        pmr.cmd_sample_run(args)
+        captured = capsys.readouterr()
+        assert "Nessun config da processare" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestReadDetectJson:
+    @pytest.mark.pure_unit
+    def test_reads_valid_json(self, sample_detect_json: Path):
+        result = pmr._read_detect_json(str(sample_detect_json))
+        assert result["has_items"] is True
+        assert len(result["configs"]) == 2
+
+    @pytest.mark.pure_unit
+    def test_file_not_found(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            pmr._read_detect_json(str(tmp_path / "nonexistent.json"))
+
+
+# ---------------------------------------------------------------------------
+# CLI arg parsing — via main() con sys.argv
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    @pytest.mark.pure_unit
+    def test_no_command_shows_help(self):
+        """Senza subcomando, SystemExit."""
+        with pytest.raises(SystemExit):
+            pmr.main()
+
+    @pytest.mark.pure_unit
+    def test_unknown_command_fails(self):
+        """Subcomando sconosciuto, SystemExit."""
+        with pytest.raises(SystemExit):
+            with pytest.MonkeyPatch().context() as mp:
+                mp.setattr("sys.argv", ["prog", "foobar"])
+                pmr.main()
+
+    @pytest.mark.pure_unit
+    def test_build_pr_body_missing_required(self, tmp_path):
+        """build-pr-body senza --pr-number fallisce."""
+        detect = tmp_path / "detect.json"
+        detect.write_text("{}")
+        with pytest.raises(SystemExit):
+            with pytest.MonkeyPatch().context() as mp:
+                mp.setattr(
+                    "sys.argv",
+                    ["prog", "build-pr-body", "--detect-json", str(detect)],
+                )
+                pmr.main()
+
+    @pytest.mark.pure_unit
+    def test_build_pr_body_via_main(self, sample_detect_json, tmp_path):
+        """build-pr-body via main() produce output."""
+        out = tmp_path / "body.md"
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr(
+                "sys.argv",
+                [
+                    "prog", "build-pr-body",
+                    "--detect-json", str(sample_detect_json),
+                    "--pr-number", "99",
+                    "--pr-title", "via-main",
+                    "--sample-result", "success",
+                    "--signals-changed", "true",
+                    "--output", str(out),
+                ],
+            )
+            pmr.main()
+        body = out.read_text()
+        assert "Source PR: #99" in body
+        assert "via-main" in body
+
+    @pytest.mark.pure_unit
+    def test_sample_run_via_main_empty(self, empty_detect_json, capsys):
+        """sample-run via main() con detect vuoto esce senza errori."""
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr(
+                "sys.argv",
+                ["prog", "sample-run", "--detect-json", str(empty_detect_json)],
+            )
+            pmr.main()
+        captured = capsys.readouterr()
+        assert "Nessun config da processare" in captured.out
+
+    @pytest.mark.pure_unit
+    def test_sample_run_skip_configs(self, tmp_path, capsys):
+        """sample-run con config_exists=False deve skippare."""
+        data = {
+            "has_items": True,
+            "has_configs": True,
+            "items": [{"slug": "test", "kind": "candidate", "root": "candidates/test"}],
+            "configs": [
+                {
+                    "kind": "candidate",
+                    "slug": "test",
+                    "config_path": "candidates/test/dataset.yml",
+                    "config_exists": False,
+                    "artifact_name": "test",
+                    "is_nested": False,
+                    "push_slug": "test",
+                },
+            ],
+        }
+        detect = tmp_path / "detect_skip.json"
+        detect.write_text(json.dumps(data))
+        args = argparse.Namespace(detect_json=str(detect), retry=3)
+        pmr.cmd_sample_run(args)
+        captured = capsys.readouterr()
+        assert "SKIP: config_path non esiste" in captured.out
+
+    @pytest.mark.pure_unit
+    def test_run_with_retry_first_attempt_succeeds(self):
+        """_run_with_retry ritorna True se il comando ha successo al primo tentativo."""
+        import subprocess
+        result = pmr._run_with_retry(
+            ["python", "-c", "exit(0)"],
+            cwd=".",
+            attempts=2,
+        )
+        assert result is True
+
+    @pytest.mark.pure_unit
+    def test_run_with_retry_second_attempt_succeeds(self):
+        """_run_with_retry riprova se primo tentativo fallisce."""
+        import subprocess
+        # Fallisce 1 volta, poi succeede
+        calls = [0]
+
+        def _run_fail_once(*a, **kw):
+            calls[0] += 1
+            r = subprocess.CompletedProcess([], 1 if calls[0] == 1 else 0)
+            return r
+
+        original_run = subprocess.run
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(subprocess, "run", _run_fail_once)
+        try:
+            result = pmr._run_with_retry(["true"], cwd=".", attempts=2)
+            assert result is True
+        finally:
+            monkeypatch.undo()


### PR DESCRIPTION
## Sintesi

Tre ottimizzazioni P0 sui GHA di dataset-incubator: ridurre boilerplate, estrarre logica inline in script testabili, aggiungere resilienza ai fallimenti di rete.

## Contesto collegato

Deriva dall'audit GHA: ~52% failure rate su Toolkit Pipeline Check, 215+ righe Python inline in post-merge-candidate.yml, 6 copie identiche di setup boilerplate.

## Cosa cambia

- [x] workflow o CI
- [x] cleanup — refactoring, rimozioni, allineamento

## Impatto

- [x] Nessun impatto visibile per chi usa il repository

I workflow si comportano allo stesso modo, ma:
- Composite action centralizza setup → se cambia Python, si tocca 1 file
- `scripts/post_merge_runner.py` sostituisce ~215 righe inline → testabile, debuggabile
- Retry x2 su toolkit-check → assorbe fallimenti transitori da fonte
- Nuovo job `report` in pr-toolkit-check → diagnostica immediata nel summary

## Verifica

```
python -m pytest tests/ -q --tb=line     # 100% pass
ruff check scripts/                        # clean
YAML valido per tutti gli 8 workflow       # pass
```

I workflow GHA veri girano su questa PR — check in corso.

- [x] `python scripts/validate_candidate_structure.py` non applicabile (nessun candidate modificato)
- [x] Perimetro stretto: solo CI/workflow, nessun candidate toccato

## Note / rischi

- La composite action non è usata in `build-pipeline-signals.yml` e `test-audit.yml` (avrebbero overhead ingiustificato)
- Il job `detect` in `post-merge-candidate.yml` non usa la composite action (installa solo PyYAML, non full requirements)
- I GHA vanno verificati su GitHub — gli step `uses: ./.github/actions/python-setup` richiedono che il checkout sia già avvenuto (garantito dalla composite action stessa)
