### PR TITLE
fix: anteponi 'compose:' all'ID del sample run per composes

### DIFF
--- a/scripts/build_pipeline_signals.py
+++ b/scripts/build_pipeline_signals.py
@@ -317,9 +317,9 @@ def build_signals(out_path: Path) -> int:
         for entry in sorted(p for p in compose_dir.iterdir() if p.is_dir()):
             slug = f"compose:{entry.name}"
             signal = _build_signal(slug, entry)
-            # sample_run per compose usa ID senza prefisso (directory name)
-            if entry.name in previous_sample_runs:
-                signal["sample_run"] = previous_sample_runs[entry.name]
+            # sample_run per compose usa ID con prefisso "compose:"
+            if slug in previous_sample_runs:
+                signal["sample_run"] = previous_sample_runs[slug]
             signals.append(signal)
 
     by_status: dict[str, int] = {"ok": 0, "warn": 0, "error": 0}

--- a/scripts/post_merge_runner.py
+++ b/scripts/post_merge_runner.py
@@ -182,8 +182,11 @@ def cmd_sample_run(args: argparse.Namespace) -> None:
 
         run_id = os.environ.get("GITHUB_RUN_ID", "0")
         repo = os.environ.get("GITHUB_REPOSITORY", "")
+        # Compose datasets usano prefisso "compose:" per allinearsi
+        # a build_pipeline_signals.py che lo usa per evitare collisioni
+        resolved_id = f"compose:{slug}" if config_path.startswith("compose/") else slug
         payload = {
-            "id": slug,
+            "id": resolved_id,
             "status": status,
             "years": all_years,
             "config_path": config_path,

--- a/tests/test_build_pipeline_signals.py
+++ b/tests/test_build_pipeline_signals.py
@@ -383,6 +383,52 @@ class TestBuildSignals:
         assert s["sample_run"]["run_id"] == "r1"
 
     @pytest.mark.contract
+    def test_preserves_compose_sample_runs(self, tmp_path):
+        """I sample run dei compose (con prefisso 'compose:') sono preservati dopo rebuild."""
+        from build_pipeline_signals import build_signals
+
+        root = tmp_path / "repo-compose-sample"
+        reg = root / "registry"
+        reg.mkdir(parents=True)
+        (reg / "pipeline_signals.json").write_text(
+            json.dumps(
+                {
+                    "signals": [
+                        {
+                            "id": "compose:agg",
+                            "sample_run": {
+                                "status": "passed",
+                                "run_id": "c1",
+                                "run_url": "u",
+                                "checked_at": "2026-06-28",
+                                "years": [2026],
+                                "config_path": "compose/agg/dataset.yml",
+                            },
+                        }
+                    ],
+                }
+            )
+        )
+        # Crea la struttura compose
+        comp = root / "compose" / "agg"
+        (comp / "sql").mkdir(parents=True)
+        (comp / "sql" / "mart.sql").write_text("SELECT 1")
+        (comp / "dataset.yml").write_text("dataset:\n  name: agg\n  years: [2026]")
+        # Crea candidates vuoto (build_signals lo richiede)
+        (root / "candidates").mkdir()
+
+        out = reg / "pipeline_signals.json"
+        with patch("build_pipeline_signals.ROOT", root):
+            assert build_signals(out) == 0
+
+        signals = json.loads(out.read_text())["signals"]
+        compose_signal = [s for s in signals if s["id"] == "compose:agg"]
+        assert len(compose_signal) == 1, "compose:agg non trovato dopo rebuild"
+        assert compose_signal[0]["sample_run"]["run_id"] == "c1", (
+            f"sample_run perso dopo rebuild: {compose_signal[0]}"
+        )
+
+    @pytest.mark.contract
     def test_handles_no_candidates_dir(self, tmp_path):
         from build_pipeline_signals import build_signals
 


### PR DESCRIPTION
## Problema

Il post-merge falliva per `costituzione-master` con `no matching signal in catalog`.

**Causa**: `build_pipeline_signals.py` crea segnali con `id: "compose:slug"`
(riga ~230), ma `post_merge_runner.py` scrive il sample run con `id: slug`
(senza prefisso). `update_pipeline_sample_runs.py` cerca l'ID senza prefisso
nella lista dei segnali che hanno il prefisso → no match.

Non era mai successo perché `costituzione-master` è il primo compose mergiato.

## Fix

In `post_merge_runner.py`, se `config_path` inizia con `compose/`,
antepone `compose:` all'ID:

```python
resolved_id = f"compose:{slug}" if config_path.startswith("compose/") else slug
```

Ora il sample run produce `id: "compose:costituzione-master"` → matcha
perfettamente con ciò che `build_pipeline_signals.py` si aspetta.