### PR TITLE
chore(post-merge): aggiorna registry per PR #528

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -1224,56 +1224,6 @@
       "registry_source": "derive_auto"
     },
     {
-      "slug": "camera_deputati_legislature",
-      "name": "Camera Deputati Legislature",
-      "description": "Deputati italiani per legislatura — Camera dei Deputati",
-      "source": "Camera dei Deputati — OpenData SPARQL endpoint",
-      "source_id": "dati_camera",
-      "period": {
-        "start": 2024,
-        "end": 2024
-      },
-      "columns": [
-        {
-          "name": "deputato",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": "URI identificativo del deputato"
-        },
-        {
-          "name": "cognome",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "nome",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": "Nome del deputato"
-        },
-        {
-          "name": "legislatura",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": "Numero della legislatura"
-        },
-        {
-          "name": "gender",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": "Genere del deputato"
-        }
-      ],
-      "location": {
-        "type": "gcs",
-        "path": "gs://dataciviclab-clean/camera_deputati_legislature/2024/camera_deputati_legislature_2024_clean.parquet",
-        "multi_file": false
-      },
-      "stage": "incubating",
-      "registry_source": "derive_auto"
-    },
-    {
       "slug": "camera_votazioni_sparql",
       "name": "Votazioni Camera dei Deputati",
       "description": "Votazioni della Camera dei deputati: esito, conteggi favorevoli/contrari/astenuti, indicatori di partecipazione (presenti, votanti) e fiducia. Serie storica 2018-2025 da endpoint SPARQL dati.camera.it.",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -1224,6 +1224,56 @@
       "registry_source": "derive_auto"
     },
     {
+      "slug": "camera_deputati_legislature",
+      "name": "Camera Deputati Legislature",
+      "description": "Deputati italiani per legislatura — Camera dei Deputati",
+      "source": "Camera dei Deputati — OpenData SPARQL endpoint",
+      "source_id": "dati_camera",
+      "period": {
+        "start": 2024,
+        "end": 2024
+      },
+      "columns": [
+        {
+          "name": "deputato",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "URI identificativo del deputato"
+        },
+        {
+          "name": "cognome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "nome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Nome del deputato"
+        },
+        {
+          "name": "legislatura",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Numero della legislatura"
+        },
+        {
+          "name": "gender",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Genere del deputato"
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/camera_deputati_legislature/2024/camera_deputati_legislature_2024_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "incubating",
+      "registry_source": "derive_auto"
+    },
+    {
       "slug": "camera_votazioni_sparql",
       "name": "Votazioni Camera dei Deputati",
       "description": "Votazioni della Camera dei deputati: esito, conteggi favorevoli/contrari/astenuti, indicatori di partecipazione (presenti, votanti) e fiducia. Serie storica 2018-2025 da endpoint SPARQL dati.camera.it.",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -334,9 +334,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "26091030726",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26091030726",
-        "checked_at": "2026-05-19",
+        "run_id": "27878799069",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27878799069",
+        "checked_at": "2026-06-20",
         "years": [
           2024
         ],
@@ -636,9 +636,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "26462812456",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26462812456",
-        "checked_at": "2026-05-26",
+        "run_id": "27878799069",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27878799069",
+        "checked_at": "2026-06-20",
         "years": [
           2023,
           2024,
@@ -894,9 +894,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "26106467223",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26106467223",
-        "checked_at": "2026-05-19",
+        "run_id": "27878799069",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27878799069",
+        "checked_at": "2026-06-20",
         "years": [
           2024
         ],


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #528 — fix: aggiorna riferimenti da FROM clean a FROM clean_input

Changed candidate/support roots:

- `ispra-consumo-suolo` (candidate, `candidates/ispra-consumo-suolo`)
- `openga-ricorsi-cds` (candidate, `candidates/openga-ricorsi-cds`)
- `mim-anagrafica-scuole-statali` (support_dataset, `support_datasets/mim-anagrafica-scuole-statali`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/ispra-consumo-suolo/dataset.yml` -> artifact `sample-run-ispra-consumo-suolo`
- `candidates/openga-ricorsi-cds/dataset.yml` -> artifact `sample-run-openga-ricorsi-cds`
- `support_datasets/mim-anagrafica-scuole-statali/dataset.yml` -> artifact `sample-run-mim-anagrafica-scuole-statali`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
