### PR TITLE
feat(skills): riscritte intake-candidate e run-candidate con tool MCP aggregati

### DIFF
--- a/skills/intake-candidate.md
+++ b/skills/intake-candidate.md
@@ -1,21 +1,21 @@
 ---
 name: intake-candidate
-description: Skill canonico di dataset-incubator per portare un caso da issue intake a PR pronta per merge.
+description: Skill canonico di dataset-incubator per portare un caso da issue intake a candidate runnable.
 license: MIT
 metadata:
-  version: "0.5"
+  version: "0.6"
   owner: "DataCivicLab"
-  tags: [dataset-incubator, intake, candidate, support-dataset]
+  tags: [dataset-incubator, intake, candidate]
 ---
 
 # Skill: intake-candidate
 
 Skill canonico di `dataset-incubator`.
-Versione: 0.5 - 2026-05-09
+Versione: 0.6 - 2026-06-17
 
 ## Obiettivo
 
-Portare un caso da issue intake a PR mergiata — candidate strutturato, runnable, pronto per il post-merge.
+Portare un caso da issue intake a candidate runnable — dataset.yml presente, run full passa, stato tecnico chiaro.
 
 ## Entry point
 
@@ -40,59 +40,96 @@ Leggi: domanda guida, fonte, perimetro, output minimo, rischi noti, prossimo pas
 
 Se il candidate esiste già → riallinea l'issue al perimetro reale. Mai aprire un doppione.
 
-### 2. Bootstrap
+Se il candidate non esiste, continua con la fase 2.
 
-Due modalità secondo il punto di partenza:
+### 2. Preview e decisione (1-2 chiamate)
 
-**Source nuova, hai un URL diretto al file:**
+Scopo: capire se la fonte è utilizzabile prima di generare scaffold.
+
+```bash
+# Se è un portale CKAN:
+toolkit_ckan_package_show(endpoint="https://portale.it", package_id="dataset-slug")
+# → risorse, formato, DataStore, metadati
+
+# Se è un file diretto CSV/TSV:
+toolkit_preview_url("https://sito.it/dati.csv")
+# → colonne, tipi, encoding, qualità
+
+# Se non sai cos'è:
+toolkit_probe_url_routed("https://sito.it/pagina")
+# → routing automatico: CKAN | HTML | file
+```
+
+Se la fonte è ok → prosegui. Se è borderline → documenta il rischio nell'issue.
+
+### 3. Bootstrap
 
 ```bash
 cd candidates
-toolkit scout https://example.com/data.csv --scaffold
+toolkit scout https://sito.it/dati.csv --scaffold
 cd ..
 ```
 
 `toolkit scout --scaffold` (alias `-s`) genera: `dataset.yml`, `sql/clean.sql`,
-`sql/mart.sql`, `README.md`, `notes.md`, `notebooks/`. Lo scaffold è creato in
-`./{slug}/` — esegui il comando da dentro `candidates/` per avere il candidate
-nella posizione giusta.
+`sql/mart.sql`, `README.md`, `notes.md`, `notebooks/`.
 
-Se vuoi anche eseguire subito il run raw dopo lo scaffold, aggiungi `--run` (alias `-r`).
-
-**Candidate strutturato già esistente, vuoi rigenerare lo scaffold:**
+Se il candidate esiste già ma vuoi rigenerare lo scaffold:
 ```bash
 toolkit run raw -c candidates/{slug}/dataset.yml -y 2024
 ```
 
-### 3. Struttura
+### 4. Run
 
-Completa quello che `toolkit scout --scaffold` ha lasciato vuoto. Template in `templates/candidate/`:
-- `README.md` — descrivi il candidate
-- `notes.md` — domanda guida, rischi, note operative
-- `notebooks/<slug>_v0.ipynb` — copia dal template, imposta `METRICA` / `METRICA_CLEAN` nella cella setup
-
-Se il candidate usa `support`, verifica che sia necessario e non sostituibile con un join a mart esistente.
-
-### 4. Revisiona scaffold
-
-Prima di lanciare il run, revisiona:
-
+Prima di runnare, revisiona velocemente:
 - `sql/clean.sql` — deve leggere da `raw_input`, niente parsing inline
-- `clean.read` — parsing RAW esplicito quando serve (encoding, delimiter, skip rows)
-- `dataset.yml` — campi `clean.read` e `clean.sql` coerenti col source profile
+- `clean.read` — parsing RAW esplicito quando serve (encoding, delimiter, skip)
+- `dataset.yml` — campi `clean.read` e `sql` coerenti col source profile
 - boundary clean/mart — clean raw-faithful, mart analitico
 
-### 5. Run e valida
-
-Vedi [run-candidate.md](./run-candidate.md) per procedura completa.
+Poi:
 
 ```bash
 toolkit run full --config candidates/{slug}/dataset.yml --years 2024
 ```
 
-Usa `--strict-config` per intercettare campi legacy o deprecati.
+Unico comando. Esegue raw + clean + mart + validate + readiness.
 
-Se fallisce → `toolkit_review_readiness(config_path)` per isolare il primo errore. Blocker specifico documentato, non formulaico.
+### 5. Verifica
+
+Prima lascia che la pipeline dica se è tutto ok, poi controlla che i dati abbiano senso.
+
+```bash
+# 1. Stato pipeline
+toolkit status -c candidates/{slug}/dataset.yml -y 2024 --json
+# Oppure MCP: toolkit_status(config_path) → paths, summary, readiness, run_stats
+
+# 2. Dati — conta righe e vedi un campione
+toolkit query -c candidates/{slug}/dataset.yml -l clean -y 2024 --sql "SELECT count(*) FROM data"
+toolkit query -c candidates/{slug}/dataset.yml -l clean -y 2024 --sql "SELECT * FROM data LIMIT 5"
+# Oppure MCP: toolkit_layer(config_path, layer="clean", mode="preview", limit=5)
+
+# 3. Se c'è mart, stessa verifica
+toolkit query -c candidates/{slug}/dataset.yml -l mart -y 2024 --sql "SELECT count(*) FROM data"
+toolkit query -c candidates/{slug}/dataset.yml -l mart -y 2024 --sql "SELECT * FROM data LIMIT 5"
+```
+
+I numeri sono nel range atteso? Le colonne sono quelle giuste? Se sì → candidate ok.
+
+Se la pipeline fallisce → diagnostica rapida:
+
+```bash
+# MCP
+toolkit_layer(config_path, layer="raw", mode="profile")   → encoding/delimiter
+toolkit_layer(config_path, layer="clean", mode="schema")  → schema parquet
+toolkit_schema_diff(config_path)                          → drift colonne tra anni
+
+# CLI
+toolkit inspect profile -c candidates/{slug}/dataset.yml --json
+toolkit inspect schema -c candidates/{slug}/dataset.yml --layer clean --json
+toolkit inspect schema-diff -c candidates/{slug}/dataset.yml --json
+```
+
+Blocker specifico documentato, non formulaico.
 
 ### 6. PR
 
@@ -106,7 +143,7 @@ Apri PR con:
 
 - PR aperta con candidate strutturato
 - issue e struttura coerenti
-- almeno un run verificato oppure blocker documentato
+- almeno un run full passato oppure blocker documentato
 - boundary clean/mart rispettato
 
 ## Dove orientarsi

--- a/skills/run-candidate.md
+++ b/skills/run-candidate.md
@@ -1,27 +1,27 @@
 ---
 name: run-candidate
-description: Skill canonico di dataset-incubator per eseguire un candidate, verificare gli output e chiudere con uno stato tecnico chiaro.
+description: Skill canonico per eseguire un candidate esistente e verificarne lo stato.
 license: MIT
 metadata:
-  version: "0.4"
+  version: "0.5"
   owner: "DataCivicLab"
-  tags: [dataset-incubator, run, candidate, validation]
+  tags: [dataset-incubator, run, candidate]
 ---
 
 # Skill: run-candidate
 
 Skill canonico di `dataset-incubator`.
-Versione: 0.4 - 2026-05-06
+Versione: 0.5 - 2026-06-17
 
 ## Obiettivo
 
-Eseguire un candidate esistente e chiudere con stato: `runnable` | `scaffolded_with_blocker` | `wait`.
+Eseguire un candidate già presente in `candidates/` e chiudere con stato:
+`runnable` | `scaffolded_with_blocker`.
 
 ## Entry point
 
-- Candidate con struttura minima (`dataset.yml`, `sql/`, `README.md` o `notes.md`)
-- Config entrypoint chiaro
-- Accesso a `toolkit/`
+- `candidates/{slug}/dataset.yml` esistente
+- Toolkit accessibile
 
 Stop: candidate immaturo, boundary clean/mart assente, problema di fase precedente.
 
@@ -30,93 +30,67 @@ Stop: candidate immaturo, boundary clean/mart assente, problema di fase preceden
 ### 1. Pre-flight
 
 ```bash
-toolkit inspect paths --config candidates/{slug}/dataset.yml --json
+toolkit status -c candidates/{slug}/dataset.yml -y 2024 --json
 ```
 
-Oppure MCP: `toolkit_inspect_paths(config_path)` → `run_file_count >= 1`, `latest_run.status` verificato.
+Oppure MCP: `toolkit_status(config_path)` → sezioni `paths_info` + `run_stats`.
 
 ### 2. Run
-
-Se il candidate è nuovo, manca `sql/clean.sql`, oppure lo scaffold non è ancora stato revisionato, non partire da `run all`.
-
-Bootstrap:
-
-```bash
-toolkit run raw -c candidates/{slug}/dataset.yml -y 2024
-```
-
-Poi revisiona prima di proseguire:
-
-- `sql/clean.sql` deve leggere da `raw_input`, non da `read_csv(...)`
-- `clean.read` deve descrivere il parsing RAW quando serve
-- eventuale proposta `clean.read`/profiling va incorporata nel `dataset.yml` solo dopo verifica
-
-Run completo, quando `clean.sql` e mart SQL sono presenti e revisionati:
 
 ```bash
 toolkit run full --config candidates/{slug}/dataset.yml --years 2024
 ```
 
-`run full` esegue run all + validate + readiness in un comando, e processa automaticamente i support dichiarati in `dataset.yml` prima del candidate.
-
-**`--years`**: specifica sempre l'anno. In CI viene rilevato automaticamente dalla matrice.
+Unico comando. Esegue raw + clean + mart + validate + readiness in sequenza.
 
 ### 3. Verifica
 
-La validazione è già inclusa in `run full`. Per eseguirla separatamente:
+Prima lo stato pipeline, poi controlla che i dati abbiano senso.
 
 ```bash
-toolkit validate all --config candidates/{slug}/dataset.yml --years 2024
+# Stato pipeline
+toolkit status -c candidates/{slug}/dataset.yml -y 2024 --json
+# Oppure MCP: toolkit_status(config_path) → sezione readiness
+
+# Ispezione dati — conta righe e campione
+toolkit query -c candidates/{slug}/dataset.yml -l clean -y 2024 --sql "SELECT count(*) FROM data"
+toolkit query -c candidates/{slug}/dataset.yml -l clean -y 2024 --sql "SELECT * FROM data LIMIT 5"
+# Oppure MCP: toolkit_layer(config_path, layer="clean", mode="preview", limit=5)
+
+# Se c'è mart
+toolkit query -c candidates/{slug}/dataset.yml -l mart -y 2024 --sql "SELECT count(*) FROM data"
+toolkit query -c candidates/{slug}/dataset.yml -l mart -y 2024 --sql "SELECT * FROM data LIMIT 5"
 ```
 
-Oppure MCP: `toolkit_review_readiness(config_path)` → `ready | needs-review | incomplete`.
-
-`validate all` controlla: esistenza parquet, coerenza run record/output, schema layer vs config.
-
-### 4. Isola blocker se fallisce
-
-In CI `blocker_count > 0` è gate hard — la PR fallisce.
-
-In locale:
+### 4. Diagnostica (se fallisce)
 
 ```bash
-toolkit review-readiness --config candidates/{slug}/dataset.yml --year 2024 --json
+# MCP (raccomandato)
+toolkit_layer(config_path, layer="raw", mode="profile")   → encoding/delimiter
+toolkit_layer(config_path, layer="clean", mode="schema")  → schema parquet
+toolkit_schema_diff(config_path)                           → drift colonne tra anni
+toolkit_list_runs(config_path, status="FAILED", limit=5)  → pattern di fallimento
+
+# CLI equivalente
+toolkit inspect profile -c candidates/{slug}/dataset.yml --json
+toolkit inspect schema -c candidates/{slug}/dataset.yml --layer clean --json
+toolkit inspect schema-diff -c candidates/{slug}/dataset.yml --json
 ```
 
-Se il blocker è isolato → documenta e passa a stato `scaffolded_with_blocker`.
+Se il blocker è isolato → documentalo e chiudi con `scaffolded_with_blocker`.
 
-### 5. Diagnostica rapida (se serve)
+### 5. Chiudi con stato
 
-```
-toolkit_summary(config_path)         → tutti i layer a colpo d'occhio
-toolkit_inspect_schema(config_path, layer="clean") → schema parquet prima di scrivere SQL
-toolkit_inspect_profile(config_path)      → encoding/delimiter dopo raw fallito
-toolkit_list_runs(config_path, status="FAILED", limit=5) → pattern di fallimento
-toolkit_run_summary(config_path)      → isolato o ricorrente?
-toolkit_schema_diff(config_path)      → confronto schema raw cross-year (colonne, encoding)
-```
-
-**Quando usare `schema_diff`**:
-- Dopo fallimento raw parsing — per vedere se encoding o colonne sono cambiate tra anni
-- Prima di lanciare run su tutti gli anni — verifica consistenza schema source
-- Durante review di candidate — segnala drift strutturale tra annualità
-
-### 6. Chiudi con stato
-
-- `runnable` — run passa, output leggibili
+- `runnable` — run full passa, output leggibili
 - `scaffolded_with_blocker` — blocker preciso documentato
-- `wait` — manca un pezzo di fase precedente
 
 ## Definition of done
 
-- entrypoint chiaro
-- esito netto
-- output verificato oppure blocker preciso
-- prossimo passo esplicito
+- run full eseguito senza errori oppure blocker documentato
+- esito netto, prossimo passo esplicito
 
 ## Errori tipici
 
-- partire dal config sbagliato
 - lanciare compose prima dei source layer
 - guardare solo exit code, non gli output reali
 - cambiare troppe cose dopo il primo errore
@@ -124,5 +98,4 @@ toolkit_schema_diff(config_path)      → confronto schema raw cross-year (colon
 ## Dove orientarsi
 
 - [README.md](../README.md)
-- [CONTRIBUTING.md](../CONTRIBUTING.md)
 - [intake-candidate.md](./intake-candidate.md)


### PR DESCRIPTION
## Sintesi

Riscritte le due skill core di dataset-incubator per usare i tool MCP aggregati (`status`, `layer`, `query`) invece dei tool granulari, con un flusso intake più efficiente.

## Cosa cambia

- [ ] candidate — nuovo dataset o aggiornamento
- [ ] support — dataset di supporto
- [x] docs — struttura candidate, README, template
- [x] cleanup — refactoring, rimozioni, allineamento
- [ ] workflow o CI
- [ ] altro

## Dettaglio

### `intake-candidate.md` (0.5 → 0.6)

Ristrutturato il flusso intake:

1. **Valuta e allinea** — invariato
2. **Preview e decisione** (NUOVO) — `probe_url_routed` / `ckan_package_show` / `preview_url` per capire se la fonte è utilizzabile prima di generare scaffold
3. **Bootstrap** — `scout --scaffold`
4. **Run** — `run full` unico comando
5. **Verifica** — `status` per pipeline + `query` per conteggio righe e campione dati
6. **Diagnostica** — `layer` + `schema_diff` se fallisce
7. **PR**

### `run-candidate.md` (0.4 → 0.5)

Skill snellita focalizzata solo su candidate già esistente:

- **Pre-flight**: `status` invece di `inspect paths`
- **Run**: `run full` unico comando
- **Verifica**: `status` + `query` (conte righe e SELECT LIMIT 5)
- **Diagnostica**: `layer` + `schema_diff` + `list_runs`
- Rimossa sezione bootstrap (compito di intake-candidate)
- Rimosso stato `wait` (mai usato)

### Sostituzioni MCP/CLI applicate

| Dov'era | Ora |
|---------|-----|
| `inspect paths` | `status -c ... -y 2024 --json` |
| `review-readiness` | `status -c ... --json` (sezione readiness) |
| `inspect_schema` | `layer(mode=schema)` / `inspect schema` |
| `inspect_profile` | `layer(mode=profile)` / `inspect profile` |
| `summary` + `run_summary` | `status` |
| *(mancante)* | `query -c ... --sql "SELECT count(*)"` per dati concreti |

## Impatto

- [ ] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
- [x] Solo documentazione o metadati
- [ ] Nessun impatto visibile per chi usa il repository

## Verifica

Le modifiche sono solo testuali (markdown). I tool referenziati esistono e sono stati verificati:

- `toolkit status -c ... --json` ✅ (CLI)
- `toolkit query -c ... -l clean ...` ✅ (CLI)
- `toolkit_status`, `toolkit_layer`, `toolkit_schema_diff` ✅ (MCP, testati)

### PR collegata
- toolkit [#384](https://github.com/dataciviclab/toolkit/pull/384): fix `list_candidates` e `ckan_package_show` necessari per i tool aggregati

## Note / rischi

- Le nuove skill presuppongono che `toolkit run full` esista e funzioni (già presente)
- `toolkit query -c ... -l mart` richiede mart presente nel dataset.yml
- Il server MCP del toolkit va riavviato per avere i fix di #384
