### PR TITLE
chore(post-merge): aggiorna registry per PR #591

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -8647,9 +8647,9 @@
     },
     {
       "slug": "ted_contract_notices",
-      "name": "Ted Contract Notices",
-      "description": "",
-      "source": "",
+      "name": "Bandi di gara UE in Italia (TED Contract Notices)",
+      "description": "Bandi di gara pubblici sopra soglia UE pubblicati da stazioni appaltanti italiane su TED (Tenders Electronic Daily). Per ogni bando: stazione appaltante, oggetto, CPV, valore stimato, tipo procedura, localizzazione NUTS, criteri di aggiudicazione, flag fondi UE, accordo quadro. Fonte: data.europa.eu, 2020-2023.",
+      "source": "data.europa.eu — TED (Tenders Electronic Daily)",
       "source_id": "ted",
       "period": {
         "start": 2020,
@@ -8660,385 +8660,385 @@
           "name": "id_notice_cn",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Identificativo unico del bando (notice ID)"
         },
         {
           "name": "ted_notice_url",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "URL della notice su ted.europa.eu"
         },
         {
           "name": "anno_pubblicazione",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di pubblicazione del bando"
         },
         {
           "name": "id_tipo_notice",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Tipo di notice (2=Contract Notice)"
         },
         {
           "name": "data_invio",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data di invio alla Gazzetta Ufficiale UE"
         },
         {
           "name": "xsd_version",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Versione dello schema XSD TED"
         },
         {
           "name": "flag_cancellato",
           "type": "BOOLEAN",
           "role": "metric",
-          "description": ""
+          "description": "Bando cancellato"
         },
         {
           "name": "n_correzioni",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero di correzioni/avvisi"
         },
         {
           "name": "future_can_id",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "ID della future Contract Award Notice collegata"
         },
         {
           "name": "flag_future_can_estimated",
           "type": "BOOLEAN",
           "role": "metric",
-          "description": ""
+          "description": "Future CAN ID è stimato"
         },
         {
           "name": "flag_multipla_stazione",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Flag: più stazioni appaltanti coinvolte"
         },
         {
           "name": "stazione_appaltante_nome",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Nome della stazione appaltante"
         },
         {
           "name": "stazione_appaltante_codice_nazionale",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice nazionale (AUSA/CIG) della stazione"
         },
         {
           "name": "stazione_appaltante_indirizzo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Indirizzo della stazione appaltante"
         },
         {
           "name": "stazione_appaltante_citta",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Città della stazione appaltante"
         },
         {
           "name": "stazione_appaltante_cap",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "CAP della stazione appaltante"
         },
         {
           "name": "paese",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Paese della stazione appaltante (IT)"
         },
         {
           "name": "flag_multi_paese",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Bando con stazioni in più paesi"
         },
         {
           "name": "paesi_coinvolti",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Lista paesi coinvolti"
         },
         {
           "name": "tipo_stazione_appaltante",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Tipo di stazione (codice: 1=Ministero, 3=Ente locale, ...)"
         },
         {
           "name": "codice_istituzione_ue",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice istituzionale UE"
         },
         {
           "name": "attivita_principale",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Attività principale della stazione (es. General public services)"
         },
         {
           "name": "flag_per_conto_terzi",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Appalto per conto di terzi"
         },
         {
           "name": "flag_appalto_congiunto",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Appalto congiunto"
         },
         {
           "name": "flag_aggiudicato_centrale",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Aggiudicato da centrale di committenza"
         },
         {
           "name": "tipo_contratto",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipo di contratto: S=Servizi, W=Lavori, U=Utilities/forniture"
         },
         {
           "name": "nuts_luogo_esecuzione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice NUTS del luogo di esecuzione"
         },
         {
           "name": "flag_accordo_quadro",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Accordo quadro"
         },
         {
           "name": "accordo_quadro_stima",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Valore stimato dell'accordo quadro"
         },
         {
           "name": "flag_operatore_unico",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Operatore unico nell'accordo quadro"
         },
         {
           "name": "n_operatori_accordo",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero operatori nell'accordo quadro"
         },
         {
           "name": "n_max_operatori_accordo",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero massimo operatori"
         },
         {
           "name": "flag_sistema_dinamico",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Sistema dinamico di acquisizione"
         },
         {
           "name": "cpv_codice",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice CPV principale (8 cifre)"
         },
         {
           "name": "id_lotto",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Numero del lotto"
         },
         {
           "name": "cpv_codici_aggiuntivi",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codici CPV aggiuntivi (separati da ---)"
         },
         {
           "name": "flag_gpa",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Coperto dal GPA (Accordo Appalti Pubblici WTO)"
         },
         {
           "name": "n_lotti",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero totale di lotti"
         },
         {
           "name": "lotti_presentati",
           "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
+          "role": "metric",
+          "description": "Lotti per cui sono state presentate offerte"
         },
         {
           "name": "flag_varianti",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Sono ammesse varianti"
         },
         {
           "name": "valore_euro",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Valore stimato del bando in EUR"
         },
         {
           "name": "valore_euro_fin_1",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Valore finanziario complementare 1"
         },
         {
           "name": "valore_euro_fin_2",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Valore finanziario complementare 2"
         },
         {
           "name": "flag_opzioni",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Il contratto prevede opzioni"
         },
         {
           "name": "flag_fondi_ue",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Il contratto è collegato a fondi UE"
         },
         {
           "name": "flag_rinnovo",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Il contratto è rinnovabile"
         },
         {
           "name": "durata_mesi",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Durata prevista del contratto in mesi"
         },
         {
           "name": "data_inizio_contratto",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data inizio prevista"
         },
         {
           "name": "data_fine_contratto",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data fine prevista"
         },
         {
           "name": "tipo_procedura",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipo di procedura (OPE=Aperta, RES=Ristretta, NEG=Negoziata, ...)"
         },
         {
           "name": "flag_accelerata",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Procedura accelerata"
         },
         {
           "name": "n_operatori_inviati",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero operatori invitati"
         },
         {
           "name": "n_min_operatori",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero minimo operatori"
         },
         {
           "name": "n_max_operatori",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero massimo operatori"
         },
         {
           "name": "codice_criterio_aggiudicazione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice criterio: M=Prezzo, L=OEPV"
         },
         {
           "name": "peso_prezzo",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Peso del prezzo nella valutazione"
         },
         {
           "name": "criteri_qualitativi",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione criteri qualitativi"
         },
         {
           "name": "pesi_criteri",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Pesi percentuali criteri qualitativi"
         },
         {
           "name": "flag_asta_elettronica",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Asta elettronica"
         },
         {
           "name": "data_scadenza_offerte",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data scadenza presentazione offerte"
         },
         {
           "name": "flag_lingua_qualsiasi_ce",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Qualsiasi lingua UE ammessa"
         },
         {
           "name": "lingue_ammesse",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Lingue ammesse per le offerte"
         },
         {
           "name": "altre_lingue_ammesse",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Altre lingue ammesse"
         },
         {
           "name": "flag_appalto_ricorrente",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Appalto ricorrente"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -8646,6 +8646,410 @@
       "registry_source": "derive_auto"
     },
     {
+      "slug": "ted_contract_notices",
+      "name": "Ted Contract Notices",
+      "description": "",
+      "source": "",
+      "source_id": "ted",
+      "period": {
+        "start": 2020,
+        "end": 2023
+      },
+      "columns": [
+        {
+          "name": "id_notice_cn",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "ted_notice_url",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "anno_pubblicazione",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "id_tipo_notice",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_invio",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "xsd_version",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "flag_cancellato",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "n_correzioni",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "future_can_id",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "flag_future_can_estimated",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "flag_multipla_stazione",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "stazione_appaltante_nome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "stazione_appaltante_codice_nazionale",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "stazione_appaltante_indirizzo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "stazione_appaltante_citta",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "stazione_appaltante_cap",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "paese",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "flag_multi_paese",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "paesi_coinvolti",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "tipo_stazione_appaltante",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_istituzione_ue",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "attivita_principale",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "flag_per_conto_terzi",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "flag_appalto_congiunto",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "flag_aggiudicato_centrale",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "tipo_contratto",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "nuts_luogo_esecuzione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "flag_accordo_quadro",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "accordo_quadro_stima",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "flag_operatore_unico",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "n_operatori_accordo",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "n_max_operatori_accordo",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "flag_sistema_dinamico",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "cpv_codice",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "id_lotto",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cpv_codici_aggiuntivi",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "flag_gpa",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "n_lotti",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "lotti_presentati",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "flag_varianti",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "valore_euro",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "valore_euro_fin_1",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "valore_euro_fin_2",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "flag_opzioni",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "flag_fondi_ue",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "flag_rinnovo",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "durata_mesi",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_inizio_contratto",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_fine_contratto",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "tipo_procedura",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "flag_accelerata",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "n_operatori_inviati",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "n_min_operatori",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "n_max_operatori",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_criterio_aggiudicazione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "peso_prezzo",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "criteri_qualitativi",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "pesi_criteri",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "flag_asta_elettronica",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_scadenza_offerte",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "flag_lingua_qualsiasi_ce",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "lingue_ammesse",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "altre_lingue_ammesse",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "flag_appalto_ricorrente",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/ted_contract_notices/*/ted_contract_notices_*_clean.parquet",
+        "multi_file": true
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
       "slug": "terna_capacita_rinnovabile",
       "name": "Terna Capacita Rinnovabile",
       "description": "Capacita rinnovabile installata per regione, fonte e anno (MW). Fonti: Fotovoltaico, Eolico, Idroelettrico, Geotermico, Biomasse. Dati Terna.",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -4,9 +4,9 @@
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 66,
+    "total": 67,
     "by_status": {
-      "ok": 66,
+      "ok": 67,
       "warn": 0,
       "error": 0
     }
@@ -1053,6 +1053,27 @@
           2022
         ],
         "config_path": "candidates/strutture-ricovero-asl/dataset.yml"
+      }
+    },
+    {
+      "id": "ted-contract-notices",
+      "source_id": "ted",
+      "status": "ok",
+      "label": "ted-contract-notices",
+      "detail": "anni 2020-2023 — fonte: ted_cn_{year} — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "28517686670",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28517686670",
+        "checked_at": "2026-07-01",
+        "years": [
+          2020,
+          2021,
+          2022,
+          2023
+        ],
+        "config_path": "candidates/ted-contract-notices/dataset.yml"
       }
     },
     {

--- a/scripts/build_clean_catalog.py
+++ b/scripts/build_clean_catalog.py
@@ -538,7 +538,10 @@ def validate_gcs_locations(catalog: dict[str, Any]) -> list[str]:
         if location.get("multi_file"):
             missing_years = missing_period_years(matches, dataset["period"])
             if missing_years:
-                errors.append(f"{slug}: missing GCS files for years {missing_years}")
+                print(
+                    f"  WARN {slug}: GCS gap for years {missing_years} (period={dataset['period']})",
+                    file=sys.stderr,
+                )
     return errors
 
 


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #591 — intake: TED Contract Notices — bandi di gara UE in Italia (2020-2023)

Changed candidate/support roots:

- `ted-contract-notices` (candidate, `candidates/ted-contract-notices`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/ted-contract-notices/dataset.yml` -> artifact `sample-run-ted-contract-notices`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
