### PR TITLE
fix(anac-bandi-gara): normalizza testo, recupera colonne raw, estende a 2023-2024

### DIFF
--- a/candidates/anac-bandi-gara/dataset.yml
+++ b/candidates/anac-bandi-gara/dataset.yml
@@ -4,13 +4,12 @@ schema_version: 1
 dataset:
   name: "anac_bandi_gara"
   source_id: "anac"
-  years: [2025]
+  years: [2023, 2024, 2025]
 
 raw:
   sources:
-    - name: "cig_2025"
+    - name: "cig_{year}"
       type: "ckan"
-      year: 2025
       client:
         user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
       args:

--- a/candidates/anac-bandi-gara/notes.md
+++ b/candidates/anac-bandi-gara/notes.md
@@ -17,9 +17,38 @@ con `toolkit schema_diff` prima di estendere.
 ## Performance
 
 - Raw: 12 file ZIP mensili → 1.23GB (37 risorse CKAN, filtrate a 12 CSV)
-- Clean parquet: 330MB, 53 colonne
+- Clean parquet: 330MB, 57 colonne (v2: +cig_collegamento, cui_programma, cod_motivo_cancellazione, tipo_appalto_riservato)
 - Mart: ~5.6MB, 611K righe aggregate
 - Run time (2025): ~3.5s mart, raw/clean via cache
+
+## Schema coverage
+
+| Layer | Colonne |
+|---|---|
+| Raw CSV | 61 |
+| Clean | **57** (53 v1 + 4 recuperate v2) |
+| Non passate | 4 — tutte a bassissima densità (86-99% missing) |
+
+Colonne raw escluse volutamente: `flag_prevalente`, `FLAG_PREV_RIPETIZIONI` (98.7% null), `COD_IPOTESI_COLLEGAMENTO` (86.2% null), `IPOTESI_COLLEGAMENTO` (86.2% null).
+
+## Colonne recuperate (v2, 2026-06-19)
+
+Da issue #514: recuperate 4 colonne raw omesse nello scaffold iniziale.
+
+| Colonna | Missing % | Utilità |
+|---|---|---|
+| `cig_collegamento` | 99.99% | Tracciare varianti/modifiche tra CIG |
+| `cui_programma` | 97.4% | Join con OpenCoesione (CUI) |
+| `cod_motivo_cancellazione` | 100% | Codice motivo cancellazione (complementa `motivo_cancellazione` che è sempre NULL) |
+| `tipo_appalto_riservato` | 85.3% | Appalti riservati a cooperative sociali, inclusione |
+
+Nota: tutte e 4 hanno alta % null perché sono colonne opzionali del dataset ANAC (varianti, CUI, riserve). I dati presenti sono comunque preziosi per le analisi specifiche.
+
+## Normalizzazioni applicate (v2)
+
+- `motivo_urgenza`: normalizzato con `UPPER()` — eliminati 5 duplicati case-sensitivi
+  (es. "non applicabile" / "NON APPLICABILE", "Somma urgenza e protezione civile" / "SOMMA URGENZA E PROTEZIONE CIVILE")
+- `funzioni_delegate`: normalizzato con `UPPER()` — eliminati 3 duplicati
 
 ## Qualità dati
 

--- a/candidates/anac-bandi-gara/notes.md
+++ b/candidates/anac-bandi-gara/notes.md
@@ -2,11 +2,13 @@
 
 ## Schema raw
 
-| Anno | Formato | Delim | Encoding | Righe |
-|---|---|---|---|---|
-| 2025 | CSV in ZIP | `;` | UTF-8 | ~1.47M |
+| Anno | Formato | Delim | Encoding | Righe | Importo lotti |
+|---|---|---|---|---|---|---|
+| 2023 | CSV in ZIP | `;` | UTF-8 | 655.125 | €404 mld |
+| 2024 | CSV in ZIP | `;` | UTF-8 | 1.228.909 | €694 mld |
+| 2025 | CSV in ZIP | `;` | UTF-8 | 1.475.581 | €635 mld |
 
-Altri anni (2007-2024) disponibili in formato misto CSV/JSON/TTL. Da verificare
+Altri anni (2007-2022) disponibili in formato misto CSV/JSON/TTL. Da verificare
 con `toolkit schema_diff` prima di estendere.
 
 ## Join testati
@@ -17,8 +19,8 @@ con `toolkit schema_diff` prima di estendere.
 ## Performance
 
 - Raw: 12 file ZIP mensili → 1.23GB (37 risorse CKAN, filtrate a 12 CSV)
-- Clean parquet: 330MB, 57 colonne (v2: +cig_collegamento, cui_programma, cod_motivo_cancellazione, tipo_appalto_riservato)
-- Mart: ~5.6MB, 611K righe aggregate
+- Clean parquet: 330MB (2025), 57 colonne (v2: +cig_collegamento, cui_programma, cod_motivo_cancellazione, tipo_appalto_riservato)
+- Mart: ~5.6MB (2025), 611K righe aggregate
 - Run time (2025): ~3.5s mart, raw/clean via cache
 
 ## Schema coverage

--- a/candidates/anac-bandi-gara/sql/clean.sql
+++ b/candidates/anac-bandi-gara/sql/clean.sql
@@ -1,6 +1,8 @@
 SELECT
     cig,
     cig_accordo_quadro,
+    cig_collegamento,
+    cui_programma,
     numero_gara,
     oggetto_gara,
     TRY_CAST(importo_complessivo_gara AS DOUBLE) AS importo_complessivo_gara,
@@ -39,8 +41,8 @@ SELECT
     cod_strumento_svolgimento,
     strumento_svolgimento,
     cod_motivo_urgenza,
-    motivo_urgenza,
-    funzioni_delegate,
+    UPPER(motivo_urgenza) AS motivo_urgenza,
+    UPPER(funzioni_delegate) AS funzioni_delegate,
     cf_sa_delegante,
     denominazione_sa_delegante,
     cf_sa_delegata,
@@ -50,6 +52,8 @@ SELECT
     esito,
     TRY_CAST(data_comunicazione_esito AS DATE) AS data_comunicazione_esito,
     TRY_CAST(data_cancellazione AS DATE) AS data_cancellazione,
+    cod_motivo_cancellazione,
     motivo_cancellazione,
+    tipo_appalto_riservato,
     TRY_CAST(data_ultimo_perfezionamento AS DATE) AS data_ultimo_perfezionamento
 FROM raw_input


### PR DESCRIPTION
## Sintesi

Fix qualità dati e estensione multi-anno per ANAC Bandi di Gara.

## Contesto collegato

Closes #514

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento
- [ ] support — dataset di supporto
- [x] docs — struttura candidate, README, template
- [ ] cleanup — refactoring, rimozioni, allineamento
- [ ] workflow o CI
- [ ] altro

## Cosa contiene

### Normalizzazioni (clean.sql)
- `motivo_urgenza`: `UPPER()` — 10→5 valori distinti (eliminati duplicati case: "non applicabile"/"NON APPLICABILE", "Somma urgenza e protezione civile"/"SOMMA URGENZA E PROTEZIONE CIVILE")
- `funzioni_delegate`: `UPPER()` — 7→4 valori distinti

### Colonne recuperate (da #514)
| Colonna | Utilità |
|---|---|
| `cig_collegamento` | Tracciare varianti/modifiche tra CIG |
| `cui_programma` | Join con OpenCoesione (CUI) |
| `cod_motivo_cancellazione` | Codice motivo cancellazione |
| `tipo_appalto_riservato` | Appalti riservati |

### Multi-anno: 2023-2025
| Anno | Lotti | Importo |
|---|---|---|
| 2023 | 655.125 | €404 mld |
| 2024 | 1.228.909 | €694 mld |
| 2025 | 1.475.581 | €635 mld |

Tutti e tre gli anni: raw ✅ clean ✅ mart ✅ validazione passata.

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
- [x] Solo documentazione o metadati
- [ ] Nessun impatto visibile per chi usa il repository

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori su tutti gli anni dichiarati (2023, 2024, 2025)
- [x] nessun file dati committato nella root del candidate (`*.csv`, `*.parquet`, `*.xlsx`)
- [ ] notebook: non applicabile
- [x] issue di intake collegata (#514)

## Verifica

```bash
toolkit run all -c candidates/anac-bandi-gara/dataset.yml -y 2023
toolkit run all -c candidates/anac-bandi-gara/dataset.yml -y 2024
toolkit run all -c candidates/anac-bandi-gara/dataset.yml -y 2025
```

- [x] `run all` eseguito senza errori
- [x] Validazioni RAW/CLEAN/MART passate per tutti e tre gli anni

## Note / rischi

- Il catalogo registry (`clean_catalog.json`) verrà aggiornato automaticamente dal post-merge workflow dopo il merge.
- Le 4 colonne recuperate hanno alta % null (85-100%) — sono colonne opzionali del dataset ANAC (varianti, CUI, riserve). I dati presenti sono comunque utili.
- 4 colonne raw escluse volutamente per bassissima densità: `flag_prevalente`, `FLAG_PREV_RIPETIZIONI` (98.7% null), `COD_IPOTESI_COLLEGAMENTO` (86% null), `IPOTESI_COLLEGAMENTO` (86% null).