### PR TITLE
chore(post-merge): aggiorna registry per PR #477

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-06-06",
+  "updated_at": "2026-06-07",
   "datasets": [
     {
       "slug": "aifa_spesa_consumo",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-06",
+  "generated_at": "2026-06-07",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 38,
+    "total": 39,
     "by_status": {
-      "ok": 38,
+      "ok": 39,
       "warn": 0,
       "error": 0
     }
@@ -461,10 +461,10 @@
       "detail": "anni 2017-2024 — fonte: mur_gettito_ckan — mart: sì",
       "action": "",
       "sample_run": {
-        "status": "failed",
-        "run_id": "26106467223",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26106467223",
-        "checked_at": "2026-05-19",
+        "status": "passed",
+        "run_id": "27104450361",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27104450361",
+        "checked_at": "2026-06-07",
         "years": [
           2017,
           2018,
@@ -760,6 +760,14 @@
         ],
         "config_path": "candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml"
       }
+    },
+    {
+      "id": "compose:malasanita-compose",
+      "source_id": "",
+      "status": "ok",
+      "label": "compose:malasanita-compose",
+      "detail": "anno 2022 — fonti: a, c — mart: sì",
+      "action": ""
     }
   ]
 }


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #477 — fix(mur-contribuzione): parametri read dinamici, paginazione datastore, aggiornamento docs

Changed candidate/support roots:

- `mur-contribuzione-universitaria` (candidate, `candidates/mur-contribuzione-universitaria`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `candidates/mur-contribuzione-universitaria/dataset.yml` -> artifact `sample-run-mur-contribuzione-universitaria`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug mur_contribuzione_universitaria --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
