### PR TITLE
feat(validate): policy validazione candidate + preflight CI + toolkit v1.40.0

### DIFF
--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -111,7 +111,7 @@ jobs:
         id: preflight
         continue-on-error: true
         run: |
-          toolkit preflight --config "${{ matrix.config.config_path }}" --json 2>&1 \
+          toolkit run preflight --config "${{ matrix.config.config_path }}" --json 2>&1 \
             || echo "::warning::Preflight issues detected for ${{ matrix.config.config_path }}"
 
       - name: "Toolkit run full (smoke: sample-bytes + sample-rows, skip min_rows) [retry x2]"

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -107,6 +107,13 @@ jobs:
           echo "REQUESTS_CA_BUNDLE=$bundle" >> "$GITHUB_ENV"
           echo "SSL_CERT_FILE=$bundle" >> "$GITHUB_ENV"
 
+      - name: "Preflight: config valida + fonte raggiungibile + quality score"
+        id: preflight
+        continue-on-error: true
+        run: |
+          toolkit preflight --config "${{ matrix.config.config_path }}" --json 2>&1 \
+            || echo "::warning::Preflight issues detected for ${{ matrix.config.config_path }}"
+
       - name: "Toolkit run full (smoke: sample-bytes + sample-rows, skip min_rows) [retry x2]"
         id: run_full
         env:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git
 
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.39.0
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.40.0
 
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0

--- a/scripts/validate_candidate_structure.py
+++ b/scripts/validate_candidate_structure.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Literal
 
 from toolkit.core.dataset_loader import load_dataset_manifest
+from toolkit.core.config_models import load_config_model
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -95,11 +96,15 @@ def validate_dataset_name_yml(yml_path: Path, failures: list[str]) -> None:
         failures.append(f"{rel}: invalid dataset.name '{name}' — must match ^[a-z0-9_]+$")
 
 
-def validate_single_source(base_dir: Path, failures: list[str]) -> None:
+def validate_single_source(
+    base_dir: Path, failures: list[str], warnings: list[str] | None = None
+) -> None:
     dataset_yml = base_dir / "dataset.yml"
     sql_dir = base_dir / "sql"
 
     validate_dataset_name_yml(dataset_yml, failures)
+    if warnings is not None:
+        check_clean_validation_config(dataset_yml, warnings)
 
     if not dataset_yml.exists():
         failures.append(f"missing {dataset_yml.relative_to(ROOT)}")
@@ -146,6 +151,46 @@ def validate_compose(base_dir: Path, failures: list[str]) -> None:
         failures.append(f"missing mart*.sql under {sql_dir.relative_to(ROOT)}")
 
 
+def check_clean_validation_config(dataset_yml: Path, warnings: list[str]) -> None:
+    """Verifica che il candidate abbia validazione minima configurata.
+
+    Policy: ogni nuovo candidate deve avere almeno not_null e required_columns
+    in clean.validate. Questa funzione produce raccomandazioni, non errori —
+    i dataset esistenti vengono migrati gradualmente.
+    """
+    if not dataset_yml.exists():
+        return
+    try:
+        cfg = load_config_model(dataset_yml)
+    except Exception:
+        return
+
+    if not cfg.clean or not cfg.clean.sql:
+        return  # compose (mart-only) — no clean layer validation needed
+
+    clean_validate = cfg.clean.validate
+    missing: list[str] = []
+    if not clean_validate.not_null:
+        missing.append("clean.validate.not_null")
+    if not cfg.clean.required_columns:
+        missing.append("clean.required_columns")
+    if not clean_validate.primary_key:
+        missing.append(
+            "clean.validate.primary_key (utile ma opzionale — deroga se PK non dichiarabile)"
+        )
+
+    if len(missing) == 1:
+        warnings.append(
+            f"{dataset_yml.relative_to(ROOT)}: manca {missing[0]} — "
+            "aggiungilo per avere validazione automatica"
+        )
+    elif len(missing) > 1:
+        warnings.append(
+            f"{dataset_yml.relative_to(ROOT)}: mancano {len(missing)} elementi di validazione "
+            f"({', '.join(missing)})"
+        )
+
+
 def validate_multi_source(base_dir: Path, failures: list[str]) -> None:
     sources_dir = base_dir / "sources"
     source_dirs = sorted(path for path in sources_dir.iterdir() if path.is_dir())
@@ -172,7 +217,7 @@ def validate_multi_source(base_dir: Path, failures: list[str]) -> None:
     validate_compose(base_dir, failures)
 
 
-def validate_entry(base_dir: Path, failures: list[str]) -> None:
+def validate_entry(base_dir: Path, failures: list[str], warnings: list[str] | None = None) -> None:
     rel_str = base_dir.relative_to(ROOT).as_posix()
 
     # Validate slug conventions
@@ -200,7 +245,7 @@ def validate_entry(base_dir: Path, failures: list[str]) -> None:
         return
 
     if layout == "single-source":
-        validate_single_source(base_dir, failures)
+        validate_single_source(base_dir, failures, warnings=warnings)
         return
 
     if layout == "compose":
@@ -216,13 +261,20 @@ def validate_entry(base_dir: Path, failures: list[str]) -> None:
 
 def main() -> int:
     failures: list[str] = []
+    validation_warnings: list[str] = []
 
     for section in ("compose", "candidates", "support_datasets"):
         base = ROOT / section
         if not base.exists():
             continue
         for entry in sorted(path for path in base.iterdir() if path.is_dir()):
-            validate_entry(entry, failures)
+            validate_entry(entry, failures, warnings=validation_warnings)
+
+    if validation_warnings:
+        print("Validation recommendations:", file=sys.stdout)
+        for w in validation_warnings:
+            print(f"  ! {w}", file=sys.stdout)
+        print(file=sys.stdout)
 
     if failures:
         print("Candidate structure validation failed:", file=sys.stderr)


### PR DESCRIPTION
## Sintesi

Tre cambiamenti collegati al nuovo sistema di validazione automatica del toolkit v1.40.0:

1. **Policy candidate**: `check_clean_validation_config()` raccomanda (non blocca) `clean.validate.not_null` e `clean.required_columns` per ogni nuovo candidate
2. **Preflight in CI**: `toolkit preflight` prima del full pipeline check — cattura subito config errate e fonti down
3. **Dipendenza**: toolkit v1.39.0 → v1.40.0 (sensible defaults, PAQA score, validation.mode)

## Contesto collegato

Toolkit PR #399 — nuovi sensible defaults di validazione.

## Cosa cambia

- [x] docs — struttura candidate, README, template
- [x] workflow o CI

## Impatto

- [x] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Nessun impatto visibile per chi usa il repository

## Verifica

```bash
python scripts/validate_candidate_structure.py
```

- [x] `python scripts/validate_candidate_structure.py` passato

## Note

- Le raccomandazioni sono warning su stdout, non bloccano il merge
- I 43 candidate esistenti producono raccomandazioni (da migrare gradualmente)
- Il preflight step ha `continue-on-error: true` — non blocca mai la PR
