### PR TITLE
chore(post-merge): aggiorna registry per PR #539

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -858,8 +858,8 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "27900963302",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27900963302",
+        "run_id": "27906300471",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27906300471",
         "checked_at": "2026-06-21",
         "years": [
           2026


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #539 — fix(unified-comuni): HTTPS esplicito invece di S3 glob per tutti i dataset

Changed candidate/support roots:

- `unified-comuni` (candidate, `candidates/unified-comuni`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/unified-comuni/dataset.yml` -> artifact `sample-run-unified-comuni`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
