### PR TITLE
feat: anpr-mobilita-residenziale — flussi cambio residenza tra regioni (ANPR)

### DIFF
--- a/candidates/anpr-mobilita-residenziale/README.md
+++ b/candidates/anpr-mobilita-residenziale/README.md
@@ -4,8 +4,8 @@
 
 **Fonte:** ANPR — Anagrafe Nazionale della Popolazione Residente (Dipartimento per la Trasformazione Digitale, PCM)
 **URL:** https://github.com/italia/anpr-opendata
-**Formato:** CSV, 7 colonne, ~98 KB
-**Copertura:** aprile 2022 – settembre 2025
+**Formato:** CSV, 7 colonne, ~800 KB
+**Copertura:** aprile 2022 – giugno 2026
 **Licenza:** CC0
 
 ## Schema (7 colonne)

--- a/candidates/anpr-mobilita-residenziale/README.md
+++ b/candidates/anpr-mobilita-residenziale/README.md
@@ -1,0 +1,33 @@
+# anpr-mobilita-residenziale
+
+**Domanda guida:** Chi si sposta tra regioni in Italia? Il controesodo post-Covid è reale?
+
+**Fonte:** ANPR — Anagrafe Nazionale della Popolazione Residente (Dipartimento per la Trasformazione Digitale, PCM)
+**URL:** https://github.com/italia/anpr-opendata
+**Formato:** CSV, 7 colonne, ~98 KB
+**Copertura:** aprile 2022 – settembre 2025
+**Licenza:** CC0
+
+## Schema (7 colonne)
+
+| Colonna | Tipo | Descrizione |
+|---|---|---|
+| `anno` | INTEGER | Anno |
+| `mese` | INTEGER | Mese (1-12) |
+| `partenza` | VARCHAR | Regione di provenienza |
+| `cod_regione_partenza` | VARCHAR | Codice ISTAT regione partenza |
+| `arrivo` | VARCHAR | Regione di destinazione |
+| `cod_regione_arrivo` | VARCHAR | Codice ISTAT regione arrivo |
+| `totale` | INTEGER | Numero trasferimenti di residenza |
+
+## Esecuzione
+
+```bash
+cd dataset-incubator
+python -m toolkit.cli.app run full \
+  --config candidates/anpr-mobilita-residenziale/dataset.yml
+```
+
+## Issue di riferimento
+
+- Intake: [#555](https://github.com/dataciviclab/dataset-incubator/issues/555)

--- a/candidates/anpr-mobilita-residenziale/dataset.yml
+++ b/candidates/anpr-mobilita-residenziale/dataset.yml
@@ -4,10 +4,10 @@ schema_version: 1
 dataset:
   name: "anpr_mobilita_residenziale"
   source_id: "anpr"
-  years: [2025]
+  years: [2026]
   time_coverage:
     start_year: 2022
-    end_year: 2025
+    end_year: 2026
 
 raw:
   output_policy: overwrite

--- a/candidates/anpr-mobilita-residenziale/dataset.yml
+++ b/candidates/anpr-mobilita-residenziale/dataset.yml
@@ -1,0 +1,45 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "anpr_mobilita_residenziale"
+  source_id: "anpr"
+  years: [2025]
+  time_coverage:
+    start_year: 2022
+    end_year: 2025
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "anpr_cambi_residenza_csv"
+      type: "http_file"
+      args:
+        url: "https://raw.githubusercontent.com/italia/anpr-opendata/main/data/cambi_residenza.csv"
+        filename: "cambi_residenza.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: auto
+    mode: latest
+    header: true
+    encoding: "utf-8"
+    trim_whitespace: true
+  validate:
+    min_rows: 1000
+
+mart:
+  tables:
+    - name: "mart_flussi_regionali"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_flussi_regionali"
+  validate:
+    table_rules:
+      mart_flussi_regionali:
+        min_rows: 1000
+
+validation:
+  fail_on_error: true

--- a/candidates/anpr-mobilita-residenziale/notes.md
+++ b/candidates/anpr-mobilita-residenziale/notes.md
@@ -16,14 +16,15 @@ Candidate v0. Run passato con years: [2026]. 21.750 righe, 7 colonne.
 
 ## Saldi netti interregionali 2025 (escluso ESTERO)
 
-| Regione | Saldo |
-|---------|:-----:|
-| Campania | -20.814 |
-| Sicilia | -13.260 |
-| Calabria | -7.530 |
-| Puglia | -7.521 |
-| Lazio | +3.079 |
-| Lombardia | +2.482 |
+| Regione | Uscite | Entrate | Saldo |
+|---------|:------:|:-------:|:----:|
+| Campania | 45.417 | 24.603 | -20.814 |
+| Sicilia | 34.765 | 21.505 | -13.260 |
+| Puglia | 28.295 | 19.723 | -8.572 |
+| Calabria | 20.113 | 12.583 | -7.530 |
+| … | … | … | … |
+| Lombardia | 63.203 | 77.870 | **+14.667** |
+| Emilia Romagna | 33.750 | 44.646 | **+10.896** |
 
 ## Fonte
 

--- a/candidates/anpr-mobilita-residenziale/notes.md
+++ b/candidates/anpr-mobilita-residenziale/notes.md
@@ -2,26 +2,37 @@
 
 ## Stato
 
-Candidate v0. Run passato. 21.750 righe, 7 colonne.
+Candidate v0. Run passato con years: [2026]. 21.750 righe, 7 colonne.
+
+## Copertura per anno
+
+| Anno | Righe | Note |
+|:----:|:-----:|------|
+| 2022 | 3.844 | Apr-Dic (subentro ANPR parziale) |
+| 2023 | 5.116 | Completo |
+| 2024 | 5.120 | Completo |
+| 2025 | 5.118 | Completo |
+| 2026 | 2.552 | Gen-Giu (dati parziali) |
+
+## Saldi netti interregionali 2025 (escluso ESTERO)
+
+| Regione | Saldo |
+|---------|:-----:|
+| Campania | -20.814 |
+| Sicilia | -13.260 |
+| Calabria | -7.530 |
+| Puglia | -7.521 |
+| Lazio | +3.079 |
+| Lombardia | +2.482 |
 
 ## Fonte
 
 Repo GitHub ufficiale: `italia/anpr-opendata`
 File: `data/cambi_residenza.csv` — aggiornato automaticamente via GitHub Actions.
 
-## Saldi netti 2025 (dati parziali, apr-set)
-
-| Regione | Saldo |
-|---------|:-----:|
-| Campania | -114.953 |
-| Sicilia | -78.361 |
-| Puglia | -48.329 |
-| Calabria | -47.822 |
-| Lazio | +3.448 |
-| Abruzzo | +3.128 |
-
 ## Note
 
 - Dato aggiornato quasi in tempo reale (ANPR, non ISTAT con 2 anni di ritardo)
 - Subentro ANPR parziale nel 2022: possibile sottostima comuni minori del Sud
 - Include flussi con ESTERO (cancellazioni/iscrizioni anagrafiche)
+- Il file è unico e contiene tutta la serie storica

--- a/candidates/anpr-mobilita-residenziale/notes.md
+++ b/candidates/anpr-mobilita-residenziale/notes.md
@@ -1,0 +1,27 @@
+# Notes — anpr-mobilita-residenziale
+
+## Stato
+
+Candidate v0. Run passato. 21.750 righe, 7 colonne.
+
+## Fonte
+
+Repo GitHub ufficiale: `italia/anpr-opendata`
+File: `data/cambi_residenza.csv` — aggiornato automaticamente via GitHub Actions.
+
+## Saldi netti 2025 (dati parziali, apr-set)
+
+| Regione | Saldo |
+|---------|:-----:|
+| Campania | -114.953 |
+| Sicilia | -78.361 |
+| Puglia | -48.329 |
+| Calabria | -47.822 |
+| Lazio | +3.448 |
+| Abruzzo | +3.128 |
+
+## Note
+
+- Dato aggiornato quasi in tempo reale (ANPR, non ISTAT con 2 anni di ritardo)
+- Subentro ANPR parziale nel 2022: possibile sottostima comuni minori del Sud
+- Include flussi con ESTERO (cancellazioni/iscrizioni anagrafiche)

--- a/candidates/anpr-mobilita-residenziale/sql/clean.sql
+++ b/candidates/anpr-mobilita-residenziale/sql/clean.sql
@@ -1,0 +1,15 @@
+-- clean.sql — anpr_mobilita_residenziale
+-- Flussi mensili di cambio residenza tra regioni italiane (ANPR)
+
+SELECT
+    CAST(ANNO AS INTEGER)                                       AS anno,
+    CAST(MESE AS INTEGER)                                       AS mese,
+    TRIM(CAST(PARTENZA AS VARCHAR))                              AS partenza,
+    LPAD(TRIM(CAST(COD_ISTAT_REGIONE_DI_PARTENZA AS VARCHAR)), 3, '0') AS cod_regione_partenza,
+    TRIM(CAST(ARRIVO AS VARCHAR))                                AS arrivo,
+    LPAD(TRIM(CAST(COD_ISTAT_REGIONE_DI_ARRIVO AS VARCHAR)), 3, '0')   AS cod_regione_arrivo,
+    CAST(TOTALE AS INTEGER)                                     AS totale
+
+FROM raw_input
+WHERE TOTALE IS NOT NULL
+  AND ANNO IS NOT NULL

--- a/candidates/anpr-mobilita-residenziale/sql/mart.sql
+++ b/candidates/anpr-mobilita-residenziale/sql/mart.sql
@@ -1,0 +1,9 @@
+-- mart.sql — anpr_mobilita_residenziale
+-- Dati pass-through con arrotondamenti
+
+SELECT
+    anno, mese,
+    partenza, cod_regione_partenza,
+    arrivo, cod_regione_arrivo,
+    totale
+FROM clean_input


### PR DESCRIPTION
## Sintesi

Nuovo candidate `anpr-mobilita-residenziale`: flussi mensili di cambio residenza tra regioni italiane, da ANPR (Anagrafe Nazionale). Dati quasi in tempo reale, aprile 2022 — giugno 2026.

Closes #555

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento
- [x] docs — README, notes
- [ ] cleanup
- [ ] workflow o CI

## Dettaglio

- **Fonte**: ANPR Open Data (github.com/italia/anpr-opendata), CC0
- **Formato**: CSV, 7 colonne, ~800 KB
- **Copertura**: aprile 2022 – giugno 2026 (aggiornamento automatico via GitHub Actions)
- **Schema**: anno, mese, partenza, cod_regione_partenza, arrivo, cod_regione_arrivo, totale

### Saldi netti interregionali 2025 (escluso ESTERO)

| Regione | Saldo |
|---|---|
| Campania | -20.814 |
| Sicilia | -13.260 |
| Puglia | -8.572 |
| Calabria | -7.530 |
| Lazio | +1.393 |
| Lombardia | +14.667 |
| Emilia Romagna | +10.896 |

## Verifica

```bash
python -m toolkit.cli.app run full --config candidates/anpr-mobilita-residenziale/dataset.yml
```

- raw: ✅ (21.750 righe)
- clean: ✅ (7 colonne)
- mart: ✅

## Note

- Subentro ANPR parziale nel 2022: possibile sottostima comuni minori del Sud
- Include flussi con ESTERO
- Complementare a `istat_migrazioni_interne` (#554) che copre lo storico pre-2022