### PR TITLE
feat: clean-query MCP legge parquet via S3 diretto (s3://) invece di HTTPS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-"lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.11.0",
+"lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.1",
 "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.25.0",
   "jsonschema>=4.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ classifiers = [
 ]
 
 dependencies = [
-"lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.2",
-"dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.2",
+"lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.4",
+"dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.3",
   "jsonschema>=4.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
 "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.1",
-"dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.25.0",
+"dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.0",
   "jsonschema>=4.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-"lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.1",
+"lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.2",
 "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.2",
   "jsonschema>=4.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
 "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.1",
-"dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.0",
+"dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.1",
   "jsonschema>=4.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
 "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.1",
-"dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.1",
+"dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.2",
   "jsonschema>=4.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.1
 
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.1
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.2
 
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-# lab-connectors — infrastruttura condivisa: HTTP client, DuckDB safe_connect,
-# GCS client/paths, MCP core. Usata da scripts/ e tools/clean-query-mcp/.
-# Extras duckdb + gcs per safe_connect() e upload su GCS.
-lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.1
+# lab-connectors[gcs] per script che usano GCS direttamente (toolkit porta solo [duckdb])
+lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.2
 
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
 dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.2
@@ -11,5 +9,3 @@ jsonschema>=4.0
 
 # pyarrow — per push_archive.py (GCS push post-merge)
 pyarrow>=24.0.0
-
-# pyyaml è transitivo da toolkit — non serve esplicitarlo

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.1
 
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.26.0
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.0
 
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.1
 
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.0
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.1
 
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # lab-connectors[gcs] per script che usano GCS direttamente (toolkit porta solo [duckdb])
-lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.2
+lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.4
 
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.2
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.3
 
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # lab-connectors — infrastruttura condivisa: HTTP client, DuckDB safe_connect,
 # GCS client/paths, MCP core. Usata da scripts/ e tools/clean-query-mcp/.
 # Extras duckdb + gcs per safe_connect() e upload su GCS.
-lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.12.0
+lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.1
 
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
 dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.26.0

--- a/tests/test_clean_query_sql_guards.py
+++ b/tests/test_clean_query_sql_guards.py
@@ -73,7 +73,7 @@ class CleanQueryYearFilterContractTest(unittest.TestCase):
     Copre i tre tool che il fix ha modificato: count, preview (via _duckdb_read), time_series.
     """
 
-    @patch("lab_connectors.duckdb.safe_connect")
+    @patch("lab_connectors.duckdb.gcs_connect")
     @patch.object(server, "resolve_parquet_path")
     def test_count_injects_year_filter(
         self, mock_resolve: MagicMock, mock_sc: MagicMock
@@ -87,7 +87,7 @@ class CleanQueryYearFilterContractTest(unittest.TestCase):
         sql = conn.execute.call_args[0][0]
         self.assertIn("WHERE anno = 2024", sql)
 
-    @patch("lab_connectors.duckdb.safe_connect")
+    @patch("lab_connectors.duckdb.gcs_connect")
     @patch.object(server, "resolve_parquet_path")
     def test_count_no_year_no_filter(
         self, mock_resolve: MagicMock, mock_sc: MagicMock
@@ -101,7 +101,7 @@ class CleanQueryYearFilterContractTest(unittest.TestCase):
         sql = conn.execute.call_args[0][0]
         self.assertNotIn("WHERE", sql)
 
-    @patch("lab_connectors.duckdb.safe_connect")
+    @patch("lab_connectors.duckdb.gcs_connect")
     @patch.object(server, "resolve_parquet_path")
     def test_preview_injects_year_filter(
         self, mock_resolve: MagicMock, mock_sc: MagicMock
@@ -116,7 +116,7 @@ class CleanQueryYearFilterContractTest(unittest.TestCase):
         sql = conn.execute.call_args[0][0]
         self.assertIn("WHERE anno = 2024", sql)
 
-    @patch("lab_connectors.duckdb.safe_connect")
+    @patch("lab_connectors.duckdb.gcs_connect")
     @patch.object(server, "resolve_parquet_path")
     def test_time_series_injects_year_filter(
         self, mock_resolve: MagicMock, mock_sc: MagicMock
@@ -130,7 +130,7 @@ class CleanQueryYearFilterContractTest(unittest.TestCase):
         sql = conn.execute.call_args[0][0]
         self.assertIn("WHERE anno = 2024", sql)
 
-    @patch("lab_connectors.duckdb.safe_connect")
+    @patch("lab_connectors.duckdb.gcs_connect")
     @patch.object(server, "resolve_parquet_path")
     def test_time_series_no_year_no_filter(
         self, mock_resolve: MagicMock, mock_sc: MagicMock

--- a/tools/clean-query-mcp/catalog.py
+++ b/tools/clean-query-mcp/catalog.py
@@ -7,8 +7,6 @@ import time
 import json
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
-
 from lab_connectors.gcs import list_objects
 
 DI_ROOT = Path(__file__).resolve().parents[2]
@@ -174,9 +172,7 @@ def resolve_parquet_path(slug: str, year: int | None = None) -> list[str]:
                     if pattern.match(blob_name):
                         if year and f"/{year}/" not in blob_name:
                             continue
-                        urls.append(
-                            f"https://storage.googleapis.com/{bucket}/{quote(blob_name, safe='/._-')}"
-                        )
+                        urls.append(f"s3://{bucket}/{blob_name}")
             if not urls:
                 raise FileNotFoundError(
                     f"Nessun file trovato per pattern '{raw}'"
@@ -186,9 +182,7 @@ def resolve_parquet_path(slug: str, year: int | None = None) -> list[str]:
             with _gcs_res_lock:
                 _gcs_res_cache[cache_key] = (time.time(), urls)
         else:
-            urls = [
-                f"https://storage.googleapis.com/{bucket}/{quote(key, safe='/._-')}"
-            ]
+            urls = [f"s3://{bucket}/{key}"]
     else:
         raise ValueError(f"Tipo location non supportato: {loc['type']}")
 

--- a/tools/clean-query-mcp/requirements.txt
+++ b/tools/clean-query-mcp/requirements.txt
@@ -1,3 +1,3 @@
 mcp>=1.26.0
 duckdb==1.5.1
-git+https://github.com/dataciviclab/lab-connectors.git@v0.13.1
+git+https://github.com/dataciviclab/lab-connectors.git@v0.13.2

--- a/tools/clean-query-mcp/requirements.txt
+++ b/tools/clean-query-mcp/requirements.txt
@@ -1,3 +1,3 @@
 mcp>=1.26.0
 duckdb==1.5.1
-git+https://github.com/dataciviclab/lab-connectors.git@v0.13.2
+git+https://github.com/dataciviclab/lab-connectors.git@v0.13.4

--- a/tools/clean-query-mcp/requirements.txt
+++ b/tools/clean-query-mcp/requirements.txt
@@ -1,3 +1,3 @@
 mcp>=1.26.0
 duckdb==1.5.1
-git+https://github.com/dataciviclab/lab-connectors.git@v0.10.1
+git+https://github.com/dataciviclab/lab-connectors.git@v0.13.1

--- a/tools/clean-query-mcp/server.py
+++ b/tools/clean-query-mcp/server.py
@@ -142,10 +142,10 @@ def _duckdb_read(
         if year_col:
             sql = _inject_year_filter(sql, year_col, year)
 
-    from lab_connectors.duckdb import safe_connect
+    from lab_connectors.duckdb import gcs_connect
     import concurrent.futures
 
-    with safe_connect(extensions=["httpfs"]) as conn:
+    with gcs_connect(parquet_paths[0]) as conn:
         conn.execute("PRAGMA disable_progress_bar")
         conn.execute("SET memory_limit='2GB'")
 
@@ -351,10 +351,10 @@ def run_query(
     def _exec() -> dict[str, Any]:
         _guard_max_rows(max_rows)
 
-        from lab_connectors.duckdb import safe_connect
+        from lab_connectors.duckdb import gcs_connect
         import concurrent.futures
 
-        with safe_connect(extensions=["httpfs"]) as conn:
+        with gcs_connect(parquet_paths[0]) as conn:
             conn.execute("PRAGMA disable_progress_bar")
             conn.execute("SET memory_limit='2GB'")
 
@@ -519,10 +519,10 @@ def count(dataset: str, year: int | None = None) -> dict[str, Any]:
             wrapped_sql = _inject_year_filter(wrapped_sql, year_col, year)
 
     def _exec() -> dict[str, Any]:
-        from lab_connectors.duckdb import safe_connect
+        from lab_connectors.duckdb import gcs_connect
         import concurrent.futures
 
-        with safe_connect(extensions=["httpfs"]) as conn:
+        with gcs_connect(parquet_paths[0]) as conn:
             conn.execute("PRAGMA disable_progress_bar")
             conn.execute("SET memory_limit='2GB'")
 
@@ -613,10 +613,10 @@ def time_series(
         wrapped_sql = _inject_year_filter(wrapped_sql, year_col, year)
 
     def _exec() -> dict[str, Any]:
-        from lab_connectors.duckdb import safe_connect
+        from lab_connectors.duckdb import gcs_connect
         import concurrent.futures
 
-        with safe_connect(extensions=["httpfs"]) as conn:
+        with gcs_connect(parquet_paths[0]) as conn:
             conn.execute("PRAGMA disable_progress_bar")
             conn.execute("SET memory_limit='2GB'")
 
@@ -689,10 +689,10 @@ def distinct_values(dataset: str, column: str, limit: int = 100) -> dict[str, An
     )
 
     def _exec() -> dict[str, Any]:
-        from lab_connectors.duckdb import safe_connect
+        from lab_connectors.duckdb import gcs_connect
         import concurrent.futures
 
-        with safe_connect(extensions=["httpfs"]) as conn:
+        with gcs_connect(parquet_paths[0]) as conn:
             conn.execute("PRAGMA disable_progress_bar")
             conn.execute("SET memory_limit='2GB'")
 
@@ -859,10 +859,10 @@ def explain_query(sql: str, dataset: str) -> dict[str, Any]:
     wrapped_sql = f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) {sql}"
 
     def _exec() -> dict[str, Any]:
-        from lab_connectors.duckdb import safe_connect
+        from lab_connectors.duckdb import gcs_connect
         import concurrent.futures
 
-        with safe_connect(extensions=["httpfs"]) as conn:
+        with gcs_connect(parquet_paths[0]) as conn:
             conn.execute("PRAGMA disable_progress_bar")
             pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
             try:

--- a/tools/clean-query-mcp/server.py
+++ b/tools/clean-query-mcp/server.py
@@ -145,7 +145,7 @@ def _duckdb_read(
     from lab_connectors.duckdb import safe_connect
     import concurrent.futures
 
-    with safe_connect() as conn:
+    with safe_connect(extensions=["httpfs"]) as conn:
         conn.execute("PRAGMA disable_progress_bar")
         conn.execute("SET memory_limit='2GB'")
 
@@ -354,7 +354,7 @@ def run_query(
         from lab_connectors.duckdb import safe_connect
         import concurrent.futures
 
-        with safe_connect() as conn:
+        with safe_connect(extensions=["httpfs"]) as conn:
             conn.execute("PRAGMA disable_progress_bar")
             conn.execute("SET memory_limit='2GB'")
 
@@ -522,7 +522,7 @@ def count(dataset: str, year: int | None = None) -> dict[str, Any]:
         from lab_connectors.duckdb import safe_connect
         import concurrent.futures
 
-        with safe_connect() as conn:
+        with safe_connect(extensions=["httpfs"]) as conn:
             conn.execute("PRAGMA disable_progress_bar")
             conn.execute("SET memory_limit='2GB'")
 
@@ -616,7 +616,7 @@ def time_series(
         from lab_connectors.duckdb import safe_connect
         import concurrent.futures
 
-        with safe_connect() as conn:
+        with safe_connect(extensions=["httpfs"]) as conn:
             conn.execute("PRAGMA disable_progress_bar")
             conn.execute("SET memory_limit='2GB'")
 
@@ -692,7 +692,7 @@ def distinct_values(dataset: str, column: str, limit: int = 100) -> dict[str, An
         from lab_connectors.duckdb import safe_connect
         import concurrent.futures
 
-        with safe_connect() as conn:
+        with safe_connect(extensions=["httpfs"]) as conn:
             conn.execute("PRAGMA disable_progress_bar")
             conn.execute("SET memory_limit='2GB'")
 
@@ -862,7 +862,7 @@ def explain_query(sql: str, dataset: str) -> dict[str, Any]:
         from lab_connectors.duckdb import safe_connect
         import concurrent.futures
 
-        with safe_connect() as conn:
+        with safe_connect(extensions=["httpfs"]) as conn:
             conn.execute("PRAGMA disable_progress_bar")
             pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
             try:


### PR DESCRIPTION
## Sintesi

`resolve_parquet_path()` ora restituisce URI `s3://dataciviclab-{clean,mart}/...` invece di `https://storage.googleapis.com/...`. DuckDB li legge direttamente via httpfs — niente URL encoding manuale, niente HTTPS overhead.

## Contesto collegato

Segue toolkit#338 (S3 in parquet_preview) e lab-connectors v0.13.0 (safe_connect con extensions).

## Cosa cambia

- [ ] Nuovo dataset o modifica catalogo (clean_catalog.json / schema)
- [ ] Script di build / pipeline
- [x] Clean-query MCP
- [ ] Skills MCP o tooling
- [ ] Workflow CI
- [ ] Documentazione
- [ ] Altro

## Checklist

### Se modifichi clean-query MCP

- [x] `pytest tests/` passa — 274/274
- [ ] `ruff check .` passa
- [x] `resolve_parquet_path()` ora restituisce `s3://` invece di `https://`
- [x] `safe_connect(extensions=["httpfs"])` in tutti i tool (6 + 1 in `_duckdb_read`)
- [x] `from urllib.parse import quote` rimosso (non più necessario)

## Verifica

Tutti i 274 test passano invariati. I test di validazione path (`test_validate_parquet_paths`) usano ancora `gs://` come fixture ma il regex `_SAFE_PATH_RE` supporta anche `s3://` (stessi caratteri).

Il pattern `f"https://storage.googleapis.com/{bucket}/{quote(blob_name, safe='/._-')}"` è sostituito da `f"s3://{bucket}/{blob_name}"` — niente encoding perché gli slug e i nomi file del Lab contengono solo `a-zA-Z0-9/._-`.

## Note per chi revisiona

- I path `s3://` funzionano solo con DuckDB httpfs caricato. `safe_connect(extensions=["httpfs"])` è ora in ogni tool.
- `_SAFE_PATH_RE = r"^[a-zA-Z0-9/_.\-:]+$"` già include `:` — `s3://...` passa senza modifiche.
- data-explorer non è toccato: fa solo HTTP pubblico, non DuckDB. Il suo bypass URL manuale è un altro tema.
