### PR TITLE
fix(registry): correggi period per 3 dataset multi-anno

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -12,8 +12,8 @@
       "source": "Agenzia delle Entrate",
       "source_id": "",
       "period": {
-        "start": 2024,
-        "end": 2024
+        "start": 2023,
+        "end": 2025
       },
       "columns": [
         {
@@ -2524,7 +2524,7 @@
       "source": "https://www.inps.it/gestione-previdenziale",
       "source_id": "inps",
       "period": {
-        "start": 2024,
+        "start": 2020,
         "end": 2024
       },
       "columns": [
@@ -7806,7 +7806,7 @@
       "source": "Terna S.p.A. — dati pubblicati su terna.com",
       "source_id": "terna",
       "period": {
-        "start": 2023,
+        "start": 2015,
         "end": 2024
       },
       "columns": [


### PR DESCRIPTION
## Sintesi

Corregge il `period` nel `clean_catalog.json` per 3 dataset il cui arco temporale era sottostimato.

## Cosa cambia

- [x] cleanup — refactoring, rimozioni, allineamento

## Dettaglio

| Dataset | Periodo vecchio | Periodo corretto |
|---------|:-:|:-:|
| `ade_cinque_per_mille` | 2024-2024 | **2023-2025** |
| `inps_pensioni_trimestrale` | 2024-2024 | **2020-2024** |
| `terna_capacita_rinnovabile` | 2023-2024 | **2015-2024** |

Il `period` derivava da un derive parziale (non tutti gli anni erano su GCS al momento dell'ultimo build). Ora rilanciato `build_clean_catalog.py --derive --write` che ha letto le cartelle complete e applicato `time_coverage` dove presente.

## Impatto

- [x] Solo documentazione o metadati
- [x] Nessun impatto visibile per chi usa il repository

## Verifica

```bash
python scripts/build_clean_catalog.py --derive --write
python scripts/build_clean_catalog.py --check-gcs
```

- [x] derive completato: 54 dataset processati, 10 aggiornati da time_coverage
- [x] check-gcs passato
