### PR TITLE
feat: istat-occupazione-provinciale — tassi occupazione provincia (SDMX 150_915)

### DIFF
--- a/candidates/istat-occupazione-provinciale/README.md
+++ b/candidates/istat-occupazione-provinciale/README.md
@@ -6,7 +6,7 @@
 **Accesso:** Endpoint HVD ISTAT, SDMX-CSV diretto
 **Licenza:** CC BY (ISTAT)
 **Granularità:** provincia (NUTS3)
-**Copertura:** 2004–2025 (22 anni)
+**Copertura:** 2018–2025 (8 anni, serie provinciale completa)
 
 ## Schema clean (9 colonne)
 

--- a/candidates/istat-occupazione-provinciale/README.md
+++ b/candidates/istat-occupazione-provinciale/README.md
@@ -1,0 +1,35 @@
+# istat-occupazione-provinciale
+
+**Domanda guida:** Come si distribuisce il tasso di occupazione tra le province italiane? Il divario Nord-Sud sta aumentando o diminuendo?
+
+**Fonte:** ISTAT — SDMX dataflow `150_915` (Tasso di occupazione, DCCV_TAXOCCU1)
+**Accesso:** Endpoint HVD ISTAT, SDMX-CSV diretto
+**Licenza:** CC BY (ISTAT)
+**Granularità:** provincia (NUTS3)
+**Copertura:** 2004–2025 (22 anni)
+
+## Schema clean (9 colonne)
+
+```
+ref_area      VARCHAR  — Codice NUTS3 provincia (es. ITC45)
+territorio    VARCHAR  — Nome provincia (es. Milano)
+anno          INTEGER  — Anno (2004–2025)
+indicatore    VARCHAR  — EMP_R (tasso occupazione)
+sesso_codice  VARCHAR  — 1=maschi, 2=femmine, 9=totale
+sesso         VARCHAR  — maschi / femmine / totale
+eta_codice    VARCHAR  — Codice classe età (es. Y15-64)
+eta           VARCHAR  — Classe età (es. 15-64 years)
+valore        DOUBLE   — Tasso di occupazione % (0–100)
+```
+
+## Esecuzione
+
+```bash
+cd dataset-incubator
+python -m toolkit.cli.app run full \
+  --config candidates/istat-occupazione-provinciale/dataset.yml
+```
+
+## Issue di riferimento
+
+- Intake: [#556](https://github.com/dataciviclab/dataset-incubator/issues/556)

--- a/candidates/istat-occupazione-provinciale/dataset.yml
+++ b/candidates/istat-occupazione-provinciale/dataset.yml
@@ -4,7 +4,7 @@ schema_version: 1
 dataset:
   name: "istat_occupazione_provinciale"
   source_id: "istat_sdmx"
-  years: [2024]
+  years: [2025]
   time_coverage:
     start_year: 2004
     end_year: 2025
@@ -26,7 +26,7 @@ raw:
           DATA_TYPE: "EMP_R"
           CITIZENSHIP: "TOTAL"
           EDU_LEV_HIGHEST: "99"
-        year: "2024"
+        year: "2025"
         filename: "istat_occupazione_serie.csv"
       primary: true
 

--- a/candidates/istat-occupazione-provinciale/dataset.yml
+++ b/candidates/istat-occupazione-provinciale/dataset.yml
@@ -1,0 +1,59 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "istat_occupazione_provinciale"
+  source_id: "istat_sdmx"
+  years: [2024]
+  time_coverage:
+    start_year: 2004
+    end_year: 2025
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "istat_sdmx_occupazione"
+      type: "sdmx"
+      client:
+        data_base_url: "https://esploradati.istat.it/SDMXWS/rest"
+        metadata_base_url: "https://esploradati.istat.it/SDMXWS/rest"
+      args:
+        agency: "IT1"
+        flow: "150_915"
+        version: "1.0"
+        filters:
+          FREQ: "A"
+          DATA_TYPE: "EMP_R"
+          CITIZENSHIP: "TOTAL"
+          EDU_LEV_HIGHEST: "99"
+        year: "2024"
+        filename: "istat_occupazione_serie.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: "auto"
+    mode: "latest"
+    delim: ","
+    encoding: "utf-8"
+    header: true
+  validate:
+    min_rows: 10000
+    promotion:
+      max_row_drop_pct: 80
+      fail_on_row_drop_exceeded: false
+
+mart:
+  tables:
+    - name: "mart_occupazione_provinciale"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_occupazione_provinciale"
+  validate:
+    table_rules:
+      mart_occupazione_provinciale:
+        min_rows: 10000
+
+validation:
+  fail_on_error: true

--- a/candidates/istat-occupazione-provinciale/dataset.yml
+++ b/candidates/istat-occupazione-provinciale/dataset.yml
@@ -6,7 +6,7 @@ dataset:
   source_id: "istat_sdmx"
   years: [2025]
   time_coverage:
-    start_year: 2004
+    start_year: 2018
     end_year: 2025
 
 raw:

--- a/candidates/istat-occupazione-provinciale/notes.md
+++ b/candidates/istat-occupazione-provinciale/notes.md
@@ -1,0 +1,48 @@
+# Notes — istat-occupazione-provinciale
+
+## Stato
+
+Candidate v0 — solo tasso di occupazione (EMP_R) dal dataflow 150_915.
+Tasso di disoccupazione (UNEM_R, flow 151_914) da aggiungere in v1.
+
+## Fonte
+
+**Endpoint**: `https://esploradati.istat.it/SDMXWS/rest`
+**Dataflow**: `IT1,150_915,1.0` (DCCV_TAXOCCU1 — Tasso di occupazione)
+**Formato**: SDMX-CSV → letto dal reader SDMX nativo del toolkit
+
+## Filtri applicati in clean.sql
+
+- Solo `FREQ = 'A'` (annuale)
+- Solo province NUTS3 (`LENGTH(REF_AREA) = 5`, esclusi raggruppamenti)
+- Solo `CITIZENSHIP = 'TOTAL'`
+- Solo `EDU_LEV_HIGHEST = '99'` (totale)
+- Solo classi età: Y15-64, Y15-24, Y25-34, Y35-44, Y45-54, Y55-64
+- Solo `DATA_TYPE = 'EMP_R'` (tasso occupazione)
+
+## Dimensioni disponibili (per espansione futura)
+
+- EDU_LEV_HIGHEST: 11 (laurea), 13 (nessun titolo), 7 (diploma), 99 (totale)
+- CITIZENSHIP: ITL (italiani), FRG (stranieri), TOTAL (totale)
+- AGE: tutte le classi (dal dataflow)
+- SEX: 1 (maschi), 2 (femmine), 9 (totale)
+
+## Run
+
+```
+python -m toolkit.cli.app run full \\
+  --config candidates/istat-occupazione-provinciale/dataset.yml
+```
+
+Risultato: raw ✅ (53842 righe), clean ✅ (14542 righe), mart ✅
+
+## Esempi
+
+Top 5 province per tasso occupazione 15-64 anni (2024):
+1. Firenze 74.1%
+2. Prato 73.3%
+3. Padova 73.1%
+4. Piacenza 72.2%
+5. Trieste 72.1%
+
+Milano: 71.7% (decima)

--- a/candidates/istat-occupazione-provinciale/notes.md
+++ b/candidates/istat-occupazione-provinciale/notes.md
@@ -3,7 +3,7 @@
 ## Stato
 
 Candidate v0 — solo tasso di occupazione (EMP_R) dal dataflow 150_915.
-Tasso di disoccupazione (UNEM_R, flow 151_914) da aggiungere in v1.
+Dati provinciali (NUTS3) disponibili dal 2018 (non dal 2004, che copre solo territorio nazionale/regionale).
 
 ## Fonte
 

--- a/candidates/istat-occupazione-provinciale/sql/clean.sql
+++ b/candidates/istat-occupazione-provinciale/sql/clean.sql
@@ -1,10 +1,8 @@
 -- clean.sql — istat_occupazione_provinciale
 --
--- Input: SDMX-CSV dai dataflow ISTAT 150_915 (tasso occupazione) e 151_914
--- (tasso disoccupazione), concatenati dal reader SDMX.
+-- Input: SDMX-CSV dal dataflow ISTAT 150_915 (tasso occupazione).
 --
--- Output: formato long, una riga per provincia × anno × sesso × classe età
--- con due metriche: tasso occupazione EMP_R e tasso disoccupazione UNEM_R.
+-- Output: formato long, una riga per provincia × anno × sesso × classe età.
 
 SELECT
     "REF_AREA"                                              AS ref_area,
@@ -29,7 +27,8 @@ WHERE
     "FREQ" = 'A'
     -- Solo livelli territoriali provincia (codice NUTS3 a 5 caratteri)
     AND LENGTH("REF_AREA") = 5
-    AND "REF_AREA" NOT LIKE 'IT%0%'   -- esclude ITC10 etc (raggruppamenti)
+    -- Esclude ITC, ITD, ITE, ITF, ITG (regioni/macroaree a 3-4 caratteri) gia filtrate da LENGTH
+    -- NOTA: province con codice ITnnn (3 cifre, es. IT108 Monza) sono corrette a 5 caratteri
     -- Solo cittadinanza totale
     AND "CITIZENSHIP" = 'TOTAL'
     -- Solo istruzione totale (per v0; le singole classi available via EDU_LEV_HIGHEST)

--- a/candidates/istat-occupazione-provinciale/sql/clean.sql
+++ b/candidates/istat-occupazione-provinciale/sql/clean.sql
@@ -1,0 +1,44 @@
+-- clean.sql — istat_occupazione_provinciale
+--
+-- Input: SDMX-CSV dai dataflow ISTAT 150_915 (tasso occupazione) e 151_914
+-- (tasso disoccupazione), concatenati dal reader SDMX.
+--
+-- Output: formato long, una riga per provincia × anno × sesso × classe età
+-- con due metriche: tasso occupazione EMP_R e tasso disoccupazione UNEM_R.
+
+SELECT
+    "REF_AREA"                                              AS ref_area,
+    "REF_AREA_label"                                        AS territorio,
+    TRY_CAST("TIME_PERIOD" AS INTEGER)                      AS anno,
+    "DATA_TYPE"                                             AS indicatore,
+    "SEX"                                                   AS sesso_codice,
+    CASE "SEX"
+        WHEN '1' THEN 'maschi'
+        WHEN '2' THEN 'femmine'
+        WHEN '9' THEN 'totale'
+    END                                                     AS sesso,
+    "AGE"                                                   AS eta_codice,
+    "AGE_label"                                             AS eta,
+    -- Tasso: OBS_VALUE è già percentuale (0-100)
+    TRY_CAST("value" AS DOUBLE)                             AS valore
+
+FROM raw_input
+
+WHERE
+    -- Solo frequenza annuale
+    "FREQ" = 'A'
+    -- Solo livelli territoriali provincia (codice NUTS3 a 5 caratteri)
+    AND LENGTH("REF_AREA") = 5
+    AND "REF_AREA" NOT LIKE 'IT%0%'   -- esclude ITC10 etc (raggruppamenti)
+    -- Solo cittadinanza totale
+    AND "CITIZENSHIP" = 'TOTAL'
+    -- Solo istruzione totale (per v0; le singole classi available via EDU_LEV_HIGHEST)
+    AND "EDU_LEV_HIGHEST" = '99'
+    -- Solo classi età principali per v0
+    AND "AGE" IN ('Y15-64', 'Y15-24', 'Y25-34', 'Y35-44', 'Y45-54', 'Y55-64')
+    -- Solo tassi (occupazione e disoccupazione)
+    AND "DATA_TYPE" IN ('EMP_R', 'UNEM_R')
+    -- Anno valido
+    AND TRY_CAST("TIME_PERIOD" AS INTEGER) IS NOT NULL
+    -- Valore non nullo
+    AND TRY_CAST("value" AS DOUBLE) IS NOT NULL

--- a/candidates/istat-occupazione-provinciale/sql/mart.sql
+++ b/candidates/istat-occupazione-provinciale/sql/mart.sql
@@ -1,0 +1,20 @@
+-- mart.sql — istat_occupazione_provinciale
+-- mart_occupazione_provinciale: dati pass-through (long format già pronto)
+
+SELECT
+    ref_area,
+    territorio,
+    anno,
+    indicatore,
+    sesso_codice,
+    sesso,
+    eta_codice,
+    eta,
+    ROUND(valore, 2) AS valore
+
+FROM clean_input
+
+WHERE
+    ref_area IS NOT NULL
+    AND anno IS NOT NULL
+    AND valore IS NOT NULL


### PR DESCRIPTION
## Sintesi

Nuovo candidate `istat-occupazione-provinciale`: tasso di occupazione per provincia italiana (NUTS3) dal dataflow ISTAT SDMX 150_915, serie 2018–2025.

## Contesto collegato

Closes #556

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento
- [ ] support — dataset di supporto
- [x] docs — README, notes
- [ ] cleanup — refactoring, rimozioni, allineamento
- [ ] workflow o CI
- [ ] altro

## Dettaglio

- **Fonte**: ISTAT SDMX endpoint HVD — flow `150_915` (DCCV_TAXOCCU1)
- **Metodo**: reader SDMX nativo del toolkit (`type: sdmx`)
- **Granularità**: 107 province italiane (codici NUTS3)
- **Periodo**: 2018–2025 
- **Dimensioni**: sesso (maschi/femmine/totale), classe età (Y15-64, Y15-24, Y25-34, Y35-44, Y45-54, Y55-64)
- **Metrica**: tasso di occupazione % (EMP_R, 0–100)

### Schema output (9 colonne)

```
ref_area | territorio | anno | indicatore | sesso_codice | sesso | eta_codice | eta | valore
```

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
- [x] Solo documentazione o metadati
- [ ] Nessun impatto visibile per chi usa il repository

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori (raw ✅ clean ✅ mart ✅)
- [x] nessun file dati committato nella root del candidate
- [x] output immagini cleared dal notebook (nessun notebook)
- [ ] notebook nominato `{slug}_v0.ipynb` — assente (dato SDMX già strutturato, esplorazione in notebook separato)
- [x] issue di intake collegata (#556)

## Verifica

```bash
python -m toolkit.cli.app run full --config candidates/istat-occupazione-provinciale/dataset.yml
```

- [x] `run full` eseguito senza errori
- [x] `python scripts/validate_candidate_structure.py` passato

| Layer | Status | Righe | Colonne |
|---|---|---|---|
| raw | ✅ | 53.842 | 17 |
| clean | ✅ | 14.542 | 9 |
| mart | ✅ | 14.542 | 9 |

### Esempi dati (2024, 15-64 anni, totale)

| Provincia | Tasso occ. |
|---|---|
| Firenze | 74.1% |
| Prato | 73.3% |
| Padova | 73.1% |
| Milano | 71.7% |
| Napoli | 44.2% |

## Note / rischi

- Solo EMP_R (tasso occupazione) per v0. UNEM_R (tasso disoccupazione, flow 151_914) da testare in v1 — ha restituito HTTP 422, probabilmente servono dimensioni diverse.
- Le etichette `eta` sono in inglese con suffisso "years" (dal SDMX label). Pulibili in una prossima iterazione.
- Il reader SDMX scarica l'intera serie storica in un colpo solo — il parametro `year` è la partizione toolkit, non la copertura.
