### PR TITLE
feat(elezioni-politiche-2022): intake Camera+Senato 2022 per comune

### DIFF
--- a/candidates/elezioni-politiche-2022/README.md
+++ b/candidates/elezioni-politiche-2022/README.md
@@ -1,0 +1,52 @@
+# Elezioni Politiche 2022 — risultati per comune
+
+Risultati delle elezioni politiche del 25 settembre 2022 (Camera dei Deputati e Senato della Repubblica) a livello comunale.
+
+**117.591 righe per la Camera**, **117.510 per il Senato**: ogni riga rappresenta il voto a una lista in un comune, con il candidato uninominale associato. 7.824 comuni coperti.
+
+## I dati
+
+Il dataset contiene 19 colonne che permettono di analizzare il voto per:
+- **comune** — denominazione
+- **lista elettorale** — descrizione (es. "FRATELLI D'ITALIA CON GIORGIA MELONI")
+- **candidato uninominale** — nome, cognome, data e luogo nascita, sesso
+- **collegio** — plurinominale e uninominale
+- **elettori e votanti** — totali e per genere, schede bianche
+- **voti** — alla lista e al candidato uninominale
+
+### Camera (C)
+| Metrica | Valore |
+|---|---|
+| Righe | 117.591 |
+| Comuni | 7.824 |
+| Liste | 23 |
+| Media voti per lista | 230 |
+
+### Senato (S)
+| Metrica | Valore |
+|---|---|
+| Righe | 117.510 |
+| Comuni | 7.545 |
+| Liste | 22 |
+| Media voti per lista | 226 |
+
+Nota: Camera e Senato hanno un diverso numero di comuni per via dell'elettorato attivo (over 18 per Camera, over 25 per Senato) e delle differenze nella rappresentanza della Valle d'Aosta.
+
+## Cross con altri dataset
+
+| Dataset | Chiave | Domanda |
+|---|---|---|
+| `irpef_comunale` | comune (testo) | I comuni ricchi votano diversamente? |
+| `dait_amministratori_locali` | comune | Il colore dell'amministrazione corrisponde al voto? |
+| `popolazione_istat_comunale` | comune | L'astensione è correlata all'età della popolazione? |
+| `ispra_ru_base` | comune | I comuni virtuosi nell'ambiente votano verde? |
+
+## Fonte
+
+**Eligendo** — Archivio storico elettorale del DAIT (Ministero dell'Interno)
+URL: https://elezionistorico.interno.gov.it/eligendo/opendata.php
+Licenza: CC BY 4.0
+
+## Issue
+
+#523 — Intake eligendo: serie storica elezioni

--- a/candidates/elezioni-politiche-2022/dataset.yml
+++ b/candidates/elezioni-politiche-2022/dataset.yml
@@ -1,0 +1,42 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "elezioni_politiche_2022"
+  source_id: "eligendo"
+  years: [2022]
+
+raw:
+  sources:
+    - name: "camera_livcomune"
+      type: "http_file"
+      year: 2022
+      args:
+        url: "https://dait.interno.gov.it/documenti/opendata/catalogoagid/camera-2022-Italia-livcomune.csv"
+      primary: true
+    - name: "senato_livcomune"
+      type: "http_file"
+      year: 2022
+      args:
+        url: "https://dait.interno.gov.it/documenti/opendata/catalogoagid/senato-2022-italia-livcomune.csv"
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: config_only
+    mode: all
+    header: true
+    delim: ";"
+    encoding: "utf-8"
+    null_padding: true
+    trim_whitespace: true
+
+mart:
+  tables:
+    - name: "mart_voti_lista_comune"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_voti_lista_comune"
+
+validation:
+  fail_on_error: true

--- a/candidates/elezioni-politiche-2022/notes.md
+++ b/candidates/elezioni-politiche-2022/notes.md
@@ -1,0 +1,76 @@
+# Note tecniche — elezioni-politiche-2022
+
+## Fonte
+
+**Eligendo** — Archivio storico elettorale del DAIT (Ministero dell'Interno)
+- Pagina: https://elezionistorico.interno.gov.it/eligendo/opendata.php
+- File: https://dait.interno.gov.it/documenti/opendata/catalogoagid/
+- Catalogo AGID (formato CSV diretto, non ZIP)
+
+### File sorgente
+
+| Camera | Senato |
+|---|---|
+| `camera-2022-Italia-livcomune.csv` (25MB) | `senato-2022-italia-livcomune.csv` (1MB) |
+
+Entrambi: CSV UTF-8, delimitatore `;`, header in prima riga.
+
+## Schema clean (19 colonne)
+
+| Colonna | Tipo | Descrizione |
+|---|---|---|
+| `data_elezione` | DATE | Data elezione (2022-09-25) |
+| `cod_tipo_elezione` | VARCHAR | 'C' = Camera, 'S' = Senato |
+| `circoscrizione` | VARCHAR | Circoscrizione elettorale (es. "PIEMONTE 1") |
+| `collegio_plurinominale` | VARCHAR | Collegio plurinominale |
+| `collegio_uninominale` | VARCHAR | Collegio uninominale |
+| `comune` | VARCHAR | Denominazione comune |
+| `elettori_totali` | BIGINT | Elettori iscritti totali |
+| `elettori_maschi` | BIGINT | Elettori maschi |
+| `votanti_totali` | BIGINT | Votanti totali |
+| `votanti_maschi` | BIGINT | Votanti maschi |
+| `schede_bianche` | BIGINT | Schede bianche |
+| `voti_lista` | BIGINT | Voti alla lista (proporzionale) |
+| `descr_lista` | VARCHAR | Nome della lista (es. "PARTITO DEMOCRATICO - ITALIA DEMOCRATICA E PROGRESSISTA") |
+| `cognome_candidato` | VARCHAR | Cognome candidato uninominale |
+| `nome_candidato` | VARCHAR | Nome candidato uninominale |
+| `luogo_nascita_candidato` | VARCHAR | Luogo di nascita candidato |
+| `data_nascita_candidato` | DATE | Data di nascita candidato |
+| `sesso_candidato` | VARCHAR | Sesso candidato ('M'/'F') |
+| `voti_candidato` | BIGINT | Voti al candidato uninominale |
+
+## Granularità
+
+Ogni riga = 1 comune × 1 lista × 1 candidato uninominale.
+Una lista presente in più collegi uninominali dello stesso comune produce più righe.
+Una lista senza candidato (solo proporzionale) produce righe con voti_lista ma voti_candidato = NULL (ma nel dataset 2022 tutte le liste avevano candidati).
+
+## Volumi
+
+| Camera | Senato |
+|---|---|
+| 117.591 righe | 117.510 righe |
+| 7.824 comuni | 7.545 comuni |
+| 23 liste | 22 liste |
+| 1.247 MB parquet | |
+
+## Qualità dati
+
+- Nomi comuni in MAIUSCOLO (es. "ROMA", "MILANO") — normalizzare per join
+- Codice ISTAT non presente — serve lookup table comuni per join preciso
+- Circoscrizioni con codice "ESTERO" per voti dall'estero
+- Candidati uninominali: alcuni comuni possono avere più candidati per lista (es. Valle d'Aosta)
+
+## Mart
+
+`mart_voti_lista_comune`: aggregazione per comune × lista, con totale voti e conteggio candidati uninominali.
+
+## Join testati
+
+- `comune` (testo) → join approssimativo. Per join preciso serve `codice_istat` da aggiungere in un prossimo giro.
+
+## Per estendere ad altri anni
+
+I file ZIP degli anni precedenti hanno formati diversi (v. issue #523 per lo scout completo):
+- 2018: TXT, 17 colonne, schema simile ma nomi diversi
+- 2013: TXT, 10 colonne (solo lista, no uninominale)

--- a/candidates/elezioni-politiche-2022/sql/clean.sql
+++ b/candidates/elezioni-politiche-2022/sql/clean.sql
@@ -1,0 +1,21 @@
+SELECT
+    CAST(DATAELEZIONE AS DATE) AS data_elezione,
+    CAST(CODTIPOELEZIONE AS VARCHAR) AS cod_tipo_elezione,
+    CAST("CIRC-REG" AS VARCHAR) AS circoscrizione,
+    CAST(COLLPLURI AS VARCHAR) AS collegio_plurinominale,
+    CAST(COLLUNINOM AS VARCHAR) AS collegio_uninominale,
+    CAST(COMUNE AS VARCHAR) AS comune,
+    TRY_CAST(ELETTORITOT AS BIGINT) AS elettori_totali,
+    TRY_CAST(ELETTORIM AS BIGINT) AS elettori_maschi,
+    TRY_CAST(VOTANTITOT AS BIGINT) AS votanti_totali,
+    TRY_CAST(VOTANTIM AS BIGINT) AS votanti_maschi,
+    TRY_CAST(SKBIANCHE AS BIGINT) AS schede_bianche,
+    TRY_CAST(VOTILISTA AS BIGINT) AS voti_lista,
+    CAST(DESCRLISTA AS VARCHAR) AS descr_lista,
+    CAST(COGNOME AS VARCHAR) AS cognome_candidato,
+    CAST(NOME AS VARCHAR) AS nome_candidato,
+    CAST(LUOGONASCITA AS VARCHAR) AS luogo_nascita_candidato,
+    CAST(DATANASCITA AS DATE) AS data_nascita_candidato,
+    CAST(SESSO AS VARCHAR) AS sesso_candidato,
+    TRY_CAST(VOTICANDIDATO AS BIGINT) AS voti_candidato
+FROM raw_input

--- a/candidates/elezioni-politiche-2022/sql/mart.sql
+++ b/candidates/elezioni-politiche-2022/sql/mart.sql
@@ -1,0 +1,11 @@
+SELECT
+    data_elezione,
+    cod_tipo_elezione,
+    circoscrizione,
+    comune,
+    descr_lista,
+    SUM(voti_lista) AS tot_voti_lista,
+    COUNT(DISTINCT collegio_uninominale) AS n_collegi,
+    COUNT(DISTINCT cognome_candidato || ' ' || nome_candidato) AS n_candidati
+FROM clean_input
+GROUP BY data_elezione, cod_tipo_elezione, circoscrizione, comune, descr_lista


### PR DESCRIPTION
## Sintesi

Nuovo candidate: risultati elezioni politiche 2022 (Camera + Senato) per comune. Fonte Eligendo, formato CSV diretto.

## Contesto collegato

Issue #523 — intake eligendo: serie storica elezioni

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento

## Cosa contiene

- `dataset.yml` — 2 fonti HTTP (Camera + Senato), 1 mart
- `sql/clean.sql` — 19 colonne normalizzate
- `sql/mart.sql` — aggregazione per comune × lista
- `README.md` — descrizione, metriche, cross-dataset
- `notes.md` — schema dettagliato, qualità, estendibilità

## Volumi

| Camera | Senato |
|---|---|
| 117.591 righe | 117.510 righe |
| 7.824 comuni | 7.545 comuni |
| 23 liste | 22 liste |

19 colonne: comune, lista, candidato uninominale, elettori, votanti, dati anagrafici candidati.

## Impatto

- [x] Aggiunge un candidate in `candidates/`

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit `run all` eseguito senza errori (2022)
- [x] nessun file dati committato nella root del candidate
- [x] `python scripts/validate_candidate_structure.py` passato
- [x] issue di intake collegata (#523)

## Verifica

```bash
toolkit run all -c candidates/elezioni-politiche-2022/dataset.yml -y 2022
python scripts/validate_candidate_structure.py candidates/elezioni-politiche-2022
```

- [x] `run all` eseguito senza errori
- [x] `validate_candidate_structure.py` passato

## Note / rischi

- Nomi comuni in MAIUSCOLO — normalizzare per join
- Codice ISTAT non presente nel dato originale — lookup da aggiungere
- La struttura colonne cambia per anni precedenti (2018: 17 colonne, 2013: 10 colonne)
