### PR TITLE
chore(post-merge): aggiorna registry per PR #536

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -5509,6 +5509,12 @@
       },
       "columns": [
         {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
           "name": "username",
           "type": "VARCHAR",
           "role": "dimension",
@@ -5583,8 +5589,8 @@
       ],
       "location": {
         "type": "gcs",
-        "path": "gs://dataciviclab-clean/opencivitas_fsc_2025_rso/2025/opencivitas_fsc_2025_rso_2025_clean.parquet",
-        "multi_file": false
+        "path": "gs://dataciviclab-clean/opencivitas_fsc_2025_rso/*/opencivitas_fsc_2025_rso_*_clean.parquet",
+        "multi_file": true
       },
       "stage": "published",
       "registry_source": "derive_auto"

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -5500,19 +5500,19 @@
     {
       "slug": "opencivitas_fsc_2025_rso",
       "name": "Opencivitas Fsc 2025 Rso",
-      "description": "Fondo di Solidarietà Comunale 2025 — 6 componenti FSC per comune RSO con geografia",
+      "description": "Fondo di Solidarietà Comunale 2022-2025 — 6 componenti FSC per comune RSO con geografia. Multi-anno: 2022-2025.",
       "source": "OpenCivitas / Sogei",
       "source_id": "opencivitas",
       "period": {
-        "start": 2025,
+        "start": 2022,
         "end": 2025
       },
       "columns": [
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di riferimento del FSC"
         },
         {
           "name": "username",
@@ -5548,25 +5548,25 @@
           "name": "popolazione",
           "type": "DOUBLE",
           "role": "metric",
-          "description": "Popolazione residente"
+          "description": "Popolazione residente (fonte FSC)"
         },
         {
           "name": "capacita_fiscale",
           "type": "DOUBLE",
           "role": "metric",
-          "description": "Capacità fiscale (euro)"
+          "description": "Capacità fiscale del comune (€)"
         },
         {
           "name": "fondo_perequativo",
           "type": "DOUBLE",
           "role": "metric",
-          "description": "Fondo perequativo (euro) — negativo = contribuente netto"
+          "description": "Fondo perequativo (€)"
         },
         {
           "name": "dotazione_finale_fsc",
           "type": "DOUBLE",
           "role": "metric",
-          "description": "Dotazione finale FSC (euro)"
+          "description": "Dotazione finale del Fondo di Solidarietà Comunale (€)"
         },
         {
           "name": "imu_tasi_standard",
@@ -5584,7 +5584,7 @@
           "name": "join_enti_ok",
           "type": "BOOLEAN",
           "role": "dimension",
-          "description": "Join con anagrafica enti riuscito (sempre TRUE su RSO 2025)"
+          "description": "Indica se il join con l'anagrafica enti è riuscito"
         }
       ],
       "location": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -608,14 +608,17 @@
       "source_id": "",
       "status": "ok",
       "label": "opencivitas-fsc-rso",
-      "detail": "anno 2025 — fonte: opencivitas_fsc_2025_zip — mart: sì",
+      "detail": "anni 2022-2025 — fonte: opencivitas_fsc_zip — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "26562225396",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26562225396",
-        "checked_at": "2026-05-28",
+        "run_id": "27903144369",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27903144369",
+        "checked_at": "2026-06-21",
         "years": [
+          2022,
+          2023,
+          2024,
           2025
         ],
         "config_path": "candidates/opencivitas-fsc-rso/dataset.yml"


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #536 — feat(fsc): esteso a 2022-2024 + formati colonna variabili

Changed candidate/support roots:

- `opencivitas-fsc-rso` (candidate, `candidates/opencivitas-fsc-rso`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/opencivitas-fsc-rso/dataset.yml` -> artifact `sample-run-opencivitas-fsc-rso`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
