### PR TITLE
chore(post-merge): aggiorna registry per PR #515

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-06-19",
+  "updated_at": "2026-06-20",
   "datasets": [
     {
       "slug": "aifa_spesa_consumo",
@@ -2178,6 +2178,140 @@
       "location": {
         "type": "gcs",
         "path": "gs://dataciviclab-clean/inps_pensioni_trimestrale/2024/inps_pensioni_trimestrale_2024_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "inps_rdc_pdc",
+      "name": "Inps Rdc Pdc",
+      "description": "",
+      "source": "",
+      "source_id": "inps_open_data",
+      "period": {
+        "start": 2020,
+        "end": 2020
+      },
+      "columns": [
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_istat",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "comune",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_regione",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_provincia",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "nuclei_familiari_percettori_rdc_luglio_2020",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "nuclei_familiari_percettori_pdc_luglio_2020",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "individui_coinvolti_luglio_2020",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "numero_componenti_per_famiglia",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "numero_donne_per_famiglia",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "numero_minori_18_anni_per_famiglia",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "numero_anziani_75_anni_per_famiglia",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "importo_medio_mensile",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "dev_standard_importo_mensile",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "uomini_residenti_al_1_1_2020",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "donne_residenti_al_1_1_2020",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "popolazione_residente_al_1_1_2020",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "takeup",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "takeup_donne",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/inps_rdc_pdc/2020/inps_rdc_pdc_2020_clean.parquet",
         "multi_file": false
       },
       "stage": "published",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2185,9 +2185,9 @@
     },
     {
       "slug": "inps_rdc_pdc",
-      "name": "Inps Rdc Pdc",
-      "description": "",
-      "source": "",
+      "name": "INPS RdC/PdC — Nuclei percettori per comune (2020)",
+      "description": "Nuclei familiari percettori di Reddito di Cittadinanza (RdC) e Pensione di Cittadinanza (PdC) per comune ISTAT. Snapshot luglio 2020. Include takeup rate, composizione familiare, genere e importo medio.",
+      "source": "INPS — Open Data (opendata.inps.it)",
       "source_id": "inps_open_data",
       "period": {
         "start": 2020,
@@ -2197,116 +2197,116 @@
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di riferimento (2020)"
         },
         {
           "name": "codice_istat",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT del comune (6 cifre)"
         },
         {
           "name": "comune",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione del comune"
         },
         {
           "name": "codice_regione",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Codice ISTAT della regione"
         },
         {
           "name": "codice_provincia",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Codice ISTAT della provincia"
         },
         {
           "name": "nuclei_familiari_percettori_rdc_luglio_2020",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Nuclei familiari percettori di RdC a luglio 2020"
         },
         {
           "name": "nuclei_familiari_percettori_pdc_luglio_2020",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Nuclei familiari percettori di PdC a luglio 2020"
         },
         {
           "name": "individui_coinvolti_luglio_2020",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Individui coinvolti nei nuclei percettori RdC/PdC a luglio 2020"
         },
         {
           "name": "numero_componenti_per_famiglia",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Numero medio di componenti per nucleo familiare"
         },
         {
           "name": "numero_donne_per_famiglia",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Numero medio di donne per nucleo familiare"
         },
         {
           "name": "numero_minori_18_anni_per_famiglia",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Numero medio di minori (< 18 anni) per nucleo familiare"
         },
         {
           "name": "numero_anziani_75_anni_per_famiglia",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Numero medio di anziani (> 75 anni) per nucleo familiare"
         },
         {
           "name": "importo_medio_mensile",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Importo medio mensile per nucleo (€)"
         },
         {
           "name": "dev_standard_importo_mensile",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Deviazione standard dell'importo medio mensile"
         },
         {
           "name": "uomini_residenti_al_1_1_2020",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Uomini residenti nel comune al 1° gennaio 2020"
         },
         {
           "name": "donne_residenti_al_1_1_2020",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Donne residenti nel comune al 1° gennaio 2020"
         },
         {
           "name": "popolazione_residente_al_1_1_2020",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Popolazione totale residente al 1° gennaio 2020"
         },
         {
           "name": "takeup",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Takeup rate RdC (nuclei percettori / popolazione residente)"
         },
         {
           "name": "takeup_donne",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Takeup rate RdC femminile (donne coinvolte / donne residenti)"
         }
       ],
       "location": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-19",
+  "generated_at": "2026-06-20",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 48,
+    "total": 49,
     "by_status": {
-      "ok": 48,
+      "ok": 49,
       "warn": 0,
       "error": 0
     }
@@ -279,6 +279,24 @@
           2024
         ],
         "config_path": "candidates/inps-pensioni/dataset.yml"
+      }
+    },
+    {
+      "id": "inps-rdc-pdc",
+      "source_id": "inps_open_data",
+      "status": "ok",
+      "label": "inps-rdc-pdc",
+      "detail": "anno 2020 — fonte: inps-rdc-pdc_source — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "27872392672",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27872392672",
+        "checked_at": "2026-06-20",
+        "years": [
+          2020
+        ],
+        "config_path": "candidates/inps-rdc-pdc/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #515 — intake: inps_rdc_pdc — Nuclei percettori RDC/PDC per comune (2020)

Changed candidate/support roots:

- `inps-rdc-pdc` (candidate, `candidates/inps-rdc-pdc`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/inps-rdc-pdc/dataset.yml` -> artifact `sample-run-inps-rdc-pdc`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
