### PR TITLE
refactor: usa reusable test-audit workflow da dataciviclab/.github

### DIFF
--- a/.github/workflows/test-audit.yml
+++ b/.github/workflows/test-audit.yml
@@ -9,36 +9,7 @@ on:
       - ".github/workflows/test-audit.yml"
 
 jobs:
-  audit-markers:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Python setup
-        uses: dataciviclab/.github/actions/python-setup@main
-
-      # Preflight: verifica che il CLI esista anche se nessun test è cambiato
-      - name: Verify audit-test-markers CLI
-        run: audit-test-markers --help
-
-      - name: Audit test markers on changed files
-        run: |
-          # List test files changed in PR (vs base branch)
-          changed=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- 'tests/test_*.py' 'tests/**/test_*.py' || true)
-
-          if [ -z "$changed" ]; then
-            echo "No test files changed. OK."
-            exit 0
-          fi
-
-          echo "Changed test files:"
-          echo "$changed"
-
-          # Extract just filenames for the audit script
-          files=$(echo "$changed" | xargs -n1 basename | tr '\n' ' ')
-
-          audit-test-markers tests/ \
-            --diff \
-            --files $files
+  audit:
+    uses: dataciviclab/.github/.github/workflows/test-audit-reusable.yml@main
+    with:
+      test-dirs: "tests"


### PR DESCRIPTION
## Sintesi

Sostituisce il `test-audit.yml` locale con una chiamata al workflow riutilizzabile `dataciviclab/.github/.github/workflows/test-audit-reusable.yml`.

## Cosa cambia

- [x] workflow o CI

## Impatto

- [x] Nessun impatto visibile per chi usa il repository

## Dettaglio

Da 42 righe (setup + preflight + git diff + audit) a 12 righe (solo path trigger + `uses`).

Il workflow riutilizzabile gestisce checkout, setup, preflight e audit per ogni directory.

## Dipende da

- `dataciviclab/.github#24` mergiata (reusable workflow su main)
