### PR TITLE
chore(post-merge): aggiorna registry per PR #480

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2693,10 +2693,10 @@
     },
     {
       "slug": "istat_pil_territoriale",
-      "name": "Istat Pil Territoriale",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "name": "PIL regionale e provinciale",
+      "description": "PIL, Valore Aggiunto e Imposte nette per nazione, macro-aree, regioni e province. Fonte: ISTAT Conti economici territoriali (DCCN_PILT). Serie 1995-2024.",
+      "source": "ISTAT — Conti economici territoriali",
+      "source_id": "istat_sdmx",
       "period": {
         "start": 2024,
         "end": 2024
@@ -2706,55 +2706,55 @@
           "name": "territorio_codice",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT/NUTS del territorio"
         },
         {
           "name": "territorio_nome",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Nome del territorio"
         },
         {
           "name": "livello",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "nazionale | macro_area | regione | provincia"
         },
         {
           "name": "tipo_dato_codice",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice tipo dato (B1GQ_B_W2_S1=PIL, B1G_B_W2_S1=VA, D21X31_C_W2_S1=imposte)"
         },
         {
           "name": "tipo_dato",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Etichetta tipo dato"
         },
         {
           "name": "valutazione_codice",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice valutazione (V=prezzi correnti, L_2020=concatenati)"
         },
         {
           "name": "valutazione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Etichetta valutazione"
         },
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di riferimento"
         },
         {
           "name": "valore_mln_eu",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Valore in milioni di euro"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2698,7 +2698,7 @@
       "source": "ISTAT — Conti economici territoriali",
       "source_id": "istat_sdmx",
       "period": {
-        "start": 2024,
+        "start": 1995,
         "end": 2024
       },
       "columns": [

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-06-07",
+  "updated_at": "2026-06-08",
   "datasets": [
     {
       "slug": "aifa_spesa_consumo",
@@ -2686,6 +2686,80 @@
       "location": {
         "type": "gcs",
         "path": "gs://dataciviclab-clean/istat_ipab_aree/2024/istat_ipab_aree_2024_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "istat_pil_territoriale",
+      "name": "Istat Pil Territoriale",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2024,
+        "end": 2024
+      },
+      "columns": [
+        {
+          "name": "territorio_codice",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "territorio_nome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "livello",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "tipo_dato_codice",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "tipo_dato",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "valutazione_codice",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "valutazione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "valore_mln_eu",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/istat_pil_territoriale/2024/istat_pil_territoriale_2024_clean.parquet",
         "multi_file": false
       },
       "stage": "published",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-07",
+  "generated_at": "2026-06-08",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 39,
+    "total": 40,
     "by_status": {
-      "ok": 39,
+      "ok": 40,
       "warn": 0,
       "error": 0
     }
@@ -677,6 +677,24 @@
           2026
         ],
         "config_path": "support_datasets/bdap-anagrafe-enti/dataset.yml"
+      }
+    },
+    {
+      "id": "istat-pil-territoriale",
+      "source_id": "istat_sdmx",
+      "status": "ok",
+      "label": "istat-pil-territoriale",
+      "detail": "anni: ? — fonte: ? — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "27136216949",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27136216949",
+        "checked_at": "2026-06-08",
+        "years": [
+          2024
+        ],
+        "config_path": "support_datasets/istat-pil-territoriale/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #480 — intake: istat_pil_territoriale — PIL regionale e provinciale da ISTAT SDMX (support)

Changed candidate/support roots:

- `istat-pil-territoriale` (support_dataset, `support_datasets/istat-pil-territoriale`)

## Automatic updates

- [x] Rebuilt `registry/pipeline_signals.json`
- [x] CI: full run completato (tutti gli anni)
- [x] CI: clean parquet pushato su GCS
- [x] CI: `registry/clean_catalog.json` aggiornato
- [ ] Maintainer: push mart + BQ (se serve)

## Sample-run artifacts

- `support_datasets/istat-pil-territoriale/dataset.yml` -> artifact `sample-run-istat-pil-territoriale`

## Maintainer commands

```bash
python scripts/push_archive.py --mart --slug istat_pil_territoriale --create-bq-table --update-catalog
```

CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.
