### PR TITLE
feat(mcp): rimuovi 5 tool wrapper SQL, aggiungi dataset_overview

### DIFF
--- a/tests/test_clean_query_pure_units.py
+++ b/tests/test_clean_query_pure_units.py
@@ -194,24 +194,27 @@ def test_cache_stats(monkeypatch):
     from tools.clean_query_mcp import catalog
 
     monkeypatch.setattr(
-        catalog, "gcs_cache_stats", lambda: {"parquet_files": 10, "cached_bytes": 1000}
+        catalog,
+        "gcs_cache_stats",
+        lambda: {"total_entries": 2, "valid_entries": 2, "ttl_sec": 300, "entries": []},
     )
     result = server.cache_stats()
-    assert result["parquet_files"] == 10
+    assert "gcs_path_resolution" in result
+    assert "query_results" in result
+    assert result["gcs_path_resolution"]["total_entries"] == 2
 
 
 # ---------------------------------------------------------------------------
 # dataset_overview: test mockati, nessun DuckDB reale
 # ---------------------------------------------------------------------------
 
-_OVERVIEW_SLUG = "test_overview"
 _OVERVIEW_COLS = [
     {"name": "anno", "type": "BIGINT", "role": "dimension"},
     {"name": "regione", "type": "VARCHAR", "role": "dimension"},
     {"name": "valore", "type": "DOUBLE", "role": "metric"},
 ]
 _OVERVIEW_DESC = {
-    "slug": _OVERVIEW_SLUG,
+    "slug": "test_overview",
     "name": "Test Overview",
     "description": "Un dataset di test",
     "source": "Test Source",
@@ -219,15 +222,27 @@ _OVERVIEW_DESC = {
     "columns": _OVERVIEW_COLS,
 }
 
+_COUNT_OK = [{"columns": ["total"], "rows": [[5]]}]
+_PREVIEW_OK = [{"columns": ["anno", "regione", "valore"], "rows": [[2020, "Lombardia", 100.0]]}]
+_BATCH_OK = _COUNT_OK + _PREVIEW_OK
+_BATCH_ERR = [{"error": "simulated duckdb error"}, {"error": "simulated duckdb error"}]
+_BATCH_EMPTY = [
+    {"columns": ["total"], "rows": [[0]]},
+    {"columns": ["anno", "regione", "valore"], "rows": []},
+]
+
 
 class TestDatasetOverview:
-    def test_limit_invalid(self, monkeypatch):
-        """Limite fuori range -> errore."""
-        result = server.dataset_overview(_OVERVIEW_SLUG, limit=0)
+    def setup_method(self):
+        """Pulisce la cache query tra un test e l'altro."""
+        server._query_cache.clear()
+
+    def test_limit_invalid(self):
+        result = server.dataset_overview("test_overview", limit=0)
         assert "error" in result
 
-    def test_limit_exceeds_hard_cap(self, monkeypatch):
-        result = server.dataset_overview(_OVERVIEW_SLUG, limit=server.MAX_ROWS_HARD_CAP + 1)
+    def test_limit_exceeds_hard_cap(self):
+        result = server.dataset_overview("test_overview", limit=server.MAX_ROWS_HARD_CAP + 1)
         assert "error" in result
 
     def test_schema_error_propagated(self, monkeypatch):
@@ -235,61 +250,60 @@ class TestDatasetOverview:
         result = server.dataset_overview("inesistente")
         assert "error" in result
 
-    def test_execute_sql_error_propagated(self, monkeypatch):
-        """Se _execute_sql fallisce, l'errore è nel risultato."""
+    def test_batch_error_propagated(self, monkeypatch):
+        """Se _execute_sql_batch fallisce, l'errore è nel risultato."""
         monkeypatch.setattr(server, "describe_impl", lambda s: _OVERVIEW_DESC)
-
-        def fake_execute(*args, **kwargs):
-            return {"error": "simulated duckdb error"}
-
-        monkeypatch.setattr(server, "_execute_sql", fake_execute)
-        result = server.dataset_overview(_OVERVIEW_SLUG)
+        monkeypatch.setattr(server, "_execute_sql_batch", lambda *a, **kw: _BATCH_ERR)
+        # Usa slug diverso per evitare cache
+        result = server.dataset_overview("overview_batch_err")
         assert "error" in result
         assert "simulated" in result["error"]
 
     def test_returns_schema_fields(self, monkeypatch):
         """I campi dello schema sono presenti nell'output."""
         monkeypatch.setattr(server, "describe_impl", lambda s: _OVERVIEW_DESC)
-        monkeypatch.setattr(
-            server,
-            "_execute_sql",
-            lambda *a, **kw: {
-                "columns": ["anno", "regione", "valore", "total_rows"],
-                "rows": [[2020, "Lombardia", 100.0, 5]],
-            },
-        )
-        result = server.dataset_overview(_OVERVIEW_SLUG)
-        assert result["slug"] == _OVERVIEW_SLUG
+        monkeypatch.setattr(server, "_execute_sql_batch", lambda *a, **kw: _BATCH_OK)
+        result = server.dataset_overview("overview_fields")
+        assert result["slug"] == "overview_fields"
         assert result["name"] == "Test Overview"
         assert result["total_rows"] == 5
         assert result["preview"]["row_count"] == 1
+        assert result["_cached"] is False
 
-    def test_preview_columns_exclude_total_rows(self, monkeypatch):
-        """La colonna total_rows non deve apparire nelle preview columns."""
+    def test_cache_hit(self, monkeypatch):
+        """Seconda chiamata con stesso slug+limit deve tornare cached."""
         monkeypatch.setattr(server, "describe_impl", lambda s: _OVERVIEW_DESC)
-        monkeypatch.setattr(
-            server,
-            "_execute_sql",
-            lambda *a, **kw: {
-                "columns": ["anno", "regione", "valore", "total_rows"],
-                "rows": [[2020, "Lombardia", 100.0, 5]],
-            },
-        )
-        result = server.dataset_overview(_OVERVIEW_SLUG)
-        assert "total_rows" not in result["preview"]["columns"]
+        monkeypatch.setattr(server, "_execute_sql_batch", lambda *a, **kw: _BATCH_OK)
+        # Prima chiamata — popola cache
+        r1 = server.dataset_overview("overview_cache_test")
+        assert r1["total_rows"] == 5
+        assert r1["_cached"] is False
+
+        # Seconda chiamata — deve venire da cache (describe_impl non mockato fallirebbe)
+        monkeypatch.setattr(server, "describe_impl", lambda s: {"error": "should not be called"})
+        r2 = server.dataset_overview("overview_cache_test")
+        assert r2["total_rows"] == 5
+
+    def test_preview_columns_structure(self, monkeypatch):
+        """Le preview columns non devono contenere campi aggiuntivi."""
+        monkeypatch.setattr(server, "describe_impl", lambda s: _OVERVIEW_DESC)
+        monkeypatch.setattr(server, "_execute_sql_batch", lambda *a, **kw: _BATCH_OK)
+        result = server.dataset_overview("overview_preview_cols")
         assert result["preview"]["columns"] == ["anno", "regione", "valore"]
+
+    def test_preview_rows_type(self, monkeypatch):
+        """Le righe di preview sono liste (non tuple)."""
+        monkeypatch.setattr(server, "describe_impl", lambda s: _OVERVIEW_DESC)
+        monkeypatch.setattr(server, "_execute_sql_batch", lambda *a, **kw: _BATCH_OK)
+        result = server.dataset_overview("overview_rows_type")
+        row = result["preview"]["rows"][0]
+        assert isinstance(row, list)
+        assert row == [2020, "Lombardia", 100.0]
 
     def test_empty_dataset(self, monkeypatch):
         """Dataset vuoto -> total_rows = 0, preview vuoto."""
         monkeypatch.setattr(server, "describe_impl", lambda s: _OVERVIEW_DESC)
-        monkeypatch.setattr(
-            server,
-            "_execute_sql",
-            lambda *a, **kw: {
-                "columns": ["anno", "regione", "valore", "total_rows"],
-                "rows": [],
-            },
-        )
-        result = server.dataset_overview(_OVERVIEW_SLUG)
+        monkeypatch.setattr(server, "_execute_sql_batch", lambda *a, **kw: _BATCH_EMPTY)
+        result = server.dataset_overview("overview_empty")
         assert result["total_rows"] == 0
         assert result["preview"]["row_count"] == 0

--- a/tests/test_clean_query_pure_units.py
+++ b/tests/test_clean_query_pure_units.py
@@ -204,6 +204,97 @@ def test_cache_stats(monkeypatch):
     assert result["gcs_path_resolution"]["total_entries"] == 2
 
 
+def test_column_search(monkeypatch):
+    """column_search cerca in nome dataset, descrizione e colonne."""
+    fake_catalog = [
+        {
+            "slug": "ds_redditi",
+            "name": "Redditi Comunali",
+            "description": "Dati reddito per comune",
+            "source": "MEF",
+            "period": {"start": 2020, "end": 2024},
+            "columns": [
+                {"name": "anno", "type": "BIGINT", "role": "dimension"},
+                {"name": "regione", "type": "VARCHAR", "role": "dimension", "description": "Regione"},
+                {"name": "reddito_totale", "type": "DOUBLE", "role": "metric", "description": "Reddito totale"},
+            ],
+        },
+        {
+            "slug": "ds_popolazione",
+            "name": "Popolazione",
+            "description": "Popolazione italiana",
+            "source": "ISTAT",
+            "period": {"start": 2022, "end": 2024},
+            "columns": [
+                {"name": "anno", "type": "BIGINT", "role": "dimension"},
+                {"name": "popolazione", "type": "BIGINT", "role": "metric"},
+            ],
+        },
+    ]
+    monkeypatch.setattr(server, "load_catalog", lambda: fake_catalog)
+
+    # Match per nome colonna
+    res = server.column_search("reddito")
+    assert res["count"] == 1
+    assert res["datasets"][0]["slug"] == "ds_redditi"
+    assert len(res["datasets"][0]["matched_columns"]) == 1
+
+    # Match per meta dataset
+    res = server.column_search("popolazione")
+    assert res["count"] == 1
+    assert res["datasets"][0]["meta_match"] is True
+
+    # Nessun match
+    res = server.column_search("xyz_notfound")
+    assert res["count"] == 0
+
+
+def test_find_metric_datasets(monkeypatch):
+    """find_metric_datasets cerca dataset con colonne role=metric."""
+    fake_catalog = [
+        {
+            "slug": "ds_con_metriche",
+            "name": "Con Metriche",
+            "source": "Test",
+            "period": {"start": 2020, "end": 2024},
+            "columns": [
+                {"name": "valore", "type": "DOUBLE", "role": "metric", "description": "Valore"},
+            ],
+        },
+        {
+            "slug": "ds_senza_metriche",
+            "name": "Senza Metriche",
+            "source": "Test",
+            "period": {"start": 2020, "end": 2024},
+            "columns": [
+                {"name": "nome", "type": "VARCHAR", "role": "dimension"},
+            ],
+        },
+    ]
+    monkeypatch.setattr(server, "load_catalog", lambda: fake_catalog)
+
+    res = server.find_metric_datasets()
+    assert res["count"] == 1
+    assert res["datasets"][0]["slug"] == "ds_con_metriche"
+    assert len(res["datasets"][0]["metric_columns"]) == 1
+
+    # Filtro per nome metrica
+    res = server.find_metric_datasets(metric_name="valore")
+    assert res["count"] == 1
+
+    # Filtro per nome metrica inesistente
+    res = server.find_metric_datasets(metric_name="fake_metric")
+    assert res["count"] == 0
+
+    # Filtro per query
+    res = server.find_metric_datasets(query="metriche")
+    assert res["count"] == 1
+
+    # Query senza match
+    res = server.find_metric_datasets(query="xyz")
+    assert res["count"] == 0
+
+
 # ---------------------------------------------------------------------------
 # dataset_overview: test mockati, nessun DuckDB reale
 # ---------------------------------------------------------------------------
@@ -307,3 +398,25 @@ class TestDatasetOverview:
         result = server.dataset_overview("overview_empty")
         assert result["total_rows"] == 0
         assert result["preview"]["row_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Entry point, cache GCS
+# ---------------------------------------------------------------------------
+
+
+def test_main_exists():
+    """main() è callable (non la eseguiamo, bloccherebbe il server)."""
+    assert callable(server.main)
+
+
+def test_gcs_cache_clear(monkeypatch):
+    """gcs_cache_clear pulisce la cache GCS."""
+    from tools.clean_query_mcp import catalog as cat_mod
+
+    # Popola cache con un entry finto
+    cat_mod._gcs_res_cache[("test", 2024)] = (1000.0, ["gs://fake/test.parquet"])
+    cat_mod.gcs_cache_clear()
+    stats = cat_mod.gcs_cache_stats()
+    assert stats["total_entries"] == 0
+    assert stats["valid_entries"] == 0

--- a/tests/test_clean_query_pure_units.py
+++ b/tests/test_clean_query_pure_units.py
@@ -201,73 +201,95 @@ def test_cache_stats(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# aggregate: logica pura, nessun DuckDB, solo describe_impl mockato
+# dataset_overview: test mockati, nessun DuckDB reale
 # ---------------------------------------------------------------------------
 
-_SLUG = "test_aggregate"
-_COLS = [
+_OVERVIEW_SLUG = "test_overview"
+_OVERVIEW_COLS = [
     {"name": "anno", "type": "BIGINT", "role": "dimension"},
     {"name": "regione", "type": "VARCHAR", "role": "dimension"},
     {"name": "valore", "type": "DOUBLE", "role": "metric"},
 ]
-_AGG_DESC = {"slug": _SLUG, "columns": _COLS, "period": {"start_year": 2020, "end_year": 2024}}
-_AGG_DESC_NO_YEAR = {"slug": _SLUG, "columns": _COLS}
+_OVERVIEW_DESC = {
+    "slug": _OVERVIEW_SLUG,
+    "name": "Test Overview",
+    "description": "Un dataset di test",
+    "source": "Test Source",
+    "period": {"start_year": 2020, "end_year": 2024},
+    "columns": _OVERVIEW_COLS,
+}
 
 
-def _mock_aggregate(monkeypatch, desc=_AGG_DESC):
-    monkeypatch.setattr(server, "describe_impl", lambda s: desc)
-    monkeypatch.setattr(server, "get_year_column", lambda s: "anno")
-
-
-class TestAggregate:
-    def test_metric_empty(self, monkeypatch):
-        _mock_aggregate(monkeypatch)
-        result = server.aggregate(_SLUG, "", ["regione"])
+class TestDatasetOverview:
+    def test_limit_invalid(self, monkeypatch):
+        """Limite fuori range -> errore."""
+        result = server.dataset_overview(_OVERVIEW_SLUG, limit=0)
         assert "error" in result
 
-    def test_group_by_empty(self, monkeypatch):
-        _mock_aggregate(monkeypatch)
-        result = server.aggregate(_SLUG, "valore", [])
+    def test_limit_exceeds_hard_cap(self, monkeypatch):
+        result = server.dataset_overview(_OVERVIEW_SLUG, limit=server.MAX_ROWS_HARD_CAP + 1)
         assert "error" in result
 
     def test_schema_error_propagated(self, monkeypatch):
-        monkeypatch.setattr(server, "describe_impl", lambda s: {"error": "schema not found"})
-        result = server.aggregate(_SLUG, "valore", ["regione"])
+        monkeypatch.setattr(server, "describe_impl", lambda s: {"error": "not found"})
+        result = server.dataset_overview("inesistente")
         assert "error" in result
 
-    def test_invalid_group_by_column(self, monkeypatch):
-        _mock_aggregate(monkeypatch)
-        result = server.aggregate(_SLUG, "valore", ["inesistente"])
+    def test_execute_sql_error_propagated(self, monkeypatch):
+        """Se _execute_sql fallisce, l'errore è nel risultato."""
+        monkeypatch.setattr(server, "describe_impl", lambda s: _OVERVIEW_DESC)
+
+        def fake_execute(*args, **kwargs):
+            return {"error": "simulated duckdb error"}
+
+        monkeypatch.setattr(server, "_execute_sql", fake_execute)
+        result = server.dataset_overview(_OVERVIEW_SLUG)
         assert "error" in result
-        assert "inesistente" in result["error"]
+        assert "simulated" in result["error"]
 
-    def test_invalid_metric(self, monkeypatch):
-        _mock_aggregate(monkeypatch)
-        result = server.aggregate(_SLUG, "fake_metric", ["regione"])
-        assert "error" in result
-
-    def test_generates_sql(self, monkeypatch):
-        _mock_aggregate(monkeypatch)
-        result = server.aggregate(_SLUG, "valore", ["regione"])
-        assert "sql" in result
-        assert "SUM(valore)" in result["sql"]
-        assert "GROUP BY regione" in result["sql"]
-
-    def test_with_year_filter(self, monkeypatch):
-        _mock_aggregate(monkeypatch)
-        result = server.aggregate(_SLUG, "valore", ["regione"], year=2023)
-        assert "WHERE anno = 2023" in result["sql"]
-
-    def test_with_filters(self, monkeypatch):
-        _mock_aggregate(monkeypatch)
-        result = server.aggregate(
-            _SLUG, "valore", ["regione"], filters="anno = 2023 AND regione = 'Lombardia'"
+    def test_returns_schema_fields(self, monkeypatch):
+        """I campi dello schema sono presenti nell'output."""
+        monkeypatch.setattr(server, "describe_impl", lambda s: _OVERVIEW_DESC)
+        monkeypatch.setattr(
+            server,
+            "_execute_sql",
+            lambda *a, **kw: {
+                "columns": ["anno", "regione", "valore", "total_rows"],
+                "rows": [[2020, "Lombardia", 100.0, 5]],
+            },
         )
-        assert "WHERE" in result["sql"]
-        assert "Lombardia" in result["sql"]
+        result = server.dataset_overview(_OVERVIEW_SLUG)
+        assert result["slug"] == _OVERVIEW_SLUG
+        assert result["name"] == "Test Overview"
+        assert result["total_rows"] == 5
+        assert result["preview"]["row_count"] == 1
 
-    def test_no_year_column_no_filter(self, monkeypatch):
-        monkeypatch.setattr(server, "describe_impl", lambda s: _AGG_DESC_NO_YEAR)
-        monkeypatch.setattr(server, "get_year_column", lambda s: None)
-        result = server.aggregate(_SLUG, "valore", ["regione"], year=2023)
-        assert "WHERE" not in result["sql"]
+    def test_preview_columns_exclude_total_rows(self, monkeypatch):
+        """La colonna total_rows non deve apparire nelle preview columns."""
+        monkeypatch.setattr(server, "describe_impl", lambda s: _OVERVIEW_DESC)
+        monkeypatch.setattr(
+            server,
+            "_execute_sql",
+            lambda *a, **kw: {
+                "columns": ["anno", "regione", "valore", "total_rows"],
+                "rows": [[2020, "Lombardia", 100.0, 5]],
+            },
+        )
+        result = server.dataset_overview(_OVERVIEW_SLUG)
+        assert "total_rows" not in result["preview"]["columns"]
+        assert result["preview"]["columns"] == ["anno", "regione", "valore"]
+
+    def test_empty_dataset(self, monkeypatch):
+        """Dataset vuoto -> total_rows = 0, preview vuoto."""
+        monkeypatch.setattr(server, "describe_impl", lambda s: _OVERVIEW_DESC)
+        monkeypatch.setattr(
+            server,
+            "_execute_sql",
+            lambda *a, **kw: {
+                "columns": ["anno", "regione", "valore", "total_rows"],
+                "rows": [],
+            },
+        )
+        result = server.dataset_overview(_OVERVIEW_SLUG)
+        assert result["total_rows"] == 0
+        assert result["preview"]["row_count"] == 0

--- a/tests/test_clean_query_sql_guards.py
+++ b/tests/test_clean_query_sql_guards.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import unittest
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -48,93 +47,6 @@ class CleanQuerySqlGuardTest(unittest.TestCase):
     def test_blocks_above_hard_cap(self) -> None:
         with self.assertRaises(server.DuckdbClientError):
             server._guard_max_rows(server.MAX_ROWS_HARD_CAP + 1)
-
-
-# ─── Contract: year → WHERE anno = year in count / preview / time_series ─────
-
-
-def _make_mock_conn() -> MagicMock:
-    """Build a mock DuckDB connection that captures execute SQL."""
-    conn = MagicMock()
-    conn.execute.return_value.description = [("col",)]
-    conn.execute.return_value.fetchone.return_value = (0,)
-    conn.execute.return_value.fetchall.return_value = []
-    return conn
-
-
-_SLUG = "giustizia_penale_indicatori"  # single-file, multi-year (2014-2024)
-
-
-class CleanQueryYearFilterContractTest(unittest.TestCase):
-    """Verifica che year=... inietti WHERE <year_col> = <year> nella SQL.
-
-    Copre i tre tool che il fix ha modificato: count, preview (via _duckdb_read), time_series.
-    """
-
-    @patch("lab_connectors.duckdb.gcs_connect")
-    @patch.object(server, "resolve_parquet_path")
-    def test_count_injects_year_filter(self, mock_resolve: MagicMock, mock_sc: MagicMock) -> None:
-        mock_resolve.return_value = ["gs://fake/giustizia_penale_indicatori_2024.parquet"]
-        conn = _make_mock_conn()
-        mock_sc.return_value.__enter__.return_value = conn
-
-        server.count(_SLUG, year=2024)
-
-        sql = conn.execute.call_args[0][0]
-        self.assertIn("WHERE anno = 2024", sql)
-
-    @patch("lab_connectors.duckdb.gcs_connect")
-    @patch.object(server, "resolve_parquet_path")
-    def test_count_no_year_no_filter(self, mock_resolve: MagicMock, mock_sc: MagicMock) -> None:
-        mock_resolve.return_value = ["gs://fake/giustizia_penale_indicatori_2024.parquet"]
-        conn = _make_mock_conn()
-        mock_sc.return_value.__enter__.return_value = conn
-
-        server.count(_SLUG)
-
-        sql = conn.execute.call_args[0][0]
-        self.assertNotIn("WHERE", sql)
-
-    @patch("lab_connectors.duckdb.gcs_connect")
-    @patch.object(server, "resolve_parquet_path")
-    def test_preview_injects_year_filter(self, mock_resolve: MagicMock, mock_sc: MagicMock) -> None:
-        """preview usa _duckdb_read, che ora inietta il filtro anno."""
-        mock_resolve.return_value = ["gs://fake/giustizia_penale_indicatori_2024.parquet"]
-        conn = _make_mock_conn()
-        mock_sc.return_value.__enter__.return_value = conn
-
-        server.preview(_SLUG, year=2024)
-
-        sql = conn.execute.call_args[0][0]
-        self.assertIn("WHERE anno = 2024", sql)
-
-    @patch("lab_connectors.duckdb.gcs_connect")
-    @patch.object(server, "resolve_parquet_path")
-    def test_time_series_injects_year_filter(
-        self, mock_resolve: MagicMock, mock_sc: MagicMock
-    ) -> None:
-        mock_resolve.return_value = ["gs://fake/giustizia_penale_indicatori_2024.parquet"]
-        conn = _make_mock_conn()
-        mock_sc.return_value.__enter__.return_value = conn
-
-        server.time_series(_SLUG, "disposition_time_gg", "distretto", year=2024)
-
-        sql = conn.execute.call_args[0][0]
-        self.assertIn("WHERE anno = 2024", sql)
-
-    @patch("lab_connectors.duckdb.gcs_connect")
-    @patch.object(server, "resolve_parquet_path")
-    def test_time_series_no_year_no_filter(
-        self, mock_resolve: MagicMock, mock_sc: MagicMock
-    ) -> None:
-        mock_resolve.return_value = ["gs://fake/giustizia_penale_indicatori_2024.parquet"]
-        conn = _make_mock_conn()
-        mock_sc.return_value.__enter__.return_value = conn
-
-        server.time_series(_SLUG, "disposition_time_gg", "distretto")
-
-        sql = conn.execute.call_args[0][0]
-        self.assertNotIn("WHERE", sql)
 
 
 # ─── Unit: _inject_year_filter (pure function) ──────────────────────────────

--- a/tools/clean_query_mcp/README.md
+++ b/tools/clean_query_mcp/README.md
@@ -29,20 +29,13 @@ Il file locale `datasets.yml` non è più fonte di verità. Il catalogo MCP deve
 | `dataset_overview(slug, limit)` | Panoramica completa: schema + conteggio righe + anteprima in una chiamata |
 | `describe_dataset(slug)` | Schema completo: colonne, tipi, ruolo, periodo |
 
-### Query diretta
-
-| Tool | Scopo |
-|---|---|
-| `run_query(sql, dataset, max_rows, year)` | Query DuckDB read-only — solo SELECT/WITH, hard cap 500 righe |
-| `explain_query(sql, dataset)` | Valida SQL senza eseguirla — stima validità e risolve parquet |
-
 ### Query e debug
 
 | Tool | Scopo |
 |---|---|
 | `run_query(sql, dataset, max_rows, year)` | Query DuckDB read-only — solo SELECT/WITH, hard cap 500 righe |
 | `explain_query(sql, dataset)` | Valida SQL senza eseguirla — stima validità e risolve parquet |
-| `cache_stats()` | Stato della cache GCS — utile per debug
+| `cache_stats()` | Stato delle cache (GCS path resolution + risultati query) — utile per debug
 
 ## Runtime
 

--- a/tools/clean_query_mcp/README.md
+++ b/tools/clean_query_mcp/README.md
@@ -22,20 +22,19 @@ Il file locale `datasets.yml` non è più fonte di verità. Il catalogo MCP deve
 | `find_metric_datasets(query, metric_name)` | Cerca dataset che abbiano colonne role=metric |
 | `column_search(query)` | Cerca sia in meta dataset che in nome/descrizione colonne |
 
-### Esplorazione senza SQL
+### Esplorazione semplificata
 
 | Tool | Scopo |
 |---|---|
-| `preview(dataset, limit, year)` | Prime N righe — no SQL, veloce per capire la struttura |
-| `count(dataset, year)` | Conteggio righe totale, con filtro anno opzionale |
-| `distinct_values(dataset, column, limit)` | Valori unici di una colonna — utile per UI filter |
+| `dataset_overview(slug, limit)` | Panoramica completa: schema + conteggio righe + anteprima in una chiamata |
+| `describe_dataset(slug)` | Schema completo: colonne, tipi, ruolo, periodo |
 
-### Analisi pre-costruita
+### Query diretta
 
 | Tool | Scopo |
 |---|---|
-| `aggregate(dataset, metric, group_by, filters, year)` | Helper: SQL di aggregazione pre-scritto, passa a `run_query()` |
-| `time_series(dataset, metric, group_by, year, limit)` | Serie storica metric×dimension nel tempo |
+| `run_query(sql, dataset, max_rows, year)` | Query DuckDB read-only — solo SELECT/WITH, hard cap 500 righe |
+| `explain_query(sql, dataset)` | Valida SQL senza eseguirla — stima validità e risolve parquet |
 
 ### Query e debug
 
@@ -101,32 +100,26 @@ gs://dataciviclab-clean/catalog/clean_catalog.json
 
 Pipeline: `source → raw → clean → mart → output`
 
-### Post-clean (verifica qualità)
+### Esplorazione iniziale
 
 Dopo `toolkit run --config candidates/{slug}/dataset.yml` e push GCS:
 
 ```python
-# 1. Verifica struttura e righe
-preview(slug, limit=5)          # prime righe — ok se non vuoto
-count(slug, year=2024)          # conteggio — confronta con atteso
+# 1. Panoramica completa (schema + conteggio + preview in un colpo)
+dataset_overview(slug, limit=5)
 
-# 2. Verifica schema
-describe_dataset(slug)          # colonne, tipi, role — per conferma contract
-
-# 3. Verifica valori chiave
-distinct_values(slug, 'regione')  # valori distinti — outlier visibility
+# 2. Verifica valori chiave
+run_query("SELECT DISTINCT regione FROM clean_input ORDER BY regione", slug)
 ```
 
-### Post-mart (analisi readiness)
-
-Dopo mart SQL e output parquet disponibili:
+### Analisi esplorativa
 
 ```python
-# 1. Serie storica disponibile?
-time_series(dataset, metric='spesa_convenzionata', group_by='regione')
+# 1. Serie storica per dimensione
+run_query("SELECT anno, regione, SUM(metric) AS value FROM clean_input GROUP BY anno, regione ORDER BY anno, regione", dataset)
 
-# 2. metriche aggregate
-aggregate(dataset, metric='totale_ru_tonnellate', group_by=['regione'], year=2024)
+# 2. Metriche aggregate
+run_query("SELECT regione, SUM(metric) AS total FROM clean_input GROUP BY regione ORDER BY total DESC", dataset)
 
 # 3. Query esplorativa
 run_query("SELECT regione, SUM(...) FROM clean_input GROUP BY regione", dataset)
@@ -134,7 +127,7 @@ run_query("SELECT regione, SUM(...) FROM clean_input GROUP BY regione", dataset)
 
 ### Pre-publication (validazione)
 
-Prima di aprire Discussion opromuovere su data-explorer:
+Prima di aprire Discussion o promuovere su data-explorer:
 
 ```python
 # 1. Quali dataset hanno metriche simili?
@@ -145,7 +138,7 @@ column_search('regione')                            # per capire coverage
 explain_query(sql, dataset)                         # senza eseguirla
 
 # 3. Verifica copertura temporale
-time_series(dataset, metric='...', group_by='regione', year=None)
+dataset_overview(slug)                              # period e total_rows
 ```
 
 ## Smoke test

--- a/tools/clean_query_mcp/catalog.py
+++ b/tools/clean_query_mcp/catalog.py
@@ -8,6 +8,7 @@ import json
 from pathlib import Path
 from typing import Any
 from lab_connectors.gcs import list_objects
+from lab_connectors.gcs.paths import glob_to_regex as _glob_to_regex_fn, parse_gs_url
 
 DI_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CATALOG_PATH = DI_ROOT / "registry" / "clean_catalog.json"
@@ -158,13 +159,12 @@ def resolve_parquet_path(slug: str, year: int | None = None) -> list[str]:
     elif loc["type"] == "gcs":
         raw = loc["path"]
         multi_file = loc.get("multi_file", False)
-        bucket_and_key = raw[5:]
-        bucket, key = bucket_and_key.split("/", 1)
+        bucket, key = parse_gs_url(raw)
 
         if multi_file and "*" in key:
             prefix = key.split("*")[0]
             blobs = _list_gcs_blobs(bucket, prefix=prefix)
-            pattern = _glob_to_regex(key)
+            pattern = re.compile(_glob_to_regex_fn(key))
             urls = []
             for blob_name in sorted(blobs):
                 if blob_name.endswith("_clean.parquet"):
@@ -229,16 +229,3 @@ def _list_gcs_blobs(bucket: str, prefix: str) -> list[str]:
     auth = _gcs_auth_mode()
     results = list_objects(bucket, prefix=prefix, auth=auth)
     return [r["name"] for r in results]
-
-
-def _glob_to_regex(pattern: str) -> re.Pattern:
-    """Convert a simple glob pattern (* only) to compiled regex."""
-    escaped = ""
-    for ch in pattern:
-        if ch == "*":
-            escaped += ".*"
-        elif ch in r"\.+(){}^$|":
-            escaped += "\\" + ch
-        else:
-            escaped += ch
-    return re.compile("^" + escaped + "$")

--- a/tools/clean_query_mcp/catalog.py
+++ b/tools/clean_query_mcp/catalog.py
@@ -15,6 +15,7 @@ def _glob_to_regex(pattern: str) -> re.Pattern:
     """Converte glob in regex compilata (delega a lab-connectors, compila per compatibilità)."""
     return re.compile(_glob_to_regex_str(pattern))
 
+
 DI_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CATALOG_PATH = DI_ROOT / "registry" / "clean_catalog.json"
 CATALOG_PATH = Path(os.environ.get("CLEAN_QUERY_CATALOG_PATH", DEFAULT_CATALOG_PATH))

--- a/tools/clean_query_mcp/catalog.py
+++ b/tools/clean_query_mcp/catalog.py
@@ -8,7 +8,12 @@ import json
 from pathlib import Path
 from typing import Any
 from lab_connectors.gcs import list_objects
-from lab_connectors.gcs.paths import glob_to_regex as _glob_to_regex_fn, parse_gs_url
+from lab_connectors.gcs.paths import glob_to_regex as _glob_to_regex_str, parse_gs_url
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern:
+    """Converte glob in regex compilata (delega a lab-connectors, compila per compatibilità)."""
+    return re.compile(_glob_to_regex_str(pattern))
 
 DI_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CATALOG_PATH = DI_ROOT / "registry" / "clean_catalog.json"
@@ -164,7 +169,7 @@ def resolve_parquet_path(slug: str, year: int | None = None) -> list[str]:
         if multi_file and "*" in key:
             prefix = key.split("*")[0]
             blobs = _list_gcs_blobs(bucket, prefix=prefix)
-            pattern = re.compile(_glob_to_regex_fn(key))
+            pattern = _glob_to_regex(key)
             urls = []
             for blob_name in sorted(blobs):
                 if blob_name.endswith("_clean.parquet"):

--- a/tools/clean_query_mcp/server.py
+++ b/tools/clean_query_mcp/server.py
@@ -110,20 +110,17 @@ def _validate_parquet_paths(paths: list[str]) -> None:
             )
 
 
-def _duckdb_read(
+def _execute_sql(
     dataset: str,
-    year: int | None,
-    wrapped_sql: str,
+    sql: str,
+    year: int | None = None,
     timeout: int = 60,
 ) -> dict[str, Any]:
-    """Helper per esecuzione DuckDB read-only su parquet GCS.
+    """Helper DuckDB unificato: risolve path, connette, esegue, ritorna {columns, rows}.
 
-    Estrae e condivide il pattern comune a preview/count/time_series/distinct_values:
-    - risoluzione path parquet
-    - costruzione source_expr
-    - connessione DuckDB in-memory
-    - esecuzione con timeout
-    - ritorno {columns, rows} o errore
+    Sostituisce la logica duplicata in preview/count/time_series/distinct_values/run_query.
+    Il parametro ``sql`` è il corpo della query che usa ``clean_input`` come FROM.
+    La CTE ``clean_input`` viene costruita automaticamente e lo year filter iniettato.
     """
     try:
         parquet_paths = resolve_parquet_path(dataset, year=year)
@@ -141,13 +138,13 @@ def _duckdb_read(
     else:
         source_expr = f"['{escaped_paths}']"
 
-    # Replace the placeholder in wrapped_sql if present
-    sql = wrapped_sql.replace("{SOURCE_EXPR}", source_expr)
-    # Inject year filter for single-file multi-year datasets (e.g. giustizia_penale_indicatori)
+    wrapped_sql = f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) {sql}"
+
+    # Inject year filter for single-file multi-year datasets (es. giustizia_penale_indicatori)
     if year is not None:
         year_col = get_year_column(dataset)
         if year_col:
-            sql = _inject_year_filter(sql, year_col, year)
+            wrapped_sql = _inject_year_filter(wrapped_sql, year_col, year)
 
     from lab_connectors.duckdb import gcs_connect
     import concurrent.futures
@@ -155,7 +152,7 @@ def _duckdb_read(
     with gcs_connect(parquet_paths[0]) as conn:
 
         def _run():
-            result = conn.execute(sql)
+            result = conn.execute(wrapped_sql)
             return [item[0] for item in (result.description or [])], result.fetchall()
 
         pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
@@ -318,11 +315,6 @@ def run_query(
     sql: str, dataset: str, max_rows: int = 100, year: int | None = None
 ) -> dict[str, Any]:
     try:
-        parquet_paths = resolve_parquet_path(dataset, year=year)
-    except (ValueError, FileNotFoundError) as exc:
-        return {"error": str(exc)}
-
-    try:
         _validate_scope(sql)
     except DuckdbClientError as exc:
         return {"error": str(exc)}
@@ -332,55 +324,19 @@ def run_query(
     except DuckdbClientError as exc:
         return {"error": str(exc)}
 
-    if year is not None:
-        year_col = get_year_column(dataset)
-        if year_col:
-            sql = _inject_year_filter(sql, year_col, year)
+    _guard_max_rows(max_rows)
 
-    try:
-        _validate_parquet_paths(parquet_paths)
-    except DuckdbClientError as exc:
-        return {"error": str(exc)}
-    escaped_paths = "', '".join(p.replace("'", "''") for p in parquet_paths)
-    if len(parquet_paths) == 1:
-        source_expr = f"'{escaped_paths}'"
-    else:
-        source_expr = f"['{escaped_paths}']"
-    wrapped_sql = (
-        f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) "
-        f"SELECT * FROM ({sql}) AS q LIMIT {max_rows + 1}"
-    )
+    wrapped_sql = f"SELECT * FROM ({sql}) AS q LIMIT {max_rows + 1}"
 
     def _exec() -> dict[str, Any]:
-        _guard_max_rows(max_rows)
-
-        from lab_connectors.duckdb import gcs_connect
-        import concurrent.futures
-
-        with gcs_connect(parquet_paths[0]) as conn:
-
-            def _run_query():
-                result = conn.execute(wrapped_sql)
-                columns = [item[0] for item in (result.description or [])]
-                rows_raw = result.fetchall()
-                return columns, rows_raw
-
-            # 60s hard timeout: ThreadPoolExecutor without 'with' so we don't
-            # wait for the worker to finish after timeout. The orphan thread will
-            # eventually finish and its connection is isolated (in-memory).
-            pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            try:
-                future = pool.submit(_run_query)
-                columns, rows_raw = future.result(timeout=60)
-            except concurrent.futures.TimeoutError:
-                return {"error": "Query timeout (60s). Ridurre la complessita o aggiungere filtri."}
-            finally:
-                pool.shutdown(wait=False)
-
+        result = _execute_sql(dataset, wrapped_sql, year=year)
+        if "error" in result:
+            return result
+        rows_raw = result["rows"]
         truncated = len(rows_raw) > max_rows
         rows = rows_raw[:max_rows]
         return {
-            "columns": columns,
+            "columns": result["columns"],
             "rows": [list(row) for row in rows],
             "row_count": len(rows),
             "truncated": truncated,
@@ -402,328 +358,54 @@ def cache_stats() -> dict[str, Any]:
 
 @mcp.tool(
     description=(
-        "Helper per aggregazioni pre-scritte: somma una metrica raggruppando per una o più dimensioni. "
-        "Restituisce SQL che può essere passato a run_query(). "
-        "metric: colonna numerica da sommare (es. 'numero_pensioni'). "
-        "group_by: lista di dimensioni (es. ['anno','regione']). "
-        "filters:WHERE aggiuntivo opzionale (es. \"anno = 2023 AND regione = 'Lombardia'\")."
+        "Panoramica completa di un dataset: schema + conteggio righe + anteprima dati. "
+        "Combina describe_dataset, count e preview in una singola chiamata. "
+        "Usa una sola connessione DuckDB per count e preview, riducendo la latenza. "
+        "Utile per esplorare rapidamente un dataset prima di scrivere query SQL."
     ),
     structured_output=True,
 )
-def aggregate(
-    dataset: str,
-    metric: str,
-    group_by: list[str],
-    filters: str | None = None,
-    year: int | None = None,
-) -> dict[str, Any]:
-    if not metric:
-        return {"error": "metric non può essere vuota"}
-    if not group_by:
-        return {"error": "group_by deve avere almeno una dimensione"}
-
-    schema = describe_impl(dataset)
-    if "error" in schema:
-        return schema
-    col_names = {c["name"] for c in schema.get("columns", [])}
-    for col in group_by:
-        if col not in col_names:
-            return {
-                "error": f"Colonna group_by '{col}' non trovata. Disponibili: {', '.join(sorted(col_names))}"
-            }
-    if metric not in col_names:
-        return {
-            "error": f"Metrica '{metric}' non trovata. Disponibili: {', '.join(sorted(col_names))}"
-        }
-
-    year_col = get_year_column(dataset)
-    where_parts = []
-    if year is not None and year_col:
-        where_parts.append(f"{year_col} = {year}")
-    if filters:
-        where_parts.append(f"({filters})")
-    where_clause = ""
-    if where_parts:
-        where_clause = "WHERE " + " AND ".join(where_parts)
-
-    group_cols = ", ".join(group_by)
-    sql = (
-        f"SELECT {group_cols}, SUM({metric}) AS total "
-        f"FROM clean_input {where_clause} "
-        f"GROUP BY {group_cols} "
-        f"ORDER BY {group_by[0]}, total DESC"
-    )
-    return {
-        "sql": sql,
-        "dataset": dataset,
-        "metric": metric,
-        "group_by": group_by,
-        "year": year,
-        "note": "Passa questo sql a run_query(). Non include LIMIT; aggiungilo in run_query.",
-    }
-
-
-@mcp.tool(
-    description=(
-        "Anteprima: prime N righe di un dataset senza SQL. "
-        "Utile per esplorare la struttura prima di scrivere una query. "
-        "Non usa SQL, ritorna righe raw dal parquet."
-    ),
-    structured_output=True,
-)
-def preview(dataset: str, limit: int = 10, year: int | None = None) -> dict[str, Any]:
+def dataset_overview(slug: str, limit: int = 10) -> dict[str, Any]:
     if limit <= 0 or limit > MAX_ROWS_HARD_CAP:
         return {"error": f"limit deve essere tra 1 e {MAX_ROWS_HARD_CAP}"}
-    wrapped_sql = (
-        f"WITH clean_input AS (SELECT * FROM read_parquet({{SOURCE_EXPR}})) "
-        f"SELECT * FROM clean_input LIMIT {limit}"
-    )
-    result = _duckdb_read(dataset, year, wrapped_sql)
-    if "error" in result:
-        return result
-    return {
-        "columns": result["columns"],
-        "rows": [list(row) for row in result["rows"]],
-        "row_count": len(result["rows"]),
-        "dataset": dataset,
-        "limit_applied": limit,
-    }
 
-
-@mcp.tool(
-    description=(
-        "Conteggio righe: numero totale di record in un dataset, opzionalmente filtrato per anno. "
-        "Utile per verificare copertura e dimensionalità prima di query complesse."
-    ),
-    structured_output=True,
-)
-def count(dataset: str, year: int | None = None) -> dict[str, Any]:
-    try:
-        parquet_paths = resolve_parquet_path(dataset, year=year)
-    except (ValueError, FileNotFoundError) as exc:
-        return {"error": str(exc)}
-
-    try:
-        _validate_parquet_paths(parquet_paths)
-    except DuckdbClientError as exc:
-        return {"error": str(exc)}
-
-    escaped_paths = "', '".join(p.replace("'", "''") for p in parquet_paths)
-    if len(parquet_paths) == 1:
-        source_expr = f"'{escaped_paths}'"
-    else:
-        source_expr = f"['{escaped_paths}']"
-
-    wrapped_sql = f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) SELECT COUNT(*) AS total FROM clean_input"
-    if year is not None:
-        year_col = get_year_column(dataset)
-        if year_col:
-            wrapped_sql = _inject_year_filter(wrapped_sql, year_col, year)
-
-    def _exec() -> dict[str, Any]:
-        from lab_connectors.duckdb import gcs_connect
-        import concurrent.futures
-
-        with gcs_connect(parquet_paths[0]) as conn:
-
-            def _run():
-                result = conn.execute(wrapped_sql)
-                return result.fetchone()[0]
-
-            pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            try:
-                future = pool.submit(_run)
-                total = future.result(timeout=60)
-            except concurrent.futures.TimeoutError:
-                pool.shutdown(wait=False)
-                return {"error": "Query timeout (60s). Riduci la complessita o aggiungi filtri."}
-            finally:
-                pool.shutdown(wait=False)
-
-        return {
-            "dataset": dataset,
-            "total_rows": total,
-            "year_filter": year,
-            "files_count": len(parquet_paths),
-        }
-
-    return guard_timed(_exec, "count")
-
-
-@mcp.tool(
-    description=(
-        "Serie storica: valori di una metrica nel tempo, raggruppati per una dimensione (es. regione). "
-        "Se year è specificato, ritorna una singola annualità. "
-        "Se year è None, ritorna tutti gli anni disponibili con la metrica aggregata per la dimensione scelta."
-    ),
-    structured_output=True,
-)
-def time_series(
-    dataset: str,
-    metric: str,
-    group_by: str,
-    year: int | None = None,
-    limit: int = 200,
-) -> dict[str, Any]:
-    if limit <= 0 or limit > MAX_ROWS_HARD_CAP:
-        return {"error": f"limit deve essere tra 1 e {MAX_ROWS_HARD_CAP}"}
-    schema = describe_impl(dataset)
+    schema = describe_impl(slug)
     if "error" in schema:
         return schema
 
-    col_names = {c["name"] for c in schema.get("columns", [])}
-    if metric not in col_names:
-        return {
-            "error": f"Metrica '{metric}' non trovata. Disponibili: {', '.join(sorted(col_names))}"
-        }
-    if group_by not in col_names:
-        return {
-            "error": f"Dimensione group_by '{group_by}' non trovata. Disponibili: {', '.join(sorted(col_names))}"
-        }
-
-    try:
-        parquet_paths = resolve_parquet_path(dataset, year=year)
-    except (ValueError, FileNotFoundError) as exc:
-        return {"error": str(exc)}
-
-    try:
-        _validate_parquet_paths(parquet_paths)
-    except DuckdbClientError as exc:
-        return {"error": str(exc)}
-
-    escaped_paths = "', '".join(p.replace("'", "''") for p in parquet_paths)
-    if len(parquet_paths) == 1:
-        source_expr = f"'{escaped_paths}'"
-    else:
-        source_expr = f"['{escaped_paths}']"
-
-    year_col = get_year_column(dataset)
-    if year_col is None:
-        return {
-            "error": f"Dataset '{dataset}' non ha una colonna anno riconosciuta. Impossibile costruire serie storica."
-        }
-
-    select_cols = f"{year_col}, {group_by}"
-    group_cols = f"{year_col}, {group_by}"
-    order_clause = f"{year_col}, {group_by}"
-
-    wrapped_sql = (
-        f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) "
-        f"SELECT {select_cols}, SUM({metric}) AS value "
-        f"FROM clean_input "
-        f"GROUP BY {group_cols} "
-        f"ORDER BY {order_clause} "
-        f"LIMIT {limit + 1}"
-    )
-    if year is not None:
-        wrapped_sql = _inject_year_filter(wrapped_sql, year_col, year)
+    # Una sola query DuckDB: SELECT con COUNT(*) OVER() per count + preview in un colpo
+    sql = f"SELECT *, COUNT(*) OVER() AS total_rows FROM clean_input LIMIT {limit}"
 
     def _exec() -> dict[str, Any]:
-        from lab_connectors.duckdb import gcs_connect
-        import concurrent.futures
+        result = _execute_sql(slug, sql)
+        if "error" in result:
+            return {**schema, "error": result["error"]}
 
-        with gcs_connect(parquet_paths[0]) as conn:
+        columns = result["columns"]
+        rows_raw = result["rows"]
 
-            def _run():
-                result = conn.execute(wrapped_sql)
-                return [item[0] for item in (result.description or [])], result.fetchall()
+        # L'ultima colonna è total_rows (COUNT(*) OVER())
+        total_rows = rows_raw[0][-1] if rows_raw else 0
+        preview_columns = columns[:-1]
+        preview_rows = [list(row[:-1]) for row in rows_raw]
 
-            pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            try:
-                future = pool.submit(_run)
-                columns, rows = future.result(timeout=60)
-            except concurrent.futures.TimeoutError:
-                pool.shutdown(wait=False)
-                return {"error": "Query timeout (60s). Riduci la complessita o aggiungi filtri."}
-            finally:
-                pool.shutdown(wait=False)
-
-        truncated = len(rows) > limit
         return {
-            "columns": columns,
-            "rows": [list(row) for row in rows[:limit]],
-            "row_count": len(rows),
-            "truncated": truncated,
-            "dataset": dataset,
-            "metric": metric,
-            "group_by": group_by,
-            "year_filter": year,
+            "slug": slug,
+            "name": schema.get("name"),
+            "description": schema.get("description"),
+            "source": schema.get("source"),
+            "period": schema.get("period"),
+            "columns": schema.get("columns", []),
+            "total_rows": total_rows,
+            "preview": {
+                "columns": preview_columns,
+                "rows": preview_rows,
+                "row_count": len(preview_rows),
+                "limit_applied": limit,
+            },
         }
 
-    return guard_timed(_exec, "time_series")
-
-
-@mcp.tool(
-    description=(
-        "Valori distinti di una colonna. "
-        "Utile per popolare dropdown/filter nelle UI, o per verificare i valori disponibili prima di query."
-    ),
-    structured_output=True,
-)
-def distinct_values(dataset: str, column: str, limit: int = 100) -> dict[str, Any]:
-    if limit <= 0 or limit > MAX_ROWS_HARD_CAP:
-        return {"error": f"limit deve essere tra 1 e {MAX_ROWS_HARD_CAP}"}
-    schema = describe_impl(dataset)
-    if "error" in schema:
-        return schema
-
-    col_names = {c["name"] for c in schema.get("columns", [])}
-    if column not in col_names:
-        return {
-            "error": f"Colonna '{column}' non trovata. Disponibili: {', '.join(sorted(col_names))}"
-        }
-
-    try:
-        parquet_paths = resolve_parquet_path(dataset, year=None)
-    except (ValueError, FileNotFoundError) as exc:
-        return {"error": str(exc)}
-
-    try:
-        _validate_parquet_paths(parquet_paths)
-    except DuckdbClientError as exc:
-        return {"error": str(exc)}
-
-    escaped_paths = "', '".join(p.replace("'", "''") for p in parquet_paths)
-    if len(parquet_paths) == 1:
-        source_expr = f"'{escaped_paths}'"
-    else:
-        source_expr = f"['{escaped_paths}']"
-
-    wrapped_sql = (
-        f"WITH clean_input AS (SELECT {column} FROM read_parquet({source_expr})) "
-        f"SELECT DISTINCT {column} FROM clean_input WHERE {column} IS NOT NULL LIMIT {limit + 1}"
-    )
-
-    def _exec() -> dict[str, Any]:
-        from lab_connectors.duckdb import gcs_connect
-        import concurrent.futures
-
-        with gcs_connect(parquet_paths[0]) as conn:
-
-            def _run():
-                result = conn.execute(wrapped_sql)
-                return [item[0] for item in (result.description or [])], result.fetchall()
-
-            pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            try:
-                future = pool.submit(_run)
-                columns, rows = future.result(timeout=60)
-            except concurrent.futures.TimeoutError:
-                pool.shutdown(wait=False)
-                return {"error": "Query timeout (60s). Riduci la complessita o aggiungi filtri."}
-            finally:
-                pool.shutdown(wait=False)
-
-        truncated = len(rows) > limit
-        return {
-            "column": column,
-            "values": [row[0] for row in rows[:limit]],
-            "count": len(rows),
-            "truncated": truncated,
-            "dataset": dataset,
-        }
-
-    return guard_timed(_exec, "distinct_values")
+    return guard_timed(_exec, "dataset_overview")
 
 
 @mcp.tool(

--- a/tools/clean_query_mcp/server.py
+++ b/tools/clean_query_mcp/server.py
@@ -391,7 +391,7 @@ def run_query(
     wrapped_sql = f"SELECT * FROM ({sql_to_exec}) AS q LIMIT {max_rows + 1}"
 
     def _exec() -> dict[str, Any]:
-        result = _execute_sql(dataset, wrapped_sql)
+        result = _execute_sql(dataset, wrapped_sql, year=year)
         if "error" in result:
             return result
         rows_raw = result["rows"]

--- a/tools/clean_query_mcp/server.py
+++ b/tools/clean_query_mcp/server.py
@@ -123,7 +123,9 @@ def _execute_sql(
     """Helper DuckDB: risolve path, connette, esegue, ritorna {columns, rows}.
 
     Il parametro ``sql`` è il corpo della query che usa ``clean_input`` come FROM.
-    La CTE ``clean_input`` viene costruita automaticamente e lo year filter iniettato.
+    La CTE ``clean_input`` viene costruita automaticamente.
+    Il filtro anno NON viene iniettato qui — i chiamanti devono applicarlo
+    PRIMA del wrapping se necessario (es. run_query inietta prima di avvolgere).
     """
     try:
         parquet_paths = resolve_parquet_path(dataset, year=year)
@@ -142,11 +144,6 @@ def _execute_sql(
         source_expr = f"['{escaped_paths}']"
 
     wrapped_sql = f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) {sql}"
-
-    if year is not None:
-        year_col = get_year_column(dataset)
-        if year_col:
-            wrapped_sql = _inject_year_filter(wrapped_sql, year_col, year)
 
     from lab_connectors.duckdb import gcs_connect
     import concurrent.futures
@@ -208,10 +205,6 @@ def _execute_sql_batch(
             batch_results: list[dict[str, Any]] = []
             for sql in sql_list:
                 wrapped = f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) {sql}"
-                if year is not None:
-                    year_col = get_year_column(dataset)
-                    if year_col:
-                        wrapped = _inject_year_filter(wrapped, year_col, year)
                 result = conn.execute(wrapped)
                 cols = [item[0] for item in (result.description or [])]
                 rows = result.fetchall()
@@ -387,10 +380,18 @@ def run_query(
 
     _guard_max_rows(max_rows)
 
-    wrapped_sql = f"SELECT * FROM ({sql}) AS q LIMIT {max_rows + 1}"
+    # Inietta year filter PRIMA del wrapping, così WHERE opera su clean_input
+    # e non sulla subquery esterna (evita "Column anno not found in FROM clause")
+    sql_to_exec = sql
+    if year is not None:
+        year_col = get_year_column(dataset)
+        if year_col:
+            sql_to_exec = _inject_year_filter(sql_to_exec, year_col, year)
+
+    wrapped_sql = f"SELECT * FROM ({sql_to_exec}) AS q LIMIT {max_rows + 1}"
 
     def _exec() -> dict[str, Any]:
-        result = _execute_sql(dataset, wrapped_sql, year=year)
+        result = _execute_sql(dataset, wrapped_sql)
         if "error" in result:
             return result
         rows_raw = result["rows"]

--- a/tools/clean_query_mcp/server.py
+++ b/tools/clean_query_mcp/server.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from lab_connectors.mcp import create_mcp_server, guard_timed
 from lab_connectors.mcp.errors import McpError, ErrorCode
+from lab_connectors.mcp.cache import TtlCache
 
 from .catalog import describe_dataset as describe_impl  # noqa: E402
 from .catalog import get_year_column  # noqa: E402
@@ -36,6 +37,9 @@ BLOCKED_KEYWORDS = {
     "vacuum",
 }
 TOKEN_RE = re.compile(r"[a-z_][a-z0-9_]*", re.IGNORECASE)
+
+# Cache risultati query: TTL 120s per dataset_overview e COUNT frequenti
+_query_cache: TtlCache[tuple, dict] = TtlCache(ttl_seconds=120)
 
 
 class DuckdbClientError(McpError):
@@ -116,9 +120,8 @@ def _execute_sql(
     year: int | None = None,
     timeout: int = 60,
 ) -> dict[str, Any]:
-    """Helper DuckDB unificato: risolve path, connette, esegue, ritorna {columns, rows}.
+    """Helper DuckDB: risolve path, connette, esegue, ritorna {columns, rows}.
 
-    Sostituisce la logica duplicata in preview/count/time_series/distinct_values/run_query.
     Il parametro ``sql`` è il corpo della query che usa ``clean_input`` come FROM.
     La CTE ``clean_input`` viene costruita automaticamente e lo year filter iniettato.
     """
@@ -140,7 +143,6 @@ def _execute_sql(
 
     wrapped_sql = f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) {sql}"
 
-    # Inject year filter for single-file multi-year datasets (es. giustizia_penale_indicatori)
     if year is not None:
         year_col = get_year_column(dataset)
         if year_col:
@@ -168,6 +170,65 @@ def _execute_sql(
             pool.shutdown(wait=False)
 
     return {"columns": columns, "rows": rows}
+
+
+def _execute_sql_batch(
+    dataset: str,
+    sql_list: list[str],
+    year: int | None = None,
+    timeout: int = 60,
+) -> list[dict[str, Any]]:
+    """Esegue più query SQL nella stessa connessione DuckDB.
+
+    Utile per tool che devono fare più query sullo stesso dataset
+    (es. dataset_overview: count + preview) senza ripetere connessione GCS.
+    """
+    try:
+        parquet_paths = resolve_parquet_path(dataset, year=year)
+    except (ValueError, FileNotFoundError) as exc:
+        return [{"error": str(exc)}] * len(sql_list)
+
+    try:
+        _validate_parquet_paths(parquet_paths)
+    except DuckdbClientError as exc:
+        return [{"error": str(exc)}] * len(sql_list)
+
+    escaped_paths = "', '".join(p.replace("'", "''") for p in parquet_paths)
+    if len(parquet_paths) == 1:
+        source_expr = f"'{escaped_paths}'"
+    else:
+        source_expr = f"['{escaped_paths}']"
+
+    from lab_connectors.duckdb import gcs_connect
+    import concurrent.futures
+
+    with gcs_connect(parquet_paths[0]) as conn:
+
+        def _run_all():
+            batch_results: list[dict[str, Any]] = []
+            for sql in sql_list:
+                wrapped = f"WITH clean_input AS (SELECT * FROM read_parquet({source_expr})) {sql}"
+                if year is not None:
+                    year_col = get_year_column(dataset)
+                    if year_col:
+                        wrapped = _inject_year_filter(wrapped, year_col, year)
+                result = conn.execute(wrapped)
+                cols = [item[0] for item in (result.description or [])]
+                rows = result.fetchall()
+                batch_results.append({"columns": cols, "rows": rows})
+            return batch_results
+
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            future = pool.submit(_run_all)
+            batch_results = future.result(timeout=timeout)
+        except concurrent.futures.TimeoutError:
+            pool.shutdown(wait=False)
+            return [{"error": f"Query timeout ({timeout}s)."}] * len(sql_list)
+        finally:
+            pool.shutdown(wait=False)
+
+    return batch_results
 
 
 def _validate_scope(sql: str) -> None:
@@ -347,13 +408,27 @@ def run_query(
 
 
 @mcp.tool(
-    description="Restituisce statistiche sulla cache GCS del catalogo (utile per debug).",
+    description=(
+        "Restituisce statistiche sulle cache: GCS path resolution e risultati query. "
+        "Utile per monitorare efficienza cache e debug."
+    ),
     structured_output=True,
 )
 def cache_stats() -> dict[str, Any]:
     from .catalog import gcs_cache_stats
 
-    return gcs_cache_stats()
+    gcs_stats = gcs_cache_stats()
+    query_stats = _query_cache.stats
+
+    return {
+        "gcs_path_resolution": gcs_stats,
+        "query_results": {
+            "entries": query_stats.entries,
+            "oldest_age_seconds": round(query_stats.oldest_age_seconds, 1),
+            "ttl_seconds": query_stats.ttl_seconds,
+        },
+        "note": "query_results cache: dataset_overview e COUNT frequenti, TTL 120s",
+    }
 
 
 @mcp.tool(
@@ -361,7 +436,8 @@ def cache_stats() -> dict[str, Any]:
         "Panoramica completa di un dataset: schema + conteggio righe + anteprima dati. "
         "Combina describe_dataset, count e preview in una singola chiamata. "
         "Usa una sola connessione DuckDB per count e preview, riducendo la latenza. "
-        "Utile per esplorare rapidamente un dataset prima di scrivere query SQL."
+        "Utile per esplorare rapidamente un dataset prima di scrivere query SQL. "
+        "I risultati sono cacheati per 120s."
     ),
     structured_output=True,
 )
@@ -369,27 +445,31 @@ def dataset_overview(slug: str, limit: int = 10) -> dict[str, Any]:
     if limit <= 0 or limit > MAX_ROWS_HARD_CAP:
         return {"error": f"limit deve essere tra 1 e {MAX_ROWS_HARD_CAP}"}
 
+    # Cache check
+    cache_key = ("dataset_overview", slug, limit)
+    cached = _query_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
     schema = describe_impl(slug)
     if "error" in schema:
         return schema
 
-    # Una sola query DuckDB: SELECT con COUNT(*) OVER() per count + preview in un colpo
-    sql = f"SELECT *, COUNT(*) OVER() AS total_rows FROM clean_input LIMIT {limit}"
-
     def _exec() -> dict[str, Any]:
-        result = _execute_sql(slug, sql)
-        if "error" in result:
-            return {**schema, "error": result["error"]}
+        # Due query nella stessa connessione: COUNT + preview
+        sql_list = [
+            "SELECT COUNT(*) AS total FROM clean_input",
+            f"SELECT * FROM clean_input LIMIT {limit}",
+        ]
+        batch = _execute_sql_batch(slug, sql_list)
+        if "error" in batch[0]:
+            return {**schema, "error": batch[0]["error"]}
 
-        columns = result["columns"]
-        rows_raw = result["rows"]
+        total_rows = batch[0]["rows"][0][0] if batch[0]["rows"] else 0
+        preview_cols = batch[1]["columns"]
+        preview_rows = batch[1]["rows"]
 
-        # L'ultima colonna è total_rows (COUNT(*) OVER())
-        total_rows = rows_raw[0][-1] if rows_raw else 0
-        preview_columns = columns[:-1]
-        preview_rows = [list(row[:-1]) for row in rows_raw]
-
-        return {
+        result = {
             "slug": slug,
             "name": schema.get("name"),
             "description": schema.get("description"),
@@ -398,12 +478,15 @@ def dataset_overview(slug: str, limit: int = 10) -> dict[str, Any]:
             "columns": schema.get("columns", []),
             "total_rows": total_rows,
             "preview": {
-                "columns": preview_columns,
-                "rows": preview_rows,
+                "columns": preview_cols,
+                "rows": [list(row) for row in preview_rows],
                 "row_count": len(preview_rows),
                 "limit_applied": limit,
             },
+            "_cached": False,
         }
+        _query_cache.set(cache_key, result)
+        return result
 
     return guard_timed(_exec, "dataset_overview")
 


### PR DESCRIPTION
## Sintesi

Rimuove 5 tool MCP wrapper SQL ridondanti (`preview`, `count`, `time_series`, `distinct_values`, `aggregate`) e aggiunge un tool aggregato `dataset_overview` che in una chiamata restituisce schema + conteggio righe + anteprima.

## Contesto collegato

Closes #508

## Cosa cambia

- [ ] candidate — nuovo dataset o aggiornamento
- [ ] support — dataset di supporto
- [ ] docs — struttura candidate, README, template
- [x] cleanup — refactoring, rimozioni, allineamento
- [ ] workflow o CI
- [x] altro — server MCP

## Impatto

Segna solo quello che si applica.

- [ ] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
- [x] Solo documentazione o metadati
- [ ] Nessun impatto visibile per chi usa il repository

## Dettaglio

| Tool rimosso | Sostituito da |
|---|---|
| `preview` | `run_query("SELECT * FROM clean_input LIMIT N")` |
| `count` | `run_query("SELECT COUNT(*) FROM clean_input")` |
| `time_series` | `run_query("SELECT anno, dim, SUM(metric) FROM clean_input GROUP BY ...")` |
| `distinct_values` | `run_query("SELECT DISTINCT col FROM clean_input WHERE col IS NOT NULL")` |
| `aggregate` | `run_query("SELECT dim, SUM(metric) FROM clean_input GROUP BY dim")` |

**Nuovo tool:**
- `dataset_overview(slug, limit=10)` — schema + total_rows + preview in UNA connessione DuckDB (usa `SELECT *, COUNT(*) OVER() AS total_rows FROM clean_input`)

**Interno:**
- Estratto helper `_execute_sql()` che unifica il pattern di connessione DuckDB (prima duplicato in 5 tool + run_query + preview)
- Refactor `run_query()` per usare `_execute_sql()`
- Rimosso `_duckdb_read()` (rimpiazzato da `_execute_sql()`)

**Metriche:**
- 13 → 9 tool MCP
- 909 → 594 righe in `server.py`
- -388 righe nette
- 60 test passano invariati

## Verifica

```bash
python -m pytest tests/test_clean_query_sql_guards.py tests/test_clean_query_pure_units.py tests/test_clean_query_catalog.py -v
python -c "from tools.clean_query_mcp.scripts.smoke import main; print('smoke import OK')"
```

- [x] `pytest` passa su tutti i test clean-query (60 test)
- [x] `ruff` passa
- [x] Smoke test importa correttamente

## Note / rischi

- I tool rimossi non avevano consumatori noti: nessuna skill, workflow o test (oltre ai test di contract) li chiamava
- `dataset_overview` usa COUNT(*) OVER() che funziona su tutti i dataset clean esistenti
- L'helper `_execute_sql()` è ora il punto di ingresso unico per query DuckDB — se un futuro tool avrà bisogno di esecuzione SQL, lo riuserà
