### PR TITLE
feat(ispra-ru-base): espansione temporale 2010-2024 (da 5 a 15 anni)

### DIFF
--- a/candidates/ispra-ru-costi-kg/README.md
+++ b/candidates/ispra-ru-costi-kg/README.md
@@ -11,8 +11,8 @@ Nucleo multi-fonte ISPRA sui rifiuti urbani, costruito come estensione del vecch
 Fonti previste nel primo ciclo:
 
 | ID | Fonte | Ruolo previsto | Stato |
-|---|---|---|---|
-| A | ISPRA RU base | base territoriale con totale RU, RD e popolazione | run verde `2020-2024` |
+|---|---|---|---|---|
+| A | ISPRA RU base | base territoriale con totale RU, RD e popolazione | run verde `2010-2024` (espanso da 5 a 15 anni) |
 | B | ISPRA kg per abitante | metrica pro capite del volume di RU | run verde `2020-2024`, mart cross mancante nel `2022` sul clone corrente |
 | C | ISPRA costo per abitante | asse economico minimo del servizio | run verde `2020-2024`, mart cross mancante nel `2021` sul clone corrente |
 
@@ -58,7 +58,7 @@ Gli anni `2021` e `2022` non sono oggi presenti nel cross mart locale per un vin
 
 Stato attuale del candidate:
 
-- source dataset `A/B/C` eseguiti su `2020-2024`
+- source dataset `A` eseguito su `2010-2024` (15 anni), `B/C` su `2020-2024`
 - compose minimo chiuso sul join `codice_comune_istat x anno`
 - notebook `v1` disponibile sul perimetro joinato
 - per vincolo del toolkit, il SQL del cross resta anche in `sources/a_ru_base/sql/` come copia eseguibile
@@ -85,6 +85,10 @@ Promuovere il filone solo se:
 ## Provenienza
 
 Il filone nasce come estensione ordinata del vecchio `progetto-pilota` ISPRA RU, oggi classificato come `legacy closed` in `dataciviclab`.
+
+## Gap noti / follow-up
+
+- **B** e **C**: lo schema dei CSV dei costi è cambiato tra 2011 e 2020 (11 colonne costo nel 2011 → 6 nel 2020). Impossibile espandere linearmente come A. Serve analisi separata con SQL condizionale per anno o skip colonne adattivo.
 
 ## Prossimo passo
 

--- a/candidates/ispra-ru-costi-kg/notes.md
+++ b/candidates/ispra-ru-costi-kg/notes.md
@@ -14,6 +14,15 @@ Stato attuale:
 - notebook `v0` e `v1` disponibili
 - Discussion pubblica già aggiornata: `#22`
 
+### Espansione temporale A (2026-06-28)
+
+- `a_ru_base` espanso da `2020-2024` a **`2010-2024`** (15 anni)
+- URL ISPRA stabile e schema identico per tutti gli anni
+- `min_rows` validazione rilassato da 7000 a 6500 per coprire la copertura ridotta degli anni 2012-2013 (molti comuni in aggregazione)
+- Transition `max_row_drop_pct` portato a 20% per assorbire il drop fisiologico degli anni con comuni aggregati (`fail_on_row_drop_exceeded: false`)
+- Run `all` verde per tutti i 15 anni
+- `B` e `C` NON espansi: schema CSV cambiato tra 2011 e 2020 (colonne costo diverse), serve SQL condizionale per anno — rimandato a follow-up
+
 ## Architettura adottata
 
 Pattern multi-fonte:

--- a/candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml
+++ b/candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml
@@ -4,7 +4,7 @@ schema_version: 1
 dataset:
   name: "ispra_ru_base"
   source_id: "ispra_linked_data"
-  years: [2020, 2021, 2022, 2023, 2024]
+  years: [2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024]
 
 raw:
   sources:
@@ -52,7 +52,10 @@ clean:
       Totale RU (t): VARCHAR
       Percentuale RD (%): VARCHAR
   validate:
-    min_rows: 7000
+    min_rows: 6500
+    promotion:
+      max_row_drop_pct: 20
+      fail_on_row_drop_exceeded: false
 
 mart:
   tables:
@@ -61,7 +64,7 @@ mart:
   validate:
     table_rules:
       mart_comuni:
-        min_rows: 7000
+        min_rows: 6500
 
 validation:
   fail_on_error: true


### PR DESCRIPTION
## Sintesi

Espansione temporale di `sources/a_ru_base` (ISPRA RU base) da 5 anni (2020-2024) a **15 anni (2010-2024)**, aggiungendo un decennio di dati storici sui rifiuti urbani comunali.

## Contesto collegato

Issue di riferimento: #33 (candidate ispra-ru-costi-kg)

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento
- [ ] support — dataset di supporto
- [x] docs — struttura candidate, README, template
- [ ] cleanup — refactoring, rimozioni, allineamento
- [ ] workflow o CI
- [ ] altro

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
- [x] Solo documentazione o metadati
- [ ] Nessun impatto visibile per chi usa il repository

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori su tutti gli anni dichiarati
- [x] nessun file dati committato nella root del candidate (`*.csv`, `*.parquet`, `*.xlsx`)
- [ ] output immagini cleared dal notebook (non toccato)
- [ ] notebook nominato `{slug}_v0.ipynb`, nessun path assoluto di macchina (non toccato)
- [ ] issue di intake collegata (#33)

## Verifica

```bash
python -m toolkit.cli.app run all --config candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml
python scripts/validate_candidate_structure.py
```

- [x] `run all` eseguito senza errori (candidate)
- [x] `python scripts/validate_candidate_structure.py` passato (solo warning pre-esistenti su altri candidate)
- [x] Perimetro stretto: candidate con domanda minima chiara

## Note / rischi

1. **2012-2013**: copertura ridotta (6781-6863 comuni vs ~7900) perché molti comuni erano rappresentati in aggregazioni. Validazione `min_rows` abbassata da 7000 a 6500 e transition `max_row_drop_pct` portato a 20% per riflettere la copertura reale. Non è un errore — è la reale disponibilità del dato storico.
2. **B e C non espansi**: lo schema dei CSV dei costi (`b_kg_per_abitante`, `c_costo_per_abitante`) è cambiato tra 2011 e 2020 (da 11 a 6 colonne costo). Per espanderli serve SQL condizionale per anno — rimandato a follow-up separato.
3. **Schema A stabile**: tutte le 24 colonne sono identiche tra 2010 e 2024. Nessuna modifica a SQL necessaria.
