### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-06-23",
+  "updated_at": "2026-06-24",
   "datasets": [
     {
       "slug": "ade_cinque_per_mille",
@@ -133,8 +133,8 @@
       ],
       "location": {
         "type": "gcs",
-        "path": "gs://dataciviclab-clean/ade_cinque_per_mille/2024/ade_cinque_per_mille_2024_clean.parquet",
-        "multi_file": false
+        "path": "gs://dataciviclab-clean/ade_cinque_per_mille/*/ade_cinque_per_mille_*_clean.parquet",
+        "multi_file": true
       },
       "stage": "published",
       "registry_source": "derive_auto"

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-23",
+  "generated_at": "2026-06-24",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -17,15 +17,17 @@
       "source_id": "",
       "status": "ok",
       "label": "ade-cinque-per-mille",
-      "detail": "anno 2024 — fonte: ? — mart: sì",
+      "detail": "anni 2023-2025 — fonte: ? — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "28028688331",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28028688331",
-        "checked_at": "2026-06-23",
+        "run_id": "28093698479",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28093698479",
+        "checked_at": "2026-06-24",
         "years": [
-          2024
+          2023,
+          2024,
+          2025
         ],
         "config_path": "candidates/ade-cinque-per-mille/dataset.yml"
       }


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `ade-cinque-per-mille` (candidate, `candidates/ade-cinque-per-mille`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/ade-cinque-per-mille/dataset.yml` -> artifact `sample-run-ade-cinque-per-mille`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
