### PR TITLE
fix: HTTPS_PROXY spostato a step-level (bloccava checkout/cache in post-merge)

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -23,7 +23,6 @@ env:
   DATACIVICLAB_WORKSPACE: ${{ github.workspace }}
   GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
   GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-  HTTPS_PROXY: ${{ vars.BLOCKED_SOURCE_PROXY }}
 
 jobs:
   detect:
@@ -131,6 +130,8 @@ jobs:
         uses: google-github-actions/setup-gcloud@v3
 
       - name: Process each detected config
+        env:
+          HTTPS_PROXY: ${{ vars.BLOCKED_SOURCE_PROXY }}
         run: python scripts/post_merge_runner.py sample-run --retry 3
 
       - name: Upload sample-run artifacts


### PR DESCRIPTION
## Problema

`HTTPS_PROXY: ${{ vars.BLOCKED_SOURCE_PROXY }}` era impostato a livello workflow (`env:`), usato da TUTTI gli step incluso `actions/checkout@v6` e `actions/cache`.

Il proxy non raggiunge GitHub → checkout falliva con retry (minuti persi), cache con `ECONNRESET`.

## Fix

Spostato `HTTPS_PROXY` a step-level, solo su `Process each detected config`.

## CI

OpenGA (openga-ricorsi-appalto) resta irraggiungibile — problema separato.
