### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -5243,6 +5243,12 @@
       },
       "columns": [
         {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
           "name": "amministrazione",
           "type": "VARCHAR",
           "role": "dimension",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -5245,8 +5245,8 @@
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di riferimento dell'incarico (2018-2023)"
         },
         {
           "name": "amministrazione",
@@ -5359,7 +5359,7 @@
         {
           "name": "rapp_id",
           "type": "BIGINT",
-          "role": "metric",
+          "role": "dimension",
           "description": "Identificativo unico del rappresentante"
         },
         {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -615,8 +615,8 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "28358517238",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28358517238",
+        "run_id": "28359395238",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28359395238",
         "checked_at": "2026-06-29",
         "years": [
           2018,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `mef-rappresentanti-partecipate` (candidate, `candidates/mef-rappresentanti-partecipate`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/mef-rappresentanti-partecipate/dataset.yml` -> artifact `sample-run-mef-rappresentanti-partecipate`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
