### PR TITLE
feat(compose): costituzione-master — JOIN metriche costituzionali

### DIFF
--- a/compose/costituzione-master/dataset.yml
+++ b/compose/costituzione-master/dataset.yml
@@ -1,0 +1,35 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "costituzione_master"
+  years: [2026]
+
+raw:
+  output_policy: overwrite
+  sources:
+    - type: script
+      args:
+        command: "python preprocess.py raw_input.csv"
+        output: "raw_input.csv"
+        filename: "raw_input.csv"
+      primary: true
+
+clean:
+  read:
+    delim: ","
+    encoding: "utf-8"
+    header: true
+    skip: 0
+  read_mode: strict
+  required_columns:
+    - articolo
+    - n_modifiche
+    - n_giudizi
+    - n_indicatori
+  sql: "sql/clean.sql"
+
+mart:
+  tables:
+    - name: "costituzione_master"
+      sql: "sql/mart.sql"

--- a/compose/costituzione-master/dataset.yml
+++ b/compose/costituzione-master/dataset.yml
@@ -4,6 +4,7 @@ schema_version: 1
 dataset:
   name: "costituzione_master"
   years: [2026]
+  source_id: "costituzione-italiana"
 
 raw:
   output_policy: overwrite
@@ -24,9 +25,13 @@ clean:
   read_mode: strict
   required_columns:
     - articolo
+    - parte
+    - heading
+    - testo_preview
     - n_modifiche
     - n_giudizi
     - n_indicatori
+    - dataset_slugs
   sql: "sql/clean.sql"
 
 mart:

--- a/compose/costituzione-master/notes.md
+++ b/compose/costituzione-master/notes.md
@@ -10,8 +10,8 @@ Ogni riga = un articolo (1-139) con metriche aggregate da:
 
 ## Dipendenza
 
-Lo script RAW scarica i parquet da GitHub (repo pubblico `dataciviclab/costituzione-italiana`).
-Il repo deve essere pubblico perché `raw.githubusercontent.com` sia accessibile senza token.
+Lo script RAW scarica i parquet da `raw.githubusercontent.com/dataciviclab/costituzione-italiana`.
+Il repo è pubblico — nessun token richiesto.
 
 ## Esecuzione
 

--- a/compose/costituzione-master/notes.md
+++ b/compose/costituzione-master/notes.md
@@ -1,0 +1,23 @@
+# costituzione-master
+
+**Dataset derivato**: JOIN tra i 4 parquet di `dataciviclab/costituzione-italiana`.
+
+Ogni riga = un articolo (1-139) con metriche aggregate da:
+- `articoli.parquet` → testo, parte, heading
+- `revisioni.parquet` → quante modifiche ha subito
+- `atti-promovimento.parquet` → quante volte evocato in giudizio
+- `indicatori-costituzionali.parquet` → quanti dataset Lab lo misurano
+
+## Dipendenza
+
+Lo script RAW scarica i parquet da GitHub (repo pubblico `dataciviclab/costituzione-italiana`).
+Il repo deve essere pubblico perché `raw.githubusercontent.com` sia accessibile senza token.
+
+## Esecuzione
+
+```bash
+cd dataset-incubator
+TOOLKIT_ALLOW_SCRIPT_SOURCE=1 toolkit run full \
+  --config compose/costituzione-master/dataset.yml \
+  --years 2026
+```

--- a/compose/costituzione-master/preprocess.py
+++ b/compose/costituzione-master/preprocess.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Preprocess: scarica i parquet da costituzione-italiana su GitHub e produce il CSV master.
+
+Ogni riga = un articolo della Costituzione (1-139) con metriche aggregate.
+
+Output: raw_input.csv (consumato dal toolkit per clean → mart)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+from collections import Counter
+from pathlib import Path
+from urllib.request import urlopen
+
+logger = logging.getLogger("costituzione-master")
+
+# Percorso locale (repo clonato accanto) — per sviluppo
+LOCAL = Path(__file__).resolve().parent.parent.parent.parent / "costituzione-italiana" / "data"
+
+# URL remoto (repo pubblico su GitHub) — per CI/produzione
+REMOTE = "https://raw.githubusercontent.com/dataciviclab/costituzione-italiana/main/data"
+
+NOMI = {
+    "articoli": "articoli.parquet",
+    "revisioni": "revisioni.parquet",
+    "atti": "atti-promovimento.parquet",
+    "indicatori": "indicatori-costituzionali.parquet",
+}
+
+
+def _leggi_file(nome: str) -> bytes:
+    """Legge un parquet: prima locale (sviluppo), poi remoto (CI)."""
+    fname = NOMI[nome]
+    locale = LOCAL / fname
+    if locale.exists():
+        logger.info("Locale %s", locale)
+        return locale.read_bytes()
+    url = f"{REMOTE}/{fname}"
+    logger.info("Remoto %s", url)
+    with urlopen(url, timeout=60) as resp:
+        return resp.read()
+
+
+def leggi_articoli(data: bytes) -> dict[int, dict]:
+    """Legge articoli.parquet: art → {testo, parte, heading}."""
+    import pyarrow.parquet as pq
+    import io
+
+    t = pq.read_table(io.BytesIO(data))
+    result = {}
+    for i in range(t.num_rows):
+        a = t.column("articolo")[i].as_py()
+        if a is not None:
+            result[a] = {
+                "testo": (t.column("testo")[i].as_py() or "")[:200],
+                "parte": t.column("parte")[i].as_py() or "",
+                "heading": t.column("heading")[i].as_py() or "",
+            }
+    return result
+
+
+def leggi_revisioni(data: bytes) -> Counter:
+    """Legge revisioni.parquet: art → numero modifiche."""
+    import pyarrow.parquet as pq
+    import io
+
+    t = pq.read_table(io.BytesIO(data))
+    c: Counter = Counter()
+    for i in range(t.num_rows):
+        if t.column("tipo")[i].as_py() == "modifica_costituzione":
+            for a in t.column("articoli_modificati")[i].as_py() or []:
+                c[a] += 1
+    return c
+
+
+def leggi_giudizi(data: bytes) -> Counter:
+    """Legge atti-promovimento.parquet: art → numero giudizi."""
+    import pyarrow.parquet as pq
+    import io
+
+    t = pq.read_table(io.BytesIO(data))
+    c: Counter = Counter()
+    for v in t.column("parametro_articolo").to_pylist():
+        if v:
+            c[v] += 1
+    return c
+
+
+def leggi_indicatori(data: bytes) -> dict[int, list[str]]:
+    """Legge indicatori-costituzionali.parquet: art → [slug, ...]."""
+    import pyarrow.parquet as pq
+    import io
+
+    t = pq.read_table(io.BytesIO(data))
+    result: dict[int, list[str]] = {}
+    for i in range(t.num_rows):
+        a = t.column("articolo")[i].as_py()
+        slug = t.column("dataset_slug")[i].as_py()
+        if a is not None and slug:
+            result.setdefault(a, []).append(slug)
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output", nargs="?", default="raw_input.csv")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    # Leggi (locale o remoto)
+    raw = {}
+    for key in NOMI:
+        raw[key] = _leggi_file(key)
+
+    # Parse
+    articoli = leggi_articoli(raw["articoli"])
+    revisioni = leggi_revisioni(raw["revisioni"])
+    giudizi = leggi_giudizi(raw["atti"])
+    indicatori = leggi_indicatori(raw["indicatori"])
+
+    # Write
+    campi = [
+        "articolo",
+        "parte",
+        "heading",
+        "testo_preview",
+        "n_modifiche",
+        "n_giudizi",
+        "n_indicatori",
+        "dataset_slugs",
+    ]
+    out_path = Path(args.output)
+    with open(out_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=campi)
+        w.writeheader()
+        for a in sorted(articoli):
+            info = articoli[a]
+            w.writerow(
+                {
+                    "articolo": a,
+                    "parte": info["parte"],
+                    "heading": info["heading"],
+                    "testo_preview": info["testo"],
+                    "n_modifiche": revisioni.get(a, 0),
+                    "n_giudizi": giudizi.get(a, 0),
+                    "n_indicatori": len(indicatori.get(a, [])),
+                    "dataset_slugs": ", ".join(indicatori.get(a, [])),
+                }
+            )
+
+    logger.info("Scritto %s — %d articoli", out_path, len(articoli))
+
+
+if __name__ == "__main__":
+    main()

--- a/compose/costituzione-master/preprocess.py
+++ b/compose/costituzione-master/preprocess.py
@@ -17,11 +17,8 @@ from urllib.request import urlopen
 
 logger = logging.getLogger("costituzione-master")
 
-# Percorso locale (repo clonato accanto) — per sviluppo
-LOCAL = Path(__file__).resolve().parent.parent.parent.parent / "costituzione-italiana" / "data"
-
-# URL remoto (repo pubblico su GitHub) — per CI/produzione
-REMOTE = "https://raw.githubusercontent.com/dataciviclab/costituzione-italiana/main/data"
+# Repository pubblico su GitHub
+BASE = "https://raw.githubusercontent.com/dataciviclab/costituzione-italiana/main/data"
 
 NOMI = {
     "articoli": "articoli.parquet",
@@ -32,14 +29,9 @@ NOMI = {
 
 
 def _leggi_file(nome: str) -> bytes:
-    """Legge un parquet: prima locale (sviluppo), poi remoto (CI)."""
-    fname = NOMI[nome]
-    locale = LOCAL / fname
-    if locale.exists():
-        logger.info("Locale %s", locale)
-        return locale.read_bytes()
-    url = f"{REMOTE}/{fname}"
-    logger.info("Remoto %s", url)
+    """Scarica un parquet dal repo pubblico costituzione-italiana."""
+    url = f"{BASE}/{NOMI[nome]}"
+    logger.info("Download %s", url)
     with urlopen(url, timeout=60) as resp:
         return resp.read()
 

--- a/compose/costituzione-master/sql/clean.sql
+++ b/compose/costituzione-master/sql/clean.sql
@@ -1,0 +1,13 @@
+-- CLEAN: costituzione-master
+-- Già pulito da preprocess.py, solo cast e normalizzazione.
+
+SELECT
+    CAST(articolo AS INTEGER) AS articolo,
+    TRIM(parte) AS parte,
+    TRIM(heading) AS heading,
+    TRIM(testo_preview) AS testo_preview,
+    CAST(n_modifiche AS INTEGER) AS n_modifiche,
+    CAST(n_giudizi AS INTEGER) AS n_giudizi,
+    CAST(n_indicatori AS INTEGER) AS n_indicatori,
+    TRIM(dataset_slugs) AS dataset_slugs
+FROM raw_input

--- a/compose/costituzione-master/sql/mart.sql
+++ b/compose/costituzione-master/sql/mart.sql
@@ -1,0 +1,20 @@
+-- MART: costituzione-master
+-- Vista analitica: metriche per articolo della Costituzione.
+
+SELECT
+    articolo,
+    parte,
+    heading,
+    testo_preview,
+    n_modifiche,
+    n_giudizi,
+    n_indicatori,
+    dataset_slugs,
+    -- Classificazione
+    CASE
+        WHEN n_modifiche = 0 AND n_giudizi = 0 THEN 'mai toccato'
+        WHEN n_modifiche = 0 AND n_giudizi > 0 THEN 'principio conteso'
+        WHEN n_modifiche > 0 AND n_giudizi = 0 THEN 'riformato senza contenzioso'
+        WHEN n_modifiche > 0 AND n_giudizi > 0 THEN 'riformato e conteso'
+    END AS profilo
+FROM clean_input


### PR DESCRIPTION
## Descrizione

Nuovo compose che unisce i 4 parquet di `dataciviclab/costituzione-italiana`
in un unico dataset master: una riga per articolo (1-139) con metriche aggregate.

## Schema

```
articolo        # 1-139
parte           # es. "Principi fondamentali"
heading         # es. "Art. 32"
testo_preview   # primi 200 caratteri
n_modifiche     # quante leggi di revisione l'hanno modificato
n_giudizi       # quante volte evocato in Corte Costituzionale
n_indicatori    # quanti dataset Lab lo misurano
dataset_slugs   # lista slug
profilo         # classificazione: conteso / riformato / mai toccato
```

## Pipeline

```
preprocess.py → scarica 4 parquet da GitHub (repo pubblico)
             → produce raw_input.csv
toolkit run full → clean.sql → mart.sql
```

Verificato: RAW✅ CLEAN✅ (139 righe) MART✅