### PR TITLE
support: ipa-istat-mapping — raccordo tra IPA e ISTAT per comuni italiani

### DIFF
--- a/support_datasets/ipa-istat-mapping/README.md
+++ b/support_datasets/ipa-istat-mapping/README.md
@@ -1,0 +1,49 @@
+# IPA ↔ ISTAT mapping — comuni italiani
+
+## Dataset
+
+Tabella di raccordo tra **IPA** (Indice delle Pubbliche Amministrazioni, AgID) e **ISTAT** (codici amministrativi). Una riga per comune italiano con codice ISTAT, codice IPA, codice fiscale, codice catastale e dati anagrafici/territoriali.
+
+- **fonte 1**: IPA enti — [datastore AgID](https://indicepa.gov.it/ipa-dati/datastore/dump/d09adf99-dc10-4349-8c53-27b1e5aa97b6?bom=True)
+- **fonte 2**: ISTAT comuni — [Elenco codici unità amministrative](https://www.istat.it/storage/codici-unita-amministrative/Elenco-comuni-italiani.csv)
+- **perimetro**: soli comuni (categoria IPA `L6`)
+- **copertura**: **7.412 / 7.415 comuni (99,96%)** — Sardegna inclusa
+- **snapshot**: 2026
+
+## Perché vale la pena averlo
+
+È un **support dataset ad alto impatto cross-analisi**. Serve per:
+
+- **Join tra dataset IPA e ISTAT** — molti dataset Lab usano codici ISTAT (6 cifre), molti dataset PA usano codici IPA (es. MEF partecipazioni, BDAP)
+- **Arricchimento anagrafico** — da IPA si ottiene codice fiscale, indirizzo PEC, sito istituzionale per ogni comune
+- **Chiave di raccordo** — il codice fiscale dell'ente permette join con BDAP, MEF e altri dataset finanziari
+
+## Output
+
+### `mart_ipa_istat`
+16 colonne — una riga per comune:
+
+| Colonna | Descrizione |
+|---|---|
+| `codice_istat` | Codice ISTAT 6 cifre |
+| `denominazione` | Nome comune (ISTAT) |
+| `regione` | Regione |
+| `sigla_provincia` | Sigla provincia |
+| `codice_regione` | Codice regione ISTAT (2 cifre) |
+| `codice_catastale_istat` | Codice catastale (Belfiore, da ISTAT) |
+| `codice_ipa` | Codice IPA (es. `c_b354`) |
+| `codice_fiscale` | Codice fiscale ente |
+| `denominazione_ipa` | Denominazione ente in IPA |
+| `codice_categoria` | Categoria IPA (sempre `L6`) |
+| `codice_catastale_comune` | Codice catastale (da IPA) |
+| `codice_istat_ipa` | Codice ISTAT attribuito da IPA |
+| `acronimo` | Acronimo (se presente) |
+| `indirizzo` | Indirizzo sede |
+| `cap` | CAP |
+| `sito_istituzionale` | Sito web |
+
+## Note tecniche
+
+- La chiave di join è il **codice catastale (Belfiore)**, non il codice ISTAT: IPA usa un sistema di codifica proprio per `Codice_comune_ISTAT` che non coincide con i codici ISTAT per tutte le regioni (es. Sardegna)
+- **3 comuni senza match IPA**: verosimilmente comuni cessati o fusi — da verificare
+- IPA filtrato per sola categoria `L6` (Comuni). Per altri enti (province, ASL, università) serve un'estensione

--- a/support_datasets/ipa-istat-mapping/dataset.yml
+++ b/support_datasets/ipa-istat-mapping/dataset.yml
@@ -1,0 +1,47 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "ipa_istat_mapping"
+  source_id: "agid"
+  years: [2026]
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "ipa_enti"
+      type: "http_file"
+      args:
+        url: "https://indicepa.gov.it/ipa-dati/datastore/dump/d09adf99-dc10-4349-8c53-27b1e5aa97b6?bom=True"
+        filename: "ipa_enti.csv"
+      primary: true
+    - name: "istat_comuni"
+      type: "http_file"
+      args:
+        url: "https://www.istat.it/storage/codici-unita-amministrative/Elenco-comuni-italiani.csv"
+        filename: "istat_comuni.csv"
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: "config_only"
+    mode: "latest"
+    header: true
+    delim: ","
+    encoding: "utf-8"
+  validate:
+    min_rows: 7000
+
+mart:
+  tables:
+    - name: "mart_ipa_istat"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_ipa_istat"
+  validate:
+    table_rules:
+      mart_ipa_istat:
+        min_rows: 7000
+
+validation:
+  fail_on_error: true

--- a/support_datasets/ipa-istat-mapping/notes.md
+++ b/support_datasets/ipa-istat-mapping/notes.md
@@ -1,0 +1,55 @@
+# IPA↔ISTAT mapping — note tecniche
+
+## Tecnico
+
+- **Fonte IPA**: dump datastore AgID (`https://indicepa.gov.it/ipa-dati/datastore/dump/d09adf99-dc10-4349-8c53-27b1e5aa97b6?bom=True`)
+  - CSV con delim `,`, encoding UTF-8
+  - ~23.700 enti di tutte le categorie (L6=comuni, L33=scuole, L1=ASL, ecc.)
+  - Il file richiede `strict_mode=false` + `ignore_errors=true` per via di righe con quoting irregolare
+- **Fonte ISTAT**: `https://www.istat.it/storage/codici-unita-amministrative/Elenco-comuni-italiani.csv`
+  - CSV con delim `;`, encoding latin-1, header multi-riga
+  - Letto posizionalmente con `header=false`, `skip=1`
+  - ~7.900 comuni + righe di riepilogo territoriale
+
+## Join e bug fix
+
+**Bug originale**: il join era su `i.codice_istat = ip.codice_comune_ISTAT`. Tuttavia IPA usa un proprio sistema di codifica per `Codice_comune_ISTAT` che **non coincide con il codice ISTAT standard** per i comuni con codice provincia > 089 (es. Sardegna).
+
+Esempi:
+- Cagliari: ISTAT `092006` → IPA `118006`
+- Sassari: ISTAT `090045` → IPA `112050`
+
+**Fix (2026-06-16)**: join via **codice catastale (Belfiore)**, universale e presente in entrambe le fonti:
+```sql
+ON UPPER(trim(i.codice_catastale)) = UPPER(trim(ip.codice_catastale_comune))
+```
+
+**Risultato**:
+| Metrica | Prima | Dopo |
+|---|---|---|
+| Comuni con IPA | 7.052 (95,1%) | **7.412 (99,96%)** |
+| Sardegna | 0% | **100%** |
+| Senza match | 363 | **3** |
+
+I 3 comuni senza match IPA sono verosimilmente cessati o fusi (da verificare).
+
+## Run
+
+```bash
+toolkit run raw -c support_datasets/ipa-istat-mapping/dataset.yml -y 2026
+toolkit run clean -c support_datasets/ipa-istat-mapping/dataset.yml -y 2026
+toolkit run mart -c support_datasets/ipa-istat-mapping/dataset.yml -y 2026
+```
+
+- **Run ID**: `20260616T181739Z_f2de0533`
+- **Esito**: ✅ SUCCESS (RAW→CLEAN→MART)
+- **Righe mart**: 7.415
+- **Colonne**: 16
+- **Readiness**: ✅
+
+## Limiti noti
+
+- **Soli comuni (L6)**: non copre province, ASL, università, regioni, altri enti PA
+- **Fonte IPA via datastore dump**: l'URL contiene un UUID del datastore — potrebbe cambiare
+- **ISTAT letto posizionalmente**: se ISTAT modifica la struttura del CSV, lo schema esplode
+- **Solo snapshot 2026**: la serie storica richiederebbe download multipli

--- a/support_datasets/ipa-istat-mapping/sql/clean.sql
+++ b/support_datasets/ipa-istat-mapping/sql/clean.sql
@@ -1,0 +1,143 @@
+-- Clean: ipa_istat_mapping
+-- Compone IPA enti (AgID) + ISTAT codici amministrativi
+-- Fonti:
+--   raw_input: IPA enti (datastore dump, UTF-8, delim=',')
+--   istat_comuni.csv: ISTAT codici amm.vi (latin-1, delim=';',
+--     header multi-riga con nomi lunghi → lettura posizionale)
+
+WITH
+
+-- Legge ISTAT con colonne posizionali (header multi-riga non rilevabile automaticamente)
+istat_raw AS (
+    SELECT * FROM read_csv(
+        '{root}/data/raw/{dataset}/{year}/istat_comuni.csv',
+        delim=';',
+        header=false,
+        skip=1,
+        strict_mode=false,
+        ignore_errors=true,
+        all_varchar=true,
+        quote='"',
+        escape='"',
+        max_line_size=500000,
+        columns = {
+            'col_cod_regione': 'VARCHAR',
+            'col_uts': 'VARCHAR',
+            'col_cod_provincia': 'VARCHAR',
+            'col_progressivo': 'VARCHAR',
+            'col_cod_alfanumerico': 'VARCHAR',
+            'col_denominazione_en': 'VARCHAR',
+            'col_denominazione': 'VARCHAR',
+            'col_denominazione_altra': 'VARCHAR',
+            'col_cod_ripartizione': 'VARCHAR',
+            'col_ripartizione': 'VARCHAR',
+            'col_denominazione_regione': 'VARCHAR',
+            'col_denominazione_uts': 'VARCHAR',
+            'col_tipologia_uts': 'VARCHAR',
+            'col_flag_capoluogo': 'VARCHAR',
+            'col_sigla_provincia': 'VARCHAR',
+            'col_cod_istat': 'VARCHAR',
+            'col_cod_110province': 'VARCHAR',
+            'col_cod_107province': 'VARCHAR',
+            'col_cod_103province': 'VARCHAR',
+            'col_cod_catastale': 'VARCHAR',
+            'col_nuts1_2021': 'VARCHAR',
+            'col_nuts2_2021': 'VARCHAR',
+            'col_nuts3_2021': 'VARCHAR',
+            'col_nuts1_2024': 'VARCHAR',
+            'col_nuts2_2024': 'VARCHAR',
+            'col_nuts3_2024': 'VARCHAR'
+        }
+    )
+),
+
+-- Normalizza ISTAT: pulizia e zero-padding
+istat AS (
+    SELECT DISTINCT
+        lpad(trim(col_cod_istat), 6, '0') AS codice_istat,
+        trim(col_denominazione) AS denominazione,
+        trim(col_denominazione_regione) AS regione,
+        trim(col_sigla_provincia) AS sigla_provincia,
+        lpad(trim(col_cod_regione), 2, '0') AS codice_regione,
+        trim(col_cod_catastale) AS codice_catastale
+    FROM istat_raw
+    WHERE col_cod_istat IS NOT NULL
+      AND trim(col_cod_istat) != ''
+),
+
+-- Filtra IPA: solo enti di categoria Comune (L6)
+ipa AS (
+    SELECT
+        trim(Codice_IPA) AS codice_ipa,
+        trim(Denominazione_ente) AS denominazione_ente,
+        trim(Codice_fiscale_ente) AS codice_fiscale_ente,
+        trim(Codice_Categoria) AS codice_categoria,
+        lpad(trim(CAST(Codice_comune_ISTAT AS VARCHAR)), 6, '0')
+            AS codice_comune_istat,
+        trim(Codice_catastale_comune) AS codice_catastale_comune,
+        CAST(Codice_ISTAT AS VARCHAR) AS codice_istat_ipa,
+        trim(Acronimo) AS acronimo,
+        trim(Indirizzo) AS indirizzo,
+        trim(CAP) AS cap,
+        trim(Sito_istituzionale) AS sito_istituzionale,
+        trim(Mail1) AS mail1,
+        trim(Tipo_Mail1) AS tipo_mail1
+    FROM raw_input
+    WHERE trim(Codice_Categoria) = 'L6'
+      AND Codice_comune_ISTAT IS NOT NULL
+),
+
+-- LEFT JOIN con dedup: un comune ISTAT può avere zero o più righe IPA
+-- Priorità: codice_ipa che inizia con 'c_' (canonico Comune in IPA)
+anagrafica_joined AS (
+    SELECT
+        i.codice_istat,
+        i.denominazione,
+        i.regione,
+        i.sigla_provincia,
+        i.codice_regione,
+        i.codice_catastale AS codice_catastale_istat,
+        ip.codice_ipa,
+        ip.codice_fiscale_ente AS codice_fiscale,
+        ip.denominazione_ente AS denominazione_ipa,
+        ip.codice_categoria,
+        ip.codice_catastale_comune,
+        ip.codice_istat_ipa,
+        ip.acronimo,
+        ip.indirizzo,
+        ip.cap,
+        ip.sito_istituzionale,
+        ROW_NUMBER() OVER (
+            PARTITION BY i.codice_istat
+            ORDER BY
+                CASE WHEN ip.codice_ipa LIKE 'c\_%' THEN 0
+                     WHEN ip.codice_ipa IS NOT NULL THEN 1
+                     ELSE 2 END,
+                ip.codice_ipa NULLS LAST
+        ) AS rn
+    FROM istat i
+    LEFT JOIN ipa ip
+        ON i.codice_istat = ip.codice_comune_istat
+)
+
+-- Output: una riga per comune
+SELECT
+    codice_istat,
+    denominazione,
+    regione,
+    sigla_provincia,
+    codice_regione,
+    codice_catastale_istat,
+    codice_ipa,
+    codice_fiscale,
+    denominazione_ipa,
+    codice_categoria,
+    codice_catastale_comune,
+    codice_istat_ipa,
+    acronimo,
+    indirizzo,
+    cap,
+    sito_istituzionale
+FROM anagrafica_joined
+WHERE rn = 1
+ORDER BY codice_istat

--- a/support_datasets/ipa-istat-mapping/sql/clean.sql
+++ b/support_datasets/ipa-istat-mapping/sql/clean.sql
@@ -84,10 +84,14 @@ ipa AS (
         trim(Tipo_Mail1) AS tipo_mail1
     FROM raw_input
     WHERE trim(Codice_Categoria) = 'L6'
-      AND Codice_comune_ISTAT IS NOT NULL
+      AND Codice_catastale_comune IS NOT NULL
+      AND trim(Codice_catastale_comune) != ''
 ),
 
--- LEFT JOIN con dedup: un comune ISTAT può avere zero o più righe IPA
+-- LEFT JOIN via codice catastale (Belfiore): chiave universale presente in
+-- entrambe le fonti. Il codice_comune_ISTAT di IPA non coincide con il codice
+-- ISTAT per tutte le regioni (es. Sardegna), mentre il codice catastale sì.
+-- Un comune ISTAT può avere zero o più righe IPA.
 -- Priorità: codice_ipa che inizia con 'c_' (canonico Comune in IPA)
 anagrafica_joined AS (
     SELECT
@@ -117,7 +121,7 @@ anagrafica_joined AS (
         ) AS rn
     FROM istat i
     LEFT JOIN ipa ip
-        ON i.codice_istat = ip.codice_comune_istat
+        ON UPPER(trim(i.codice_catastale)) = UPPER(trim(ip.codice_catastale_comune))
 )
 
 -- Output: una riga per comune

--- a/support_datasets/ipa-istat-mapping/sql/clean.sql
+++ b/support_datasets/ipa-istat-mapping/sql/clean.sql
@@ -114,7 +114,7 @@ anagrafica_joined AS (
         ROW_NUMBER() OVER (
             PARTITION BY i.codice_istat
             ORDER BY
-                CASE WHEN ip.codice_ipa LIKE 'c\_%' THEN 0
+                CASE WHEN lower(ip.codice_ipa) LIKE 'c\_%' ESCAPE '\' THEN 0
                      WHEN ip.codice_ipa IS NOT NULL THEN 1
                      ELSE 2 END,
                 ip.codice_ipa NULLS LAST

--- a/support_datasets/ipa-istat-mapping/sql/mart.sql
+++ b/support_datasets/ipa-istat-mapping/sql/mart.sql
@@ -1,0 +1,23 @@
+-- Mart: ipa_istat_mapping
+-- Pass-through: tutto il clean, nessuna aggregazione
+
+SELECT
+    codice_istat,
+    denominazione,
+    regione,
+    sigla_provincia,
+    codice_regione,
+    codice_catastale_istat,
+    codice_ipa,
+    codice_fiscale,
+    denominazione_ipa,
+    codice_categoria,
+    codice_catastale_comune,
+    codice_istat_ipa,
+    acronimo,
+    indirizzo,
+    cap,
+    sito_istituzionale
+FROM clean_input
+WHERE codice_istat IS NOT NULL
+ORDER BY codice_istat


### PR DESCRIPTION
## Sintesi

Nuovo support dataset **ipa_istat_mapping**: tabella di raccordo tra codici IPA (Indice PA, AgID) e codici ISTAT per tutti i comuni italiani. Copertura **7.412 / 7.415 comuni (99,96%)**, Sardegna inclusa.

## Contesto collegato

Work in progress da branch locale `feat/ipa-istat-mapping` — nato come necessario per join cross-dataset (DAIT, BDAP, MEF).

## Cosa cambia

- [x] support — dataset di supporto

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
- [ ] Solo documentazione o metadati
- [x] Nessun impatto visibile per chi usa il repository

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori su tutti gli anni dichiarati
- [x] nessun file dati committato nella root del candidate
- [ ] notebook — non previsto per support dataset
- [ ] issue di intake collegata

## Fix applicato

Durante la verifica è emerso un **bug strutturale nel join**: il `Codice_comune_ISTAT` di IPA non coincide con il codice ISTAT reale per i comuni con codice provincia > 089 (es. Sardegna). Cagliari è `118006` in IPA vs `092006` in ISTAT.

**Soluzione**: join via **codice catastale (Belfiore)**, universale in entrambe le fonti.

Risultato:

| Metrica | Prima | Dopo |
|---|---|---|
| Comuni con IPA | 7.052 (95,1%) | **7.412 (99,96%)** |
| Sardegna | 0% | **100%** |
| Senza match | 363 | **3** (cessazioni/fusioni) |

## Verifica

```bash
toolkit run full --config support_datasets/ipa-istat-mapping/dataset.yml --years 2026
```

- [x] `run full` eseguito con successo (RAW→CLEAN→MART)
- [x] Copertura verificata: 7.412/7.415 comuni con IPA, Sardegna 360/360

## Note / rischi

- Solo comuni (categoria IPA L6) — non copre altri enti (province, ASL, università)
- Fonte IPA via datastore dump (UUID) — potrebbe cambiare
- ISTAT letto posizionalmente — fragile a cambi di struttura
