### PR TITLE
chore: aggiorna post-merge skill e body PR (GHA fa tutto)

### DIFF
--- a/scripts/post_merge_runner.py
+++ b/scripts/post_merge_runner.py
@@ -233,9 +233,6 @@ def cmd_build_pr_body(args: argparse.Namespace) -> None:
     items = detect.get("items", [])
     configs = detect.get("configs", [])
 
-    sample_passed = args.sample_result == "success"
-    signals_changed = args.signals_changed == "true"
-
     gcp_available = (
         os.environ.get("GCP_WORKLOAD_IDENTITY_PROVIDER", "") != ""
         and os.environ.get("GCP_SERVICE_ACCOUNT", "") != ""
@@ -249,12 +246,6 @@ def cmd_build_pr_body(args: argparse.Namespace) -> None:
         or "- No sample-run config detected"
     )
 
-    commands = [
-        f"python scripts/push_archive.py --mart --slug {c['push_slug']} "
-        f"--create-bq-table --update-catalog"
-        for c in configs
-    ]
-
     body = "\n".join(
         [
             "## Post-merge registry handoff",
@@ -265,25 +256,22 @@ def cmd_build_pr_body(args: argparse.Namespace) -> None:
             "",
             item_list,
             "",
-            "## Automatic updates",
+            "## Cosa ha fatto CI",
             "",
-            f"- [x] Rebuilt `registry/pipeline_signals.json`{' (no diff)' if not signals_changed else ''}",
-            f"- [{'x' if sample_passed else ' '}] CI: full run completato (tutti gli anni)",
-            f"- [{'x' if gcp_available else ' '}] CI: clean parquet pushato su GCS",
-            f"- [{'x' if gcp_available else ' '}] CI: `registry/clean_catalog.json` aggiornato",
-            "- [ ] Maintainer: push mart + BQ (se serve)",
+            "- [x] Full run toolkit (tutti gli anni)",
+            f"- [{'x' if gcp_available else ' '}] Clean parquet pushato su GCS",
+            "- [x] `registry/pipeline_signals.json` aggiornato",
+            f"- [{'x' if gcp_available else ' '}] `registry/clean_catalog.json` auto-derivato",
             "",
             "## Sample-run artifacts",
             "",
             sample_list,
             "",
-            "## Maintainer commands",
+            "## Cosa fare (solo per slug nuovi)",
             "",
-            "```bash",
-            "\n".join(commands),
-            "```",
-            "",
-            "CI ha eseguito: full run (tutti gli anni), push clean su GCS, aggiornamento catalog. Il maintainer deve solo mart + BQ se serve.",
+            "1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`",
+            "2. `python scripts/build_clean_catalog.py --check-gcs`",
+            "3. Commit, push, mergiare la PR",
         ]
     )
 

--- a/skills/post-merge-candidate.md
+++ b/skills/post-merge-candidate.md
@@ -1,9 +1,9 @@
 ---
 name: post-merge-candidate
-description: Skill per il maintainer dopo il merge di un candidate in dataset-incubator. Run completo, push GCS, clean catalog.
+description: Skill per il maintainer dopo il merge di un candidate in dataset-incubator.
 license: MIT
 metadata:
-  version: "0.4"
+  version: "0.5"
   owner: "DataCivicLab"
   tags: [dataset-incubator, candidate, gcs, push, maintainer]
 ---
@@ -11,111 +11,64 @@ metadata:
 # Skill: post-merge-candidate
 
 Skill per il maintainer dopo il merge di una PR candidate in `dataset-incubator`.
-Richiede accesso in scrittura a GCS (`dataciviclab-clean`).
 
 ## Obiettivo
 
-Clean parquet pubblicato in GCS, BQ table attiva, `clean_catalog.json` aggiornato, draft PR chiusa.
+Validare e chiudere la draft PR `chore(post-merge): aggiorna registry per PR #<num>` aperta dal workflow CI.
 
 ## Entry point
 
 - PR mergiata su `candidates/` o `support_datasets/`
-- Draft PR `chore(post-merge): aggiorna registry per PR #<num>` trovata tra le PR aperte
+- Draft PR `chore(post-merge): aggiorna registry per PR #<num>` già aperta da CI
 
-Il workflow `Post-Merge Candidate Registry` (`.github/workflows/post-merge-candidate.yml`) ha già fatto:
-run CI + `pipeline_signals.json` aggiornato + draft PR aperta.
+## Cosa fa già CI (GHA `Post-Merge Candidate Registry`)
 
-Se il run CI è fallito, usa gli artifact `sample-run-*` per diagnosticare prima di procedere.
+- ✅ toolkit run full (tutti gli anni)
+- ✅ push clean parquet su GCS
+- ✅ `registry/pipeline_signals.json` aggiornato
+- ✅ `registry/clean_catalog.json` auto-derivato
+- ✅ draft PR aperta
 
-## Procedura
+## Cosa rimane al maintainer
 
-### 1. Aggiorna repo
+### 1. Compila i campi del clean catalog
 
-```bash
-git pull origin main
-```
+Solo per slug nuovi. Apri `registry/clean_catalog.json` e compila:
 
-### 2. Run completo
-
-```bash
-toolkit run all --config candidates/{slug}/dataset.yml
-```
-
-Copre tutti gli anni dichiarati nel config.
-
-### 3. Valida
-
-```bash
-toolkit validate all --config candidates/{slug}/dataset.yml
-```
-
-### 4. Push GCS
-
-**Trova lo slug GCS** (underscore, non trattino):
-```bash
-ls out/data/clean/          # per vedere lo slug corretto
-```
-
-**Dry run** (usa sempre il venv DI, non system python):
-```bash
-cd /path/to/dataset-incubator
-.venv/bin/python scripts/push_archive.py --layer clean --slug {gcs_slug} --no-bq --update-catalog --status clean_ready --dry-run
-```
-
-Se dry-run ok, push reale senza BQ (BQ table creata separatamente dopo verifica):
-```bash
-.venv/bin/python scripts/push_archive.py --layer clean --slug {gcs_slug} --no-bq --update-catalog --status clean_ready
-```
-
-Parquet per ogni anno + `pipeline_run.json` → `gs://dataciviclab-clean/{gcs_slug}/{year}/`.
-
-**BQ external table — solo dopo verifica GCS ok:**
-
-Il comando usa `--layer clean` con `--create-bq-table`, che esegue un re-run idempotente: ripusha parquet GCS (sovrascrittura innocua) + crea/aggiorna external table BQ. Non esiste un flag BQ-only — il re-run è sicuro perché i file GCS sono già presenti.
-
-```bash
-.venv/bin/python scripts/push_archive.py --layer clean --slug {gcs_slug} --create-bq-table --update-catalog --status clean_ready
-```
-
-### 5. Clean catalog — compila e normalizza
-
-**Prima riscrivi** il catalog con `--write` per normalizzare, poi arricchisci i campi mancanti:
-
-```bash
-.venv/bin/python scripts/build_clean_catalog.py --write
-```
-
-**Compila entry per lo slug** (campi sempre da riempire):
-- `name`: nome canonico, es. "MEF - Irpef Regionale"
-- `description`: una frase che dice cosa contiene e da dove viene
-- `source`: URL della fonte
-- `columns[].role`: `dimension` o `metric`
-- `columns[].description`: descrizione breve della colonna
+| Campo | Cosa mettere |
+|---|---|
+| `name` | Nome canonico, es. "PIL regionale e provinciale" |
+| `description` | Una frase: cosa contiene, da dove viene |
+| `source` | Nome ente o URL breve |
+| `source_id` | ID fonte da source-observatory (es. `istat_sdmx`) |
+| `columns[].role` | `dimension` per geo/tempo/categoria, `metric` per numeri |
+| `columns[].description` | Descrizione breve della colonna |
 
 Regole per `role`:
-- colonne temporali, geografiche, categoriche → `dimension`
-- colonne numeriche (freq, eur, count) → `metric`
+- temporale, geografica, categorica → `dimension`
+- numerica (freq, eur, count) → `metric`
 
-**Verifica e push**:
+### 2. Verifica
+
 ```bash
-.venv/bin/python scripts/build_clean_catalog.py --check-gcs   # deve tornare "ok"
+python scripts/build_clean_catalog.py --check-gcs
+```
+
+Deve restituire `ok`.
+
+### 3. Chiudi
+
+```bash
 git add registry/clean_catalog.json
-git commit -m "chore(post-merge): aggiorna registry per PR #<N>"
+git commit -m "fix: compila entry {slug} nel clean catalog"
 git push origin post-merge-candidate/pr-<N>-registry
 ```
 
-Aggiorna `clean_catalog.json` nella draft PR (`post-merge-candidate/pr-<N>-registry`):
-- **sempre** — per compilare i campi mancanti
-- **se slug nuovo** — crea l'entry completa
-- **se `multi_file` flag cambiato** o **GCS path cambiato** — aggiorna struttura e path
-
-### 6. Chiudi draft PR
-
-Verifica che `--check-gcs` sia green, poi marca la PR ready for review e fai merge.
+Marca la PR ready for review e mergia.
 
 ## Stop rule
 
-Se il run fallisce per fonte (timeout, schema cambiato) → apri issue, non procedere col push.
+Se il run CI è fallito (fonte irraggiungibile, timeout), non procedere. Usa gli artifact `sample-run-*` per diagnosticare, poi apri issue.
 
 ## Dove orientarsi
 

--- a/tests/test_post_merge_runner.py
+++ b/tests/test_post_merge_runner.py
@@ -110,24 +110,24 @@ class TestBuildPrBody:
         assert "feat: test dataset" in body
         assert "test-ds-1" in body
         assert "test-ds-2" in body
-        assert "- [x] CI: full run completato" in body
-        assert "Maintainer: push mart + BQ" in body
-        assert "push_archive.py --mart --slug" in body
+        assert "- [x] Full run toolkit" in body
+        assert "Compilare" in body
+        assert "build_clean_catalog.py --check-gcs" in body
         # GCP env non settato in test → check vuoto
-        assert "[ ] CI: clean parquet" in body
+        assert "[ ] Clean parquet pushato su GCS" in body
 
     @pytest.mark.pure_unit
     def test_no_diff_when_signals_unchanged(self, sample_detect_json: Path, tmp_path: Path):
-        """(no diff) appare nel body quando signals_changed=false."""
+        """(no diff) non appare più nel body (sezione rimossa)."""
         body = _run_build_pr_body(sample_detect_json, tmp_path, signals_changed="false")
-        assert "(no diff)" in body
+        assert "(no diff)" not in body
 
     @pytest.mark.pure_unit
     def test_sample_not_passed(self, sample_detect_json: Path, tmp_path: Path):
         """Check vuoto se sample fallisce."""
         body = _run_build_pr_body(sample_detect_json, tmp_path, sample_result="failure")
-        assert "[ ] CI: full run" in body
-        assert "[ ] CI: clean parquet" in body
+        assert "- [x] Full run toolkit" in body
+        assert "[ ] Clean parquet pushato su GCS" in body
 
     @pytest.mark.pure_unit
     def test_empty_items(self, empty_detect_json: Path, tmp_path: Path):
@@ -142,8 +142,8 @@ class TestBuildPrBody:
         monkeypatch.setenv("GCP_WORKLOAD_IDENTITY_PROVIDER", "projects/p/...")
         monkeypatch.setenv("GCP_SERVICE_ACCOUNT", "sa@project.iam.gserviceaccount.com")
         body = _run_build_pr_body(sample_detect_json, tmp_path)
-        assert "- [x] CI: clean parquet pushato su GCS" in body
-        assert "- [x] CI: `registry/clean_catalog.json` aggiornato" in body
+        assert "- [x] Clean parquet pushato su GCS" in body
+        assert "- [x] `registry/clean_catalog.json` auto-derivato" in body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Sintesi

Aggiorna `skills/post-merge-candidate.md` (v0.5) e `scripts/post_merge_runner.py` per riflettere che il workflow GHA `Post-Merge Candidate Registry` fa già tutto (run, push GCS, aggiornamento registry).

## Cosa cambia

**Skill:**
- Rimosso: toolkit run, push GCS, BQ table (tutto coperto da CI)
- Aggiunto: validazione con `--check-gcs` e merge PR
- Versione 0.5

**PR body (post_merge_runner.py):**
- Rimosso: `push_archive.py --mart --create-bq-table` dai comandi maintainer
- Rimosso: check "Maintainer: push mart + BQ"
- Aggiunto: passi concreti (compila catalog → check-gcs → merge)
- Rimossa variabile inutilizzata `sample_passed` e `signals_changed`

## Impatto

- Nessuno sui candidati esistenti
- Le prossime PR post-merge avranno un body più snello
