### PR TITLE
feat: intake elezioni regionali 2018-2024 (Eligendo)

### DIFF
--- a/candidates/elezioni-regionali/README.md
+++ b/candidates/elezioni-regionali/README.md
@@ -1,0 +1,48 @@
+# Elezioni Regionali 2018-2024 — risultati per comune
+
+Risultati delle elezioni regionali italiane a livello comunale.
+
+## Dati
+
+Periodo: 2018-2024 (in progress — attivo 2023)
+Tornate: 9 totali, esclusa 2020-09-20 (file Excel)
+
+### Schema clean
+
+| Colonna | Tipo | Note |
+|---|---|---|
+| `data_elezione` | DATE | Data del voto |
+| `regione` | VARCHAR | |
+| `circoscrizione` | VARCHAR | |
+| `provincia` | VARCHAR | |
+| `comune` | VARCHAR | |
+| `elettori` | BIGINT | |
+| `votanti` | BIGINT | |
+| `schede_bianche` | BIGINT | |
+| `candidato` | VARCHAR | Cognome e nome candidato presidente |
+| `voti_candidato` | BIGINT | Voti al candidato presidente |
+| `lista` | VARCHAR | Lista di appoggio |
+| `voti_lista` | BIGINT | Voti alla lista |
+
+### Mart
+
+- `mart_voti_lista_comune` — voti aggregati per lista × comune × elezione
+
+## Cross con altri dataset
+
+| Dataset | Chiave | Domanda |
+|---|---|---|
+| `bdap_lea` | regione | Spesa sanitaria e voto regionale |
+| `irpef_comunale` | comune | Reddito e voto |
+| `elezioni_politiche` (issue #523) | comune × anno | Correlazione voto politiche vs regionali |
+| `popolazione_istat_comunale` | comune | Affluenza e demografia |
+
+## Fonte
+
+**Eligendo** — Archivio storico elettorale del DAIT (Ministero dell'Interno)
+URL: https://elezionistorico.interno.gov.it/eligendo/opendata.php
+Licenza: CC BY 4.0
+
+## Issue
+
+#588 — Intake eligendo: elezioni regionali

--- a/candidates/elezioni-regionali/README.md
+++ b/candidates/elezioni-regionali/README.md
@@ -1,13 +1,26 @@
 # Elezioni Regionali 2018-2024 — risultati per comune
 
-Risultati delle elezioni regionali italiane a livello comunale.
+Risultati delle elezioni regionali italiane a livello comunale, da Eligendo (DAIT).
 
 ## Dati
 
-Periodo: 2018-2024 (in progress — attivo 2023)
-Tornate: 9 totali, esclusa 2020-09-20 (file Excel)
+**Periodo**: 2018-2024 (6 anni, 9 tornate)
+**Righe totali**: ~117.879
+**Qualità clean**: 100/100
 
-### Schema clean
+| Anno | Tornate | Regioni | Righe clean | Affluenza media |
+|---|---|---|---|---|
+| 2018 | 04/03 | Lombardia, Lazio | 35.060 | 71,9% |
+| 2019 | 10/02, 24/03, 26/05, 27/10 | Abruzzo, Basilicata, Piemonte, Umbria | 24.645 | 61,2% |
+| 2020 | 26/01 | Emilia-Romagna, Calabria | 10.299 | 53,7% |
+| 2021 | 03/10 | Calabria | 8.484 | 43,5% |
+| 2023 | 12/02 | Lombardia, Lazio | 24.125 | 42,9% |
+| 2024 | 09/06 | Piemonte | 15.266 | 59,2% |
+
+### Escluse
+- 20/09/2020: file XLSX non gestiti dal toolkit
+
+### Schema clean (12 colonne)
 
 | Colonna | Tipo | Note |
 |---|---|---|
@@ -24,11 +37,13 @@ Tornate: 9 totali, esclusa 2020-09-20 (file Excel)
 | `lista` | VARCHAR | Lista di appoggio |
 | `voti_lista` | BIGINT | Voti alla lista |
 
+Dato normalize dal preprocess: nomi colonna unificati, encoding utf-8, numeri interi.
+
 ### Mart
 
 - `mart_voti_lista_comune` — voti aggregati per lista × comune × elezione
 
-## Cross con altri dataset
+## Cross con altri dataset del Lab
 
 | Dataset | Chiave | Domanda |
 |---|---|---|
@@ -45,4 +60,4 @@ Licenza: CC BY 4.0
 
 ## Issue
 
-#588 — Intake eligendo: elezioni regionali
+#588 — Intake eligendo: elezioni regionali 2018-2024

--- a/candidates/elezioni-regionali/dataset.yml
+++ b/candidates/elezioni-regionali/dataset.yml
@@ -1,0 +1,41 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "elezioni_regionali"
+  source_id: "eligendo"
+  years: [2018, 2019, 2020, 2021, 2023, 2024]
+
+raw:
+  output_policy: overwrite
+  sources:
+    - type: script
+      args:
+        command: "python preprocess.py {year} raw_input.csv"
+        output: "raw_input.csv"
+        filename: "raw_input.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: auto
+    delim: ";"
+    encoding: "utf-8"
+    header: true
+    strict_mode: false
+    ignore_errors: true
+  validate:
+    min_rows: 100
+
+mart:
+  tables:
+    - name: "mart_voti_lista_comune"
+      sql: "sql/mart.sql"
+  validate:
+    table_rules:
+      mart_voti_lista_comune:
+        min_rows: 100
+
+validation:
+  fail_on_error: true

--- a/candidates/elezioni-regionali/notes.md
+++ b/candidates/elezioni-regionali/notes.md
@@ -1,45 +1,108 @@
-# Note tecniche — elezioni_regionali
+# Note tecniche — elezioni-regionali
+
+## Struttura
+
+```
+candidates/elezioni-regionali/
+├── dataset.yml        # script source multi-anno
+├── preprocess.py      # download, unzip, normalizza
+├── sql/
+│   ├── clean.sql      # schema unificato 12 colonne
+│   └── mart.sql       # aggregazione lista × comune
+├── README.md
+└── notes.md
+```
 
 ## Perimetro
 
-Attuale: 2023 (Lazio, Lombardia — 12/02/2023)
-Prossimi: 2024 (Piemonte), 2021, 2020, 2019 (×4), 2018
+6 anni, 9 tornate, esclusa 2020-09-20 (XLSX).
 
-## Variazioni schema tra anni
+## Mappa fonti
 
-| Anno | File | Delim | Numeri | Colonne particolari |
+| Anno | URL | Formato |
+|---|---|---|
+| 2018 | ZIP `regionali-20180304.zip` | 2 TXT (scrutini + preferenze) |
+| 2019a | ZIP `regionali-20190210.zip` | 2 TXT |
+| 2019b | ZIP `regionali-20190324.zip` | 2 TXT |
+| 2019c | ZIP `regionali-20190526.zip` | 2 TXT |
+| 2019d | ZIP `regionali-20191027.zip` | 2 TXT |
+| 2020 | ZIP `regionali-20200126.zip` | 2 TXT |
+| 2021 | ZIP `regionali-20211003.zip` | 2 TXT (nomi file diversi) |
+| 2023 | CSV diretto catalogoagid | 1 CSV |
+| 2024 | ZIP `regionali-20240609.zip` | 1 CSV (combinato) |
+
+## Variazioni schema raw tra anni
+
+Il `preprocess.py` normalizza tutte queste differenze:
+
+### Nomi colonna
+| Concetto | 2018-2020 | 2021 | 2023 | 2024 |
 |---|---|---|---|---|
-| 2023 | catalogoagid CSV diretto | `;` | interi | `ELETTORITOT, VOTICAND, DESCRLISTA` |
-| 2024 | ZIP → 1 CSV combinato | `;` | interi | `REG, CIRC, PROV, ALTRONOME, VOTICANDIDATO` |
-| 2021 | ZIP → 2 TXT (scrutini+pref) | `;` | comma decimal | `provincia` lowercase, `ALTRO_NOME` |
-| 2020-gen | ZIP → 2 TXT | `;` | comma decimal | Stesso schema 2018 |
-| 2020-set | ZIP → XLSX | — | — | Da escludere (Excel) |
-| 2019 (×4) | ZIP → 2 TXT | `;` | comma decimal | Stesso schema 2018 |
-| 2018 | ZIP → 2 TXT | `;` | comma decimal | Schema base |
+| Regione | `REGIONE` | `REGIONE` | `REGIONE` | `REG` |
+| Circoscrizione | `CIRCOSCRIZIONE` | `CIRCOSCRIZIONE` | `CIRCOSCRIZIONE` | `CIRC` |
+| Provincia | `PROVINCIA` | `provincia` (lower!) | `PROVINCIA` | `PROV` |
+| Elettori | `ELETTORI` | `ELETTORI` | `ELETTORITOT` | `ELETTORITOT` |
+| Voti candidato | `VOTI_CANDIDATO` | `VOTI_CANDIDATO` | `VOTICAND` | `VOTICANDIDATO` |
+| Lista | `LISTA` | `LISTA` | `DESCRLISTA` | `DESCRLISTA` |
 
-## Comma decimal
+### Formato numeri
+- 2018-2021: comma decimal (`5849,00`) — il preprocess normalizza a interi
+- 2023-2024: interi diretti
 
-2018-2021 usano la virgola come separatore decimale (es. `5849,00`).
-DuckDB li legge come VARCHAR. Nel clean.sql: `TRY_CAST(REPLACE(colonna, ',', '.') AS DOUBLE)` oppure `TRY_CAST(colonna AS BIGINT)` per valori interi con `,00`.
+### Encoding
+- 2019-05-26 (Piemonte): ISO-8859-1 (lettere accentate in nomi/luoghi)
+- Tutti gli altri: ASCII / UTF-8
+- Preprocess: tentativo UTF-8 → latin-1 → cp1252
 
-Preferisco `TRY_CAST(REPLACE(colonna, ',', '') AS BIGINT)` che elimina la virgola e tratta come intero.
+### Nomi file dentro ZIP
+| Periodo | File scrutini | File preferenze |
+|---|---|---|
+| 2018-2020, 2023 | `regionali-YYYYMMDD.txt` / `.csv` | `Preferenze_*.txt` / `.csv` |
+| 2021 | `scrutini-YYYYMMDD.txt` | `CandidatiLista-Preferenze_*.txt` |
+| 2024 | `regionali-YYYYMMDD.csv` (unico) | N/A |
 
-## Preferenze
+## Note implementative
 
-Le preferenze dei consiglieri sono in un secondo file dentro ogni ZIP (nome variabile).
-Non incluse nel perimetro iniziale. Mart futuro.
+### Perché preprocess invece di http_file diretto
+- Ogni anno ha URL diverso (non template {year} semplice)
+- ZIP con 2 file di cui serve solo 1 (scrutini)
+- Nomi colonna e formati numerici variano per anno
+- Encoding misto (utf-8 / latin-1)
 
-## Date elezione
+### TOOLKIT_ALLOW_SCRIPT_SOURCE
+Il source type `script` è disabilitato di default per sicurezza.
+Va attivato con `TOOLKIT_ALLOW_SCRIPT_SOURCE=1` nell'ambiente di run.
 
-Le date non sono nei CSV — vanno derivate dal nome file ZIP. Nel clean.sql vanno hardcoded o passate come parametro.
+### Esclusioni
+- **2020-09-20**: file XLSX. Il toolkit non gestisce Excel via ZIP extractor.
+  Soluzione futura: estrarre XLSX manualmente o estendere toolkit.
+- **2014 e precedenti**: schema diverso (no circoscrizione, formato intero).
+  Estendere in futuro.
+- **File preferenze**: ogni ZIP ha un secondo file con i voti di preferenza
+  ai singoli consiglieri. Non incluso nel perimetro iniziale.
 
-## 2020-09-20 (escluso)
+## Verifica
 
-File XLSX per scrutini. Il toolkit non supporta Excel.
-Soluzione futura: estrarre XLSX a mano e convertire in CSV, oppure estendere toolkit.
+```bash
+cd dataset-incubator
+TOOLKIT_ALLOW_SCRIPT_SOURCE=1 toolkit run full \
+  --config candidates/elezioni-regionali/dataset.yml \
+  --years 2018,2019,2020,2021,2023,2024
+```
 
-## Nomi file dentro ZIP
+## Output pipeline
 
-- 2018-2020, 2023: `regionali-YYYYMMDD.txt` / `.csv`
-- 2021: `scrutini-YYYYMMDD.txt`
-- 2024: `regionali-YYYYMMDD.csv` (unico file)
+| Anno | Layer | Righe | Qualità |
+|---|---|---|---|
+| 2018 | clean | 35.060 | 100 |
+| 2019 | clean | 24.645 | 100 |
+| 2020 | clean | 10.299 | 100 |
+| 2021 | clean | 8.484 | 100 |
+| 2023 | clean | 24.125 | 100 |
+| 2024 | clean | 15.266 | 100 |
+
+## Cross-repo
+
+Issue: https://github.com/DataCivicLab/dataset-incubator/issues/588
+Scorporata da: https://github.com/DataCivicLab/dataset-incubator/issues/523
+Fonte SO: `eligendo` (radar-only)

--- a/candidates/elezioni-regionali/notes.md
+++ b/candidates/elezioni-regionali/notes.md
@@ -1,0 +1,45 @@
+# Note tecniche — elezioni_regionali
+
+## Perimetro
+
+Attuale: 2023 (Lazio, Lombardia — 12/02/2023)
+Prossimi: 2024 (Piemonte), 2021, 2020, 2019 (×4), 2018
+
+## Variazioni schema tra anni
+
+| Anno | File | Delim | Numeri | Colonne particolari |
+|---|---|---|---|---|
+| 2023 | catalogoagid CSV diretto | `;` | interi | `ELETTORITOT, VOTICAND, DESCRLISTA` |
+| 2024 | ZIP → 1 CSV combinato | `;` | interi | `REG, CIRC, PROV, ALTRONOME, VOTICANDIDATO` |
+| 2021 | ZIP → 2 TXT (scrutini+pref) | `;` | comma decimal | `provincia` lowercase, `ALTRO_NOME` |
+| 2020-gen | ZIP → 2 TXT | `;` | comma decimal | Stesso schema 2018 |
+| 2020-set | ZIP → XLSX | — | — | Da escludere (Excel) |
+| 2019 (×4) | ZIP → 2 TXT | `;` | comma decimal | Stesso schema 2018 |
+| 2018 | ZIP → 2 TXT | `;` | comma decimal | Schema base |
+
+## Comma decimal
+
+2018-2021 usano la virgola come separatore decimale (es. `5849,00`).
+DuckDB li legge come VARCHAR. Nel clean.sql: `TRY_CAST(REPLACE(colonna, ',', '.') AS DOUBLE)` oppure `TRY_CAST(colonna AS BIGINT)` per valori interi con `,00`.
+
+Preferisco `TRY_CAST(REPLACE(colonna, ',', '') AS BIGINT)` che elimina la virgola e tratta come intero.
+
+## Preferenze
+
+Le preferenze dei consiglieri sono in un secondo file dentro ogni ZIP (nome variabile).
+Non incluse nel perimetro iniziale. Mart futuro.
+
+## Date elezione
+
+Le date non sono nei CSV — vanno derivate dal nome file ZIP. Nel clean.sql vanno hardcoded o passate come parametro.
+
+## 2020-09-20 (escluso)
+
+File XLSX per scrutini. Il toolkit non supporta Excel.
+Soluzione futura: estrarre XLSX a mano e convertire in CSV, oppure estendere toolkit.
+
+## Nomi file dentro ZIP
+
+- 2018-2020, 2023: `regionali-YYYYMMDD.txt` / `.csv`
+- 2021: `scrutini-YYYYMMDD.txt`
+- 2024: `regionali-YYYYMMDD.csv` (unico file)

--- a/candidates/elezioni-regionali/preprocess.py
+++ b/candidates/elezioni-regionali/preprocess.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Scarica e normalizza i CSV delle elezioni regionali da Eligendo.
+
+Uso: python preprocess.py <anno> <output.csv>
+
+Scarica ZIP/CSV da Eligendo per l'anno specificato, estrae il file scrutini,
+normalizza colonne e numeri, e produce un CSV unico con schema standard.
+"""
+
+import sys
+import csv
+import io
+import os
+import re
+import zipfile
+import urllib.request
+
+# ── mappa anni → lista di (url, data_elezione, is_zip) ──────────────────
+SOURCES: dict[int, list[tuple[str, str, bool]]] = {
+    2018: [
+        (
+            "https://dait.interno.gov.it/documenti/opendata/regionali/regionali-20180304.zip",
+            "2018-03-04",
+            True,
+        ),
+    ],
+    2019: [
+        (
+            "https://dait.interno.gov.it/documenti/opendata/regionali/regionali-20190210.zip",
+            "2019-02-10",
+            True,
+        ),
+        (
+            "https://dait.interno.gov.it/documenti/opendata/regionali/regionali-20190324.zip",
+            "2019-03-24",
+            True,
+        ),
+        (
+            "https://dait.interno.gov.it/documenti/opendata/regionali/regionali-20190526.zip",
+            "2019-05-26",
+            True,
+        ),
+        (
+            "https://dait.interno.gov.it/documenti/opendata/regionali/regionali-20191027.zip",
+            "2019-10-27",
+            True,
+        ),
+    ],
+    2020: [
+        (
+            "https://dait.interno.gov.it/documenti/opendata/regionali/regionali-20200126.zip",
+            "2020-01-26",
+            True,
+        ),
+        # 2020-09-20 escluso: file XLSX non gestiti
+    ],
+    2021: [
+        (
+            "https://dait.interno.gov.it/documenti/opendata/regionali/regionali-20211003.zip",
+            "2021-10-03",
+            True,
+        ),
+    ],
+    2023: [
+        (
+            "https://dait.interno.gov.it/documenti/opendata/catalogoagid/regionali-20230212.csv",
+            "2023-02-12",
+            False,
+        ),
+    ],
+    2024: [
+        (
+            "https://dait.interno.gov.it/documenti/opendata/regionali/regionali-20240609.zip",
+            "2024-06-09",
+            True,
+        ),
+    ],
+}
+
+
+def download(url: str) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return resp.read()
+
+
+def normalize_number(val: str) -> str:
+    """Normalizza numero: rimuovi punti migliaia, trasforma virgola in punto.
+    Esempi: '1.234,56' → '1234.56', '5849,00' → '5849', '1234' → '1234'"""
+    val = val.strip().strip('"')
+    if not val or val in ("***", "-"):
+        return ""
+    if "," in val:
+        val = val.replace(".", "").replace(",", ".")
+        # Se era intero con virgola (.00), rimuovi la parte decimale
+        if val.endswith(".0"):
+            val = val[:-2]
+    else:
+        val = val.replace(".", "")
+    return val
+
+
+def smart_decode(data: bytes) -> str:
+    """Decode bytes tentando UTF-8 prima, poi latin-1/ISO-8859-1."""
+    for enc in ("utf-8-sig", "utf-8", "iso-8859-1", "cp1252"):
+        try:
+            return data.decode(enc)
+        except UnicodeDecodeError:
+            continue
+    return data.decode("utf-8", errors="replace")
+
+
+def extract_scrutini_from_zip(raw: bytes, election_date: str) -> list[list[str]]:
+    """Estrae il file scrutini da uno ZIP Eligendo.
+    Cerca il file che NON si chiama 'Preferenze*' o 'CandidatiLista*'."""
+    with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+        # Trova il file scrutini (non preferenze)
+        scrutini_name = None
+        for name in zf.namelist():
+            base = os.path.basename(name)
+            if base.startswith("~") or base.startswith("."):
+                continue
+            if "preferenze" not in base.lower() and "candidatilista" not in base.lower():
+                scrutini_name = name
+                break
+        if scrutini_name is None:
+            # fallback: prendi il primo file non-directory
+            for name in zf.namelist():
+                if not name.endswith("/"):
+                    scrutini_name = name
+                    break
+        if scrutini_name is None:
+            raise ValueError(f"Nessun file trovato nello ZIP per {election_date}")
+
+        content = zf.read(scrutini_name)
+        decoded = smart_decode(content)
+    return parse_csv(decoded)
+
+
+def parse_csv(content: str) -> list[list[str]]:
+    reader = csv.reader(io.StringIO(content), delimiter=";")
+    return [row for row in reader if any(cell.strip() for cell in row)]
+
+
+# ── Mappa normalizzazione colonne ───────────────────────────────────────
+# (pattern nel nome colonna → nome normalizzato)
+COL_MAP: list[tuple[re.Pattern, str]] = [
+    (re.compile(r"^REG(IONE)?$", re.I), "regione"),
+    (re.compile(r"^CIRC(OSCR(IZIONE)?)?$", re.I), "circoscrizione"),
+    (re.compile(r"^PROV(INCIA)?$", re.I), "provincia"),
+    (re.compile(r"^COMUNE$", re.I), "comune"),
+    (re.compile(r"^(ELETTORI(TOT)?)$", re.I), "elettori"),
+    (re.compile(r"^(VOTANTI(TOT)?)$", re.I), "votanti"),
+    (re.compile(r"^(SCHEDE_BIANCHE|SKBIANCHE)$", re.I), "schede_bianche"),
+    (re.compile(r"^(COGNOME|COGNOME_CANDIDATO)$", re.I), "cognome"),
+    (re.compile(r"^(NOME|NOME_CANDIDATO)$", re.I), "nome"),
+    (re.compile(r"^(LISTA|DESCRLISTA)$", re.I), "lista"),
+    (re.compile(r"^(VOTI_LISTA|VOTILISTA)$", re.I), "voti_lista"),
+    (re.compile(r"^(VOTI_CAND(IDATO)?|VOTICAND(IDATO)?)$", re.I), "voti_candidato"),
+]
+
+
+def normalize_columns(header: list[str]) -> tuple[list[str], list[int]]:
+    """Mappa le colonne raw ai nomi standard.
+    Restituisce (nomi_normalizzati, indici_validi)."""
+    norm = []
+    indices = []
+    for i, col in enumerate(header):
+        col = col.strip().strip('"')
+        mapped = None
+        for pattern, name in COL_MAP:
+            if pattern.match(col):
+                mapped = name
+                break
+        if mapped:
+            norm.append(mapped)
+            indices.append(i)
+    return norm, indices
+
+
+def process_url(url: str, election_date: str, is_zip: bool) -> list[dict]:
+    """Scarica e normalizza un file da Eligendo. Restituisce lista di dict."""
+    raw = download(url)
+    if is_zip:
+        raw_rows = extract_scrutini_from_zip(raw, election_date)
+    else:
+        raw_rows = parse_csv(smart_decode(raw))
+
+    if not raw_rows:
+        return []
+
+    header = raw_rows[0]
+    col_names, col_indices = normalize_columns(header)
+
+    records = []
+    for row in raw_rows[1:]:
+        if not row or not any(cell.strip() for cell in row):
+            continue
+        rec = {"data_elezione": election_date}
+        for name, idx in zip(col_names, col_indices):
+            if idx < len(row):
+                val = row[idx].strip().strip('"')
+                # Normalizza campi numerici
+                if name in (
+                    "elettori",
+                    "votanti",
+                    "schede_bianche",
+                    "voti_lista",
+                    "voti_candidato",
+                ):
+                    val = normalize_number(val)
+                rec[name] = val
+        # Unisci cognome + nome in 'candidato'
+        if "cognome" in rec and "nome" in rec:
+            rec["candidato"] = f"{rec.pop('cognome', '')} {rec.pop('nome', '')}".strip()
+        records.append(rec)
+
+    return records
+
+
+def main():
+    year = int(sys.argv[1]) if len(sys.argv) > 1 else 2023
+    output = sys.argv[2] if len(sys.argv) > 2 else "raw_input.csv"
+
+    sources = SOURCES.get(year)
+    if not sources:
+        print(f"Nessuna fonte configurata per l'anno {year}", file=sys.stderr)
+        sys.exit(1)
+
+    all_records: list[dict] = []
+    for url, election_date, is_zip in sources:
+        print(f"  {election_date} → download...", file=sys.stderr)
+        records = process_url(url, election_date, is_zip)
+        print(f"    {len(records)} righe", file=sys.stderr)
+        all_records.extend(records)
+
+    if not all_records:
+        print("Nessun dato estratto!", file=sys.stderr)
+        sys.exit(1)
+
+    # Ricava header da tutti i record
+    fieldnames = list(all_records[0].keys())
+
+    with open(output, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter=";")
+        writer.writeheader()
+        writer.writerows(all_records)
+
+    print(f"✅ Fatto: anno={year} totale={len(all_records)} righe → {output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/candidates/elezioni-regionali/sql/clean.sql
+++ b/candidates/elezioni-regionali/sql/clean.sql
@@ -1,0 +1,14 @@
+SELECT
+    CAST(data_elezione AS DATE) AS data_elezione,
+    CAST(regione AS VARCHAR) AS regione,
+    CAST(circoscrizione AS VARCHAR) AS circoscrizione,
+    CAST(provincia AS VARCHAR) AS provincia,
+    CAST(comune AS VARCHAR) AS comune,
+    TRY_CAST(elettori AS BIGINT) AS elettori,
+    TRY_CAST(votanti AS BIGINT) AS votanti,
+    TRY_CAST(schede_bianche AS BIGINT) AS schede_bianche,
+    CAST(candidato AS VARCHAR) AS candidato,
+    TRY_CAST(voti_candidato AS BIGINT) AS voti_candidato,
+    CAST(lista AS VARCHAR) AS lista,
+    TRY_CAST(voti_lista AS BIGINT) AS voti_lista
+FROM raw_input

--- a/candidates/elezioni-regionali/sql/mart.sql
+++ b/candidates/elezioni-regionali/sql/mart.sql
@@ -5,11 +5,11 @@ SELECT
     provincia,
     comune,
     lista,
+    candidato,
     SUM(voti_lista) AS tot_voti_lista,
-    SUM(voti_candidato) AS tot_voti_candidato,
-    COUNT(DISTINCT candidato) AS n_candidati,
+    MAX(voti_candidato) AS voti_candidato,  -- stesso valore su tutte le righe del presidente
     MAX(elettori) AS elettori,
     MAX(votanti) AS votanti,
     MAX(schede_bianche) AS schede_bianche
 FROM clean_input
-GROUP BY data_elezione, regione, circoscrizione, provincia, comune, lista
+GROUP BY data_elezione, regione, circoscrizione, provincia, comune, lista, candidato

--- a/candidates/elezioni-regionali/sql/mart.sql
+++ b/candidates/elezioni-regionali/sql/mart.sql
@@ -1,0 +1,15 @@
+SELECT
+    data_elezione,
+    regione,
+    circoscrizione,
+    provincia,
+    comune,
+    lista,
+    SUM(voti_lista) AS tot_voti_lista,
+    SUM(voti_candidato) AS tot_voti_candidato,
+    COUNT(DISTINCT candidato) AS n_candidati,
+    MAX(elettori) AS elettori,
+    MAX(votanti) AS votanti,
+    MAX(schede_bianche) AS schede_bianche
+FROM clean_input
+GROUP BY data_elezione, regione, circoscrizione, provincia, comune, lista


### PR DESCRIPTION
## Sintesi

Nuovo candidate `elezioni-regionali` — risultati delle elezioni regionali italiane per comune, da Eligendo (DAIT). 6 anni, 9 tornate, ~117.879 righe.

## Contesto collegato

Closes #588

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento
- [x] docs — struttura candidate, README, template

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
- [ ] Solo documentazione o metadati
- [ ] Nessun impatto visibile per chi usa il repository

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori su tutti gli anni dichiarati (2018, 2019, 2020, 2021, 2023, 2024)
- [x] nessun file dati committato nella root del candidate
- [x] issue di intake collegata (#588)

## Verifica

```bash
cd dataset-incubator
TOOLKIT_ALLOW_SCRIPT_SOURCE=1 toolkit run full \
  --config candidates/elezioni-regionali/dataset.yml \
  --years 2018,2019,2020,2021,2023,2024
```

- [x] `run full` eseguito senza errori su tutti gli anni
- [x] Perimetro stretto: candidate con domanda minima chiara

## Note / rischi

- Richiede `TOOLKIT_ALLOW_SCRIPT_SOURCE=1` per via del source type `script`
- 2020-09-20 esclusa: file XLSX non gestiti dal toolkit
- Preferenze (secondo file ZIP) non incluse — future issue
- 2014 e precedenti hanno schema diverso (no circoscrizione) — estensione futura
