### PR TITLE
chore(post-merge): aggiorna registry per PR #545

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2605,10 +2605,10 @@
     },
     {
       "slug": "ipa_enti",
-      "name": "Ipa Enti",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "name": "Anagrafica Enti PA (IndicePA)",
+      "description": "Anagrafica completa delle pubbliche amministrazioni e gestori di pubblici servizi dall'Indice dei domicili digitali della PA (IPA). Fonte AgID, CC-BY-4.0, aggiornamento giornaliero. 23.709 enti con PEC, indirizzi, responsabili.",
+      "source": "AgID — IndicePA (ipa-dati)",
+      "source_id": "agid",
       "period": {
         "start": 2026,
         "end": 2026
@@ -2618,181 +2618,181 @@
           "name": "codice_ipa",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice identificativo univoco dell'ente in IPA"
         },
         {
           "name": "denominazione_ente",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione ufficiale dell'ente"
         },
         {
           "name": "codice_fiscale_ente",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice fiscale dell'ente"
         },
         {
           "name": "tipologia",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipologia ente (PA, Stazione Appaltante, Gestore, ecc.)"
         },
         {
           "name": "codice_categoria",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice categoria IPA (L6=Comune, C1=Ministero, L7=ASL, ecc.)"
         },
         {
           "name": "codice_natura",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice natura giuridica dell'ente"
         },
         {
           "name": "codice_ateco",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice Ateco dell'attività dell'ente"
         },
         {
           "name": "ente_in_liquidazione",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Indicatore ente in liquidazione (true/false)"
         },
         {
           "name": "codice_miur",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice MIUR per istituti scolastici"
         },
         {
           "name": "codice_istat",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT dell'ente"
         },
         {
           "name": "acronimo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Acronimo o sigla dell'ente"
         },
         {
           "name": "nome_responsabile",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Nome del responsabile/vertice dell'ente"
         },
         {
           "name": "cognome_responsabile",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Cognome del responsabile/vertice dell'ente"
         },
         {
           "name": "titolo_responsabile",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Qualifica del responsabile (Ministro, Sindaco, DG, ecc.)"
         },
         {
           "name": "codice_comune_istat",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT del comune sede dell'ente"
         },
         {
           "name": "codice_catastale_comune",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice catastale (Belfiore) del comune sede"
         },
         {
           "name": "cap",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "CAP della sede dell'ente"
         },
         {
           "name": "indirizzo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Indirizzo della sede dell'ente"
         },
         {
           "name": "mail1",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Indirizzo email principale dell'ente"
         },
         {
           "name": "tipo_mail1",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipologia mail1 (Pec/Altro)"
         },
         {
           "name": "mail2",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Indirizzo email secondario dell'ente"
         },
         {
           "name": "tipo_mail2",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipologia mail2 (Pec/Altro)"
         },
         {
           "name": "mail3",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Indirizzo email terziario dell'ente"
         },
         {
           "name": "tipo_mail3",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipologia mail3 (Pec/Altro)"
         },
         {
           "name": "mail4",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Indirizzo email quarto dell'ente"
         },
         {
           "name": "tipo_mail4",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipologia mail4 (Pec/Altro)"
         },
         {
           "name": "mail5",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Indirizzo email quinto dell'ente"
         },
         {
           "name": "tipo_mail5",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipologia mail5 (Pec/Altro)"
         },
         {
           "name": "sito_istituzionale",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Sito web istituzionale dell'ente"
         },
         {
           "name": "data_aggiornamento",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Data ultimo aggiornamento dei dati IPA dell'ente"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-06-21",
+  "updated_at": "2026-06-23",
   "datasets": [
     {
       "slug": "aifa_spesa_consumo",
@@ -2598,6 +2598,206 @@
       "location": {
         "type": "gcs",
         "path": "gs://dataciviclab-clean/inps_rdc_pdc/2020/inps_rdc_pdc_2020_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "ipa_enti",
+      "name": "Ipa Enti",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2026,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "codice_ipa",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "denominazione_ente",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_fiscale_ente",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "tipologia",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_categoria",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_natura",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_ateco",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "ente_in_liquidazione",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_miur",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_istat",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "acronimo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "nome_responsabile",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cognome_responsabile",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "titolo_responsabile",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_comune_istat",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_catastale_comune",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cap",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "indirizzo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "mail1",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "tipo_mail1",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "mail2",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "tipo_mail2",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "mail3",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "tipo_mail3",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "mail4",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "tipo_mail4",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "mail5",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "tipo_mail5",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "sito_istituzionale",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "data_aggiornamento",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/ipa_enti/2026/ipa_enti_2026_clean.parquet",
         "multi_file": false
       },
       "stage": "published",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-21",
+  "generated_at": "2026-06-23",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 53,
+    "total": 54,
     "by_status": {
-      "ok": 53,
+      "ok": 54,
       "warn": 0,
       "error": 0
     }
@@ -901,6 +901,24 @@
           2026
         ],
         "config_path": "support_datasets/comuni-master/dataset.yml"
+      }
+    },
+    {
+      "id": "ipa-enti",
+      "source_id": "agid",
+      "status": "ok",
+      "label": "ipa-enti",
+      "detail": "anni: ? — fonte: ? — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "28023791270",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28023791270",
+        "checked_at": "2026-06-23",
+        "years": [
+          2026
+        ],
+        "config_path": "support_datasets/ipa-enti/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #545 — feat(support): ipa-enti — anagrafica completa enti PA da IndicePA (AgID)

Changed candidate/support roots:

- `ipa-enti` (support_dataset, `support_datasets/ipa-enti`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `support_datasets/ipa-enti/dataset.yml` -> artifact `sample-run-ipa-enti`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
