### PR TITLE
chore(post-merge): aggiorna registry per PR #532

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-06-20",
+  "updated_at": "2026-06-21",
   "datasets": [
     {
       "slug": "aifa_spesa_consumo",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-20",
+  "generated_at": "2026-06-21",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -322,8 +322,23 @@
       "source_id": "mef_irpef",
       "status": "ok",
       "label": "irpef-comunale",
-      "detail": "anni 2019-2023 — fonte: finanze_http_zip — mart: sì",
-      "action": ""
+      "detail": "anni 2019-2024 — fonte: finanze_http_zip — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "27899103827",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27899103827",
+        "checked_at": "2026-06-21",
+        "years": [
+          2019,
+          2020,
+          2021,
+          2022,
+          2023,
+          2024
+        ],
+        "config_path": "candidates/irpef-comunale/dataset.yml"
+      }
     },
     {
       "id": "ispra-consumo-suolo",


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #532 — feat(irpef): aggiunto anno 2024 + README riscritto

Changed candidate/support roots:

- `irpef-comunale` (candidate, `candidates/irpef-comunale`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/irpef-comunale/dataset.yml` -> artifact `sample-run-irpef-comunale`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
