### PR TITLE
docs: aggiorna skills e notebook_helpers ai nuovi comandi inspect

### DIFF
--- a/scripts/notebook_helpers.py
+++ b/scripts/notebook_helpers.py
@@ -78,7 +78,10 @@ class NotebookHelper:
             Dict con chiavi ``columns``, ``schema``, etc. In caso di errore
             restituisce ``{"columns": 0, "schema": []}``.
         """
-        data = self.tk_year("inspect", "config", "-l", layer, "-m", "schema")
+        try:
+            data = self.tk_year("inspect", "config", "-l", layer, "-m", "schema")
+        except Exception:
+            return {"columns": 0, "schema": []}
         if isinstance(data, dict) and "column_count" in data and "columns" in data:
             return {"columns": data["column_count"], "schema": data["columns"]}
         return data

--- a/scripts/notebook_helpers.py
+++ b/scripts/notebook_helpers.py
@@ -44,8 +44,8 @@ class NotebookHelper:
     def tk(self, *args: str) -> dict[str, Any]:
         """Esegue un comando toolkit e restituisce il JSON di output.
 
-        I comandi supportati includono: ``inspect paths``, ``review-readiness``,
-        ``inspect schema``, etc.
+        I comandi supportati includono: ``inspect config``, ``inspect summary``,
+        ``inspect runs``, etc.
 
         Args:
             *args: Argomenti del comando (es. ``"inspect", "paths"``).
@@ -63,8 +63,8 @@ class NotebookHelper:
     def tk_year(self, *args: str) -> dict[str, Any]:
         """Come :meth:`tk` ma aggiunge automaticamente ``--year <anno>``.
 
-        Utile per comandi che richiedono l'anno (``inspect paths``,
-        ``inspect schema``).
+        Utile per comandi che richiedono l'anno (``inspect config``,
+        ``inspect summary``).
         """
         return self.tk(*args, "--year", str(self.anno))
 
@@ -78,24 +78,8 @@ class NotebookHelper:
             Dict con chiavi ``columns``, ``schema``, etc. In caso di errore
             restituisce ``{"columns": 0, "schema": []}``.
         """
-        cmd = [
-            "toolkit",
-            "inspect",
-            "schema",
-            "-l",
-            layer,
-            str(self.cfg_path),
-            "--json",
-            "--year",
-            str(self.anno),
-        ]
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode:
-            print(result.stderr, file=sys.stderr)
-            return {"columns": 0, "schema": []}
-        data = json.loads(result.stdout) if result.stdout.strip() else {}
+        data = self.tk_year("inspect", "config", "-l", layer, "-m", "schema")
         if isinstance(data, dict) and "column_count" in data and "columns" in data:
-            # Normalizza: toolkit torna column_count/columns → columns/schema
             return {"columns": data["column_count"], "schema": data["columns"]}
         return data
 

--- a/skills/intake-candidate.md
+++ b/skills/intake-candidate.md
@@ -100,17 +100,17 @@ Prima lascia che la pipeline dica se è tutto ok, poi controlla che i dati abbia
 
 ```bash
 # 1. Stato pipeline
-toolkit status -c candidates/{slug}/dataset.yml -y 2024 --json
+toolkit inspect summary -c candidates/{slug}/dataset.yml -y 2024 --json
 # Oppure MCP: toolkit_status(config_path) → paths, summary, readiness, run_stats
 
 # 2. Dati — conta righe e vedi un campione
-toolkit query -c candidates/{slug}/dataset.yml -l clean -y 2024 --sql "SELECT count(*) FROM data"
-toolkit query -c candidates/{slug}/dataset.yml -l clean -y 2024 --sql "SELECT * FROM data LIMIT 5"
+toolkit inspect config -c candidates/{slug}/dataset.yml -l clean -m sql --sql "SELECT count(*) FROM data"
+toolkit inspect config -c candidates/{slug}/dataset.yml -l clean -m preview --limit 5
 # Oppure MCP: toolkit_layer(config_path, layer="clean", mode="preview", limit=5)
 
 # 3. Se c'è mart, stessa verifica
-toolkit query -c candidates/{slug}/dataset.yml -l mart -y 2024 --sql "SELECT count(*) FROM data"
-toolkit query -c candidates/{slug}/dataset.yml -l mart -y 2024 --sql "SELECT * FROM data LIMIT 5"
+toolkit inspect config -c candidates/{slug}/dataset.yml -l mart -m sql --sql "SELECT count(*) FROM data"
+toolkit inspect config -c candidates/{slug}/dataset.yml -l mart -m preview --limit 5
 ```
 
 I numeri sono nel range atteso? Le colonne sono quelle giuste? Se sì → candidate ok.
@@ -124,9 +124,9 @@ toolkit_layer(config_path, layer="clean", mode="schema")  → schema parquet
 toolkit_schema_diff(config_path)                          → drift colonne tra anni
 
 # CLI
-toolkit inspect profile -c candidates/{slug}/dataset.yml --json
-toolkit inspect schema -c candidates/{slug}/dataset.yml --layer clean --json
-toolkit inspect schema-diff -c candidates/{slug}/dataset.yml --json
+toolkit inspect config -c candidates/{slug}/dataset.yml -l raw -m profile --json
+toolkit inspect config -c candidates/{slug}/dataset.yml -l clean -m schema --json
+toolkit inspect config -c candidates/{slug}/dataset.yml --diff --json
 ```
 
 Blocker specifico documentato, non formulaico.

--- a/skills/run-candidate.md
+++ b/skills/run-candidate.md
@@ -30,7 +30,7 @@ Stop: candidate immaturo, boundary clean/mart assente, problema di fase preceden
 ### 1. Pre-flight
 
 ```bash
-toolkit status -c candidates/{slug}/dataset.yml -y 2024 --json
+toolkit inspect summary -c candidates/{slug}/dataset.yml -y 2024 --json
 ```
 
 Oppure MCP: `toolkit_status(config_path)` → sezioni `paths_info` + `run_stats`.
@@ -49,17 +49,17 @@ Prima lo stato pipeline, poi controlla che i dati abbiano senso.
 
 ```bash
 # Stato pipeline
-toolkit status -c candidates/{slug}/dataset.yml -y 2024 --json
+toolkit inspect summary -c candidates/{slug}/dataset.yml -y 2024 --json
 # Oppure MCP: toolkit_status(config_path) → sezione readiness
 
 # Ispezione dati — conta righe e campione
-toolkit query -c candidates/{slug}/dataset.yml -l clean -y 2024 --sql "SELECT count(*) FROM data"
-toolkit query -c candidates/{slug}/dataset.yml -l clean -y 2024 --sql "SELECT * FROM data LIMIT 5"
+toolkit inspect config -c candidates/{slug}/dataset.yml -l clean -m sql --sql "SELECT count(*) FROM data"
+toolkit inspect config -c candidates/{slug}/dataset.yml -l clean -m preview --limit 5
 # Oppure MCP: toolkit_layer(config_path, layer="clean", mode="preview", limit=5)
 
 # Se c'è mart
-toolkit query -c candidates/{slug}/dataset.yml -l mart -y 2024 --sql "SELECT count(*) FROM data"
-toolkit query -c candidates/{slug}/dataset.yml -l mart -y 2024 --sql "SELECT * FROM data LIMIT 5"
+toolkit inspect config -c candidates/{slug}/dataset.yml -l mart -m sql --sql "SELECT count(*) FROM data"
+toolkit inspect config -c candidates/{slug}/dataset.yml -l mart -m preview --limit 5
 ```
 
 ### 4. Diagnostica (se fallisce)
@@ -72,9 +72,9 @@ toolkit_schema_diff(config_path)                           → drift colonne tra
 toolkit_list_runs(config_path, status="FAILED", limit=5)  → pattern di fallimento
 
 # CLI equivalente
-toolkit inspect profile -c candidates/{slug}/dataset.yml --json
-toolkit inspect schema -c candidates/{slug}/dataset.yml --layer clean --json
-toolkit inspect schema-diff -c candidates/{slug}/dataset.yml --json
+toolkit inspect config -c candidates/{slug}/dataset.yml -l raw -m profile --json
+toolkit inspect config -c candidates/{slug}/dataset.yml -l clean -m schema --json
+toolkit inspect config -c candidates/{slug}/dataset.yml --diff --json
 ```
 
 Se il blocker è isolato → documentalo e chiudi con `scaffolded_with_blocker`.


### PR DESCRIPTION
## Sintesi

Aggiorna le skill e gli helper DI dopo il refactor CLI del toolkit (PR dataciviclab/toolkit#395). I comandi `toolkit status`, `toolkit query`, `inspect profile`, `inspect schema` sono stati sostituiti da `inspect config/summary/runs`.

## Cosa cambia

- [ ] candidate — nuovo dataset o aggiornamento
- [ ] support — dataset di supporto
- [ ] docs — struttura candidate, README, template
- [x] cleanup — refactoring, rimozioni, allineamento
- [ ] workflow o CI
- [ ] altro

## Modifiche

- `skills/run-candidate.md` e `intake-candidate.md`: `status` → `inspect summary`, `query` → `inspect config -m sql`, `inspect profile/schema` → `inspect config -l -m`
- `scripts/notebook_helpers.py`: `tk_schema` ora usa `inspect config`, docstring aggiornati

## Impatto

- [x] Nessun impatto visibile per chi usa il repository

## Verifica

Nessuna — solo documentazione e alias interni.
