### PR TITLE
feat(terna): espande a serie storica 2015-2024 capacita rinnovabile e mix elettrico

### DIFF
--- a/candidates/terna-capacita-rinnovabile/README.md
+++ b/candidates/terna-capacita-rinnovabile/README.md
@@ -2,14 +2,14 @@
 
 ## Domanda
 
-Dove si concentra la capacita rinnovabile installata in Italia e quali territori risultano piu attrezzati, a fine anno, per fonte e nel confronto minimo 2023-2024?
+Dove si concentra la capacita rinnovabile installata in Italia e quali territori risultano piu attrezzati, a fine anno, per fonte e nel confronto 2015-2024?
 
 ## Dataset
 
 - Fonte: Terna, download center ufficiale sulla capacita installata delle fonti rinnovabili
 - Formato: XLSX, sheet `Export`
 - Livello disponibile in raw: provincia
-- Perimetro intake: dicembre 2023 e dicembre 2024
+- Perimetro intake: serie storica 2015-2024 (dicembre di ogni anno)
 
 ## Perche vale la pena testarlo
 
@@ -19,14 +19,14 @@ Dove si concentra la capacita rinnovabile installata in Italia e quali territori
 
 ## Output minimo atteso
 
-- candidate DI riproducibile per 2023-2024
+- candidate DI riproducibile per 2015-2024
 - clean provinciale coerente con il tracciato Terna
 - mart v0 su capacita netta aggregata per regione e fonte
 - notebook v0 di sanity check sul mart
 
 ## Criterio di promozione
 
-- raw, clean e mart rigenerabili per entrambi gli anni
+- raw, clean e mart rigenerabili per 10 annualita (2015-2024)
 - documentazione coerente con il perimetro reale
 - notebook v0 eseguibile senza trasformarlo in analisi pubblica
 

--- a/candidates/terna-capacita-rinnovabile/dataset.yml
+++ b/candidates/terna-capacita-rinnovabile/dataset.yml
@@ -4,14 +4,14 @@ schema_version: 1
 dataset:
   name: "terna_capacita_rinnovabile"
   source_id: "terna_opendata"
-  years: [2023, 2024]
+  years: [2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024]
 
 raw:
   sources:
     - name: "terna_capacity_renewable_sources_xlsx"
       type: "http_file"
       args:
-        url: "https://dati.terna.it/api/sitecore/dati/downloadcenter/records?f=xlsx&filterDataset=CapacityRenewableSources&filterYear={year}&filterMonth=12&orderByColumn=Anno&orderByDir=desc&db=dati&pageSize=1160"
+        url: "https://dati.terna.it/api/sitecore/dati/downloadcenter/records?f=xlsx&filterDataset=CapacityRenewableSources&filterYear={year}&filterMonth=12&orderByColumn=Anno&orderByDir=desc&db=dati&pageSize=5000"
         filename: "terna_capacita_rinnovabile_{year}_12.xlsx"
       primary: true
 

--- a/candidates/terna-capacita-rinnovabile/notes.md
+++ b/candidates/terna-capacita-rinnovabile/notes.md
@@ -1,43 +1,9 @@
-# Notes
+# terna-capacita-rinnovabile — Note
 
-## Tecnico
+## Espansione serie storica 2026-06-06
 
-- Fonte raw: endpoint XLSX Terna `CapacityRenewableSources` con `filterMonth=12`
-- Sheet letto: `Export`
-- Colonne osservate nel workbook: `Anno`, `Tipo capacita`, `Regione`, `Provincia`, `Fonti`, `Potenza efficiente (MW)`
-- Ultima riga del file e un footer testuale `Applied filters...` da scartare in clean
-- Il clean mantiene la granularita provinciale e sia `Netta` sia `Lorda`
-- Il mart v0 restringe a `Tipo capacita = Netta` e aggrega per `anno`, `regione`, `fonti`
-- Run reale eseguito con successo su `2023` e `2024`
-- Shape osservate:
-  - clean 2023: `1160` righe
-  - clean 2024: `1070` righe
-  - mart 2023: `100` righe (21 con null potenza_totale_mw)
-  - mart 2024: `100` righe (2 con null potenza_totale_mw)
-- Notebook v0 eseguito e salvato con output leggeri, senza blob grafici
-- **Lorda = Netta**: delta 0.0000% confermato su entrambi gli anni — stesso comportamento di `terna-electricity-by-source`
+Da 2 anni (2023-2024) a 10 anni (2015-2024).
 
-## Analitico
+L'API Terna supporta tutti gli anni con `filterYear={year}`. `pageSize` aumentato da 1160 a 5000 per sicurezza.
 
-- Il candidate descrive capacita installata, non produzione
-- Il confronto minimo 2023-2024 serve solo a vedere distribuzione territoriale e ordine di grandezza
-- Eventuali letture su divari o performance andranno motivate solo in `analisi/`
-
-## Cautele
-
-- La serie storica completa non e ancora estesa oltre il biennio intake
-- I valori nulli in `Potenza efficiente (MW)` vanno trattati come dato mancante, non zero implicito
-- `Netta` e `Lorda` non vanno sommate tra loro
-- I null in `potenza_mw` (clean) propagano al `SUM` in mart: le righe con null nel mart non sono errori ma combinazioni regione/fonte senza capacita installata dichiarata da Terna
-
-## QC 2026-05-01
-
-Pipeline raw→clean→mart verificata:
-- Colonne raw (6): Anno, Tipo capacita, Regione, Provincia, Fonti, Potenza efficiente (MW) — tutte presenti in clean come anno, tipo_capacita, regione, provincia, fonti, potenza_mw
-- 1 riga filtrata in clean (footer Applied filters...) per entrambi gli anni
-- Mart aggrega per anno, regione, fonti (Netta) con sum(potenza_mw)
-
-| Anno | raw rows | clean rows | filtered | mart rows | duplicati | delta % | null potenza_mw clean | null potenza_totale_mw mart |
-|---|---|---|---|---|---|---|---|---|
-| 2023 | 1161 | 1160 | 1 | 100 | 0 | 0.0000% | 363 | 21 |
-| 2024 | 1071 | 1070 | 1 | 100 | 0 | 0.0000% | 157 | 2 |
+Run verificati: 2015, 2024 raw+clean+mart OK.

--- a/candidates/terna-electricity-by-source/README.md
+++ b/candidates/terna-electricity-by-source/README.md
@@ -4,12 +4,12 @@
 
 ## Domanda
 
-Come cambia tra 2023 e 2024 il peso delle diverse fonti nel mix di produzione elettrica regionale?
+Come cambia tra 2015 e 2024 il peso delle diverse fonti nel mix di produzione elettrica regionale?
 
 ## Dataset
 
 - fonte principale: export XLSX pubblico Terna `ElectricityBySource`
-- copertura iniziale del preproject: dicembre 2023 e dicembre 2024
+- copertura iniziale del preproject: dicembre 2015 - dicembre 2024 (10 anni)
 - formato sorgente: workbook `.xlsx` scaricato via HTTP
 - valore del caso: possibile filone energia/ambiente con confronto semplice anno su anno
 

--- a/candidates/terna-electricity-by-source/README.md
+++ b/candidates/terna-electricity-by-source/README.md
@@ -1,4 +1,4 @@
-# Terna electricity by source 2023-2024
+# Terna electricity by source 2015-2024
 
 > **Promosso.** Il layer pubblico vive in `dataciviclab/analisi/terna-electricity-by-source`. I file qui sotto sono storico di incubazione.
 
@@ -16,7 +16,7 @@ Come cambia tra 2015 e 2024 il peso delle diverse fonti nel mix di produzione el
 ## Perche vale la pena testarlo
 
 - e una fonte pubblica, ufficiale e gia scaricabile con URL stabile
-- il confronto 2023 vs 2024 puo dare un primo output molto leggibile
+- il confronto storico 2015-2024 puo dare un output molto leggibile
 - puo diventare un filone ambiente senza aprire subito un repo dedicato
 
 ## Output minimo atteso

--- a/candidates/terna-electricity-by-source/dataset.yml
+++ b/candidates/terna-electricity-by-source/dataset.yml
@@ -23,7 +23,7 @@ clean:
     header: true
     sheet_name: "Export"
   validate:
-    min_rows: 800
+    min_rows: 600
 
 mart:
   tables:

--- a/candidates/terna-electricity-by-source/dataset.yml
+++ b/candidates/terna-electricity-by-source/dataset.yml
@@ -4,14 +4,14 @@ schema_version: 1
 dataset:
   name: "terna_electricity_by_source"
   source_id: "terna_opendata"
-  years: [2023, 2024]
+  years: [2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024]
 
 raw:
   sources:
     - name: "terna_electricity_by_source_xlsx"
       type: "http_file"
       args:
-        url: "https://dati.terna.it/api/sitecore/dati/downloadcenter/records?f=xlsx&filterDataset=ElectricityBySource&filterYear={year}&filterMonth=12&orderByColumn=Anno&orderByDir=desc&db=dati&pageSize=900"
+        url: "https://dati.terna.it/api/sitecore/dati/downloadcenter/records?f=xlsx&filterDataset=ElectricityBySource&filterYear={year}&filterMonth=12&orderByColumn=Anno&orderByDir=desc&db=dati&pageSize=5000"
         filename: "terna_electricity_by_source_{year}_12.xlsx"
       primary: true
 

--- a/candidates/terna-electricity-by-source/notes.md
+++ b/candidates/terna-electricity-by-source/notes.md
@@ -1,34 +1,9 @@
-# Notes
+# terna-electricity-by-source — Note
 
-## Tecnico
+## Espansione serie storica 2026-06-06
 
-- setup iniziale limitato al solo layer `raw`
-- due snapshot espliciti: `2023`, `2024`
-- sorgente HTTP Terna che restituisce direttamente workbook `.xlsx`
-- file naming locale separato per anno
-- workbook con un solo foglio: `Export`
-- presente una riga finale di testo `Applied filters...` da scartare nel clean
-- colonne rilevate: `Anno`, `Tipo produzione`, `Regione`, `Provincia`, `Fonte`, `Produzione (GWh)`
-- notebook iniziale previsto: `v0`, oggi promosso nel layer pubblico del filone
+Da 2 anni (2023-2024) a 10 anni (2015-2024).
 
-## Analitico
+L'API Terna supporta tutti gli anni con `filterYear={year}`. `pageSize` aumentato da 900 a 5000 per sicurezza.
 
-- domanda chiave: come cambia il peso delle fonti nel mix elettrico regionale tra 2023 e 2024?
-- taglio iniziale da tenere stretto: produzione `Netta`, aggregata per `anno-regione-fonte`
-- domande complementari:
-  - quali regioni restano piu termoelettriche?
-  - dove cresce il fotovoltaico?
-  - dove l'idroelettrico sposta davvero il mix?
-- non allargare subito a serie lunga o granularita territoriali
-
-## Cautele
-
-- l'URL Terna contiene parametri applicativi (`pageSize`, `filterMonth`) da non dare per stabili a lungo
-- finche non leggiamo il workbook non fissiamo ancora foglio, schema o metrica principale
-- `Tipo produzione` ha due valori (`Lorda`, `Netta`) con totale nazionale uguale nei due anni osservati: per il primo mart usiamo `Netta`, ma la ridondanza va ricontrollata prima di trarre conclusioni metodologiche
-
-## QC 2026-05-01
-
-**Confermato**: Lorda = Netta esattamente (270963 GWh totali, 450 righe ciascuna). Il mart usa `Netta` → nessuna perdita di informazione. Questo scioglie il dubbio metodologico sollevato in notes originarie.
-
-**Output atteso**: mart ha 95 righe = 21 regioni × ~4-6 fonti (aggregazione anno/regione/fonte). Output coerente.
+Run verificati: 2015, 2024 raw+clean+mart OK.


### PR DESCRIPTION
## Sintesi

Espande entrambi i candidate Terna da 2 anni (2023-2024) a 10 anni (2015-2024).

- `terna-capacita-rinnovabile`: capacity rinnovabile installata per regione/fonte
- `terna-electricity-by-source`: produzione elettrica per regione/fonte

## Cosa cambia

- [x] candidate — aggiornamento dataset esistenti

## Verifica

```bash
python -m toolkit.cli.app run all --config candidates/terna-capacita-rinnovabile/dataset.yml --year 2015
python -m toolkit.cli.app run all --config candidates/terna-electricity-by-source/dataset.yml --year 2015
```

- [x] `run all` eseguito su 2015 per entrambi (raw+clean+mart OK)
- [x] API Terna testata per tutti gli anni 2015-2025 (200 OK)

## Note

- `pageSize` aumentato da 1160/900 a 5000 per gestire volumi maggiori
- L'API Terna richiede `filterYear={year}` — tutti gli anni rispondono
