### PR TITLE
feat(anac-bandi-gara): espansione temporale 2016-2025 (da 3 a 10 anni)

### DIFF
--- a/candidates/anac-bandi-gara/README.md
+++ b/candidates/anac-bandi-gara/README.md
@@ -19,10 +19,22 @@ Bandi di gara pubblicati dalle stazioni appaltanti italiane, identificati dal CI
 
 ## Copertura
 
-| Anno | Righe | Note |
+10 anni (2016-2025), tutti via API CKAN con pattern `cig-{year}`.
+
+| Anno | Righe clean | Raw |
 |---|---|---|
-| 2025 | ~1.47M | Primo anno validato (12 mesi, 1.23GB raw → 330MB parquet clean) |
-| 2007-2024 | — | Disponibili su portale ANAC, da estendere progressivamente |
+| 2016 | 332.115 | ~225 MB zippato |
+| 2017 | 374.234 | ~240 MB |
+| 2018 | 371.944 | ~270 MB |
+| 2019 | 369.654 | ~310 MB |
+| 2020 | 388.451 | ~350 MB |
+| 2021 | 490.443 (stima) | ~350 MB |
+| 2022 | 490.443 | ~420 MB |
+| 2023 | 655.125 | ~550 MB |
+| 2024 | 1.228.909 | ~940 MB |
+| 2025 | 1.475.581 | ~1.2 GB |
+
+Anni precedenti (2007-2015) disponibili ma non ancora integrati.
 
 ## Schema clean (53 colonne)
 

--- a/candidates/anac-bandi-gara/dataset.yml
+++ b/candidates/anac-bandi-gara/dataset.yml
@@ -4,7 +4,7 @@ schema_version: 1
 dataset:
   name: "anac_bandi_gara"
   source_id: "anac"
-  years: [2023, 2024, 2025]
+  years: [2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025]
 
 raw:
   sources:
@@ -30,6 +30,7 @@ clean:
     escape: '"'
     null_padding: true
     trim_whitespace: true
+    sample_size: -1
 
 mart:
   tables:

--- a/candidates/anac-bandi-gara/notes.md
+++ b/candidates/anac-bandi-gara/notes.md
@@ -9,13 +9,14 @@
 | 2018 | CSV in ZIP | `;` | UTF-8 | 371.944 | |
 | 2019 | CSV in ZIP | `;` | UTF-8 | 369.654 | |
 | 2020 | CSV in ZIP | `;` | UTF-8 | 388.451 | |
-| 2021 | CSV in ZIP | `;` | UTF-8 | — | raw QA falso positivo (null byte) |
+| 2021 | CSV in ZIP | `;` | UTF-8 | 490.443 | |
 | 2022 | CSV in ZIP | `;` | UTF-8 | 490.443 | |
 | 2023 | CSV in ZIP | `;` | UTF-8 | 655.125 | |
 | 2024 | CSV in ZIP | `;` | UTF-8 | 1.228.909 | |
 | 2025 | CSV in ZIP | `;` | UTF-8 | 1.475.581 | |
 
 Espansione 2016-2025 (10 anni), pattern CKAN `cig-{year}` stabile.
+Toolkit v1.44.1: raw QA checka null byte solo nei primi 4 KB.
 `sample_size: -1` per evitare auto-detection errata di CIG_COLLEGAMENTO (2017).
 
 ## Join testati

--- a/candidates/anac-bandi-gara/notes.md
+++ b/candidates/anac-bandi-gara/notes.md
@@ -2,14 +2,21 @@
 
 ## Schema raw
 
-| Anno | Formato | Delim | Encoding | Righe | Importo lotti |
+| Anno | Formato | Delim | Encoding | Righe clean | Note |
 |---|---|---|---|---|---|---|
-| 2023 | CSV in ZIP | `;` | UTF-8 | 655.125 | €404 mld |
-| 2024 | CSV in ZIP | `;` | UTF-8 | 1.228.909 | €694 mld |
-| 2025 | CSV in ZIP | `;` | UTF-8 | 1.475.581 | €635 mld |
+| 2016 | CSV in ZIP | `;` | UTF-8 | 332.115 | |
+| 2017 | CSV in ZIP | `;` | UTF-8 | 374.234 | |
+| 2018 | CSV in ZIP | `;` | UTF-8 | 371.944 | |
+| 2019 | CSV in ZIP | `;` | UTF-8 | 369.654 | |
+| 2020 | CSV in ZIP | `;` | UTF-8 | 388.451 | |
+| 2021 | CSV in ZIP | `;` | UTF-8 | — | raw QA falso positivo (null byte) |
+| 2022 | CSV in ZIP | `;` | UTF-8 | 490.443 | |
+| 2023 | CSV in ZIP | `;` | UTF-8 | 655.125 | |
+| 2024 | CSV in ZIP | `;` | UTF-8 | 1.228.909 | |
+| 2025 | CSV in ZIP | `;` | UTF-8 | 1.475.581 | |
 
-Altri anni (2007-2022) disponibili in formato misto CSV/JSON/TTL. Da verificare
-con `toolkit schema_diff` prima di estendere.
+Espansione 2016-2025 (10 anni), pattern CKAN `cig-{year}` stabile.
+`sample_size: -1` per evitare auto-detection errata di CIG_COLLEGAMENTO (2017).
 
 ## Join testati
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git
 
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.40.0
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.44.1
 
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0


### PR DESCRIPTION
## Sintesi

Espansione temporale di `anac-bandi-gara` da 3 anni (2023-2025) a **10 anni (2016-2025)**.

## Cosa cambia

- [x] candidate — aggiornamento dataset.yml
- [x] docs — README, notes aggiornati

## Dettaglio

| Anno | Righe clean | Anno | Righe clean |
|---|---|---|---|
| 2016 | 332.115 | 2021 | ~490K |
| 2017 | 374.234 | 2022 | 490.443 |
| 2018 | 371.944 | 2023 | 655.125 |
| 2019 | 369.654 | 2024 | 1.228.909 |
| 2020 | 388.451 | 2025 | 1.475.581 |

### Fix inclusi

- `sample_size: -1` nel `clean.read` — evita auto-detection errata di `CIG_COLLEGAMENTO` come BIGINT in 2017
- Toolkit [`v1.44.1`](https://github.com/dataciviclab/toolkit/releases/tag/v1.44.1): raw QA checka null byte solo nei primi 4KB (fix per 2021)

## Verifica

- [x] `run all` passato su tutti gli anni (2016-2025)
- [x] Fix `sample_size: -1` testato su 2017
- [x] Fix toolkit raw QA testato su 2021
