### PR TITLE
chore: bump dataciviclab-toolkit v1.34.2 → v1.35.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.15.0
 
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.34.2
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.35.0
 
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0


### PR DESCRIPTION
## Sintesi

Aggiorna la dipendenza `dataciviclab-toolkit` da v1.34.2 a v1.35.0.

## Cosa cambia in v1.35.0

- **dateformat/timestampformat in clean.read** (#366): parsing date direttamente in DuckDB senza strptime in clean.sql
- **dateformat automatico in scaffold** (#367): `toolkit scout --scaffold` rileva date in formato italiano e suggerisce `dateformat: "%d/%m/%Y"`
- **trim sicuro** (#362): `trim(CAST(x AS VARCHAR))` previene crash su colonne sniffate come BIGINT

## Verifica

```bash
pip install -r requirements.txt
toolkit --version  # → 1.35.0
```

- [x] Test locale: `toolkit --version` → 1.35.0
