### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -455,9 +455,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "26091030726",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26091030726",
-        "checked_at": "2026-05-19",
+        "run_id": "28322708552",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28322708552",
+        "checked_at": "2026-06-28",
         "years": [
           2020,
           2021,
@@ -465,7 +465,7 @@
           2023,
           2024
         ],
-        "config_path": "candidates/ispra-ru-costi-kg/sources/a_ru_base/dataset.yml"
+        "config_path": "candidates/ispra-ru-costi-kg/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `ispra-ru-costi-kg` (candidate, `candidates/ispra-ru-costi-kg`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/ispra-ru-costi-kg/dataset.yml` -> artifact `sample-run-ispra-ru-costi-kg`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
