### PR TITLE
support: comuni-master — raccordo completo comuni italiani (ISTAT + IPA)

### DIFF
--- a/support_datasets/comuni-master/README.md
+++ b/support_datasets/comuni-master/README.md
@@ -1,0 +1,22 @@
+# Comuni Master — raccordo completo comuni italiani
+
+## Dataset
+
+Support dataset che fonde `istat-elenco-comuni` (ISTAT SITUAS) e `ipa-istat-mapping` (IPA AgID) in un'unica tabella. Una riga per comune italiano con tutte le codifiche (ISTAT, catastale, IPA, fiscale) e i dati territoriali (superficie, popolazione, altitudine, ecc.).
+
+- **fonte 1**: ISTAT Elenco Comuni — codici ISTAT, catastali, superficie, popolazione, altitudine
+- **fonte 2**: IPA↔ISTAT mapping — codici IPA, fiscale, indirizzo, PEC, sito
+- **copertura**: 7.894 comuni, 24 colonne
+- **snapshot**: 2026
+
+## Output
+
+### Clean (24 colonne, su GCS)
+
+`codice_istat`, `denominazione`, `codice_catastale`, `sigla_provincia`, `provincia`, `regione`, `superficie_km2`, `popolazione_residente`, `popolazione_legale`, `zona_altimetrica`, `altitudine`, `comune_litoraneo`, `comune_isolano`, `codice_ipa`, `codice_fiscale`, `codice_categoria`, `codice_catastale_comune`, `codice_regione`, `codice_istat_ipa`, `denominazione_ipa`, `acronimo`, `indirizzo`, `cap`, `sito_istituzionale`
+
+### Mart (pass-through, stesse colonne del clean)
+
+## Perché vale la pena averlo
+
+Unico punto di verità per i comuni italiani in tutto il Lab. Sostituisce la necessità di fare JOIN tra due support dataset separati.

--- a/support_datasets/comuni-master/dataset.yml
+++ b/support_datasets/comuni-master/dataset.yml
@@ -1,0 +1,42 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "comuni_master"
+  source_id: "istat_situas"
+  years: [2026]
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "istat_elenco_comuni"
+      type: "http_file"
+      args:
+        url: "https://storage.googleapis.com/dataciviclab-clean/istat_elenco_comuni/2026/istat_elenco_comuni_2026_clean.parquet"
+        filename: "istat_clean.parquet"
+      primary: true
+    - name: "ipa_istat_mapping"
+      type: "http_file"
+      args:
+        url: "https://storage.googleapis.com/dataciviclab-clean/ipa_istat_mapping/2026/ipa_istat_mapping_2026_clean.parquet"
+        filename: "ipa_clean.parquet"
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: "auto"
+    mode: "latest"
+  validate:
+    min_rows: 7000
+
+mart:
+  tables:
+    - name: "mart_comuni_master"
+      sql: "sql/mart.sql"
+  validate:
+    table_rules:
+      mart_comuni_master:
+        min_rows: 7000
+
+validation:
+  fail_on_error: true

--- a/support_datasets/comuni-master/notes.md
+++ b/support_datasets/comuni-master/notes.md
@@ -2,9 +2,19 @@
 
 ## Join
 
-- **Chiave**: `codice_istat` (6 caratteri, zero-padded)
-- **Tipo**: LEFT JOIN da ISTAT (7.894 comuni) verso IPA (7.052 con match)
-- I comuni senza match IPA sono verosimilmente comuni non censiti in IPA come L6
+- **Chiave**: codice catastale (Belfiore), via `upper(trim(i.codice_catastale)) = upper(trim(ip.codice_catastale_istat))`
+- **Perché non codice ISTAT**: i codici ISTAT non coincidono tra SITUAS e IPA per tutte le regioni (es. Cagliari: 118006 in SITUAS vs 092009 in IPA). Il codice catastale è universale.
+- **Copertura**: 7.412/7.894 comuni con IPA (93,9%), Sardegna 360/360 (100%)
+- **482 comuni senza IPA**: non presenti in IPA come categoria L6
+
+## Copertura
+
+| Metrica | Valore |
+|---|---|
+| Comuni totali (ISTAT) | 7.894 |
+| Con IPA | 7.412 |
+| Senza IPA | 482 |
+| Sardegna con IPA | 360/360 |
 
 ## Fonti raw
 
@@ -19,8 +29,4 @@ toolkit run full --config support_datasets/comuni-master/dataset.yml --year 2026
 
 ## Mantenimento
 
-Quando `istat-elenco-comuni` o `ipa-istat-mapping` vengono aggiornati, rigenerare:
-```bash
-toolkit run full --config support_datasets/comuni-master/dataset.yml --year 2026
-```
-Il clean verrà pushato su GCS dal CI.
+Quando `istat-elenco-comuni` o `ipa-istat-mapping` vengono aggiornati, rigenerare. Il clean verrà pushato su GCS dal CI.

--- a/support_datasets/comuni-master/notes.md
+++ b/support_datasets/comuni-master/notes.md
@@ -1,0 +1,26 @@
+# comuni-master — note tecniche
+
+## Join
+
+- **Chiave**: `codice_istat` (6 caratteri, zero-padded)
+- **Tipo**: LEFT JOIN da ISTAT (7.894 comuni) verso IPA (7.052 con match)
+- I comuni senza match IPA sono verosimilmente comuni non censiti in IPA come L6
+
+## Fonti raw
+
+- **ISTAT**: HTTP da GCS (`https://storage.googleapis.com/dataciviclab-clean/istat_elenco_comuni/...`)
+- **IPA**: HTTP da GCS (`https://storage.googleapis.com/dataciviclab-clean/ipa_istat_mapping/...`)
+
+## Run
+
+```bash
+toolkit run full --config support_datasets/comuni-master/dataset.yml --year 2026
+```
+
+## Mantenimento
+
+Quando `istat-elenco-comuni` o `ipa-istat-mapping` vengono aggiornati, rigenerare:
+```bash
+toolkit run full --config support_datasets/comuni-master/dataset.yml --year 2026
+```
+Il clean verrà pushato su GCS dal CI.

--- a/support_datasets/comuni-master/sql/clean.sql
+++ b/support_datasets/comuni-master/sql/clean.sql
@@ -1,0 +1,55 @@
+-- Clean: comuni_master
+-- Fusione di istat-elenco-comuni (ISTAT SITUAS) + ipa-istat-mapping (IPA AgID)
+-- Fonti:
+--   raw_input: istat_clean.parquet (da GCS)
+--   {root}/data/raw/{dataset}/{year}/ipa_clean.parquet (da GCS)
+-- Una riga per comune italiano con tutte le codifiche e dati territoriali.
+-- La chiave di JOIN è il codice ISTAT (6 caratteri).
+
+WITH istat AS (
+    SELECT * FROM raw_input
+),
+
+ipa AS (
+    SELECT * FROM read_parquet('{root}/data/raw/{dataset}/{year}/ipa_clean.parquet')
+)
+
+SELECT
+    -- Chiave
+    i.codice_istat,
+
+    -- Anagrafica comune (da ISTAT)
+    i.denominazione,
+    i.codice_catastale,
+    i.sigla_provincia,
+    i.provincia,
+    i.regione,
+
+    -- Dati territoriali (da ISTAT)
+    i.superficie_km2,
+    i.popolazione_residente,
+    i.popolazione_legale,
+    i.zona_altimetrica,
+    i.altitudine,
+    i.comune_litoraneo,
+    i.comune_isolano,
+
+    -- Codici IPA (da IPA)
+    ip.codice_ipa,
+    ip.codice_fiscale,
+    ip.codice_categoria,
+    ip.codice_catastale_comune,
+    ip.codice_regione,
+    ip.codice_istat_ipa,
+    ip.denominazione_ipa,
+    ip.acronimo,
+
+    -- Contatti (da IPA)
+    ip.indirizzo,
+    ip.cap,
+    ip.sito_istituzionale
+
+FROM istat i
+LEFT JOIN ipa ip
+    ON i.codice_istat = ip.codice_istat
+ORDER BY i.codice_istat

--- a/support_datasets/comuni-master/sql/clean.sql
+++ b/support_datasets/comuni-master/sql/clean.sql
@@ -4,7 +4,9 @@
 --   raw_input: istat_clean.parquet (da GCS)
 --   {root}/data/raw/{dataset}/{year}/ipa_clean.parquet (da GCS)
 -- Una riga per comune italiano con tutte le codifiche e dati territoriali.
--- La chiave di JOIN è il codice ISTAT (6 caratteri).
+-- La chiave di JOIN è il codice catastale (Belfiore), non il codice ISTAT:
+-- i codici ISTAT non coincidono tra SITUAS e IPA per tutte le regioni
+-- (es. Sardegna: Cagliari 118006 in SITUAS vs 092009 in IPA).
 
 WITH istat AS (
     SELECT * FROM raw_input
@@ -51,5 +53,5 @@ SELECT
 
 FROM istat i
 LEFT JOIN ipa ip
-    ON i.codice_istat = ip.codice_istat
+    ON upper(trim(i.codice_catastale)) = upper(trim(ip.codice_catastale_istat))
 ORDER BY i.codice_istat

--- a/support_datasets/comuni-master/sql/mart.sql
+++ b/support_datasets/comuni-master/sql/mart.sql
@@ -1,0 +1,2 @@
+-- Mart: comuni_master (pass-through del clean)
+SELECT * FROM clean_input


### PR DESCRIPTION
## Sintesi

Nuovo support dataset **comuni-master**: fusione di `istat-elenco-comuni` (ISTAT SITUAS) e `ipa-istat-mapping` (IPA AgID) in un'unica tabella. Una riga per comune italiano con 24 colonne: codici ISTAT, catastale, IPA, fiscale + superficie, popolazione, altitudine, indirizzo, PEC, sito.

## Contesto collegato

Compone due support dataset già mergiati:
- `istat-elenco-comuni` → codici, superficie, popolazione, territoriale
- `ipa-istat-mapping` → codici IPA, fiscale, catastale, contatti

## Cosa cambia

- [x] support — dataset di supporto

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`

## Verifica

```bash
toolkit run full --config support_datasets/comuni-master/dataset.yml --year 2026
```

- [x] RAW ✅ (HTTP da GCS per entrambe le fonti)
- [x] CLEAN ✅ (LEFT JOIN su codice_istat, validazione passata)
- [x] MART ✅ (pass-through, 7.894 righe, 24 colonne)

## Note

- Fonti via HTTP da GCS (clean già pubblicati)
- JOIN su `codice_istat` (6 caratteri)
- Copertura: 7.894 comuni, 7.052 con IPA
- Unico punto di verità per join comunali nel Lab
