### PR TITLE
chore(post-merge): aggiorna registry per PR #584

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -624,6 +624,68 @@
       "registry_source": "derive_auto"
     },
     {
+      "slug": "anpr_mobilita_residenziale",
+      "name": "Anpr Mobilita Residenziale",
+      "description": "",
+      "source": "",
+      "source_id": "anpr",
+      "period": {
+        "start": 2022,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "mese",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "partenza",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cod_regione_partenza",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "arrivo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cod_regione_arrivo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "totale",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/anpr_mobilita_residenziale/2026/anpr_mobilita_residenziale_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
       "slug": "bdap_anagrafe_enti",
       "name": "BDAP Anagrafe Enti Pubblici",
       "description": "Anagrafe completa degli enti pubblici italiani. 63 colonne, ~38k enti. Mappa codici IPA, SIOPE, ISTAT, MIUR, SSN, catastale. Usata come bridge table per join cross-dataset nel joinability scan.",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -625,9 +625,9 @@
     },
     {
       "slug": "anpr_mobilita_residenziale",
-      "name": "Anpr Mobilita Residenziale",
-      "description": "",
-      "source": "",
+      "name": "ANPR — Mobilita Residenziale Interregionale (2022-2026)",
+      "description": "Flussi mensili di cambio residenza tra regioni italiane, da ANPR (Anagrafe Nazionale della Popolazione Residente). Serie mensile 2022-2026, aggiornata quasi in tempo reale via GitHub Actions.",
+      "source": "ANPR — Anagrafe Nazionale della Popolazione Residente (PCM)",
       "source_id": "anpr",
       "period": {
         "start": 2022,
@@ -637,44 +637,44 @@
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno del trasferimento"
         },
         {
           "name": "mese",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Mese del trasferimento (1-12)"
         },
         {
           "name": "partenza",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Regione di provenienza"
         },
         {
           "name": "cod_regione_partenza",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT regione di provenienza (3 cifre)"
         },
         {
           "name": "arrivo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Regione di destinazione"
         },
         {
           "name": "cod_regione_arrivo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT regione di destinazione (3 cifre)"
         },
         {
           "name": "totale",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero di trasferimenti di residenza"
         }
       ],
       "location": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -4,9 +4,9 @@
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 63,
+    "total": 64,
     "by_status": {
-      "ok": 63,
+      "ok": 64,
       "warn": 0,
       "error": 0
     }
@@ -81,6 +81,24 @@
           2025
         ],
         "config_path": "candidates/anac-bandi-gara/dataset.yml"
+      }
+    },
+    {
+      "id": "anpr-mobilita-residenziale",
+      "source_id": "anpr",
+      "status": "ok",
+      "label": "anpr-mobilita-residenziale",
+      "detail": "anno 2026 — fonte: anpr_cambi_residenza_csv — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "28370691002",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28370691002",
+        "checked_at": "2026-06-29",
+        "years": [
+          2026
+        ],
+        "config_path": "candidates/anpr-mobilita-residenziale/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #584 — feat: anpr-mobilita-residenziale — flussi cambio residenza tra regioni (ANPR)

Changed candidate/support roots:

- `anpr-mobilita-residenziale` (candidate, `candidates/anpr-mobilita-residenziale`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/anpr-mobilita-residenziale/dataset.yml` -> artifact `sample-run-anpr-mobilita-residenziale`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
