### PR TITLE
chore(post-merge): aggiorna registry per PR #487

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2387,10 +2387,10 @@
     },
     {
       "slug": "istat_elenco_comuni",
-      "name": "Istat Elenco Comuni",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "name": "Elenco comuni italiani (codici ISTAT, catastali, superficie km²)",
+      "description": "Elenco completo dei 7.894 comuni italiani con codici ISTAT (6 cifre), codici catastali Belfiore, superficie territoriale in km², popolazione residente e legale, e caratteristiche geografiche (regione, provincia, zona altimetrica, altitudine, litoraneità/insularità). Fonte: ISTAT SITUAS.",
+      "source": "ISTAT SITUAS (via opensituas)",
+      "source_id": "istat_situas",
       "period": {
         "start": 2026,
         "end": 2026
@@ -2400,79 +2400,79 @@
           "name": "codice_istat",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT del comune (6 caratteri: codice regione + provincia + comune)"
         },
         {
           "name": "denominazione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione ufficiale del comune in italiano"
         },
         {
           "name": "codice_catastale",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice catastale Belfiore (4-5 caratteri, es. A074 per Agliè)"
         },
         {
           "name": "superficie_km2",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Superficie territoriale del comune in km²"
         },
         {
           "name": "popolazione_residente",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Popolazione residente al momento dello snapshot"
         },
         {
           "name": "popolazione_legale",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Popolazione legale (censita) al momento dello snapshot"
         },
         {
           "name": "regione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Nome della regione di appartenenza"
         },
         {
           "name": "provincia",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Nome della provincia (denominazione UTS) di appartenenza"
         },
         {
           "name": "sigla_provincia",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Sigla automobilistica della provincia (2 caratteri)"
         },
         {
           "name": "zona_altimetrica",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Codice zona altimetrica ISTAT: 1=Montagna, 2=Collina, 3=Pianura"
         },
         {
           "name": "altitudine",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Altitudine del comune in metri sul livello del mare"
         },
         {
           "name": "comune_litoraneo",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Indica se il comune è bagnato dal mare (vero/falso)"
         },
         {
           "name": "comune_isolano",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Indica se il comune è situato su un'isola (vero/falso)"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-06-09",
+  "updated_at": "2026-06-10",
   "datasets": [
     {
       "slug": "aifa_spesa_consumo",
@@ -2383,6 +2383,104 @@
         "multi_file": true
       },
       "stage": "incubating",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "istat_elenco_comuni",
+      "name": "Istat Elenco Comuni",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2026,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "codice_istat",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "denominazione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_catastale",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "superficie_km2",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "popolazione_residente",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "popolazione_legale",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "regione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "provincia",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "sigla_provincia",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "zona_altimetrica",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "altitudine",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "comune_litoraneo",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "comune_isolano",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/istat_elenco_comuni/2026/istat_elenco_comuni_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
       "registry_source": "derive_auto"
     },
     {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-09",
+  "generated_at": "2026-06-10",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 41,
+    "total": 42,
     "by_status": {
-      "ok": 41,
+      "ok": 42,
       "warn": 0,
       "error": 0
     }
@@ -698,6 +698,24 @@
           2026
         ],
         "config_path": "support_datasets/bdap-anagrafe-enti/dataset.yml"
+      }
+    },
+    {
+      "id": "istat-elenco-comuni",
+      "source_id": "istat_situas",
+      "status": "ok",
+      "label": "istat-elenco-comuni",
+      "detail": "anni: ? — fonte: ? — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "27298960373",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27298960373",
+        "checked_at": "2026-06-10",
+        "years": [
+          2026
+        ],
+        "config_path": "support_datasets/istat-elenco-comuni/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #487 — intake: istat-elenco-comuni — Elenco dei comuni italiani (codici ISTAT, catastali, superficie km²)

Changed candidate/support roots:

- `istat-elenco-comuni` (support_dataset, `support_datasets/istat-elenco-comuni`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `support_datasets/istat-elenco-comuni/dataset.yml` -> artifact `sample-run-istat-elenco-comuni`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
