### PR TITLE
chore(post-merge): aggiorna registry per PR #577

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -4282,6 +4282,80 @@
       "registry_source": "derive_auto"
     },
     {
+      "slug": "istat_occupazione_provinciale",
+      "name": "Istat Occupazione Provinciale",
+      "description": "",
+      "source": "",
+      "source_id": "istat_sdmx",
+      "period": {
+        "start": 2018,
+        "end": 2025
+      },
+      "columns": [
+        {
+          "name": "ref_area",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "territorio",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "indicatore",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "sesso_codice",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "sesso",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "eta_codice",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "eta",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "valore",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/istat_occupazione_provinciale/2025/istat_occupazione_provinciale_2025_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
       "slug": "istat_pil_territoriale",
       "name": "PIL regionale e provinciale",
       "description": "PIL, Valore Aggiunto e Imposte nette per nazione, macro-aree, regioni e province. Fonte: ISTAT Conti economici territoriali (DCCN_PILT). Serie 1995-2024.",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -4283,9 +4283,9 @@
     },
     {
       "slug": "istat_occupazione_provinciale",
-      "name": "Istat Occupazione Provinciale",
-      "description": "",
-      "source": "",
+      "name": "ISTAT — Tasso di Occupazione Provinciale (2018-2025)",
+      "description": "Tasso di occupazione (EMP_R) per provincia italiana: serie annuale 2018-2025, per sesso e classe età. Fonte ISTAT SDMX flow 150_915. 105 province, 6 classi età.",
+      "source": "ISTAT — SDMX (DCCV_TAXOCCU1)",
       "source_id": "istat_sdmx",
       "period": {
         "start": 2018,
@@ -4296,55 +4296,55 @@
           "name": "ref_area",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice NUTS3 della provincia (es. ITC45 per Milano)"
         },
         {
           "name": "territorio",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Nome della provincia (es. Milano)"
         },
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di riferimento (2018-2025)"
         },
         {
           "name": "indicatore",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipo di indicatore: EMP_R = tasso di occupazione"
         },
         {
           "name": "sesso_codice",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Codice sesso: 1=maschi, 2=femmine, 9=totale"
         },
         {
           "name": "sesso",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Sesso: maschi / femmine / totale"
         },
         {
           "name": "eta_codice",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice classe età ISTAT (es. Y15-64)"
         },
         {
           "name": "eta",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Classe età (es. \"15-64 years\")"
         },
         {
           "name": "valore",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Tasso di occupazione percentuale (0-100)"
         }
       ],
       "location": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -4,9 +4,9 @@
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 60,
+    "total": 61,
     "by_status": {
-      "ok": 60,
+      "ok": 61,
       "warn": 0,
       "error": 0
     }
@@ -549,6 +549,24 @@
           2024
         ],
         "config_path": "candidates/istat-ipab-aree/dataset.yml"
+      }
+    },
+    {
+      "id": "istat-occupazione-provinciale",
+      "source_id": "istat_sdmx",
+      "status": "ok",
+      "label": "istat-occupazione-provinciale",
+      "detail": "anno 2025 — fonte: istat_sdmx_occupazione — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "28329727205",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28329727205",
+        "checked_at": "2026-06-28",
+        "years": [
+          2025
+        ],
+        "config_path": "candidates/istat-occupazione-provinciale/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #577 — feat: istat-occupazione-provinciale — tassi occupazione provincia (SDMX 150_915)

Changed candidate/support roots:

- `istat-occupazione-provinciale` (candidate, `candidates/istat-occupazione-provinciale`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/istat-occupazione-provinciale/dataset.yml` -> artifact `sample-run-istat-occupazione-provinciale`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
