### PR TITLE
feat(irpef): aggiunto anno 2024 + README riscritto

### DIFF
--- a/candidates/irpef-comunale/README.md
+++ b/candidates/irpef-comunale/README.md
@@ -1,10 +1,78 @@
 # irpef-comunale
 
-**Domanda principale:** Come varia la capacità fiscale tra comuni e regioni nel dataset IRPEF comunale?
+**Domanda principale:** Come varia la capacità fiscale tra comuni e regioni italiane?
 
-**Fonte:** [ZIP annuali ufficiali MEF / Finanze](https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?search_class%5B0%5D=cCOMUNE&opendata=yes)
+Redditi IRPEF dichiarati da persone fisiche, per comune italiano. Include
+numero contribuenti, imponibile, imposta netta, addizionali e distribuzione
+per fasce di reddito.
 
-**Nota:** questo candidato è stato migrato retroattivamente da `dataciviclab/analisi/irpef-comunale/`,
-dove viveva prima come contratto tecnico autosufficiente. La migrazione allinea il filone al modello canonico: contratto in DI, layer pubblico in `analisi/`.
+---
 
-Il layer pubblico (README civico, notebook) vive in dataciviclab/analisi/irpef-comunale/.
+## Fonte
+
+MEF — Dipartimento delle Finanze. ZIP annuali pubblicati su:
+```
+https://www1.finanze.gov.it/finanze/analisi_stat/public/v_4_0_0/contenuti/
+Redditi_e_principali_variabili_IRPEF_su_base_comunale_CSV_{year}.zip
+```
+
+Anni disponibili dalla fonte: **2000–2024** (URL pattern confermato).
+Attualmente intakati: **2019–2024** (6 anni).
+
+## Schema clean (52 colonne)
+
+| Col | Nome | Note |
+|:---:|------|------|
+| 0 | `anno_di_imposta` | |
+| 1 | `codice_catastale` | Chiave di join con `comuni_master` |
+| 2 | `codice_istat_comune` | Chiave di join con `comuni_master` |
+| 3–6 | Anagrafica comune | denominazione, provincia, regione |
+| 7 | `numero_contribuenti` | Totale contribuenti del comune |
+| 8–9 | Reddito da fabbricati | frequenza + ammontare |
+| 10–11 | Reddito lav. dipendente | frequenza + ammontare |
+| 12–13 | Reddito da pensione | frequenza + ammontare |
+| 14–21 | Altri redditi | autonomo, impresa, partecipazione |
+| 22–23 | `reddito_imponibile` | **freq + eur** — copertura 2019–2024 |
+| 24–25 | `imposta_netta` | **freq + eur** — copertura 2019–2024 |
+| 26–27 | Bonus / Trattamento | semantica varia per anno (vedi caveat) |
+| 28–31 | Addizionali | regionale + comunale |
+| 32–33 | Addizionale comunale | freq + eur |
+| 34–35 | `reddito_complessivo` | **freq + eur** — solo 2023+ |
+| 36–51 | Fasce reddito complessivo | 8 fasce × (freq + eur) |
+
+## Copertura
+
+| Dimensione | Valore |
+|------------|--------|
+| **Anni** | 2019–2024 (6 anni) |
+| **Territorio** | ~7.900 comuni/anno |
+| **Variabili** | 52 colonne (26 metriche × freq/eur) |
+| **Contribuenti (Italia, 2024)** | ~41,6M |
+
+## Join con altri dataset
+
+Tramite `codice_istat_comune` (6 cifre) si collega a `comuni_master` e quindi
+a tutti i dataset del Join Map Registry (`registry/join_map.yaml`).
+
+Usato in `candidates/unified-comuni/` per la colonna `reddito_imponibile_eur`
+(copertura 2019–2024) e `reddito_procapite` (calcolato su popolazione ISTAT).
+
+## Mart disponibili
+
+| Mart | Descrizione |
+|------|-------------|
+| `irpef_by_regione` | Aggregazione per regione |
+| `irpef_by_comune` | Vista per comune con indicatori |
+| `irpef_capacita_fiscale_multi_anno` | Serie storica con rank nazionale/regionale e delta YoY |
+
+## Limiti
+
+- **`reddito_complessivo_eur`** popolato solo dal 2023. Per 2019–2022 usare `reddito_imponibile_eur`.
+- **Bonus vs Trattamento** (col 26–27): il MEF ha cambiato semantica nel 2021. Non confrontabili direttamente.
+- **Somalettura regionale**: la somma dei comuni può non coincidere con i totali regionali ufficiali.
+
+## Note tecniche
+
+Vedi `notes.md` per dettagli su struttura raw, schema, e caveat operativi.
+
+Il layer pubblico (notebook, analisi) vive in `dataciviclab/analisi/irpef-comunale/`.

--- a/candidates/irpef-comunale/dataset.yml
+++ b/candidates/irpef-comunale/dataset.yml
@@ -95,7 +95,7 @@ mart:
       sql: "sql/mart_comuni.sql"
     - name: "irpef_capacita_fiscale_multi_anno"
       sql: "sql/mart_multi_anno.sql"
-      years: [2019, 2020, 2021, 2022, 2023]
+      years: [2019, 2020, 2021, 2022, 2023, 2024]
       source_layer: "clean"
   required_tables: ["irpef_by_regione", "irpef_by_comune"]
   validate: {}

--- a/candidates/irpef-comunale/dataset.yml
+++ b/candidates/irpef-comunale/dataset.yml
@@ -4,7 +4,7 @@ schema_version: 1
 dataset:
   name: "irpef_comunale"
   source_id: mef_irpef
-  years: [2019, 2020, 2021, 2022, 2023]
+  years: [2019, 2020, 2021, 2022, 2023, 2024]
 
 raw:
   extractor:

--- a/candidates/irpef-comunale/notes.md
+++ b/candidates/irpef-comunale/notes.md
@@ -7,7 +7,7 @@ ZIP annuali ufficiali MEF / Finanze:
 
 ## Copertura temporale
 
-2019–2023 (5 anni di dichiarazione)
+2019–2024 (6 anni di dichiarazione). URL pattern confermato per anni dal 2000 al 2024.
 
 ## Copertura territoriale
 
@@ -22,12 +22,13 @@ Tutti i comuni italiani (~7.900 per anno). I codici ISTAT sono stabili nel tempo
 | 2021 | 50 | Header: `Trattamento spettante` (col 26-27) — nuovo |
 | 2022 | 50 | Header: `Trattamento spettante` (col 26-27) |
 | 2023 | 52 | Aggiunte `Reddito complessivo` (col 34-35) + `Trattamento spettante` |
+| 2024 | 52 | Stessa struttura 2023. `Reddito complessivo` ora popolato |
 
 ## Struttura clean
 
 52 colonne fisse per tutti gli anni (slot 0–51). Le colonne assenti nel raw originale hanno valore NULL:
 - **col 26–27**: `Bonus spettante` per 2019-2020 (NULL dal 2021); `Trattamento spettante` per 2021-2023 (NULL nel 2019-2020)
-- **col 34–35**: `Reddito complessivo` solo per 2023 (assenti = NULL per 2019-2022)
+- **col 34–35**: `Reddito complessivo` per 2023 e 2024 (assenti = NULL per 2019-2022)
 
 Il clean è raw-faithful: nessuna logica interpretativa, nessun case/when, nessuna colonna derivata. Il consumatore vede esattamente cosa c'è nel raw per ogni anno.
 
@@ -68,8 +69,8 @@ Il clean è raw-faithful: nessuna logica interpretativa, nessun case/when, nessu
 31 addizionale_regionale_dovuta_eur
 32 addizionale_comunale_dovuta_freq
 33 addizionale_comunale_dovuta_eur
-34 reddito_complessivo_freq             ← NULL per 2019-2022 (introdotto nel 2023)
-35 reddito_complessivo_eur             ← NULL per 2019-2022 (introdotto nel 2023)
+34 reddito_complessivo_freq             ← NULL per 2019-2022 (introdotto nel 2023; popolato anche 2024)
+35 reddito_complessivo_eur             ← NULL per 2019-2022 (introdotto nel 2023; popolato anche 2024)
 36 reddito_complessivo_minore_o_uguale_a_zero_euro_freq
 37 reddito_complessivo_minore_o_uguale_a_zero_euro_eur
 38–51 reddito_complessivo_da_NN_a_MM_euro (fasce freq+eur)
@@ -78,7 +79,7 @@ Il clean è raw-faithful: nessuna logica interpretativa, nessun case/when, nessu
 ## Limiti e caveat
 
 - **Bonus vs Trattamento**: il MEF ha sostituito il Bonus Covid con il Trattamento (legge 2021). Le due misure non sono direttamente confrontabili come semantica economica — il Bonus era un credito d'imposta una tantum, il Trattamento è un importo erogato. Non sommarle mai come "spettante totale".
-- **Reddito complessivo** (2023): non esiste nei precedenti — non è ricostruibile dai raw precedenti.
+- **Reddito complessivo** (2023+): non esiste nei precedenti 2019-2022 — non è ricostruibile dai raw di quegli anni.
 - **Frequenze vs ammontare**: le frequenze (colonne `*_freq`) per le fasce di reddito complessivo (col 38-51) sono conteggi di contribuenti, non valori monetari. Non hanno corrispondente euro.
 - **Somalettura regionale**: la somma dei comuni può non coincidere con il totale regionale (dati.flags rettifiche, segreti comunali, variazioni anagrafiche). I totali regionali vanno chiesti direttamente al MEF.
 - **Anno di imposta vs anno di dichiarazione**: i dati si riferiscono all'anno di imposta, non all'anno di presentazione della dichiarazione. Di norma c'è un anno di ritardo.


### PR DESCRIPTION
## Sintesi

Aggiunge l'anno 2024 ai dati IRPEF comunali. Include anche l'espansione del mart multi-anno e un README completamente riscritto.

## Contesto collegato

—— decisione operativa interna (nuovo dato MEF pubblicato)

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento
- [x] docs — struttura candidate, README, template

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`
- [x] Solo documentazione o metadati

## Verifica

```bash
toolkit run full --config candidates/irpef-comunale/dataset.yml --years 2024
```

- [x] `run all` eseguito senza errori

Output: 7.897 comuni, 52 colonne, qs=90. Verificato su Abbiategrasso: reddito imponibile €631M (+4% vs 2023).

## Dettaglio

### dataset.yml
- `dataset.years`: aggiunto 2024
- `mart.irpef_capacita_fiscale_multi_anno.years`: aggiunto 2024

### notes.md
- Copertura temporale: 2019–2024 + nota URL funzionante dal 2000
- Struttura raw: aggiunta riga 2024 (52 colonne, stessa struttura 2023)
- Schema: `reddito_complessivo` ora popolato anche per 2024
- Caveat: aggiornato a (2023+)

### README.md (78 righe, da 10)
- Tabella schema 52 colonne con ruoli
- Copertura temporale e territoriale
- Join map: come si collega a comuni_master e unified-comuni
- Mart disponibili con descrizione
- Limiti noti
