### PR TITLE
chore(post-merge): aggiorna registry per PR #439

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-06-05",
+  "updated_at": "2026-06-06",
   "datasets": [
     {
       "slug": "aifa_spesa_consumo",
@@ -765,6 +765,98 @@
         "type": "gcs",
         "path": "gs://dataciviclab-clean/bdap_lea/*/bdap_lea_*_clean.parquet",
         "multi_file": true
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "bdap_spese_stato",
+      "name": "Bdap Spese Stato",
+      "description": "",
+      "source": "",
+      "source_id": "openbdap",
+      "period": {
+        "start": 2008,
+        "end": 2024
+      },
+      "columns": [
+        {
+          "name": "esercizio_finanziario",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "stato_previsione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "amministrazione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "missione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "programma",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "udv_livello_1",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "udv_livello_2",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "udv_livello_3",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_puntato_udv",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "macroaggregato",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "previsioni_definitive_cp",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "previsioni_definitive_cs",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/bdap_spese_stato/2024/bdap_spese_stato_2024_clean.parquet",
+        "multi_file": false
       },
       "stage": "published",
       "registry_source": "derive_auto"

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -771,9 +771,9 @@
     },
     {
       "slug": "bdap_spese_stato",
-      "name": "Bdap Spese Stato",
-      "description": "",
-      "source": "",
+      "name": "BDAP Spese Stato",
+      "description": "Spese statali da BDAP, aggregate per amministrazione, missione, programma, macroaggregato",
+      "source": "MEF-BDAP",
       "source_id": "openbdap",
       "period": {
         "start": 2008,
@@ -783,74 +783,74 @@
         {
           "name": "esercizio_finanziario",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di riferimento"
         },
         {
           "name": "stato_previsione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Stato della previsione (Previsioni definitive)"
         },
         {
           "name": "amministrazione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Amministrazione dello Stato"
         },
         {
           "name": "missione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Missione di spesa"
         },
         {
           "name": "programma",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Programma di spesa"
         },
         {
           "name": "udv_livello_1",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Unità di voto livello 1"
         },
         {
           "name": "udv_livello_2",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Unità di voto livello 2"
         },
         {
           "name": "udv_livello_3",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Unità di voto livello 3"
         },
         {
           "name": "codice_puntato_udv",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice puntato unità di voto"
         },
         {
           "name": "macroaggregato",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Macroaggregato economico"
         },
         {
           "name": "previsioni_definitive_cp",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Previsioni definitive competenze di cassa"
         },
         {
           "name": "previsioni_definitive_cs",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Previsioni definitive competenze di competenza"
         }
       ],
       "location": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-05",
+  "generated_at": "2026-06-06",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 37,
+    "total": 38,
     "by_status": {
-      "ok": 37,
+      "ok": 38,
       "warn": 0,
       "error": 0
     }
@@ -75,6 +75,24 @@
           2024
         ],
         "config_path": "candidates/bdap-lea/dataset.yml"
+      }
+    },
+    {
+      "id": "bdap-spese-stato",
+      "source_id": "openbdap",
+      "status": "ok",
+      "label": "bdap-spese-stato",
+      "detail": "anno 2024 — fonte: openbdap_spese_csv — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "27060712871",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27060712871",
+        "checked_at": "2026-06-06",
+        "years": [
+          2024
+        ],
+        "config_path": "candidates/bdap-spese-stato/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #439 — feat(bdap-spese-stato): candidate intake #437 — spese Stato per missione 2008-2024

Changed candidate/support roots:

- `bdap-spese-stato` (candidate, `candidates/bdap-spese-stato`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/bdap-spese-stato/dataset.yml` -> artifact `sample-run-bdap-spese-stato`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug bdap_spese_stato --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
