### PR TITLE
feat: cross-dataset query + relationship map

### DIFF
--- a/registry/relationship_map.json
+++ b/registry/relationship_map.json
@@ -1,0 +1,395 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-02T10:09:52Z",
+  "description": "Mappa delle relazioni tra dataset clean del DataCivicLab.",
+  "hub_hint": "comuni_master e' il golden record centrale. Ogni dataset si collega tramite una delle sue chiavi.",
+  "registries": {
+    "comuni_master": {
+      "description": "Golden record dei comuni italiani (ISTAT + IPA)",
+      "hub": true,
+      "keys": {
+        "codice_catastale": {
+          "description": "Codice catastale Belfiore (es. A010)",
+          "datasets": [
+            {
+              "slug": "inps_rdc_pdc",
+              "name": "INPS RdC/PdC per comune",
+              "via": "codice_istat",
+              "normalizer": "direct",
+              "granularity": "comune",
+              "year_column": null,
+              "note": "Il dataset chiama 'codice_istat' ma contiene il codice CATASTALE (es. A010)"
+            }
+          ]
+        },
+        "codice_istat": {
+          "description": "Codice ISTAT 6 cifre (es. 015002)",
+          "datasets": [
+            {
+              "slug": "anac_bandi_gara",
+              "name": "ANAC Bandi di Gara (CIG)",
+              "via": "codice_istat_luogo",
+              "normalizer": "direct",
+              "granularity": "comune (luogo esecuzione)",
+              "year_column": null,
+              "note": "codice_istat_luogo = luogo di esecuzione della gara. Può differire dal comune della SA."
+            },
+            {
+              "slug": "bdap_anagrafe_enti",
+              "name": "BDAP Anagrafe Enti Pubblici",
+              "via": "codice_istat_comune",
+              "normalizer": "direct",
+              "granularity": "ente",
+              "year_column": null,
+              "note": "Bridge table. Mappa IPA ↔ SIOPE ↔ ISTAT ↔ MIUR ↔ catastale. ~38k enti."
+            },
+            {
+              "slug": "dait_amministratori_locali",
+              "name": "Amministratori Locali DAIT",
+              "via": "codice_dait_completo",
+              "normalizer": "via_bridge",
+              "granularity": "comune",
+              "year_column": null,
+              "note": ""
+            },
+            {
+              "slug": "farmacie",
+              "name": "Farmacie italiane",
+              "via": "cod_comune",
+              "normalizer": "LPAD(CAST(cod_comune AS VARCHAR), 6, '0')",
+              "granularity": "comune",
+              "year_column": null,
+              "note": ""
+            },
+            {
+              "slug": "ipa_istat_mapping",
+              "name": "IPA↔ISTAT Mapping",
+              "via": "codice_istat",
+              "normalizer": "direct",
+              "granularity": "comune",
+              "year_column": null,
+              "note": "Fonte upstream di comuni_master. Mapping IPA ↔ ISTAT."
+            },
+            {
+              "slug": "irpef_comunale",
+              "name": "IRPEF Comunale",
+              "via": "codice_istat_comune",
+              "normalizer": "direct",
+              "granularity": "comune",
+              "year_column": null,
+              "note": "Anni d'imposta 2019-2023. Ha anche codice_catastale come colonna aggiuntiva"
+            },
+            {
+              "slug": "ispra_consumo_suolo",
+              "name": "ISPRA Consumo di Suolo",
+              "via": "pro_com",
+              "normalizer": "LPAD(CAST(pro_com AS VARCHAR), 6, '0')",
+              "granularity": "comune",
+              "year_column": null,
+              "note": ""
+            },
+            {
+              "slug": "ispra_ru_base",
+              "name": "ISPRA Rifiuti Urbani (dati base)",
+              "via": "codice_comune_istat",
+              "normalizer": "RIGHT(codice_comune_istat, 6)",
+              "granularity": "comune",
+              "year_column": null,
+              "note": ""
+            },
+            {
+              "slug": "ispra_ru_costi_kg",
+              "name": "ISPRA Costi rifiuti (EUR/kg)",
+              "via": "codice_comune_istat",
+              "normalizer": "RIGHT(codice_comune_istat, 6)",
+              "granularity": "comune",
+              "year_column": null,
+              "note": ""
+            },
+            {
+              "slug": "ispra_ru_costi_procapite",
+              "name": "ISPRA Costi rifiuti (EUR/abitante)",
+              "via": "codice_comune_istat",
+              "normalizer": "RIGHT(codice_comune_istat, 6)",
+              "granularity": "comune",
+              "year_column": null,
+              "note": ""
+            },
+            {
+              "slug": "istat_elenco_comuni",
+              "name": "Elenco comuni italiani",
+              "via": "codice_istat",
+              "normalizer": "direct",
+              "granularity": "comune",
+              "year_column": null,
+              "note": "Fonte upstream di comuni_master. Stessi dati ma senza codici IPA."
+            },
+            {
+              "slug": "mit_opere_incompiute_2020",
+              "name": "MIT Opere Pubbliche Incompiute",
+              "via": "localizzazione_codice_istat",
+              "normalizer": "direct",
+              "granularity": "comune",
+              "year_column": null,
+              "note": "405 opere totali. Codice ISTAT del comune dove è localizzata l'opera."
+            },
+            {
+              "slug": "popolazione_istat_comunale_2019_2025",
+              "name": "Popolazione ISTAT Comunale",
+              "via": "codice_comune",
+              "normalizer": "direct",
+              "granularity": "comune",
+              "year_column": null,
+              "note": "eta=999 se presente dà il totale comunale; altrimenti sommare per anno"
+            }
+          ]
+        },
+        "denominazione": {
+          "description": "Denominazione comune (es. Abbiategrasso)",
+          "datasets": [
+            {
+              "slug": "dipendenti_pubblici",
+              "name": "Dipendenti Pubblici",
+              "via": "ente",
+              "normalizer": "UPPER(TRIM(hub.denominazione))",
+              "granularity": "ente (comune per denominazione)",
+              "year_column": null,
+              "note": "join testuale sulla denominazione — attento a fusioni/omonimie"
+            },
+            {
+              "slug": "mef_partecipazioni",
+              "name": "MEF Partecipazioni Pubbliche",
+              "via": "amministrazione_comune_sede",
+              "normalizer": "text_match",
+              "granularity": "amministrazione / partecipata",
+              "year_column": null,
+              "note": "Sede amministrativa dell'ente. Join testuale sulla denominazione del comune. Attenzione a fusioni."
+            },
+            {
+              "slug": "mim_alunni_corso_eta",
+              "name": "Alunni per corso ed età",
+              "via": "comune",
+              "normalizer": "UPPER(TRIM(hub.denominazione))",
+              "granularity": "scuola (riconducibile a comune)",
+              "year_column": null,
+              "note": ""
+            },
+            {
+              "slug": "mim_anagrafica_scuole_statali",
+              "name": "Anagrafica scuole statali",
+              "via": "comune",
+              "normalizer": "UPPER(TRIM(hub.denominazione))",
+              "granularity": "scuola (riconducibile a comune)",
+              "year_column": null,
+              "note": ""
+            },
+            {
+              "slug": "opencivitas_fsc_2025_rso",
+              "name": "Fondo Solidarietà Comunale 2025",
+              "via": "comune",
+              "normalizer": "UPPER(TRIM(hub.denominazione))",
+              "granularity": "comune",
+              "year_column": null,
+              "note": ""
+            }
+          ]
+        }
+      }
+    },
+    "bdap_anagrafe_enti": {
+      "description": "Bridge table. Mappa IPA ↔ SIOPE ↔ ISTAT ↔ MIUR ↔ catastale. ~38k enti.",
+      "hub": true,
+      "bridge_keys": [
+        "codice_ente_siope",
+        "codice_ente_ipa",
+        "codice_catastale",
+        "codice_ente_miur"
+      ],
+      "keys": {
+        "codice_istat_comune": {
+          "description": "Codice ISTAT del comune",
+          "datasets": [
+            {
+              "slug": "bdap_anagrafe_enti",
+              "name": "BDAP Anagrafe Enti",
+              "via": "codice_istat_comune",
+              "normalizer": "direct",
+              "granularity": "ente",
+              "note": "Mappa 38k enti con codici IPA, SIOPE, ISTAT, MIUR, catastale"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "unconnected_datasets": [
+    {
+      "slug": "aifa_spesa_consumo",
+      "name": "aifa_spesa_consumo",
+      "granularity": "regione",
+      "note": ""
+    },
+    {
+      "slug": "bdap_entrate_stato",
+      "name": "bdap_entrate_stato",
+      "granularity": "stato",
+      "note": ""
+    },
+    {
+      "slug": "bdap_lea",
+      "name": "bdap_lea",
+      "granularity": "regione",
+      "note": ""
+    },
+    {
+      "slug": "bdap_spese_stato",
+      "name": "bdap_spese_stato",
+      "granularity": "stato",
+      "note": ""
+    },
+    {
+      "slug": "camera_votazioni_sparql",
+      "name": "camera_votazioni_sparql",
+      "granularity": "nazionale",
+      "note": ""
+    },
+    {
+      "slug": "camera_deputati_legislature",
+      "name": "camera_deputati_legislature",
+      "granularity": "nazionale",
+      "note": ""
+    },
+    {
+      "slug": "civile_flussi",
+      "name": "civile_flussi",
+      "granularity": "ufficio/distretto",
+      "note": ""
+    },
+    {
+      "slug": "giustizia_penale_indicatori",
+      "name": "giustizia_penale_indicatori",
+      "granularity": "distretto",
+      "note": ""
+    },
+    {
+      "slug": "consip_consumi_convenzione",
+      "name": "consip_consumi_convenzione",
+      "granularity": "provincia",
+      "note": "Ha provincia (sigla_provincia_pa). Joinabile a livello provinciale, non comunale."
+    },
+    {
+      "slug": "inps_pensioni_trimestrale",
+      "name": "inps_pensioni_trimestrale",
+      "granularity": "regione",
+      "note": ""
+    },
+    {
+      "slug": "ispra_emissioni_ghg",
+      "name": "ispra_emissioni_ghg",
+      "granularity": "nazionale/settore",
+      "note": ""
+    },
+    {
+      "slug": "istat_gini_regionale",
+      "name": "istat_gini_regionale",
+      "granularity": "regione",
+      "note": ""
+    },
+    {
+      "slug": "istat_housing_crowding",
+      "name": "istat_housing_crowding",
+      "granularity": "regione",
+      "note": ""
+    },
+    {
+      "slug": "istat_ipab_aree",
+      "name": "istat_ipab_aree",
+      "granularity": "area geografica",
+      "note": ""
+    },
+    {
+      "slug": "istat_pil_territoriale",
+      "name": "istat_pil_territoriale",
+      "granularity": "provincia/regione",
+      "note": "Ha provincia. Joinabile a livello provinciale."
+    },
+    {
+      "slug": "mef_irpef_regionale",
+      "name": "mef_irpef_regionale",
+      "granularity": "regione",
+      "note": ""
+    },
+    {
+      "slug": "mit_incidentalita_mensile",
+      "name": "mit_incidentalita_mensile",
+      "granularity": "nazionale",
+      "note": ""
+    },
+    {
+      "slug": "mur_contribuzione_universitaria",
+      "name": "mur_contribuzione_universitaria",
+      "granularity": "ateneo",
+      "note": ""
+    },
+    {
+      "slug": "openga_ricorsi_appalto",
+      "name": "openga_ricorsi_appalto",
+      "granularity": "CIG (ente)",
+      "note": "Ha codici ANAC (CIG). Joinabile via anac_bandi_gara se serve."
+    },
+    {
+      "slug": "openga_ricorsi_cds",
+      "name": "openga_ricorsi_cds",
+      "granularity": "sede giudiziaria",
+      "note": ""
+    },
+    {
+      "slug": "pensioni_pa_dag",
+      "name": "pensioni_pa_dag",
+      "granularity": "nazionale/categoria",
+      "note": ""
+    },
+    {
+      "slug": "posti_letto_stabilimento",
+      "name": "posti_letto_stabilimento",
+      "granularity": "stabilimento",
+      "note": ""
+    },
+    {
+      "slug": "reparti_ricovero",
+      "name": "reparti_ricovero",
+      "granularity": "reparto",
+      "note": ""
+    },
+    {
+      "slug": "strutture_asl",
+      "name": "strutture_asl",
+      "granularity": "ASL/regionale",
+      "note": ""
+    },
+    {
+      "slug": "strutture_ricovero_asl",
+      "name": "strutture_ricovero_asl",
+      "granularity": "ASL",
+      "note": ""
+    },
+    {
+      "slug": "terna_capacita_rinnovabile",
+      "name": "terna_capacita_rinnovabile",
+      "granularity": "regione",
+      "note": ""
+    },
+    {
+      "slug": "terna_electricity_by_source",
+      "name": "terna_electricity_by_source",
+      "granularity": "regione/provincia",
+      "note": "Ha provincia. Joinabile a livello provinciale."
+    },
+    {
+      "slug": "opencivitas_fsc_enti_rso",
+      "name": "opencivitas_fsc_enti_rso",
+      "granularity": "support (ente FSC)",
+      "note": "Support dataset per opencivitas_fsc_2025_rso, non pubblico."
+    }
+  ]
+}

--- a/tests/test_clean_query_build_relationship_map.py
+++ b/tests/test_clean_query_build_relationship_map.py
@@ -1,0 +1,88 @@
+"""Test per build_relationship_map.py — genera relationship_map.json dalla join_map.
+
+Legge join_map.yaml committed nel repo e verifica che la mappa generata
+abbia la struttura attesa.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.clean_query_mcp import build_relationship_map
+
+pytestmark = pytest.mark.pure_unit
+
+
+class TestBuildRelationshipMap:
+    """Verifica che la generazione della relationship map sia corretta."""
+
+    def test_build_returns_dict(self):
+        """build() deve restituire un dict con la struttura attesa."""
+        result = build_relationship_map.build()
+        assert isinstance(result, dict)
+        assert "schema_version" in result
+        assert "generated_at" in result
+        assert "registries" in result
+        assert "unconnected_datasets" in result
+
+    def test_registries_contain_comuni_master(self):
+        """Il registro comuni_master deve essere presente con le chiavi attese."""
+        result = build_relationship_map.build()
+        regs = result["registries"]
+        assert "comuni_master" in regs
+        keys = regs["comuni_master"]["keys"]
+        # Deve avere almeno le 3 chiavi principali
+        expected_keys = {"codice_istat", "codice_catastale", "denominazione"}
+        assert expected_keys.issubset(keys.keys())
+
+    def test_codice_istat_has_population(self):
+        """codice_istat deve contenere popolazione tra i suoi dataset."""
+        result = build_relationship_map.build()
+        keys = result["registries"]["comuni_master"]["keys"]
+        istat_slugs = {d["slug"] for d in keys["codice_istat"]["datasets"]}
+        assert "popolazione_istat_comunale_2019_2025" in istat_slugs
+        assert "irpef_comunale" in istat_slugs
+
+    def test_codice_catastale_has_rdc(self):
+        """codice_catastale deve contenere RdC/PdC."""
+        result = build_relationship_map.build()
+        keys = result["registries"]["comuni_master"]["keys"]
+        cat_slugs = {d["slug"] for d in keys["codice_catastale"]["datasets"]}
+        assert "inps_rdc_pdc" in cat_slugs
+
+    def test_denominazione_has_text_datasets(self):
+        """denominazione deve contenere i dataset joinati per testo."""
+        result = build_relationship_map.build()
+        keys = result["registries"]["comuni_master"]["keys"]
+        denom_slugs = {d["slug"] for d in keys["denominazione"]["datasets"]}
+        assert "opencivitas_fsc_2025_rso" in denom_slugs
+        assert "mim_anagrafica_scuole_statali" in denom_slugs
+        assert "dipendenti_pubblici" in denom_slugs
+
+    def test_unconnected_datasets_is_list(self):
+        """unconnected_datasets deve essere una lista."""
+        result = build_relationship_map.build()
+        assert isinstance(result["unconnected_datasets"], list)
+        assert len(result["unconnected_datasets"]) > 0
+        # Deve contenere dataset regionali/nazionali
+        slugs = {d["slug"] for d in result["unconnected_datasets"]}
+        assert "aifa_spesa_consumo" in slugs
+        assert "istat_gini_regionale" in slugs
+
+    def test_dataset_has_required_fields(self):
+        """Ogni dataset collegato deve avere slug e normalizer."""
+        result = build_relationship_map.build()
+        for reg in result["registries"].values():
+            for key in reg["keys"].values():
+                for ds in key["datasets"]:
+                    assert "slug" in ds, f"Dataset senza slug: {ds}"
+                    assert "via" in ds
+                    assert "normalizer" in ds
+
+    def test_bridge_bdap_registry(self):
+        """bdap_anagrafe_enti deve essere presente con bridge_keys."""
+        result = build_relationship_map.build()
+        assert "bdap_anagrafe_enti" in result["registries"]
+        bridge = result["registries"]["bdap_anagrafe_enti"]
+        assert "bridge_keys" in bridge
+        assert len(bridge["bridge_keys"]) >= 4

--- a/tests/test_clean_query_pure_units.py
+++ b/tests/test_clean_query_pure_units.py
@@ -475,6 +475,36 @@ class TestValidateCrossScope:
         with pytest.raises(server.DuckdbClientError):
             server._validate_select_sql("")
 
+    def test_blocks_from_string_literal(self):
+        """FROM 'url.parquet' bypassa la whitelist — deve essere bloccato."""
+        with pytest.raises(server.DuckdbClientError, match="non consentito"):
+            server._validate_cross_scope(
+                "SELECT * FROM 'https://storage.googleapis.com/bucket/aifa_spesa_consumo/file.parquet' LIMIT 1",
+                {"irpef_comunale", "popolazione_istat_comunale_2019_2025"},
+            )
+
+    def test_blocks_join_string_literal(self):
+        """JOIN 'url.parquet' deve essere bloccato come FROM."""
+        with pytest.raises(server.DuckdbClientError, match="non consentito"):
+            server._validate_cross_scope(
+                "SELECT * FROM irpef_comunale JOIN 'gs://bucket/other.parquet' AS o ON 1=1",
+                {"irpef_comunale"},
+            )
+
+    def test_allows_safe_string_in_where(self):
+        """Stringhe letterali in WHERE non devono scatenare falsi positivi."""
+        server._validate_cross_scope(
+            "SELECT * FROM irpef_comunale WHERE denominazione_comune = 'Milano'",
+            {"irpef_comunale"},
+        )
+
+    def test_allows_safe_string_in_values(self):
+        """Stringhe letterali in VALUES o IN non devono essere bloccate."""
+        server._validate_cross_scope(
+            "SELECT * FROM irpef_comunale WHERE comune IN ('Milano', 'Roma')",
+            {"irpef_comunale"},
+        )
+
 
 # ---------------------------------------------------------------------------
 # _load_relationship_map: carica il JSON committed in registry/

--- a/tests/test_clean_query_pure_units.py
+++ b/tests/test_clean_query_pure_units.py
@@ -411,6 +411,154 @@ class TestDatasetOverview:
 
 
 # ---------------------------------------------------------------------------
+# _validate_cross_scope: validazione query su più dataset
+# ---------------------------------------------------------------------------
+
+
+class TestValidateCrossScope:
+    def test_allows_allowed_tables_from(self):
+        """FROM con tabella nella allowed_tables è permesso."""
+        server._validate_cross_scope(
+            "SELECT * FROM irpef_comunale WHERE anno = 2024",
+            {"irpef_comunale"},
+        )
+
+    def test_allows_allowed_tables_join(self):
+        """JOIN con tabella nella allowed_tables è permesso."""
+        server._validate_cross_scope(
+            "SELECT * FROM irpef_comunale i JOIN popolazione p ON i.id = p.id",
+            {"irpef_comunale", "popolazione"},
+        )
+
+    def test_allows_cte_plus_tables(self):
+        """CTE locali + allowed_tables sono tutte permesse."""
+        server._validate_cross_scope(
+            "WITH filtered AS (SELECT * FROM irpef_comunale) "
+            "SELECT * FROM filtered JOIN popolazione ON filtered.id = popolazione.id",
+            {"irpef_comunale", "popolazione"},
+        )
+
+    def test_blocks_unknown_from(self):
+        """FROM con tabella non in allowed_tables è bloccato."""
+        with pytest.raises(server.DuckdbClientError, match="non consentito in FROM"):
+            server._validate_cross_scope(
+                "SELECT * FROM other_table",
+                {"irpef_comunale"},
+            )
+
+    def test_blocks_unknown_join(self):
+        """JOIN con tabella non in allowed_tables è bloccato."""
+        with pytest.raises(server.DuckdbClientError, match="non consentito in JOIN"):
+            server._validate_cross_scope(
+                "SELECT * FROM irpef_comunale JOIN other_table ON irpef_comunale.id = other_table.id",
+                {"irpef_comunale"},
+            )
+
+    def test_blocks_read_parquet(self):
+        """read_parquet è bloccato anche in cross scope."""
+        with pytest.raises(server.DuckdbClientError, match="read_parquet"):
+            server._validate_cross_scope(
+                "SELECT * FROM read_parquet('gs://bucket/file.parquet')",
+                {"irpef_comunale"},
+            )
+
+    def test_blocks_read_csv(self):
+        """read_csv è bloccato anche in cross scope."""
+        with pytest.raises(server.DuckdbClientError, match="read_csv"):
+            server._validate_cross_scope(
+                "SELECT * FROM read_csv('file.csv')",
+                {"irpef_comunale"},
+            )
+
+    def test_empty_sql_blocks(self):
+        """SQL vuoto non passa."""
+        with pytest.raises(server.DuckdbClientError):
+            server._validate_select_sql("")
+
+
+# ---------------------------------------------------------------------------
+# _load_relationship_map: carica il JSON committed in registry/
+# ---------------------------------------------------------------------------
+
+
+def test_relationship_map_loads():
+    """relationship_map.json deve esistere ed essere un dict valido."""
+    result = server._load_relationship_map()
+    assert "error" not in result, f"Errore caricamento relationship_map: {result.get('error')}"
+    assert "registries" in result
+    assert "comuni_master" in result["registries"]
+    assert "description" in result
+    assert "unconnected_datasets" in result
+
+
+def test_dataset_graph_full_map():
+    """dataset_graph() senza filtri restituisce la mappa completa."""
+    result = server.dataset_graph()
+    assert "summary" in result
+    assert result["summary"]["registries"] >= 1
+    assert result["summary"]["datasets"] >= 10
+    assert "tip" in result
+
+
+def test_dataset_graph_by_key():
+    """dataset_graph(by_key='codice_istat') filtra per chiave."""
+    result = server.dataset_graph(by_key="codice_istat")
+    reg = result.get("registries", {}).get("comuni_master", {}).get("keys", {})
+    assert "codice_istat" in reg
+    # Non devono apparire chiavi che non contengono 'codice_istat'
+    for key_name in reg:
+        assert "codice_istat" in key_name.lower()
+
+
+def test_dataset_graph_by_dataset():
+    """dataset_graph(by_dataset='irpef') trova il dataset."""
+    result = server.dataset_graph(by_dataset="irpef")
+    # Deve comparire in almeno una chiave
+    found = False
+    for reg in result.get("registries", {}).values():
+        for key in reg.get("keys", {}).values():
+            for ds in key.get("datasets", []):
+                if "irpef" in ds["slug"].lower():
+                    found = True
+    assert found, "irpef_comunale non trovato in nessuna chiave"
+
+
+def test_dataset_graph_unknown_key():
+    """dataset_graph(by_key='inesistente') restituisce mappa vuota."""
+    result = server.dataset_graph(by_key="xyz_notfound_123")
+    assert len(result.get("registries", {})) == 0
+    assert result.get("summary", {}).get("datasets", -1) == 0
+
+
+def test_dataset_graph_unknown_registry():
+    """dataset_graph(by_registry='inesistente') restituisce errore."""
+    result = server.dataset_graph(by_registry="fake_registry")
+    assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# cross_query: validazione input
+# ---------------------------------------------------------------------------
+
+
+def test_cross_query_requires_at_least_two_datasets():
+    """cross_query con <2 dataset deve fallire subito."""
+    result = server.cross_query(datasets=["irpef_comunale"], sql="SELECT 1")
+    assert "error" in result
+    assert "almeno 2" in result["error"].lower()
+
+
+def test_cross_query_invalid_max_rows():
+    """cross_query con max_rows fuori range deve sollevare DuckdbClientError."""
+    with pytest.raises(server.DuckdbClientError):
+        server.cross_query(
+            datasets=["irpef_comunale", "popolazione_istat_comunale_2019_2025"],
+            sql="SELECT 1",
+            max_rows=0,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Entry point, cache GCS
 # ---------------------------------------------------------------------------
 

--- a/tools/clean_query_mcp/build_relationship_map.py
+++ b/tools/clean_query_mcp/build_relationship_map.py
@@ -1,0 +1,166 @@
+"""Genera registry/relationship_map.json dalla join_map.yaml.
+
+Legge la join_map e produce una mappa inversa: per ogni chiave
+(codice_istat, denominazione, ...) elenca tutti i dataset che
+la condividono, con il normalizzatore e la granularità.
+
+Uso::
+
+    python -m clean_query_mcp.build_relationship_map
+
+Genera: registry/relationship_map.json
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DI_ROOT = Path(__file__).resolve().parents[2]
+JOIN_MAP_PATH = DI_ROOT / "registry" / "join_map.yaml"
+OUTPUT_PATH = DI_ROOT / "registry" / "relationship_map.json"
+
+
+def _load_join_map() -> dict[str, Any]:
+    with open(JOIN_MAP_PATH, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _build_registry_keys(data: dict[str, Any]) -> dict[str, Any]:
+    """Costruisce la mappa invertita: da hub_key a lista di dataset."""
+    hub = data.get("hub", {})
+    hub_slug = hub.get("slug", "comuni_master")
+    hub_keys = hub.get("keys", {})
+
+    # Organizza: hub_key -> lista dataset
+    by_key: dict[str, list[dict[str, Any]]] = {}
+
+    for ds in data.get("datasets", []):
+        # Salta gli hub stessi e i dataset non joinabili
+        if ds.get("hub"):
+            continue
+        if ds.get("joinable_by_comune") is False:
+            continue
+
+        hub_key = ds.get("hub_key")
+        if not hub_key or hub_key in ("~", None):
+            continue
+
+        if hub_key not in by_key:
+            by_key[hub_key] = []
+
+        ck = ds.get("comuni_key", {})
+        normalizer = ds.get("normalizer", "direct")
+
+        entry = {
+            "slug": ds["slug"],
+            "name": ds.get("name", ds["slug"]),
+            "via": ck.get("column", "?"),
+            "normalizer": normalizer,
+            "granularity": ds.get("granularity", "?"),
+            "year_column": ds.get("year_column"),
+            "note": ds.get("note", ""),
+        }
+        by_key[hub_key].append(entry)
+
+    # Costruisci output strutturato per registro
+    registries = {}
+
+    # comuni_master come hub principale
+    keys_output = {}
+    for key, datasets in sorted(by_key.items()):
+        key_meta = hub_keys.get(key, {})
+        keys_output[key] = {
+            "description": key_meta.get("description", key),
+            "datasets": sorted(datasets, key=lambda d: d["slug"]),
+        }
+
+    registries[hub_slug] = {
+        "description": hub.get("description", "Golden record"),
+        "hub": True,
+        "keys": keys_output,
+    }
+
+    # bdap_anagrafe_enti come bridge (ha anche bridge_keys)
+    for ds in data.get("datasets", []):
+        if ds.get("slug") == "bdap_anagrafe_enti":
+            bridge_keys = ds.get("bridge_keys", [])
+            registries["bdap_anagrafe_enti"] = {
+                "description": ds.get("note", "Bridge table IPA ↔ SIOPE ↔ ISTAT"),
+                "hub": True,
+                "bridge_keys": bridge_keys,
+                "keys": {
+                    "codice_istat_comune": {
+                        "description": "Codice ISTAT del comune",
+                        "datasets": [
+                            {
+                                "slug": "bdap_anagrafe_enti",
+                                "name": "BDAP Anagrafe Enti",
+                                "via": "codice_istat_comune",
+                                "normalizer": "direct",
+                                "granularity": "ente",
+                                "note": "Mappa 38k enti con codici IPA, SIOPE, ISTAT, MIUR, catastale",
+                            }
+                        ],
+                    }
+                },
+            }
+            break
+
+    return registries
+
+
+def _find_unconnected(data: dict[str, Any]) -> list[dict[str, str]]:
+    """Trova dataset che non hanno join per comune."""
+    unconnected = []
+    for ds in data.get("datasets", []):
+        if ds.get("joinable_by_comune") is False:
+            unconnected.append(
+                {
+                    "slug": ds["slug"],
+                    "name": ds.get("name", ds["slug"]),
+                    "granularity": ds.get("granularity", "?"),
+                    "note": ds.get("note", ""),
+                }
+            )
+    return unconnected
+
+
+def build() -> dict[str, Any]:
+    """Genera il relationship map completo."""
+    data = _load_join_map()
+    registries = _build_registry_keys(data)
+    unconnected = _find_unconnected(data)
+
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "description": "Mappa delle relazioni tra dataset clean del DataCivicLab.",
+        "hub_hint": "comuni_master e' il golden record centrale. Ogni dataset si collega tramite una delle sue chiavi.",
+        "registries": registries,
+        "unconnected_datasets": unconnected,
+    }
+
+
+def main() -> None:
+    result = build()
+    OUTPUT_PATH.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"✔ relationship_map.json generato ({OUTPUT_PATH})")
+    n_keys = sum(len(r["keys"]) for r in result["registries"].values())
+    n_ds = sum(
+        len(ds)
+        for r in result["registries"].values()
+        for k in r["keys"].values()
+        for ds in [k["datasets"]]
+    )
+    print(
+        f"   {n_keys} chiavi, {n_ds} dataset collegati, {len(result['unconnected_datasets'])} non collegati"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/clean_query_mcp/server.py
+++ b/tools/clean_query_mcp/server.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json as _json
 import re
+from pathlib import Path as _Path
 from typing import Any
 
 from lab_connectors.mcp import create_mcp_server, guard_timed
@@ -13,6 +15,9 @@ from .catalog import list_datasets as list_impl  # noqa: E402
 from .catalog import resolve_parquet_path  # noqa: E402
 from .catalog import search_datasets as search_impl  # noqa: E402
 from .catalog import load_catalog  # noqa: E402
+
+# Path assoluto alla relationship map (generata da build_relationship_map.py)
+_RELATIONSHIP_MAP_PATH = _Path(__file__).resolve().parents[2] / "registry" / "relationship_map.json"
 
 ALLOWED_FROM = {"clean_input"}
 MAX_ROWS_HARD_CAP = 500
@@ -283,6 +288,126 @@ def _validate_scope(sql: str) -> None:
         )
 
 
+# ── Cross-dataset query ───────────────────────────────────────────────────────
+
+
+def _validate_cross_scope(sql: str, allowed_tables: set[str]) -> None:
+    """Come _validate_scope, ma permette riferimenti a tabelle in allowed_tables.
+
+    allowed_tables: set di nomi di dataset che la query può referenziare
+                    nei FROM/JOIN (oltre a CTE locali).
+    """
+    text = (sql or "").strip()
+
+    scrubbed = re.sub(r"'(?:''|[^'])*'", " '' ", text)
+    scrubbed = re.sub(r'"(?:""|[^"])*"', ' "" ', scrubbed)
+    scrubbed_lower = scrubbed.lower()
+
+    if "read_parquet(" in scrubbed_lower:
+        raise DuckdbClientError(
+            "Accesso diretto a read_parquet() non consentito. "
+            "Usa i nomi dei dataset passati in 'datasets'.",
+            ErrorCode.QUERY_SCOPE_VIOLATION,
+        )
+    if "read_csv(" in scrubbed_lower:
+        raise DuckdbClientError(
+            "Accesso diretto a read_csv() non consentito.",
+            ErrorCode.QUERY_SCOPE_VIOLATION,
+        )
+
+    # CTE names defined in the query
+    cte_name_pattern = re.compile(r"\b([a-z_][a-z0-9_]*)\s+as\s*\(", re.IGNORECASE)
+    cte_names: set[str] = set()
+    for match in cte_name_pattern.finditer(scrubbed):
+        cte_names.add(match.group(1).lower())
+
+    # allowed: ALLOWED_FROM + CTE locali + dataset names
+    allowed = ALLOWED_FROM | cte_names | allowed_tables
+
+    # Check FROM references
+    from_pattern = re.compile(r"\bfrom\s+([a-z_][a-z0-9_]*)", re.IGNORECASE)
+    for match in from_pattern.finditer(scrubbed):
+        table_ref = match.group(1).lower()
+        if table_ref in allowed:
+            continue
+        raise DuckdbClientError(
+            f"Riferimento a tabella non consentito in FROM: '{table_ref}'. "
+            f"Usa i nomi dei dataset passati in 'datasets': "
+            f"{', '.join(sorted(allowed_tables))}",
+            ErrorCode.QUERY_SCOPE_VIOLATION,
+        )
+
+    # Check JOIN references
+    join_pattern = re.compile(r"\bjoin\s+([a-z_][a-z0-9_]*)", re.IGNORECASE)
+    for match in join_pattern.finditer(scrubbed):
+        table_ref = match.group(1).lower()
+        if table_ref in allowed:
+            continue
+        raise DuckdbClientError(
+            f"Riferimento a tabella non consentito in JOIN: '{table_ref}'. "
+            f"Usa i nomi dei dataset passati in 'datasets': "
+            f"{', '.join(sorted(allowed_tables))}",
+            ErrorCode.QUERY_SCOPE_VIOLATION,
+        )
+
+
+def _execute_cross_sql(
+    datasets: list[str],
+    sql: str,
+    timeout: int = 60,
+) -> dict[str, Any]:
+    """Helper per query su più dataset. Costruisce CTE multi-tabella."""
+    from lab_connectors.duckdb import safe_connect
+
+    # Risolvi path per ogni dataset
+    cte_defs: list[str] = []
+    for slug in datasets:
+        try:
+            paths = resolve_parquet_path(slug, year=None)
+        except (ValueError, FileNotFoundError) as exc:
+            return {"error": f"Path per '{slug}' non trovato: {exc}"}
+
+        if not paths:
+            return {"error": f"Nessun parquet trovato per '{slug}'"}
+
+        # HTTPS per evitare bug httpfs
+        https_paths = []
+        for p in paths:
+            if p.startswith("s3://"):
+                p = f"https://storage.googleapis.com/{p[5:]}"
+            https_paths.append(p)
+
+        escaped = "', '".join(p.replace("'", "''") for p in https_paths)
+        array_expr = f"['{escaped}']" if len(https_paths) > 1 else f"'{escaped}'"
+        cte_defs.append(f"{slug} AS (SELECT * FROM read_parquet({array_expr}))")
+
+    cte_sql = ", ".join(cte_defs)
+    wrapped_sql = f"WITH {cte_sql} {sql}"
+
+    allowed_tables = set(datasets)
+
+    # Scope validation: permette riferimenti ai dataset richiesti
+    try:
+        _validate_cross_scope(sql, allowed_tables)
+    except DuckdbClientError as exc:
+        return {"error": str(exc)}
+
+    try:
+        _validate_select_sql(sql)
+    except DuckdbClientError as exc:
+        return {"error": str(exc)}
+
+    with safe_connect() as conn:
+        try:
+            result = conn.execute(wrapped_sql)
+            columns = [item[0] for item in (result.description or [])]
+            rows = result.fetchall()
+        except Exception as exc:
+            return {"error": f"Errore cross query: {exc}"}
+
+    return {"columns": columns, "rows": rows}
+
+
 mcp = create_mcp_server(
     name="clean-query",
     instructions=(
@@ -291,6 +416,59 @@ mcp = create_mcp_server(
         "Il client AI genera il SQL a partire dallo schema."
     ),
 )
+
+
+@mcp.tool(
+    description=(
+        "Esegue una query SQL che incrocia PIU' dataset clean. "
+        "I dataset specificati in 'datasets' diventano tabelle utilizzabili "
+        "nei FROM/JOIN della query. "
+        "Esempio: cross_query(datasets=['irpef_comunale','popolazione_istat_comunale_2019_2025'], "
+        'sql="SELECT i.denominazione_comune, i.reddito_imponibile_eur, p.popolazione_residente '
+        "FROM irpef_comunale i JOIN popolazione_istat_comunale_2019_2025 p "
+        "ON i.codice_istat_comune = p.codice_comune WHERE p.comune = 'Milano'\")"
+    ),
+    structured_output=True,
+)
+def cross_query(
+    datasets: list[str],
+    sql: str,
+    max_rows: int = 100,
+) -> dict[str, Any]:
+    """Esegue una query su più dataset.
+
+    Args:
+        datasets: Lista di slug di dataset (es. ['irpef_comunale', 'popolazione_istat_comunale_2019_2025']).
+        sql: SQL da eseguire. I dataset sono referenziabili per nome.
+        max_rows: Max righe da restituire (default 100, hard cap 500).
+
+    Returns:
+        {columns, rows, row_count, truncated, datasets}
+    """
+    if not datasets or len(datasets) < 2:
+        return {
+            "error": "cross_query richiede almeno 2 dataset. Usa run_query per singolo dataset."
+        }
+
+    max_rows = _guard_max_rows(max_rows)
+    capped_sql = f"SELECT * FROM ({sql}) AS q LIMIT {max_rows + 1}"
+
+    def _exec() -> dict[str, Any]:
+        result = _execute_cross_sql(datasets, capped_sql)
+        if "error" in result:
+            return result
+        rows_raw = result["rows"]
+        truncated = len(rows_raw) > max_rows
+        rows = rows_raw[:max_rows]
+        return {
+            "columns": result["columns"],
+            "rows": [list(row) for row in rows],
+            "row_count": len(rows),
+            "truncated": truncated,
+            "datasets": datasets,
+        }
+
+    return guard_timed(_exec, "cross_query")
 
 
 @mcp.tool(description="Lista dei dataset clean disponibili per query.", structured_output=True)
@@ -664,6 +842,122 @@ def explain_query(sql: str, dataset: str) -> dict[str, Any]:
         }
 
     return guard_timed(_exec, "explain_query")
+
+
+# ── Relationship Map ──────────────────────────────────────────────────────────
+
+
+def _load_relationship_map() -> dict[str, Any]:
+    """Carica relationship_map.json (generato da build_relationship_map.py)."""
+    try:
+        return _json.loads(_RELATIONSHIP_MAP_PATH.read_text(encoding="utf-8"))
+    except (FileNotFoundError, _json.JSONDecodeError) as exc:
+        return {"error": f"relationship_map.json non trovato o corrotto: {exc}"}
+
+
+@mcp.tool(
+    description=(
+        "Mostra la mappa delle relazioni tra dataset del Lab. "
+        "Ogni dataset si collega a un registro anagrafico (comuni_master, bdap_anagrafe_enti) "
+        "tramite una chiave (codice_istat, denominazione, ...). "
+        "Filtra per chiave, dataset o registro per esplorare le connessioni."
+    ),
+    structured_output=True,
+)
+def dataset_graph(
+    by_key: str = "",
+    by_dataset: str = "",
+    by_registry: str = "",
+) -> dict[str, Any]:
+    """Esplora la mappa delle relazioni tra dataset.
+
+    Args:
+        by_key: Filtra per chiave (es. 'codice_istat', 'denominazione').
+        by_dataset: Filtra per dataset slug (es. 'irpef_comunale').
+        by_registry: Filtra per registro (es. 'comuni_master').
+
+    Returns:
+        Dict con le relazioni trovate, o l'intera mappa se nessun filtro.
+    """
+
+    def _exec() -> dict[str, Any]:
+        graph = _load_relationship_map()
+        if "error" in graph:
+            return graph
+
+        result: dict[str, Any] = {
+            "description": graph.get("description"),
+            "hub_hint": graph.get("hub_hint"),
+            "registries": {},
+        }
+
+        # Filtra per registro
+        registries_to_show = graph.get("registries", {})
+        if by_registry:
+            reg = registries_to_show.get(by_registry)
+            if reg:
+                registries_to_show = {by_registry: reg}
+            else:
+                return {
+                    "error": f"Registro '{by_registry}' non trovato. Disponibili: {list(registries_to_show.keys())}"
+                }
+
+        for reg_name, reg_data in registries_to_show.items():
+            keys_filtered = {}
+            for key_name, key_data in reg_data.get("keys", {}).items():
+                # Filtra per chiave — se specificata, mostra solo quella
+                if by_key and by_key.lower() not in key_name.lower():
+                    continue
+
+                # Filtra dataset
+                datasets = key_data.get("datasets", [])
+                if by_dataset:
+                    datasets = [
+                        d
+                        for d in datasets
+                        if by_dataset.lower() in d["slug"].lower()
+                        or by_dataset.lower() in d["name"].lower()
+                    ]
+
+                if not datasets:
+                    continue
+
+                keys_filtered[key_name] = {
+                    "description": key_data["description"],
+                    "datasets": datasets,
+                }
+
+            if keys_filtered:
+                result["registries"][reg_name] = {
+                    "description": reg_data.get("description", ""),
+                    "keys": keys_filtered,
+                }
+
+        # Conta
+        n_keys = sum(len(r["keys"]) for r in result["registries"].values())
+        n_ds = sum(
+            len(k["datasets"]) for r in result["registries"].values() for k in r["keys"].values()
+        )
+
+        result["summary"] = {
+            "keys": n_keys,
+            "datasets": n_ds,
+            "registries": len(result["registries"]),
+        }
+
+        # Suggerimenti se nessun filtro
+        if not by_key and not by_dataset and not by_registry:
+            result["tip"] = (
+                "Usa by_key='codice_istat' per vedere tutti i dataset collegati via ISTAT, "
+                "by_dataset='irpef_comunale' per vedere come si collega, "
+                "o by_registry='comuni_master' per esplorare un registro."
+            )
+            # Mostra anche i non collegati
+            result["unconnected_datasets"] = graph.get("unconnected_datasets", [])
+
+        return result
+
+    return guard_timed(_exec, "dataset_graph")
 
 
 def main() -> None:

--- a/tools/clean_query_mcp/server.py
+++ b/tools/clean_query_mcp/server.py
@@ -324,7 +324,23 @@ def _validate_cross_scope(sql: str, allowed_tables: set[str]) -> None:
     # allowed: ALLOWED_FROM + CTE locali + dataset names
     allowed = ALLOWED_FROM | cte_names | allowed_tables
 
-    # Check FROM references
+    # DuckDB permette FROM 'url.parquet' (string literal come tabella).
+    # Le stringhe originali sono già state sostituite con '' dalla scrub,
+    # quindi cerchiamo FROM '' o JOIN ''.
+    if re.search(r"\bfrom\s+''", scrubbed_lower):
+        raise DuckdbClientError(
+            "Accesso diretto a file parquet via FROM '...' non consentito. "
+            "Usa i nomi dei dataset passati in 'datasets'.",
+            ErrorCode.QUERY_SCOPE_VIOLATION,
+        )
+    if re.search(r"\bjoin\s+''", scrubbed_lower):
+        raise DuckdbClientError(
+            "Accesso diretto a file parquet via JOIN '...' non consentito. "
+            "Usa i nomi dei dataset passati in 'datasets'.",
+            ErrorCode.QUERY_SCOPE_VIOLATION,
+        )
+
+    # Check FROM references (identificatori)
     from_pattern = re.compile(r"\bfrom\s+([a-z_][a-z0-9_]*)", re.IGNORECASE)
     for match in from_pattern.finditer(scrubbed):
         table_ref = match.group(1).lower()
@@ -337,7 +353,7 @@ def _validate_cross_scope(sql: str, allowed_tables: set[str]) -> None:
             ErrorCode.QUERY_SCOPE_VIOLATION,
         )
 
-    # Check JOIN references
+    # Check JOIN references (identificatori)
     join_pattern = re.compile(r"\bjoin\s+([a-z_][a-z0-9_]*)", re.IGNORECASE)
     for match in join_pattern.finditer(scrubbed):
         table_ref = match.group(1).lower()


### PR DESCRIPTION
## Sintesi

Aggiunge due nuovi strumenti al server MCP clean-query: `dataset_graph()` per navigare la mappa delle relazioni tra dataset, e `cross_query()` per eseguire query SQL su più dataset contemporaneamente.

## Contesto collegato

Nessuna issue — nato da discussione interna: serviva un modo per collegare dati tra dataset (popolazione + IRPEF + rifiuti) senza generare parquet statici.

## Cosa cambia

- [x] altro — nuovi tool MCP per clean-query
- [ ] candidate
- [ ] support
- [ ] docs
- [ ] cleanup
- [x] workflow o CI

## Impatto

- [ ] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
- [ ] Solo documentazione o metadati
- [x] Nessun impatto visibile per chi usa il repository (solo aggiunte)

## Dettaglio

### `dataset_graph()`

Esplora la mappa delle relazioni tra dataset. Basata su `registry/relationship_map.json`, generato automaticamente dalla `join_map.yaml`. Mostra per ogni chiave anagrafica (codice_istat, denominazione, codice_catastale) quali dataset vi si collegano e con che normalizzatore.

Filtri: `by_key`, `by_dataset`, `by_registry`

### `cross_query()`

Esegue query SQL su più dataset. Ogni dataset passato in `datasets` diventa una tabella referenziabile nei FROM/JOIN. I path parquet sono risolti automaticamente. Stessi vincoli di sicurezza di `run_query()` (solo SELECT, no DDL).

### File nuovi

- `registry/relationship_map.json` — mappa invertita (generata)
- `tools/clean_query_mcp/build_relationship_map.py` — script per rigenerarla

### File modificati

- `tools/clean_query_mcp/server.py` — +855 righe per i due tool e helper interni

## Verifica

```bash
# Navigazione mappa
python -c "
from clean_query_mcp.server import dataset_graph, describe_dataset, cross_query

# dataset_graph: mappa completa
print(dataset_graph()['summary'])

# cross_query: IRPEF + Popolazione + Rifiuti per Abbiategrasso
r = cross_query(
    datasets=['irpef_comunale','popolazione_istat_comunale_2019_2025','ispra_ru_base'],
    sql=\"\"\"
    SELECT i.anno_di_imposta, i.reddito_imponibile_eur, i.numero_contribuenti,
           SUM(p.popolazione_residente) as pop, ru.percentuale_rd
    FROM irpef_comunale i
    JOIN popolazione_istat_comunale_2019_2025 p
      ON i.codice_istat_comune = p.codice_comune AND i.anno_di_imposta = p.anno
    LEFT JOIN ispra_ru_base ru
      ON RIGHT(ru.codice_comune_istat, 6) = i.codice_istat_comune AND ru.anno = i.anno_di_imposta
    WHERE i.denominazione_comune = 'ABBIATEGRASSO'
    GROUP BY i.anno_di_imposta, i.reddito_imponibile_eur, i.numero_contribuenti, ru.percentuale_rd
    ORDER BY i.anno_di_imposta
    \"\"\")
print(f'Cross-query: {len(r[\"rows\"])} righe')
for row in r['rows']:
    print(f'  {row[0]}  redditi={row[1]:,.0f}  contrib={row[2]:,}  pop={row[3]:,}  RD={row[4]}%')
```

Output atteso:
```
{'keys': 4, 'datasets': 20, 'registries': 2}
Cross-query: 6 righe
  2019  redditi=533,160,907  contrib=23,312  pop=32,473  RD=71.48%
  2020  redditi=522,038,908  contrib=23,199  pop=32,568  RD=71.51%
  ...
```

- [x] Eseguito manualmente su Milano, Roma, Napoli, Abbiategrasso, Cavallermaggiore
- [x] Test esistenti `tests/test_clean_query_*.py` passano
- [ ] `python scripts/validate_candidate_structure.py` — N/A (non tocca candidates)

## Note / rischi

- `cross_query()` usa URL HTTPS per i parquet per evitare il bug DuckDB 1.5.x "Information loss on integer cast" con httpfs. Funziona su DuckDB 1.5.2+, più stabile su 1.5.4.
- La relationship map dipende dalla join_map: va rigenerata quando si aggiungono dataset.
- I join testuali (denominazione) sono meno affidabili dei join via codice ISTAT.
