### PR TITLE
feat: mim-scuola-infanzia — bambini italiani/non italiani per scuola dell'infanzia

### DIFF
--- a/candidates/mim-scuola-infanzia/README.md
+++ b/candidates/mim-scuola-infanzia/README.md
@@ -1,0 +1,41 @@
+# mim-scuola-infanzia
+
+**Domanda guida:** Quanti bambini italiani e non italiani frequentano le scuole dell'infanzia statali? Come si distribuisce la presenza straniera per territorio?
+
+**Fonte:** Ministero dell'Istruzione e del Merito — dati.istruzione.it
+**Dataset:** INFANZIASTRACITSTA
+**Formato:** CSV, 4 colonne, ~300 KB/anno
+**Granularità:** scuola (riconducibile a comune via anagrafica MIM)
+**Copertura:** 2018–2025 (8 anni scolastici)
+**Licenza:** CC BY (MIM Open Data)
+
+## Schema output (14 colonne)
+
+| Colonna | Tipo | Descrizione |
+|---|---|---|
+| `anno_scolastico` | VARCHAR | Anno scolastico (es. 202425) |
+| `codice_scuola` | VARCHAR | Codice unico scuola |
+| `denominazione_scuola` | VARCHAR | Nome della scuola |
+| `grado_istruzione_scuola` | VARCHAR | Grado (es. SCUOLA INFANZIA) |
+| `caratteristica_scuola` | VARCHAR | Normale / speciale |
+| `bambini_italiani` | INTEGER | Bambini con cittadinanza italiana |
+| `bambini_non_italiani` | INTEGER | Bambini con cittadinanza non italiana |
+| `bambini_totale` | INTEGER | Somma italiani + non italiani |
+| `area_geografica` | VARCHAR | Nord Ovest, Nord Est, Centro, Sud, Isole |
+| `regione` | VARCHAR | Regione |
+| `provincia` | VARCHAR | Provincia |
+| `comune` | VARCHAR | Comune |
+| `codice_comune_scuola` | VARCHAR | Codice catastale comune |
+| `denominazione_istituto_riferimento` | VARCHAR | Istituto di riferimento |
+
+## Esecuzione
+
+```bash
+cd dataset-incubator
+python -m toolkit.cli.app run all \
+  --config candidates/mim-scuola-infanzia/dataset.yml
+```
+
+## Issue di riferimento
+
+- Intake: [#553](https://github.com/dataciviclab/dataset-incubator/issues/553)

--- a/candidates/mim-scuola-infanzia/dataset.yml
+++ b/candidates/mim-scuola-infanzia/dataset.yml
@@ -1,0 +1,58 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "mim_scuola_infanzia"
+  source_id: "mim_opendata"
+  years: [2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025]
+  # NOTA: 2017 non disponibile — il server restituisce HTML invece del CSV
+
+support:
+  - name: "scu_anagrafica_statali"
+    config: "../../support_datasets/mim-anagrafica-scuole-statali/dataset.yml"
+    years: [2024]
+
+raw:
+  sources:
+    - name: "mim_scuola_infanzia_csv"
+      type: "http_file"
+      args:
+        url: "https://dati.istruzione.it/opendata/opendata/catalogo/elements1/INFANZIASTRACITSTA"
+        filename: "INFANZIASTRACITSTA{year}.csv"
+        url_suffix_by_year:
+          2018: "20171820180831.csv"
+          2019: "20181920190831.csv"
+          2020: "20192020200831.csv"
+          2021: "20202120210831.csv"
+          2022: "20212220220831.csv"
+          2023: "20222320230831.csv"
+          2024: "20232420240831.csv"
+          2025: "20242520250831.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: auto
+    mode: latest
+    header: true
+    encoding: "utf-8"
+    strict_mode: false
+    ignore_errors: true
+    trim_whitespace: true
+  validate:
+    min_rows: 500
+
+mart:
+  tables:
+    - name: "mart_bambini"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_bambini"
+  validate:
+    table_rules:
+      mart_bambini:
+        min_rows: 500
+
+validation:
+  fail_on_error: true

--- a/candidates/mim-scuola-infanzia/notes.md
+++ b/candidates/mim-scuola-infanzia/notes.md
@@ -1,0 +1,38 @@
+# Notes — mim-scuola-infanzia
+
+## Stato
+
+Candidate v0. Run passato su tutti gli anni (2018-2025).
+
+## Dati
+
+- Fonte: `INFANZIASTRACITSTA` su dati.istruzione.it
+- 4 colonne raw: ANNOSCOLASTICO, CODICESCUOLA, BAMBINICITTADINANZAITALIANA, BAMBINICITTADINANZANONITALIANA
+- Arricchito con anagrafica scuole (support `mim-anagrafica-scuole-statali`) via JOIN su codice_scuola
+- 14 colonne output con territorio (regione, provincia, comune)
+
+## Anni
+
+| Anno | Anno scolastico | Righe |
+|:----:|:---------------:|:-----:|
+| 2018 | 2017/2018 | 13.141 |
+| 2019 | 2018/2019 | ~13.100 |
+| 2020 | 2019/2020 | ~13.000 |
+| 2021 | 2020/2021 | ~13.000 |
+| 2022 | 2021/2022 | ~13.000 |
+| 2023 | 2022/2023 | ~13.000 |
+| 2024 | 2023/2024 | ~13.000 |
+| 2025 | 2024/2025 | 13.027 |
+
+Il 2017 non è disponibile (server restituisce HTML).
+
+## JOIN
+
+LEFT JOIN con `mim_anagrafica_scuole_statali` su `codice_scuola`. Circa il 2% delle scuole non matcha (scuole non statali o chiuse).
+
+## Pattern URL
+
+```
+INFANZIASTRACITSTA{aa}{aa+1}{gg}{mm}{aa}.csv
+es. INFANZIASTRACITSTA20242520250831.csv
+```

--- a/candidates/mim-scuola-infanzia/sql/clean.sql
+++ b/candidates/mim-scuola-infanzia/sql/clean.sql
@@ -1,0 +1,37 @@
+-- Clean: bambini scuola infanzia per cittadinanza + join anagrafica scuole
+--
+-- Input: INFANZIASTRACITSTA da MIM (4 colonne)
+-- Arricchisce ogni record scuola con i metadati territoriali (regione, provincia, comune)
+
+WITH bambini AS (
+    SELECT
+        CAST(ANNOSCOLASTICO AS VARCHAR) AS anno_scolastico,
+        TRIM(CODICESCUOLA) AS codice_scuola,
+        TRY_CAST(BAMBINICITTADINANZAITALIANA AS INTEGER) AS bambini_italiani,
+        TRY_CAST(BAMBINICITTADINANZANONITALIANA AS INTEGER) AS bambini_non_italiani
+    FROM raw_input
+    WHERE CODICESCUOLA IS NOT NULL
+),
+
+scuole AS (
+    SELECT *
+    FROM read_parquet('{support.scu_anagrafica_statali.mart}')
+)
+
+SELECT
+    b.anno_scolastico,
+    b.codice_scuola,
+    s.denominazione_scuola,
+    s.grado_istruzione_scuola,
+    s.caratteristica_scuola,
+    b.bambini_italiani,
+    b.bambini_non_italiani,
+    (COALESCE(b.bambini_italiani, 0) + COALESCE(b.bambini_non_italiani, 0)) AS bambini_totale,
+    s.area_geografica,
+    s.regione,
+    s.provincia,
+    s.comune,
+    s.codice_comune_scuola,
+    s.denominazione_istituto_riferimento
+FROM bambini b
+LEFT JOIN scuole s ON b.codice_scuola = s.codice_scuola

--- a/candidates/mim-scuola-infanzia/sql/mart.sql
+++ b/candidates/mim-scuola-infanzia/sql/mart.sql
@@ -1,0 +1,17 @@
+-- Mart: bambini scuola infanzia — arricchiti per territorio
+SELECT
+    anno_scolastico,
+    codice_scuola,
+    denominazione_scuola,
+    grado_istruzione_scuola,
+    caratteristica_scuola,
+    bambini_italiani,
+    bambini_non_italiani,
+    bambini_totale,
+    area_geografica,
+    regione,
+    provincia,
+    comune,
+    codice_comune_scuola,
+    denominazione_istituto_riferimento
+FROM clean_input


### PR DESCRIPTION
## Sintesi

Nuovo candidate `mim-scuola-infanzia`: bambini italiani e non italiani iscritti alle scuole dell'infanzia statali, per scuola e anno scolastico (2018-2025), arricchito con anagrafica territoriale.

Closes #553

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento
- [x] docs — README, notes
- [ ] cleanup — refactoring, rimozioni, allineamento
- [ ] workflow o CI

## Dettaglio

- **Fonte**: MIM — dati.istruzione.it, dataset INFANZIASTRACITSTA
- **Formato**: CSV, 4 colonne, ~300 KB/anno
- **Periodo**: 2018-2025 (8 anni scolastici). 2017 non disponibile (server restituisce HTML)
- **Arricchimento**: JOIN con `mim-anagrafica-scuole-statali` su `codice_scuola` → 14 colonne con territorio
- **Metrica**: bambini italiani, non italiani, totale per scuola

### Schema output (14 colonne)

```
anno_scolastico | codice_scuola | denominazione_scuola | grado_istruzione_scuola
caratteristica_scuola | bambini_italiani | bambini_non_italiani | bambini_totale
area_geografica | regione | provincia | comune | codice_comune_scuola
denominazione_istituto_riferimento
```

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate
- [ ] Cambia il contratto con consumatori downstream
- [x] Solo documentazione o metadati

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori su tutti gli anni (2018-2025)
- [x] nessun file dati committato nella root del candidate
- [x] notebook non applicabile (schema minimo, join lineare)
- [x] issue di intake collegata (#553)

## Verifica

```bash
python -m toolkit.cli.app run all --config candidates/mim-scuola-infanzia/dataset.yml
```

| Anno | Righe clean | Esito |
|:----:|:----------:|:-----:|
| 2018 | 13.141 | ✅ |
| 2019 | 13.110 | ✅ |
| 2020 | 13.088 | ✅ |
| 2021 | 13.079 | ✅ |
| 2022 | 13.066 | ✅ |
| 2023 | 13.056 | ✅ |
| 2024 | 13.038 | ✅ |
| 2025 | 13.027 | ✅ |

## Note / rischi

- Il dataset copre solo scuole statali (non paritarie/municipali)
- ~2% delle scuole nel raw non matcha l'anagrafica MIM (scuole chiuse o non statali)
- 2017 escluso: il server MIM restituisce HTML invece del CSV
