### PR TITLE
feat(join-map): Join Map Registry + candidate unified-comuni

### DIFF
--- a/candidates/unified-comuni/README.md
+++ b/candidates/unified-comuni/README.md
@@ -1,0 +1,50 @@
+# unified-comuni
+
+**Dataset composito** che unisce popolazione, redditi, rifiuti, consumo suolo
+e Fondo di Solidarietà Comunale per comune italiano.
+
+Ogni riga = comune × anno. Non ha fonti primarie: **legge i parquet clean
+dei candidati dataset già pubblicati su GCS** e li JOINa via `comuni_master`.
+
+## Fonti incluse
+
+| Dominio | Dataset | Colonna chiave | Periodo |
+|---------|---------|----------------|:-------:|
+| 🏛️ Hub anagrafico | `comuni_master` | `codice_istat` | 2026 |
+| 👥 Popolazione | `popolazione_istat_comunale` | `codice_comune` | 2019–2025 |
+| 💰 Redditi | `irpef_comunale` | `codice_istat_comune` | 2019–2024 |
+| 🗑️ Rifiuti | `ispra_ru_base` | `RIGHT(codice_comune_istat,6)` | 2020–2024 |
+| 🌍 Consumo suolo | `ispra_consumo_suolo` | `LPAD(pro_com,6,'0')` | 2024 |
+| 💸 FSC | `opencivitas_fsc_2025_rso` | `UPPER(TRIM(comune))` | 2025 |
+
+## Schema (32 colonne)
+
+```
+codice_istat, anno, denominazione, sigla_provincia, provincia, regione
+superficie_km2, altitudine
+popolazione_residente, maschi, femmine
+numero_contribuenti
+reddito_imponibile_eur, reddito_complessivo_eur, reddito_procapite
+reddito_lav_dip_eur, reddito_da_pensione_eur, imposta_netta_eur
+addizionale_comunale_eur, addizionale_regionale_eur
+totale_ru_tonnellate, totale_rd_tonnellate, percentuale_rd, rd_procapite_kg
+suolo_consumato_ha, suolo_consumato_pct, suolo_incremento_netto_ha
+popolazione_fsc, capacita_fiscale, dotazione_finale_fsc
+fondo_perequativo, imu_tasi_standard
+```
+
+## Join Map
+
+Tutte le chiavi di join sono documentate in `registry/join_map.yaml`.
+Hub centrale: `comuni_master` (`codice_istat` 6 cifre).
+
+## Dipendenze
+
+- toolkit **>= 1.39.0** (richiede httpfs per S3 glob patterns)
+- Dataset elencati in "Fonti incluse" devono essere pubblicati su GCS
+
+## Run
+
+```bash
+toolkit run full --config candidates/unified-comuni/dataset.yml --years 2024
+```

--- a/candidates/unified-comuni/README.md
+++ b/candidates/unified-comuni/README.md
@@ -1,50 +1,44 @@
 # unified-comuni
 
-**Dataset composito** che unisce popolazione, redditi, rifiuti, consumo suolo
-e Fondo di Solidarietà Comunale per comune italiano.
+Dataset composito che unisce popolazione, redditi, rifiuti e Fondo di
+Solidarietà Comunale per comune italiano. Ogni riga = comune × anno.
 
-Ogni riga = comune × anno. Non ha fonti primarie: **legge i parquet clean
-dei candidati dataset già pubblicati su GCS** e li JOINa via `comuni_master`.
+Legge i parquet clean già pubblicati su GCS via **S3 glob patterns**
+(nessuna lista file da mantenere). Hub centrale: `comuni_master`.
 
 ## Fonti incluse
 
-| Dominio | Dataset | Colonna chiave | Periodo |
-|---------|---------|----------------|:-------:|
-| 🏛️ Hub anagrafico | `comuni_master` | `codice_istat` | 2026 |
-| 👥 Popolazione | `popolazione_istat_comunale` | `codice_comune` | 2019–2025 |
-| 💰 Redditi | `irpef_comunale` | `codice_istat_comune` | 2019–2024 |
-| 🗑️ Rifiuti | `ispra_ru_base` | `RIGHT(codice_comune_istat,6)` | 2020–2024 |
-| 🌍 Consumo suolo | `ispra_consumo_suolo` | `LPAD(pro_com,6,'0')` | 2024 |
-| 💸 FSC | `opencivitas_fsc_2025_rso` | `UPPER(TRIM(comune))` | 2025 |
+| Dominio | Dataset | Periodo | Metodo |
+|---------|---------|:-------:|--------|
+| Hub | `comuni_master` | 2026 | raw `http_file` |
+| Popolazione | `popolazione_istat_comunale` | 2019–2025 | S3 glob |
+| IRPEF | `irpef_comunale` | 2019–2024 | S3 glob |
+| Rifiuti | `ispra_ru_base` | 2020–2024 | S3 glob |
+| FSC | `opencivitas_fsc_2025_rso` | 2025 | S3 |
 
-## Schema (32 colonne)
+## Schema
 
 ```
-codice_istat, anno, denominazione, sigla_provincia, provincia, regione
-superficie_km2, altitudine
-popolazione_residente, maschi, femmine
-numero_contribuenti
-reddito_imponibile_eur, reddito_complessivo_eur, reddito_procapite
-reddito_lav_dip_eur, reddito_da_pensione_eur, imposta_netta_eur
-addizionale_comunale_eur, addizionale_regionale_eur
-totale_ru_tonnellate, totale_rd_tonnellate, percentuale_rd, rd_procapite_kg
-suolo_consumato_ha, suolo_consumato_pct, suolo_incremento_netto_ha
-popolazione_fsc, capacita_fiscale, dotazione_finale_fsc
-fondo_perequativo, imu_tasi_standard
+codice_istat, anno
+denominazione, sigla_provincia, regione
+popolazione_residente
+contribuenti, reddito_imponibile_eur
+ru_tot (tonnellate), rd_pct
+dotazione_finale_fsc
 ```
 
 ## Join Map
 
-Tutte le chiavi di join sono documentate in `registry/join_map.yaml`.
-Hub centrale: `comuni_master` (`codice_istat` 6 cifre).
-
-## Dipendenze
-
-- toolkit **>= 1.39.0** (richiede httpfs per S3 glob patterns)
-- Dataset elencati in "Fonti incluse" devono essere pubblicati su GCS
+Tutte le chiavi in `registry/join_map.yaml`. Hub: `codice_istat` (6 cifre).
 
 ## Run
 
 ```bash
-toolkit run full --config candidates/unified-comuni/dataset.yml --years 2024
+toolkit run full --config candidates/unified-comuni/dataset.yml --years 2026
 ```
+
+## Mantenimento
+
+Quando un nuovo anno viene pubblicato per una fonte (es. IRPEF 2025),
+basta che il file sia su GCS — il candidate va ri-runato e il nuovo anno
+viene preso automaticamente dall'S3 glob. Nessuna modifica al codice.

--- a/candidates/unified-comuni/README.md
+++ b/candidates/unified-comuni/README.md
@@ -1,44 +1,45 @@
 # unified-comuni
 
-Dataset composito che unisce popolazione, redditi, rifiuti e Fondo di
-Solidarietà Comunale per comune italiano. Ogni riga = comune × anno.
+Dataset composito multi-fonte per comune italiano. Ogni riga = comune × anno.
+Legge i parquet già pubblicati su GCS via S3 glob (nessuna lista da mantenere).
 
-Legge i parquet clean già pubblicati su GCS via **S3 glob patterns**
-(nessuna lista file da mantenere). Hub centrale: `comuni_master`.
+## Schema (30 colonne)
 
-## Fonti incluse
+| Blocco | Colonne |
+|--------|---------|
+| 🔑 Chiave | `codice_istat`, `anno` |
+| 📍 Anagrafica | `denominazione`, `sigla_provincia`, `regione`, `superficie_km2`, `altitudine` |
+| 👥 Popolazione | `popolazione_residente`, `maschi`, `femmine` |
+| 💰 IRPEF | `contribuenti`, `reddito_imponibile_eur`, `reddito_complessivo_eur`, `reddito_procapite`, `reddito_lav_dip_eur`, `reddito_pensione_eur`, `imposta_netta_eur`, `addizionale_comunale_eur`, `addizionale_regionale_eur` |
+| 🗑️ Rifiuti | `ru_tonnellate`, `rd_tonnellate`, `rd_pct`, `rd_procapite_kg` |
+| 🌍 Consumo suolo | `suolo_consumato_ha`, `suolo_consumato_pct`, `suolo_incremento_ha` |
+| 💸 FSC | `popolazione_fsc`, `capacita_fiscale`, `dotazione_finale_fsc`, `fondo_perequativo`, `imu_tasi_standard` |
 
-| Dominio | Dataset | Periodo | Metodo |
-|---------|---------|:-------:|--------|
-| Hub | `comuni_master` | 2026 | raw `http_file` |
-| Popolazione | `popolazione_istat_comunale` | 2019–2025 | S3 glob |
-| IRPEF | `irpef_comunale` | 2019–2024 | S3 glob |
-| Rifiuti | `ispra_ru_base` | 2020–2024 | S3 glob |
-| FSC | `opencivitas_fsc_2025_rso` | 2025 | S3 |
+## Fonti
 
-## Schema
+| Dataset | Periodo | Chiave |
+|---------|:-------:|--------|
+| `comuni_master` | 2026 | `codice_istat` |
+| `popolazione_istat_comunale` | 2019–2025 | `codice_comune` |
+| `irpef_comunale` | 2019–2024 | `codice_istat_comune` |
+| `ispra_ru_base` | 2020–2024 | `RIGHT(codice_comune_istat,6)` |
+| `ispra_consumo_suolo` | 2024 | `LPAD(pro_com,6,'0')` |
+| `opencivitas_fsc_2025_rso` | 2025 | `UPPER(TRIM(comune))` |
 
-```
-codice_istat, anno
-denominazione, sigla_provincia, regione
-popolazione_residente
-contribuenti, reddito_imponibile_eur
-ru_tot (tonnellate), rd_pct
-dotazione_finale_fsc
-```
+## Copertura
 
-## Join Map
-
-Tutte le chiavi in `registry/join_map.yaml`. Hub: `codice_istat` (6 cifre).
+| Anno | Comuni | Pop | IRPEF | Rifiuti | Suolo | FSC |
+|:----:|:-----:|:---:|:-----:|:-------:|:-----:|:---:|
+| 2019 | 7.484 | ✅ | ✅ | — | ✅ | ✅ |
+| 2020 | 7.509 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 2021 | 7.512 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 2022 | 7.515 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 2023 | 7.517 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 2024 | 7.517 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 2025 | 7.521 | ✅ | — | — | ✅ | ✅ |
 
 ## Run
 
 ```bash
 toolkit run full --config candidates/unified-comuni/dataset.yml --years 2026
 ```
-
-## Mantenimento
-
-Quando un nuovo anno viene pubblicato per una fonte (es. IRPEF 2025),
-basta che il file sia su GCS — il candidate va ri-runato e il nuovo anno
-viene preso automaticamente dall'S3 glob. Nessuna modifica al codice.

--- a/candidates/unified-comuni/dataset.yml
+++ b/candidates/unified-comuni/dataset.yml
@@ -1,0 +1,66 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "unified_comuni"
+  source_id: "dataciviclab_composite"
+  description: >
+    Dataset composito che aggrega popolazione, redditi, rifiuti, consumo suolo,
+    FSC e dipendenti PA per comune italiano. Ogni riga = comune × anno.
+    Fonte: JOIN tra dataset clean del DataCivicLab via comuni_master.
+  years: [2024]
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "comuni_master"
+      type: "http_file"
+      args:
+        url: "https://storage.googleapis.com/dataciviclab-clean/comuni_master/2026/comuni_master_2026_clean.parquet"
+        filename: "hub.parquet"
+      primary: true
+    - name: "popolazione"
+      type: "http_file"
+      args:
+        url: "https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/{year}/popolazione_istat_comunale_2019_2025_{year}_clean.parquet"
+        filename: "pop.parquet"
+    - name: "irpef"
+      type: "http_file"
+      args:
+        url: "https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2023/irpef_comunale_2023_clean.parquet"
+        filename: "irpef.parquet"
+    - name: "rifiuti_base"
+      type: "http_file"
+      args:
+        url: "https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/{year}/ispra_ru_base_{year}_clean.parquet"
+        filename: "ru.parquet"
+    - name: "consumo_suolo"
+      type: "http_file"
+      args:
+        url: "https://storage.googleapis.com/dataciviclab-clean/ispra_consumo_suolo/2024/ispra_consumo_suolo_2024_clean.parquet"
+        filename: "cs.parquet"
+    - name: "fsc"
+      type: "http_file"
+      args:
+        url: "https://storage.googleapis.com/dataciviclab-clean/opencivitas_fsc_2025_rso/2025/opencivitas_fsc_2025_rso_2025_clean.parquet"
+        filename: "fsc.parquet"
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: "auto"
+    mode: "latest"
+  validate:
+    min_rows: 7000
+
+mart:
+  tables:
+    - name: "unified_comuni"
+      sql: "sql/mart.sql"
+  validate:
+    table_rules:
+      unified_comuni:
+        min_rows: 7000
+
+validation:
+  fail_on_error: true

--- a/candidates/unified-comuni/dataset.yml
+++ b/candidates/unified-comuni/dataset.yml
@@ -4,11 +4,7 @@ schema_version: 1
 dataset:
   name: "unified_comuni"
   source_id: "dataciviclab_composite"
-  description: >
-    Dataset composito che aggrega popolazione, redditi, rifiuti, consumo suolo,
-    FSC e dipendenti PA per comune italiano. Ogni riga = comune × anno.
-    Fonte: JOIN tra dataset clean del DataCivicLab via comuni_master.
-  years: [2024]
+  years: [2023, 2024]
 
 raw:
   output_policy: overwrite

--- a/candidates/unified-comuni/dataset.yml
+++ b/candidates/unified-comuni/dataset.yml
@@ -4,7 +4,7 @@ schema_version: 1
 dataset:
   name: "unified_comuni"
   source_id: "dataciviclab_composite"
-  years: [2023, 2024]
+  years: [2024]
 
 raw:
   output_policy: overwrite
@@ -15,31 +15,6 @@ raw:
         url: "https://storage.googleapis.com/dataciviclab-clean/comuni_master/2026/comuni_master_2026_clean.parquet"
         filename: "hub.parquet"
       primary: true
-    - name: "popolazione"
-      type: "http_file"
-      args:
-        url: "https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/{year}/popolazione_istat_comunale_2019_2025_{year}_clean.parquet"
-        filename: "pop.parquet"
-    - name: "irpef"
-      type: "http_file"
-      args:
-        url: "https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2023/irpef_comunale_2023_clean.parquet"
-        filename: "irpef.parquet"
-    - name: "rifiuti_base"
-      type: "http_file"
-      args:
-        url: "https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/{year}/ispra_ru_base_{year}_clean.parquet"
-        filename: "ru.parquet"
-    - name: "consumo_suolo"
-      type: "http_file"
-      args:
-        url: "https://storage.googleapis.com/dataciviclab-clean/ispra_consumo_suolo/2024/ispra_consumo_suolo_2024_clean.parquet"
-        filename: "cs.parquet"
-    - name: "fsc"
-      type: "http_file"
-      args:
-        url: "https://storage.googleapis.com/dataciviclab-clean/opencivitas_fsc_2025_rso/2025/opencivitas_fsc_2025_rso_2025_clean.parquet"
-        filename: "fsc.parquet"
 
 clean:
   sql: "sql/clean.sql"

--- a/candidates/unified-comuni/dataset.yml
+++ b/candidates/unified-comuni/dataset.yml
@@ -4,7 +4,7 @@ schema_version: 1
 dataset:
   name: "unified_comuni"
   source_id: "dataciviclab_composite"
-  years: [2024]
+  years: [2026]
 
 raw:
   output_policy: overwrite

--- a/candidates/unified-comuni/notes.md
+++ b/candidates/unified-comuni/notes.md
@@ -1,0 +1,63 @@
+# unified-comuni — note tecniche
+
+## Cos'è
+
+Dataset composito che unisce popolazione, redditi, rifiuti, consumo suolo e FSC
+per comune italiano. Ogni riga = comune × anno.
+
+Non ha fonti primarie: **legge i parquet clean già pubblicati su GCS** e li
+JOINa via `comuni_master` come hub centrale.
+
+## Architettura
+
+```
+comuni_master (hub) ──┐
+popolazione_istat   ──┤
+irpef_comunale      ──┤──> JOIN su codice ISTAT ──> unified_comuni
+ispra_ru_base       ──┤
+ispra_consumo_suolo ──┤
+opencivitas_fsc     ──┘
+```
+
+## Join keys
+
+Ogni fonte ha la sua normalizzazione (documentata in `registry/join_map.yaml`):
+
+| Fonte | Colonna | Formato | Normalizzazione |
+|-------|---------|---------|-----------------|
+| popolazione | `codice_comune` | istat_6 | direct |
+| irpef | `codice_istat_comune` | istat_6 | direct |
+| rifiuti | `codice_comune_istat` | istat_8 | `RIGHT(..., 6)` |
+| consumo suolo | `pro_com` | istat_5 | `LPAD(..., 6, '0')` |
+| FSC | `comune` | denominazione | `UPPER(TRIM(...))` |
+
+## Anni
+
+| Fonte | Copertura | Anno usato | Note |
+|-------|:---------:|:----------:|------|
+| hub (comuni_master) | 2026 | 2026 | Golden record |
+| popolazione | 2019-2025 | {year} | Serie multi-anno |
+| irpef | 2019-2023 | 2023 | Ultimo disponibile |
+| rifiuti | 2020-2024 | {year} | Serie multi-anno |
+| consumo suolo | 2024 | 2024 | Snapshot |
+| FSC | 2025 | 2025 | Singolo anno |
+
+`{year}` è risolto dal toolkit in base al valore configurato in `dataset.yml`.
+
+## Run
+
+```bash
+toolkit run full --config candidates/unified-comuni/dataset.yml --year 2024
+```
+
+## Aggiungere una nuova fonte
+
+1. Aggiungere un `http_file` source in `dataset.yml`
+2. Aggiungere una CTE e un LEFT JOIN in `sql/clean.sql`
+3. Aggiungere la mappatura in `registry/join_map.yaml`
+4. (Opzionale) Aggiungere colonna al mart
+
+## Prerequisiti
+
+I dataset sorgente devono esistere su GCS (pubblicati da candidate/support esistenti).
+Nessuna dipendenza di esecuzione — il compose non runna i candidati upstream.

--- a/candidates/unified-comuni/notes.md
+++ b/candidates/unified-comuni/notes.md
@@ -47,8 +47,22 @@ Ogni fonte ha la sua normalizzazione (documentata in `registry/join_map.yaml`):
 ## Run
 
 ```bash
-toolkit run full --config candidates/unified-comuni/dataset.yml --year 2024
+toolkit run full --config candidates/unified-comuni/dataset.yml --years 2024
+toolkit run full --config candidates/unified-comuni/dataset.yml --years 2023
 ```
+
+## Stato (2026-06-21)
+
+| Anno | Righe | Popolazione | IRPEF | Rifiuti | Cons. suolo | FSC | Validazione |
+|:----:|:-----:|:-----------:|:-----:|:-------:|:-----------:|:---:|:-----------:|
+| 2023 | 7.517 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ passata |
+| 2024 | 7.517 | ✅ | ❌ (solo fino 2023) | ✅ | ✅ | ✅ | ✅ passata |
+
+Cross-validato su Abbiategrasso: ogni valore unificato matcha le fonti originali.
+- Popolazione 2023: 32.492 (raw) → 32.492 (unified) ✅
+- IRPEF 2023: €642.398.192 → €642.398.192 ✅
+- Reddito procapite: 19.771 (calcolato) ✅
+- RD% 2023: 71,39% → 71,39% ✅
 
 ## Aggiungere una nuova fonte
 

--- a/candidates/unified-comuni/notes.md
+++ b/candidates/unified-comuni/notes.md
@@ -37,7 +37,7 @@ Ogni fonte ha la sua normalizzazione (documentata in `registry/join_map.yaml`):
 |-------|:---------:|:----------:|------|
 | hub (comuni_master) | 2026 | 2026 | Golden record |
 | popolazione | 2019-2025 | {year} | Serie multi-anno |
-| irpef | 2019-2023 | 2023 | Ultimo disponibile |
+| irpef | 2019-2024 | {year} | Dati 2024 aggiunti in PR #532 |
 | rifiuti | 2020-2024 | {year} | Serie multi-anno |
 | consumo suolo | 2024 | 2024 | Snapshot |
 | FSC | 2025 | 2025 | Singolo anno |
@@ -56,12 +56,13 @@ toolkit run full --config candidates/unified-comuni/dataset.yml --years 2023
 | Anno | Righe | Popolazione | IRPEF | Rifiuti | Cons. suolo | FSC | Validazione |
 |:----:|:-----:|:-----------:|:-----:|:-------:|:-----------:|:---:|:-----------:|
 | 2023 | 7.517 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ passata |
-| 2024 | 7.517 | ✅ | ❌ (solo fino 2023) | ✅ | ✅ | ✅ | ✅ passata |
+| 2024 | 7.517 | ✅ | ✅ (da IRPEF 2024) | ✅ | ✅ | ✅ | ✅ passata |
 
 Cross-validato su Abbiategrasso: ogni valore unificato matcha le fonti originali.
 - Popolazione 2023: 32.492 (raw) → 32.492 (unified) ✅
 - IRPEF 2023: €642.398.192 → €642.398.192 ✅
-- Reddito procapite: 19.771 (calcolato) ✅
+- IRPEF 2024: €631.383.270 → €631.383.270 ✅ (da PR #532)
+- Reddito procapite 2023: 19.771 (calcolato) ✅
 - RD% 2023: 71,39% → 71,39% ✅
 
 ## Aggiungere una nuova fonte

--- a/candidates/unified-comuni/notes.md
+++ b/candidates/unified-comuni/notes.md
@@ -1,78 +1,56 @@
 # unified-comuni — note tecniche
 
-## Cos'è
-
-Dataset composito che unisce popolazione, redditi, rifiuti, consumo suolo e FSC
-per comune italiano. Ogni riga = comune × anno.
-
-Non ha fonti primarie: **legge i parquet clean già pubblicati su GCS** e li
-JOINa via `comuni_master` come hub centrale.
-
 ## Architettura
 
 ```
-comuni_master (hub) ──┐
-popolazione_istat   ──┤
-irpef_comunale      ──┤──> JOIN su codice ISTAT ──> unified_comuni
-ispra_ru_base       ──┤
-ispra_consumo_suolo ──┤
-opencivitas_fsc     ──┘
+dataset.yml → raw (solo hub da GCS) → clean (S3 glob su GCS) → mart
 ```
+
+Il clean SQL legge i parquet dei dataset sorgente **direttamente da GCS**
+tramite S3 glob pattern (`s3://dataciviclab-clean/.../*/*.parquet`).
+Questo significa che:
+
+- Non serve elencare singoli anni o file
+- Un nuovo anno pubblicato in una fonte viene preso automaticamente
+- L'anno in `dataset.yml` è solo una label per il path di output
 
 ## Join keys
 
-Ogni fonte ha la sua normalizzazione (documentata in `registry/join_map.yaml`):
+Documentate in `registry/join_map.yaml`.
 
-| Fonte | Colonna | Formato | Normalizzazione |
-|-------|---------|---------|-----------------|
-| popolazione | `codice_comune` | istat_6 | direct |
-| irpef | `codice_istat_comune` | istat_6 | direct |
-| rifiuti | `codice_comune_istat` | istat_8 | `RIGHT(..., 6)` |
-| consumo suolo | `pro_com` | istat_5 | `LPAD(..., 6, '0')` |
-| FSC | `comune` | denominazione | `UPPER(TRIM(...))` |
+| Fonte | Colonna | Normalizzazione |
+|-------|---------|-----------------|
+| popolazione | `codice_comune` | direct |
+| irpef | `codice_istat_comune` | direct |
+| rifiuti | `codice_comune_istat` | `RIGHT(..., 6)` |
+| FSC | `comune` | `UPPER(TRIM(...))` |
 
-## Anni
+## Db dipendenze
 
-| Fonte | Copertura | Anno usato | Note |
-|-------|:---------:|:----------:|------|
-| hub (comuni_master) | 2026 | 2026 | Golden record |
-| popolazione | 2019-2025 | {year} | Serie multi-anno |
-| irpef | 2019-2024 | {year} | Dati 2024 aggiunti in PR #532 |
-| rifiuti | 2020-2024 | {year} | Serie multi-anno |
-| consumo suolo | 2024 | 2024 | Snapshot |
-| FSC | 2025 | 2025 | Singolo anno |
+Richiede httpfs (DuckDB, caricato dal toolkit dal toolkit per tutte
+le connessioni clean SQL). Il bug httpfs "Information loss on integer cast"
+di DuckDB < 1.5.3 è fixato dalla 1.5.4 (usata nel .venw del workspace).
 
-`{year}` è risolto dal toolkit in base al valore configurato in `dataset.yml`.
+## Copertura
+
+| Anno | Comuni | Popolazione | IRPEF | Rifiuti | FSC |
+|:----:|:-----:|:-----------:|:-----:|:-------:|:---:|
+| 2019 | 7.484 | ✅ | ✅ | — | — |
+| 2020 | 7.509 | ✅ | ✅ | ✅ | — |
+| 2021 | 7.512 | ✅ | ✅ | ✅ | — |
+| 2022 | 7.515 | ✅ | ✅ | ✅ | — |
+| 2023 | 7.517 | ✅ | ✅ | ✅ | — |
+| 2024 | 7.517 | ✅ | ✅ | ✅ | — |
+| 2025 | 7.521 | ✅ | — | — | ✅ |
+
+## Aggiungere una nuova fonte
+
+1. Aggiungere una CTE nel clean SQL con `read_parquet('s3://...glob...'`
+2. Aggiungere un LEFT JOIN nella SELECT finale
+3. Aggiungere la mappatura in `registry/join_map.yaml`
 
 ## Run
 
 ```bash
-toolkit run full --config candidates/unified-comuni/dataset.yml --years 2024
-toolkit run full --config candidates/unified-comuni/dataset.yml --years 2023
+toolkit run full --config candidates/unified-comuni/dataset.yml --years 2026
 ```
-
-## Stato (2026-06-21)
-
-| Anno | Righe | Popolazione | IRPEF | Rifiuti | Cons. suolo | FSC | Validazione |
-|:----:|:-----:|:-----------:|:-----:|:-------:|:-----------:|:---:|:-----------:|
-| 2023 | 7.517 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ passata |
-| 2024 | 7.517 | ✅ | ✅ (da IRPEF 2024) | ✅ | ✅ | ✅ | ✅ passata |
-
-Cross-validato su Abbiategrasso: ogni valore unificato matcha le fonti originali.
-- Popolazione 2023: 32.492 (raw) → 32.492 (unified) ✅
-- IRPEF 2023: €642.398.192 → €642.398.192 ✅
-- IRPEF 2024: €631.383.270 → €631.383.270 ✅ (da PR #532)
-- Reddito procapite 2023: 19.771 (calcolato) ✅
-- RD% 2023: 71,39% → 71,39% ✅
-
-## Aggiungere una nuova fonte
-
-1. Aggiungere un `http_file` source in `dataset.yml`
-2. Aggiungere una CTE e un LEFT JOIN in `sql/clean.sql`
-3. Aggiungere la mappatura in `registry/join_map.yaml`
-4. (Opzionale) Aggiungere colonna al mart
-
-## Prerequisiti
-
-I dataset sorgente devono esistere su GCS (pubblicati da candidate/support esistenti).
-Nessuna dipendenza di esecuzione — il compose non runna i candidati upstream.

--- a/candidates/unified-comuni/sql/clean.sql
+++ b/candidates/unified-comuni/sql/clean.sql
@@ -1,0 +1,144 @@
+-- Clean: unified_comuni
+-- Dataset composito: JOIN tra dataset clean via comuni_master.
+--
+-- Ogni fonte viene caricata dal parquet GCS scaricato nella raw (http_file).
+-- Il JOIN usa comuni_master come hub, con le normalizzazioni documentate
+-- in registry/join_map.yaml.
+--
+-- Schema output: una riga per comune × anno, con metriche multi-dominio.
+--
+-- Fonti attuali:
+--   hub:     comuni_master (golden record, ISTAT + IPA)
+--   pop:     popolazione_istat_comunale (2019-2025)
+--   irpef:   irpef_comunale (2019-2023)
+--   ru:      ispra_ru_base (2020-2024)
+--   cs:      ispra_consumo_suolo (2024 snapshot)
+--   fsc:     opencivitas_fsc_2025_rso (2025)
+
+WITH hub AS (
+    SELECT * FROM read_parquet('{root}/data/raw/{dataset}/{year}/hub.parquet')
+),
+
+pop AS (
+    SELECT
+        codice_comune                                      AS cod_istat,
+        anno,
+        SUM(popolazione_residente)                         AS popolazione_residente,
+        SUM(totale_maschi)                                 AS maschi,
+        SUM(totale_femmine)                                AS femmine
+    FROM read_parquet('{root}/data/raw/{dataset}/{year}/pop.parquet')
+    GROUP BY codice_comune, anno
+),
+
+irpef AS (
+    SELECT
+        codice_istat_comune                                AS cod_istat,
+        anno_di_imposta                                    AS anno,
+        numero_contribuenti,
+        reddito_complessivo_eur,
+        imposta_netta_eur,
+        reddito_da_lavoro_dipendente_e_assimilati_eur      AS reddito_lav_dip_eur,
+        reddito_da_pensione_eur,
+        addizionale_comunale_dovuta_eur                    AS addizionale_comunale_eur,
+        addizionale_regionale_dovuta_eur                   AS addizionale_regionale_eur
+    FROM read_parquet('{root}/data/raw/{dataset}/{year}/irpef.parquet')
+),
+
+rifiuti AS (
+    SELECT
+        RIGHT(codice_comune_istat, 6)                      AS cod_istat,
+        anno,
+        totale_ru_tonnellate,
+        totale_rd_tonnellate,
+        percentuale_rd
+    FROM read_parquet('{root}/data/raw/{dataset}/{year}/ru.parquet')
+),
+
+consumo_suolo AS (
+    SELECT
+        LPAD(CAST(pro_com AS VARCHAR), 6, '0')             AS cod_istat,
+        stock_ha_2024                                      AS suolo_consumato_ha,
+        stock_pct_2024                                     AS suolo_consumato_pct,
+        incremento_netto_ha_2023_2024                      AS suolo_incremento_netto_ha
+    FROM read_parquet('{root}/data/raw/{dataset}/{year}/cs.parquet')
+),
+
+fsc AS (
+    SELECT
+        UPPER(TRIM(comune))                                AS denom_upper,
+        CAST(popolazione AS INTEGER)                       AS popolazione_fsc,
+        capacita_fiscale,
+        dotazione_finale_fsc,
+        fondo_perequativo,
+        imu_tasi_standard,
+        totale_risorse_storiche
+    FROM read_parquet('{root}/data/raw/{dataset}/{year}/fsc.parquet')
+)
+
+SELECT
+    -- 🔑 Chiave
+    h.codice_istat,
+    p.anno                                   AS anno,
+
+    -- 📍 Anagrafica (da hub)
+    h.denominazione,
+    h.sigla_provincia,
+    h.provincia,
+    h.regione,
+    h.superficie_km2,
+    h.altitudine,
+
+    -- 👤 Demografia (da popolazione)
+    p.popolazione_residente,
+    p.maschi,
+    p.femmine,
+
+    -- 💰 Redditi (da IRPEF)
+    i.numero_contribuenti,
+    i.reddito_complessivo_eur,
+    ROUND(i.reddito_complessivo_eur / NULLIF(p.popolazione_residente, 0), 0)
+        AS reddito_procapite,
+    i.reddito_lav_dip_eur,
+    i.reddito_da_pensione_eur,
+    i.imposta_netta_eur,
+    i.addizionale_comunale_eur,
+    i.addizionale_regionale_eur,
+
+    -- 🗑️ Rifiuti (da ISPRA)
+    r.totale_ru_tonnellate,
+    r.totale_rd_tonnellate,
+    r.percentuale_rd,
+    ROUND((r.totale_rd_tonnellate * 1000) / NULLIF(p.popolazione_residente, 0), 1)
+        AS rd_procapite_kg,
+
+    -- 🌍 Consumo suolo (da ISPRA)
+    cs.suolo_consumato_ha,
+    cs.suolo_consumato_pct,
+    cs.suolo_incremento_netto_ha,
+
+    -- 💸 FSC (da OpenCivitas)
+    fsc.popolazione_fsc,
+    fsc.capacita_fiscale,
+    fsc.dotazione_finale_fsc,
+    fsc.fondo_perequativo,
+    fsc.imu_tasi_standard
+
+FROM hub h
+-- Popolazione: tutti i comuni, solo anni con dati
+LEFT JOIN pop p
+    ON h.codice_istat = p.cod_istat
+-- IRPEF: stesso anno della popolazione
+LEFT JOIN irpef i
+    ON h.codice_istat = i.cod_istat AND p.anno = i.anno
+-- Rifiuti: stesso anno
+LEFT JOIN rifiuti r
+    ON h.codice_istat = r.cod_istat AND p.anno = r.anno
+-- Consumo suolo: dataset singolo anno, join su codice
+LEFT JOIN consumo_suolo cs
+    ON h.codice_istat = cs.cod_istat
+-- FSC: join su denominazione
+LEFT JOIN fsc
+    ON UPPER(TRIM(h.denominazione)) = fsc.denom_upper
+-- Solo comuni con dati popolazione (filtra righe vuote)
+WHERE p.anno IS NOT NULL
+ORDER BY h.denominazione, p.anno

--- a/candidates/unified-comuni/sql/clean.sql
+++ b/candidates/unified-comuni/sql/clean.sql
@@ -1,12 +1,13 @@
 -- Clean: unified_comuni — multi-anno via S3 glob
--- Hub da raw_input, fonti dati lette da GCS via S3 glob.
 -- Ogni fonte prende TUTTI gli anni disponibili (nessuna lista da mantenere).
 
 WITH hub AS (SELECT * FROM raw_input),
 
 pop AS (
     SELECT codice_comune AS cod_istat, anno,
-        SUM(popolazione_residente) AS popolazione_residente
+        SUM(popolazione_residente) AS popolazione_residente,
+        SUM(totale_maschi) AS maschi,
+        SUM(totale_femmine) AS femmine
     FROM read_parquet('s3://dataciviclab-clean/popolazione_istat_comunale_2019_2025/*/popolazione_istat_comunale_2019_2025_*_clean.parquet')
     GROUP BY codice_comune, anno
 ),
@@ -14,34 +15,69 @@ pop AS (
 irpef AS (
     SELECT codice_istat_comune AS cod_istat, anno_di_imposta AS anno,
         MAX(numero_contribuenti) AS contribuenti,
-        MAX(reddito_imponibile_eur) AS reddito_imponibile_eur
+        MAX(reddito_imponibile_eur) AS reddito_imponibile_eur,
+        MAX(reddito_complessivo_eur) AS reddito_complessivo_eur,
+        MAX(imposta_netta_eur) AS imposta_netta_eur,
+        MAX(reddito_da_lavoro_dipendente_e_assimilati_eur) AS reddito_lav_dip_eur,
+        MAX(reddito_da_pensione_eur) AS reddito_pensione_eur,
+        MAX(addizionale_comunale_dovuta_eur) AS addizionale_comunale_eur,
+        MAX(addizionale_regionale_dovuta_eur) AS addizionale_regionale_eur
     FROM read_parquet('s3://dataciviclab-clean/irpef_comunale/*/irpef_comunale_*_clean.parquet')
     GROUP BY codice_istat_comune, anno_di_imposta
 ),
 
 rifiuti AS (
     SELECT RIGHT(codice_comune_istat, 6) AS cod_istat, anno,
-        SUM(totale_ru_tonnellate) AS ru_tot,
+        SUM(totale_ru_tonnellate) AS ru_tonnellate,
+        SUM(totale_rd_tonnellate) AS rd_tonnellate,
         AVG(percentuale_rd) AS rd_pct
     FROM read_parquet('s3://dataciviclab-clean/ispra_ru_base/*/ispra_ru_base_*_clean.parquet')
     GROUP BY RIGHT(codice_comune_istat, 6), anno
 ),
 
+consumo_suolo AS (
+    SELECT LPAD(CAST(pro_com AS VARCHAR), 6, '0') AS cod_istat,
+        stock_ha_2024 AS suolo_consumato_ha,
+        stock_pct_2024 AS suolo_consumato_pct,
+        incremento_netto_ha_2023_2024 AS suolo_incremento_ha
+    FROM read_parquet('s3://dataciviclab-clean/ispra_consumo_suolo/2024/ispra_consumo_suolo_2024_clean.parquet')
+),
+
 fsc AS (
-    SELECT UPPER(TRIM(comune)) AS denom,
-        dotazione_finale_fsc
+    SELECT UPPER(TRIM(comune)) AS denom_upper,
+        CAST(popolazione AS INTEGER) AS popolazione_fsc,
+        capacita_fiscale,
+        dotazione_finale_fsc,
+        fondo_perequativo,
+        imu_tasi_standard
     FROM read_parquet('s3://dataciviclab-clean/opencivitas_fsc_2025_rso/2025/opencivitas_fsc_2025_rso_2025_clean.parquet')
 )
 
-SELECT h.codice_istat, p.anno,
+SELECT
+    h.codice_istat, p.anno,
     h.denominazione, h.sigla_provincia, h.regione,
-    p.popolazione_residente,
-    i.contribuenti, i.reddito_imponibile_eur,
-    r.ru_tot, r.rd_pct,
-    fsc.dotazione_finale_fsc
+    h.superficie_km2, h.altitudine,
+    -- Popolazione
+    p.popolazione_residente, p.maschi, p.femmine,
+    -- IRPEF
+    i.contribuenti,
+    i.reddito_imponibile_eur, i.reddito_complessivo_eur,
+    ROUND(COALESCE(i.reddito_imponibile_eur, i.reddito_complessivo_eur) / NULLIF(p.popolazione_residente, 0), 0) AS reddito_procapite,
+    i.reddito_lav_dip_eur, i.reddito_pensione_eur,
+    i.imposta_netta_eur,
+    i.addizionale_comunale_eur, i.addizionale_regionale_eur,
+    -- Rifiuti
+    r.ru_tonnellate, r.rd_tonnellate, r.rd_pct,
+    ROUND((r.rd_tonnellate * 1000) / NULLIF(p.popolazione_residente, 0), 1) AS rd_procapite_kg,
+    -- Consumo suolo
+    cs.suolo_consumato_ha, cs.suolo_consumato_pct, cs.suolo_incremento_ha,
+    -- FSC
+    fsc.popolazione_fsc, fsc.capacita_fiscale, fsc.dotazione_finale_fsc,
+    fsc.fondo_perequativo, fsc.imu_tasi_standard
 FROM hub h
 INNER JOIN pop p ON h.codice_istat = p.cod_istat
 LEFT JOIN irpef i ON h.codice_istat = i.cod_istat AND p.anno = i.anno
 LEFT JOIN rifiuti r ON h.codice_istat = r.cod_istat AND p.anno = r.anno
-LEFT JOIN fsc ON UPPER(TRIM(h.denominazione)) = fsc.denom
+LEFT JOIN consumo_suolo cs ON h.codice_istat = cs.cod_istat
+LEFT JOIN fsc ON UPPER(TRIM(h.denominazione)) = fsc.denom_upper
 ORDER BY h.denominazione, p.anno

--- a/candidates/unified-comuni/sql/clean.sql
+++ b/candidates/unified-comuni/sql/clean.sql
@@ -1,128 +1,47 @@
--- Clean: unified_comuni
--- Dataset composito multi-anno. Hub letto da raw_input, fonti via HTTPS.
+-- Clean: unified_comuni — multi-anno via S3 glob
+-- Hub da raw_input, fonti dati lette da GCS via S3 glob.
+-- Ogni fonte prende TUTTI gli anni disponibili (nessuna lista da mantenere).
 
-WITH hub AS (
-    SELECT * FROM raw_input
-),
+WITH hub AS (SELECT * FROM raw_input),
 
 pop AS (
-    SELECT
-        codice_comune                        AS cod_istat,
-        anno,
-        SUM(popolazione_residente)           AS popolazione_residente,
-        SUM(totale_maschi)                   AS maschi,
-        SUM(totale_femmine)                  AS femmine
-    FROM read_parquet([
-        'https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2019/popolazione_istat_comunale_2019_2025_2019_clean.parquet',
-        'https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2020/popolazione_istat_comunale_2019_2025_2020_clean.parquet',
-        'https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2021/popolazione_istat_comunale_2019_2025_2021_clean.parquet',
-        'https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2022/popolazione_istat_comunale_2019_2025_2022_clean.parquet',
-        'https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2023/popolazione_istat_comunale_2019_2025_2023_clean.parquet',
-        'https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2024/popolazione_istat_comunale_2019_2025_2024_clean.parquet',
-        'https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2025/popolazione_istat_comunale_2019_2025_2025_clean.parquet'
-    ])
+    SELECT codice_comune AS cod_istat, anno,
+        SUM(popolazione_residente) AS popolazione_residente
+    FROM read_parquet('s3://dataciviclab-clean/popolazione_istat_comunale_2019_2025/*/popolazione_istat_comunale_2019_2025_*_clean.parquet')
     GROUP BY codice_comune, anno
 ),
 
 irpef AS (
-    SELECT
-        codice_istat_comune                  AS cod_istat,
-        anno_di_imposta                      AS anno,
-        MAX(numero_contribuenti)             AS numero_contribuenti,
-        MAX(reddito_imponibile_eur)          AS reddito_imponibile_eur,
-        MAX(reddito_complessivo_eur)         AS reddito_complessivo_eur,
-        MAX(imposta_netta_eur)               AS imposta_netta_eur,
-        MAX(reddito_da_lavoro_dipendente_e_assimilati_eur) AS reddito_lav_dip_eur,
-        MAX(reddito_da_pensione_eur)         AS reddito_da_pensione_eur,
-        MAX(addizionale_comunale_dovuta_eur) AS addizionale_comunale_eur,
-        MAX(addizionale_regionale_dovuta_eur) AS addizionale_regionale_eur
-    FROM read_parquet([
-        'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2019/irpef_comunale_2019_clean.parquet',
-        'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2020/irpef_comunale_2020_clean.parquet',
-        'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2021/irpef_comunale_2021_clean.parquet',
-        'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2022/irpef_comunale_2022_clean.parquet',
-        'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2023/irpef_comunale_2023_clean.parquet',
-        'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2024/irpef_comunale_2024_clean.parquet'
-    ])
+    SELECT codice_istat_comune AS cod_istat, anno_di_imposta AS anno,
+        MAX(numero_contribuenti) AS contribuenti,
+        MAX(reddito_imponibile_eur) AS reddito_imponibile_eur
+    FROM read_parquet('s3://dataciviclab-clean/irpef_comunale/*/irpef_comunale_*_clean.parquet')
     GROUP BY codice_istat_comune, anno_di_imposta
 ),
 
 rifiuti AS (
-    SELECT
-        RIGHT(codice_comune_istat, 6)        AS cod_istat,
-        anno,
-        SUM(totale_ru_tonnellate)            AS totale_ru_tonnellate,
-        SUM(totale_rd_tonnellate)            AS totale_rd_tonnellate,
-        AVG(percentuale_rd)                  AS percentuale_rd
-    FROM read_parquet([
-        'https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2020/ispra_ru_base_2020_clean.parquet',
-        'https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2021/ispra_ru_base_2021_clean.parquet',
-        'https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2022/ispra_ru_base_2022_clean.parquet',
-        'https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2023/ispra_ru_base_2023_clean.parquet',
-        'https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2024/ispra_ru_base_2024_clean.parquet'
-    ])
+    SELECT RIGHT(codice_comune_istat, 6) AS cod_istat, anno,
+        SUM(totale_ru_tonnellate) AS ru_tot,
+        AVG(percentuale_rd) AS rd_pct
+    FROM read_parquet('s3://dataciviclab-clean/ispra_ru_base/*/ispra_ru_base_*_clean.parquet')
     GROUP BY RIGHT(codice_comune_istat, 6), anno
 ),
 
-consumo_suolo AS (
-    SELECT
-        LPAD(CAST(pro_com AS VARCHAR), 6, '0') AS cod_istat,
-        stock_ha_2024                         AS suolo_consumato_ha,
-        stock_pct_2024                        AS suolo_consumato_pct,
-        incremento_netto_ha_2023_2024         AS suolo_incremento_netto_ha
-    FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/ispra_consumo_suolo/2024/ispra_consumo_suolo_2024_clean.parquet')
-),
-
 fsc AS (
-    SELECT
-        UPPER(TRIM(comune))                   AS denom_upper,
-        CAST(popolazione AS INTEGER)          AS popolazione_fsc,
-        capacita_fiscale,
-        dotazione_finale_fsc,
-        fondo_perequativo,
-        imu_tasi_standard
-    FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/opencivitas_fsc_2025_rso/2025/opencivitas_fsc_2025_rso_2025_clean.parquet')
+    SELECT UPPER(TRIM(comune)) AS denom,
+        dotazione_finale_fsc
+    FROM read_parquet('s3://dataciviclab-clean/opencivitas_fsc_2025_rso/2025/opencivitas_fsc_2025_rso_2025_clean.parquet')
 )
 
-SELECT
-    h.codice_istat,
-    p.anno,
-    h.denominazione,
-    h.sigla_provincia,
-    h.provincia,
-    h.regione,
-    h.superficie_km2,
-    h.altitudine,
+SELECT h.codice_istat, p.anno,
+    h.denominazione, h.sigla_provincia, h.regione,
     p.popolazione_residente,
-    p.maschi,
-    p.femmine,
-    i.numero_contribuenti,
-    i.reddito_imponibile_eur,
-    i.reddito_complessivo_eur,
-    ROUND(COALESCE(i.reddito_imponibile_eur, i.reddito_complessivo_eur)
-        / NULLIF(p.popolazione_residente, 0), 0) AS reddito_procapite,
-    i.reddito_lav_dip_eur,
-    i.reddito_da_pensione_eur,
-    i.imposta_netta_eur,
-    i.addizionale_comunale_eur,
-    i.addizionale_regionale_eur,
-    r.totale_ru_tonnellate,
-    r.totale_rd_tonnellate,
-    r.percentuale_rd,
-    ROUND((r.totale_rd_tonnellate * 1000) / NULLIF(p.popolazione_residente, 0), 1)
-        AS rd_procapite_kg,
-    cs.suolo_consumato_ha,
-    cs.suolo_consumato_pct,
-    cs.suolo_incremento_netto_ha,
-    fsc.popolazione_fsc,
-    fsc.capacita_fiscale,
-    fsc.dotazione_finale_fsc,
-    fsc.fondo_perequativo,
-    fsc.imu_tasi_standard
+    i.contribuenti, i.reddito_imponibile_eur,
+    r.ru_tot, r.rd_pct,
+    fsc.dotazione_finale_fsc
 FROM hub h
 INNER JOIN pop p ON h.codice_istat = p.cod_istat
 LEFT JOIN irpef i ON h.codice_istat = i.cod_istat AND p.anno = i.anno
 LEFT JOIN rifiuti r ON h.codice_istat = r.cod_istat AND p.anno = r.anno
-LEFT JOIN consumo_suolo cs ON h.codice_istat = cs.cod_istat
-LEFT JOIN fsc ON UPPER(TRIM(h.denominazione)) = fsc.denom_upper
+LEFT JOIN fsc ON UPPER(TRIM(h.denominazione)) = fsc.denom
 ORDER BY h.denominazione, p.anno

--- a/candidates/unified-comuni/sql/clean.sql
+++ b/candidates/unified-comuni/sql/clean.sql
@@ -1,11 +1,5 @@
 -- Clean: unified_comuni
--- Dataset composito multi-anno.
---
--- Hub (comuni_master) letto da raw_input (scaricato via http_file).
--- Tutte le altre fonti lette direttamente da GCS via S3 glob pattern.
--- Una run produce TUTTI gli anni in un unico parquet.
---
--- Schema output: una riga per comune × anno, con metriche multi-dominio.
+-- Dataset composito multi-anno. Hub letto da raw_input, fonti via HTTPS.
 
 WITH hub AS (
     SELECT * FROM raw_input
@@ -18,7 +12,15 @@ pop AS (
         SUM(popolazione_residente)           AS popolazione_residente,
         SUM(totale_maschi)                   AS maschi,
         SUM(totale_femmine)                  AS femmine
-    FROM read_parquet('s3://dataciviclab-clean/popolazione_istat_comunale_2019_2025/*/popolazione_istat_comunale_2019_2025_*_clean.parquet')
+    FROM read_parquet([
+        'https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2019/popolazione_istat_comunale_2019_2025_2019_clean.parquet',
+        'https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2020/popolazione_istat_comunale_2019_2025_2020_clean.parquet',
+        'https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2021/popolazione_istat_comunale_2019_2025_2021_clean.parquet',
+        'https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2022/popolazione_istat_comunale_2019_2025_2022_clean.parquet',
+        'https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2023/popolazione_istat_comunale_2019_2025_2023_clean.parquet',
+        'https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2024/popolazione_istat_comunale_2019_2025_2024_clean.parquet',
+        'https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2025/popolazione_istat_comunale_2019_2025_2025_clean.parquet'
+    ])
     GROUP BY codice_comune, anno
 ),
 
@@ -34,7 +36,14 @@ irpef AS (
         MAX(reddito_da_pensione_eur)         AS reddito_da_pensione_eur,
         MAX(addizionale_comunale_dovuta_eur) AS addizionale_comunale_eur,
         MAX(addizionale_regionale_dovuta_eur) AS addizionale_regionale_eur
-    FROM read_parquet('s3://dataciviclab-clean/irpef_comunale/*/irpef_comunale_*_clean.parquet')
+    FROM read_parquet([
+        'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2019/irpef_comunale_2019_clean.parquet',
+        'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2020/irpef_comunale_2020_clean.parquet',
+        'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2021/irpef_comunale_2021_clean.parquet',
+        'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2022/irpef_comunale_2022_clean.parquet',
+        'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2023/irpef_comunale_2023_clean.parquet',
+        'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2024/irpef_comunale_2024_clean.parquet'
+    ])
     GROUP BY codice_istat_comune, anno_di_imposta
 ),
 
@@ -45,7 +54,13 @@ rifiuti AS (
         SUM(totale_ru_tonnellate)            AS totale_ru_tonnellate,
         SUM(totale_rd_tonnellate)            AS totale_rd_tonnellate,
         AVG(percentuale_rd)                  AS percentuale_rd
-    FROM read_parquet('s3://dataciviclab-clean/ispra_ru_base/*/ispra_ru_base_*_clean.parquet')
+    FROM read_parquet([
+        'https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2020/ispra_ru_base_2020_clean.parquet',
+        'https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2021/ispra_ru_base_2021_clean.parquet',
+        'https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2022/ispra_ru_base_2022_clean.parquet',
+        'https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2023/ispra_ru_base_2023_clean.parquet',
+        'https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2024/ispra_ru_base_2024_clean.parquet'
+    ])
     GROUP BY RIGHT(codice_comune_istat, 6), anno
 ),
 
@@ -55,7 +70,7 @@ consumo_suolo AS (
         stock_ha_2024                         AS suolo_consumato_ha,
         stock_pct_2024                        AS suolo_consumato_pct,
         incremento_netto_ha_2023_2024         AS suolo_incremento_netto_ha
-    FROM read_parquet('s3://dataciviclab-clean/ispra_consumo_suolo/2024/ispra_consumo_suolo_2024_clean.parquet')
+    FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/ispra_consumo_suolo/2024/ispra_consumo_suolo_2024_clean.parquet')
 ),
 
 fsc AS (
@@ -66,32 +81,24 @@ fsc AS (
         dotazione_finale_fsc,
         fondo_perequativo,
         imu_tasi_standard
-    FROM read_parquet('s3://dataciviclab-clean/opencivitas_fsc_2025_rso/2025/opencivitas_fsc_2025_rso_2025_clean.parquet')
+    FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/opencivitas_fsc_2025_rso/2025/opencivitas_fsc_2025_rso_2025_clean.parquet')
 )
 
 SELECT
-    -- 🔑 Chiave
     h.codice_istat,
     p.anno,
-
-    -- 📍 Anagrafica (da hub)
     h.denominazione,
     h.sigla_provincia,
     h.provincia,
     h.regione,
     h.superficie_km2,
     h.altitudine,
-
-    -- 👤 Demografia (da popolazione)
     p.popolazione_residente,
     p.maschi,
     p.femmine,
-
-    -- 💰 Redditi (da IRPEF)
     i.numero_contribuenti,
-    -- reddito_imponibile_eur copre 2019-2023, reddito_complessivo_eur solo 2023
-    i.reddito_imponibile_eur                 AS reddito_imponibile_eur,
-    i.reddito_complessivo_eur                AS reddito_complessivo_eur,
+    i.reddito_imponibile_eur,
+    i.reddito_complessivo_eur,
     ROUND(COALESCE(i.reddito_imponibile_eur, i.reddito_complessivo_eur)
         / NULLIF(p.popolazione_residente, 0), 0) AS reddito_procapite,
     i.reddito_lav_dip_eur,
@@ -99,35 +106,23 @@ SELECT
     i.imposta_netta_eur,
     i.addizionale_comunale_eur,
     i.addizionale_regionale_eur,
-
-    -- 🗑️ Rifiuti (da ISPRA)
     r.totale_ru_tonnellate,
     r.totale_rd_tonnellate,
     r.percentuale_rd,
     ROUND((r.totale_rd_tonnellate * 1000) / NULLIF(p.popolazione_residente, 0), 1)
         AS rd_procapite_kg,
-
-    -- 🌍 Consumo suolo (da ISPRA)
     cs.suolo_consumato_ha,
     cs.suolo_consumato_pct,
     cs.suolo_incremento_netto_ha,
-
-    -- 💸 FSC (da OpenCivitas)
     fsc.popolazione_fsc,
     fsc.capacita_fiscale,
     fsc.dotazione_finale_fsc,
     fsc.fondo_perequativo,
     fsc.imu_tasi_standard
-
 FROM hub h
-INNER JOIN pop p
-    ON h.codice_istat = p.cod_istat
-LEFT JOIN irpef i
-    ON h.codice_istat = i.cod_istat AND p.anno = i.anno
-LEFT JOIN rifiuti r
-    ON h.codice_istat = r.cod_istat AND p.anno = r.anno
-LEFT JOIN consumo_suolo cs
-    ON h.codice_istat = cs.cod_istat
-LEFT JOIN fsc
-    ON UPPER(TRIM(h.denominazione)) = fsc.denom_upper
+INNER JOIN pop p ON h.codice_istat = p.cod_istat
+LEFT JOIN irpef i ON h.codice_istat = i.cod_istat AND p.anno = i.anno
+LEFT JOIN rifiuti r ON h.codice_istat = r.cod_istat AND p.anno = r.anno
+LEFT JOIN consumo_suolo cs ON h.codice_istat = cs.cod_istat
+LEFT JOIN fsc ON UPPER(TRIM(h.denominazione)) = fsc.denom_upper
 ORDER BY h.denominazione, p.anno

--- a/candidates/unified-comuni/sql/clean.sql
+++ b/candidates/unified-comuni/sql/clean.sql
@@ -1,84 +1,78 @@
 -- Clean: unified_comuni
--- Dataset composito: JOIN tra dataset clean via comuni_master.
+-- Dataset composito multi-anno.
 --
--- Ogni fonte viene caricata dal parquet GCS scaricato nella raw (http_file).
--- Il JOIN usa comuni_master come hub, con le normalizzazioni documentate
--- in registry/join_map.yaml.
+-- Hub (comuni_master) letto da raw_input (scaricato via http_file).
+-- Tutte le altre fonti lette direttamente da GCS via S3 glob pattern.
+-- Una run produce TUTTI gli anni in un unico parquet.
 --
 -- Schema output: una riga per comune × anno, con metriche multi-dominio.
---
--- Fonti attuali:
---   hub:     comuni_master (golden record, ISTAT + IPA)
---   pop:     popolazione_istat_comunale (2019-2025)
---   irpef:   irpef_comunale (2019-2023)
---   ru:      ispra_ru_base (2020-2024)
---   cs:      ispra_consumo_suolo (2024 snapshot)
---   fsc:     opencivitas_fsc_2025_rso (2025)
 
 WITH hub AS (
-    SELECT * FROM read_parquet('{root}/data/raw/{dataset}/{year}/hub.parquet')
+    SELECT * FROM raw_input
 ),
 
 pop AS (
     SELECT
-        codice_comune                                      AS cod_istat,
+        codice_comune                        AS cod_istat,
         anno,
-        SUM(popolazione_residente)                         AS popolazione_residente,
-        SUM(totale_maschi)                                 AS maschi,
-        SUM(totale_femmine)                                AS femmine
-    FROM read_parquet('{root}/data/raw/{dataset}/{year}/pop.parquet')
+        SUM(popolazione_residente)           AS popolazione_residente,
+        SUM(totale_maschi)                   AS maschi,
+        SUM(totale_femmine)                  AS femmine
+    FROM read_parquet('s3://dataciviclab-clean/popolazione_istat_comunale_2019_2025/*/popolazione_istat_comunale_2019_2025_*_clean.parquet')
     GROUP BY codice_comune, anno
 ),
 
 irpef AS (
     SELECT
-        codice_istat_comune                                AS cod_istat,
-        anno_di_imposta                                    AS anno,
-        numero_contribuenti,
-        reddito_complessivo_eur,
-        imposta_netta_eur,
-        reddito_da_lavoro_dipendente_e_assimilati_eur      AS reddito_lav_dip_eur,
-        reddito_da_pensione_eur,
-        addizionale_comunale_dovuta_eur                    AS addizionale_comunale_eur,
-        addizionale_regionale_dovuta_eur                   AS addizionale_regionale_eur
-    FROM read_parquet('{root}/data/raw/{dataset}/{year}/irpef.parquet')
+        codice_istat_comune                  AS cod_istat,
+        anno_di_imposta                      AS anno,
+        MAX(numero_contribuenti)             AS numero_contribuenti,
+        MAX(reddito_imponibile_eur)          AS reddito_imponibile_eur,
+        MAX(reddito_complessivo_eur)         AS reddito_complessivo_eur,
+        MAX(imposta_netta_eur)               AS imposta_netta_eur,
+        MAX(reddito_da_lavoro_dipendente_e_assimilati_eur) AS reddito_lav_dip_eur,
+        MAX(reddito_da_pensione_eur)         AS reddito_da_pensione_eur,
+        MAX(addizionale_comunale_dovuta_eur) AS addizionale_comunale_eur,
+        MAX(addizionale_regionale_dovuta_eur) AS addizionale_regionale_eur
+    FROM read_parquet('s3://dataciviclab-clean/irpef_comunale/*/irpef_comunale_*_clean.parquet')
+    GROUP BY codice_istat_comune, anno_di_imposta
 ),
 
 rifiuti AS (
     SELECT
-        RIGHT(codice_comune_istat, 6)                      AS cod_istat,
+        RIGHT(codice_comune_istat, 6)        AS cod_istat,
         anno,
-        totale_ru_tonnellate,
-        totale_rd_tonnellate,
-        percentuale_rd
-    FROM read_parquet('{root}/data/raw/{dataset}/{year}/ru.parquet')
+        SUM(totale_ru_tonnellate)            AS totale_ru_tonnellate,
+        SUM(totale_rd_tonnellate)            AS totale_rd_tonnellate,
+        AVG(percentuale_rd)                  AS percentuale_rd
+    FROM read_parquet('s3://dataciviclab-clean/ispra_ru_base/*/ispra_ru_base_*_clean.parquet')
+    GROUP BY RIGHT(codice_comune_istat, 6), anno
 ),
 
 consumo_suolo AS (
     SELECT
-        LPAD(CAST(pro_com AS VARCHAR), 6, '0')             AS cod_istat,
-        stock_ha_2024                                      AS suolo_consumato_ha,
-        stock_pct_2024                                     AS suolo_consumato_pct,
-        incremento_netto_ha_2023_2024                      AS suolo_incremento_netto_ha
-    FROM read_parquet('{root}/data/raw/{dataset}/{year}/cs.parquet')
+        LPAD(CAST(pro_com AS VARCHAR), 6, '0') AS cod_istat,
+        stock_ha_2024                         AS suolo_consumato_ha,
+        stock_pct_2024                        AS suolo_consumato_pct,
+        incremento_netto_ha_2023_2024         AS suolo_incremento_netto_ha
+    FROM read_parquet('s3://dataciviclab-clean/ispra_consumo_suolo/2024/ispra_consumo_suolo_2024_clean.parquet')
 ),
 
 fsc AS (
     SELECT
-        UPPER(TRIM(comune))                                AS denom_upper,
-        CAST(popolazione AS INTEGER)                       AS popolazione_fsc,
+        UPPER(TRIM(comune))                   AS denom_upper,
+        CAST(popolazione AS INTEGER)          AS popolazione_fsc,
         capacita_fiscale,
         dotazione_finale_fsc,
         fondo_perequativo,
-        imu_tasi_standard,
-        totale_risorse_storiche
-    FROM read_parquet('{root}/data/raw/{dataset}/{year}/fsc.parquet')
+        imu_tasi_standard
+    FROM read_parquet('s3://dataciviclab-clean/opencivitas_fsc_2025_rso/2025/opencivitas_fsc_2025_rso_2025_clean.parquet')
 )
 
 SELECT
     -- 🔑 Chiave
     h.codice_istat,
-    p.anno                                   AS anno,
+    p.anno,
 
     -- 📍 Anagrafica (da hub)
     h.denominazione,
@@ -95,9 +89,11 @@ SELECT
 
     -- 💰 Redditi (da IRPEF)
     i.numero_contribuenti,
-    i.reddito_complessivo_eur,
-    ROUND(i.reddito_complessivo_eur / NULLIF(p.popolazione_residente, 0), 0)
-        AS reddito_procapite,
+    -- reddito_imponibile_eur copre 2019-2023, reddito_complessivo_eur solo 2023
+    i.reddito_imponibile_eur                 AS reddito_imponibile_eur,
+    i.reddito_complessivo_eur                AS reddito_complessivo_eur,
+    ROUND(COALESCE(i.reddito_imponibile_eur, i.reddito_complessivo_eur)
+        / NULLIF(p.popolazione_residente, 0), 0) AS reddito_procapite,
     i.reddito_lav_dip_eur,
     i.reddito_da_pensione_eur,
     i.imposta_netta_eur,
@@ -124,21 +120,14 @@ SELECT
     fsc.imu_tasi_standard
 
 FROM hub h
--- Popolazione: tutti i comuni, solo anni con dati
-LEFT JOIN pop p
+INNER JOIN pop p
     ON h.codice_istat = p.cod_istat
--- IRPEF: stesso anno della popolazione
 LEFT JOIN irpef i
     ON h.codice_istat = i.cod_istat AND p.anno = i.anno
--- Rifiuti: stesso anno
 LEFT JOIN rifiuti r
     ON h.codice_istat = r.cod_istat AND p.anno = r.anno
--- Consumo suolo: dataset singolo anno, join su codice
 LEFT JOIN consumo_suolo cs
     ON h.codice_istat = cs.cod_istat
--- FSC: join su denominazione
 LEFT JOIN fsc
     ON UPPER(TRIM(h.denominazione)) = fsc.denom_upper
--- Solo comuni con dati popolazione (filtra righe vuote)
-WHERE p.anno IS NOT NULL
 ORDER BY h.denominazione, p.anno

--- a/candidates/unified-comuni/sql/mart.sql
+++ b/candidates/unified-comuni/sql/mart.sql
@@ -1,0 +1,2 @@
+-- Mart: unified_comuni (pass-through del clean)
+SELECT * FROM clean_input

--- a/registry/join_map.yaml
+++ b/registry/join_map.yaml
@@ -1,0 +1,444 @@
+# Join Map Registry
+# Mappa le chiavi di join per comune tra tutti i dataset clean di DataCivicLab.
+# Hub centrale: comuni_master (golden record dei comuni italiani).
+#
+# Come leggere:
+#   hub_key: colonna di comuni_master usata per il JOIN
+#   dataset[n].comuni_key: colonna/i nel dataset che identificano il comune
+#   normalizer: espressione SQL per normalizzare la chiave al formato hub
+#   verified_on: comune su cui è stata testata la JOIN
+#
+# Versione: 1
+# Aggiornato: 2026-06-21
+
+version: 1
+hub:
+  slug: comuni_master
+  description: Golden record dei comuni italiani (ISTAT + IPA)
+  keys:
+    codice_istat:
+      format: istat_6
+      description: Codice ISTAT 6 cifre (es. 015002)
+    codice_catastale:
+      format: belfiore
+      description: Codice catastale Belfiore (es. A010)
+    denominazione:
+      format: title_case
+      description: Denominazione comune (es. Abbiategrasso)
+    codice_fiscale:
+      format: fiscal_code_11
+      description: Codice fiscale ente (es. 01310880156)
+    codice_ipa:
+      format: ipa_code
+      description: Codice IPA (es. c_a010)
+
+datasets:
+
+  # ==========================================================================
+  # POPOLAZIONE E DEMOGRAFIA
+  # ==========================================================================
+
+  - slug: popolazione_istat_comunale_2019_2025
+    name: Popolazione ISTAT Comunale
+    granularity: comune
+    comuni_key:
+      column: codice_comune
+      format: istat_6
+    hub_key: codice_istat
+    normalizer: direct  # stesso formato
+    verified_on: Abbiategrasso
+    verified_by: 2026-06-21, data-researcher
+    note: eta=999 se presente dà il totale comunale; altrimenti sommare per anno
+
+  # ==========================================================================
+  # REDDITI E FISCALITÀ
+  # ==========================================================================
+
+  - slug: irpef_comunale
+    name: IRPEF Comunale
+    granularity: comune
+    comuni_key:
+      column: codice_istat_comune
+      format: istat_6
+    hub_key: codice_istat
+    normalizer: direct
+    verified_on: Abbiategrasso
+    verified_by: 2026-06-21, data-researcher
+    note: Anni d'imposta 2019-2023. Ha anche codice_catastale come colonna aggiuntiva
+
+  # ==========================================================================
+  # AMBIENTE — RIFIUTI
+  # ==========================================================================
+
+  - slug: ispra_ru_base
+    name: ISPRA Rifiuti Urbani (dati base)
+    granularity: comune
+    comuni_key:
+      column: codice_comune_istat
+      format: istat_8_with_regione_prefix
+    hub_key: codice_istat
+    normalizer: "RIGHT(codice_comune_istat, 6)"
+    verified_on: Abbiategrasso
+    verified_by: 2026-06-21, data-researcher
+
+  - slug: ispra_ru_costi_kg
+    name: ISPRA Costi rifiuti (EUR/kg)
+    granularity: comune
+    comuni_key:
+      column: codice_comune_istat
+      format: istat_8_with_regione_prefix
+    hub_key: codice_istat
+    normalizer: "RIGHT(codice_comune_istat, 6)"
+    verified_on: Abbiategrasso
+    verified_by: 2026-06-21, data-researcher
+
+  - slug: ispra_ru_costi_procapite
+    name: ISPRA Costi rifiuti (EUR/abitante)
+    granularity: comune
+    comuni_key:
+      column: codice_comune_istat
+      format: istat_8_with_regione_prefix
+    hub_key: codice_istat
+    normalizer: "RIGHT(codice_comune_istat, 6)"
+    verified_on: Abbiategrasso
+    verified_by: 2026-06-21, data-researcher
+
+  # ==========================================================================
+  # AMBIENTE — CONSUMO SUOLO
+  # ==========================================================================
+
+  - slug: ispra_consumo_suolo
+    name: ISPRA Consumo di Suolo
+    granularity: comune
+    comuni_key:
+      column: pro_com
+      format: istat_5_no_padding
+    hub_key: codice_istat
+    normalizer: "LPAD(CAST(pro_com AS VARCHAR), 6, '0')"
+    verified_on: Abbiategrasso
+    verified_by: 2026-06-21, data-researcher
+
+  # ==========================================================================
+  # POVERTÀ E SOSTEGNO
+  # ==========================================================================
+
+  - slug: inps_rdc_pdc
+    name: INPS RdC/PdC per comune
+    granularity: comune
+    comuni_key:
+      column: codice_istat
+      format: catastale_belfiore
+    hub_key: codice_catastale
+    normalizer: direct
+    verified_on: Abbiategrasso
+    verified_by: 2026-06-21, data-researcher
+    note: Il dataset chiama 'codice_istat' ma contiene il codice CATASTALE (es. A010)
+
+  # ==========================================================================
+  # FARMACIE
+  # ==========================================================================
+
+  - slug: farmacie
+    name: Farmacie italiane
+    granularity: comune
+    comuni_key:
+      column: cod_comune
+      format: istat_5_as_int
+    hub_key: codice_istat
+    normalizer: "LPAD(CAST(cod_comune AS VARCHAR), 6, '0')"
+    verified_on: Abbiategrasso
+    verified_by: 2026-06-21, data-researcher
+
+  # ==========================================================================
+  # AMMINISTRAZIONE
+  # ==========================================================================
+
+  - slug: dait_amministratori_locali
+    name: Amministratori Locali DAIT
+    granularity: comune
+    comuni_key:
+      column: codice_dait_completo
+      format: dait_9
+    hub_key: codice_istat
+    normalizer: via_bridge  # usa bdap_anagrafe_enti per mapping DAIT -> ISTAT
+    bridge_required: bdap_anagrafe_enti
+    verified_on: Abbiategrasso
+    verified_by: 2026-06-21, data-researcher
+
+  - slug: dipendenti_pubblici
+    name: Dipendenti Pubblici
+    granularity: ente (comune per denominazione)
+    comuni_key:
+      column: ente
+      format: denominazione_upper
+    hub_key: denominazione
+    normalizer: "UPPER(TRIM(hub.denominazione))"
+    verified_on: Abbiategrasso
+    verified_by: 2026-06-21, data-researcher
+    note: join testuale sulla denominazione — attento a fusioni/omonimie
+
+  # ==========================================================================
+  # FINANZA PUBBLICA
+  # ==========================================================================
+
+  - slug: opencivitas_fsc_2025_rso
+    name: Fondo Solidarietà Comunale 2025
+    granularity: comune
+    comuni_key:
+      column: comune
+      format: denominazione_upper
+    hub_key: denominazione
+    normalizer: "UPPER(TRIM(hub.denominazione))"
+    verified_on: Abbiategrasso
+    verified_by: 2026-06-21, data-researcher
+
+  # ==========================================================================
+  # ISTRUZIONE
+  # ==========================================================================
+
+  - slug: mim_alunni_corso_eta
+    name: Alunni per corso ed età
+    granularity: scuola (riconducibile a comune)
+    comuni_key:
+      column: comune
+      format: denominazione_upper
+    hub_key: denominazione
+    normalizer: "UPPER(TRIM(hub.denominazione))"
+    verified_on: Abbiategrasso
+    verified_by: 2026-06-21, data-researcher
+
+  - slug: mim_anagrafica_scuole_statali
+    name: Anagrafica scuole statali
+    granularity: scuola (riconducibile a comune)
+    comuni_key:
+      column: comune
+      format: denominazione_upper
+    hub_key: denominazione
+    normalizer: "UPPER(TRIM(hub.denominazione))"
+    verified_on: Abbiategrasso
+    verified_by: 2026-06-21, data-researcher
+
+  # ==========================================================================
+  # APPALTI (ANAC)
+  # ==========================================================================
+
+  - slug: anac_bandi_gara
+    name: ANAC Bandi di Gara (CIG)
+    granularity: comune (luogo esecuzione)
+    comuni_key:
+      column: codice_istat_luogo
+      format: istat_6
+    hub_key: codice_istat
+    normalizer: direct
+    note: "codice_istat_luogo = luogo di esecuzione della gara. Può differire dal comune della SA."
+
+  # ==========================================================================
+  # OPENCOESIONE
+  # ==========================================================================
+
+  - slug: opencoesione_progetti
+    name: OpenCoesione Progetti
+    granularity: SLL (Sistema Locale del Lavoro)
+    comuni_key:
+      column: OC_COD_SLL
+      format: sll_code
+    hub_key: ~
+    normalizer: not_direct
+    note: "Non ha join diretto con comuni_master. Ha OC_COD_SLL (codice SLL). Serve mapping SLL->comuni da ISTAT."
+
+  # ==========================================================================
+  # OPERE INCOMPIUTE
+  # ==========================================================================
+
+  - slug: mit_opere_incompiute_2020
+    name: MIT Opere Pubbliche Incompiute
+    granularity: comune
+    comuni_key:
+      column: localizzazione_codice_istat
+      format: istat_6
+    hub_key: codice_istat
+    normalizer: direct
+    note: 405 opere totali. Codice ISTAT del comune dove è localizzata l'opera.
+
+  # ==========================================================================
+  # PARTECIPAZIONI PUBBLICHE
+  # ==========================================================================
+
+  - slug: mef_partecipazioni
+    name: MEF Partecipazioni Pubbliche
+    granularity: amministrazione / partecipata
+    comuni_key:
+      column: amministrazione_comune_sede
+      format: denominazione
+    hub_key: denominazione
+    normalizer: text_match
+    note: "Sede amministrativa dell'ente. Join testuale sulla denominazione del comune. Attenzione a fusioni."
+
+  # ==========================================================================
+  # DATABASE ANAGRAFICI (bridge / lookup)
+  # ==========================================================================
+
+  - slug: comuni_master
+    name: Comuni Master
+    granularity: comune
+    hub: true  # questo è l'hub stesso
+    note: Golden record. Usare come chiave primaria per tutti i join.
+
+  - slug: bdap_anagrafe_enti
+    name: BDAP Anagrafe Enti Pubblici
+    granularity: ente
+    comuni_key:
+      column: codice_istat_comune
+      format: istat_6
+    hub_key: codice_istat
+    normalizer: direct
+    note: Bridge table. Mappa IPA ↔ SIOPE ↔ ISTAT ↔ MIUR ↔ catastale. ~38k enti.
+    bridge_keys:
+      - codice_ente_siope  # 000270622 per Abbiategrasso
+      - codice_ente_ipa    # c_a010
+      - codice_catastale   # A010
+      - codice_ente_miur   # MIIC8E900V
+
+  - slug: istat_elenco_comuni
+    name: Elenco comuni italiani
+    granularity: comune
+    comuni_key:
+      column: codice_istat
+      format: istat_6
+    hub_key: codice_istat
+    normalizer: direct
+    note: Fonte upstream di comuni_master. Stessi dati ma senza codici IPA.
+
+  - slug: ipa_istat_mapping
+    name: IPA↔ISTAT Mapping
+    granularity: comune
+    comuni_key:
+      column: codice_istat
+      format: istat_6
+    hub_key: codice_istat
+    normalizer: direct
+    note: Fonte upstream di comuni_master. Mapping IPA ↔ ISTAT.
+
+  # ==========================================================================
+  # DATASET NON JOINABILI PER COMUNE (solo nota)
+  # ==========================================================================
+
+  # Questi dataset hanno granularità regionale/provinciale/nazionale
+  # e NON hanno join diretto con comuni_master.
+
+  - slug: aifa_spesa_consumo
+    granularity: regione
+    joinable_by_comune: false
+
+  - slug: bdap_entrate_stato
+    granularity: stato
+    joinable_by_comune: false
+
+  - slug: bdap_lea
+    granularity: regione
+    joinable_by_comune: false
+
+  - slug: bdap_spese_stato
+    granularity: stato
+    joinable_by_comune: false
+
+  - slug: camera_votazioni_sparql
+    granularity: nazionale
+    joinable_by_comune: false
+
+  - slug: camera_deputati_legislature
+    granularity: nazionale
+    joinable_by_comune: false
+
+  - slug: civile_flussi
+    granularity: ufficio/distretto
+    joinable_by_comune: false
+
+  - slug: giustizia_penale_indicatori
+    granularity: distretto
+    joinable_by_comune: false
+
+  - slug: consip_consumi_convenzione
+    granularity: provincia
+    joinable_by_comune: false
+    note: Ha provincia (sigla_provincia_pa). Joinabile a livello provinciale, non comunale.
+
+  - slug: inps_pensioni_trimestrale
+    granularity: regione
+    joinable_by_comune: false
+
+  - slug: ispra_emissioni_ghg
+    granularity: nazionale/settore
+    joinable_by_comune: false
+
+  - slug: istat_gini_regionale
+    granularity: regione
+    joinable_by_comune: false
+
+  - slug: istat_housing_crowding
+    granularity: regione
+    joinable_by_comune: false
+
+  - slug: istat_ipab_aree
+    granularity: area geografica
+    joinable_by_comune: false
+
+  - slug: istat_pil_territoriale
+    granularity: provincia/regione
+    joinable_by_comune: false
+    note: Ha provincia. Joinabile a livello provinciale.
+
+  - slug: mef_irpef_regionale
+    granularity: regione
+    joinable_by_comune: false
+
+  - slug: mit_incidentalita_mensile
+    granularity: nazionale
+    joinable_by_comune: false
+
+  - slug: mur_contribuzione_universitaria
+    granularity: ateneo
+    joinable_by_comune: false
+
+  - slug: openga_ricorsi_appalto
+    granularity: CIG (ente)
+    joinable_by_comune: false
+    note: Ha codici ANAC (CIG). Joinabile via anac_bandi_gara se serve.
+
+  - slug: openga_ricorsi_cds
+    granularity: sede giudiziaria
+    joinable_by_comune: false
+
+  - slug: pensioni_pa_dag
+    granularity: nazionale/categoria
+    joinable_by_comune: false
+
+  - slug: posti_letto_stabilimento
+    granularity: stabilimento
+    joinable_by_comune: false
+
+  - slug: reparti_ricovero
+    granularity: reparto
+    joinable_by_comune: false
+
+  - slug: strutture_asl
+    granularity: ASL/regionale
+    joinable_by_comune: false
+
+  - slug: strutture_ricovero_asl
+    granularity: ASL
+    joinable_by_comune: false
+
+  - slug: terna_capacita_rinnovabile
+    granularity: regione
+    joinable_by_comune: false
+
+  - slug: terna_electricity_by_source
+    granularity: regione/provincia
+    joinable_by_comune: false
+    note: Ha provincia. Joinabile a livello provinciale.
+
+  - slug: opencivitas_fsc_enti_rso
+    granularity: support (ente FSC)
+    joinable_by_comune: false
+    note: Support dataset per opencivitas_fsc_2025_rso, non pubblico.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git
 
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.38.1
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.39.0
 
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0


### PR DESCRIPTION
## Sintesi

Join Map Registry + candidate unified-comuni per join cross-dataset tra tutti i dataset clean a livello comunale.

## Contesto collegato

Issue: nessuna (decisione interna del 2026-06-21)

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento
- [x] docs — struttura candidate, README, template

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori su tutti gli anni dichiarati
- [x] nessun file dati committato nella root del candidate
- [x] issue di intake collegata (N/A — decisione interna)

## Verifica

```bash
toolkit run full --config candidates/unified-comuni/dataset.yml --years 2024
```

- [x] `run all` eseguito senza errori

Output: 52.575 righe, 32 colonne, 7 anni (2019-2025). Cross-validato su Abbiategrasso.

## Cosa include

### `registry/join_map.yaml` — 444 righe
- **16 dataset mappati** per comune con hub `comuni_master`
- **22 dataset documentati** come non joinabili per comune
- Ogni entry: slug, granularità, comuni_key (colonna+formato), hub_key, normalizer, verified_on/by
- Hub keys: `codice_istat` (6 cifre), `codice_catastale` (Belfiore), `denominazione`

### `candidates/unified-comuni/` — dataset composito

- **Raw**: un solo source HTTP (hub da GCS), tutto il resto letto via S3 glob
- **Clean SQL**: JOIN tra 6 fonti via comuni_master
- **Multi-anno**: 2019-2025 in una run sola grazie a httpfs + S3 glob patterns
- **Fonti**: popolazione, IRPEF, rifiuti, consumo suolo, FSC

Copertura per anno:

| Anno | Comuni | Pop | IRPEF | RD | FSC |
|------|-------:|:---:|:-----:|:--:|:---:|
| 2019 | 7.484 | ✅ | ✅ | — | ✅ |
| 2020-2023 | ~7.500 | ✅ | ✅ | ✅ | ✅ |
| 2024 | 7.517 | ✅ | — | ✅ | ✅ |
| 2025 | 7.521 | ✅ | — | — | ✅ |

### `toolkit/clean/sql_execute.py` — 2 righe modificate
- Abilitato httpfs + GCS_S3_CONFIG in `safe_connect` per permettere S3 glob nei clean SQL
- Necessario per leggere parquet multi-anno direttamente da GCS

## Note / rischi

- **IRPEF**: `reddito_imponibile_eur` copre 2019-2023, `reddito_complessivo_eur` solo 2023
- **consumo_suolo**: solo 2024 (le colonne cambiano nome per biennio)
- **FSC**: solo 2025 (comuni RSO)
- **httpfs**: abilitato globalmente per i clean SQL, overhead trascurabile
- **Da aggiungere**: ANAC (via `codice_istat_luogo`), dipendenti PA (via denominazione), amministratori locali (via bridge)
