### PR TITLE
intake: silos-infrastrutture — opere strategiche prioritarie (Camera dei Deputati)

### DIFF
--- a/candidates/silos-infrastrutture/README.md
+++ b/candidates/silos-infrastrutture/README.md
@@ -7,7 +7,7 @@ Report annuale del Servizio Studi che censisce lo stato di attuazione delle infr
 - **Fonte**: https://dati.camera.it/ocd/dump/silos/PISRapportoCSV2024.zip
 - **Licenza**: CC BY-SA 4.0
 - **Copertura**: 2024 (report annuale, serie storica dal 2004)
-- **Granularità**: singolo intervento con CUP, regione, soggetto competente, stato attuazione
+- **Granularità**: singolo intervento con CUP, localizzazione, soggetto competente, stato attuazione
 
 ## Domanda civica
 
@@ -16,7 +16,7 @@ Dove sono finite le infrastrutture strategiche? Quali opere sono in ritardo e in
 ## Shape
 
 - 3.527 righe, 15 colonne
-- 12 sistemi infrastrutturali (Ferrovie, Strade, Sistemi Urbani, Porti, ecc.)
+- 13 sistemi infrastrutturali (Ferrovie, Strade e autostrade, Sistemi urbani, Porti e interporti, Aeroporti, Ponte sullo Stretto, Mo.S.E., Infrastrutture Idriche, Ciclovie, Edilizia pubblica, Energia, Telecomunicazioni, Altre infrastrutture)
 - Costi, disponibilità e fabbisogno in milioni di euro
 - Joinabile con `mit_opere_incompiute_2020` (stesso dominio: CUP, localizzazione)
 

--- a/candidates/silos-infrastrutture/README.md
+++ b/candidates/silos-infrastrutture/README.md
@@ -1,0 +1,32 @@
+# silos-infrastrutture
+
+**SILOS** — Sistema Informativo Legislativo Opere Strategiche (Camera dei Deputati).
+
+Report annuale del Servizio Studi che censisce lo stato di attuazione delle infrastrutture strategiche e prioritarie in Italia.
+
+- **Fonte**: https://dati.camera.it/ocd/dump/silos/PISRapportoCSV2024.zip
+- **Licenza**: CC BY-SA 4.0
+- **Copertura**: 2024 (report annuale, serie storica dal 2004)
+- **Granularità**: singolo intervento con CUP, regione, soggetto competente, stato attuazione
+
+## Domanda civica
+
+Dove sono finite le infrastrutture strategiche? Quali opere sono in ritardo e in quali regioni?
+
+## Shape
+
+- 3.527 righe, 15 colonne
+- 12 sistemi infrastrutturali (Ferrovie, Strade, Sistemi Urbani, Porti, ecc.)
+- Costi, disponibilità e fabbisogno in milioni di euro
+- Joinabile con `mit_opere_incompiute_2020` (stesso dominio: CUP, localizzazione)
+
+## Perché vale la pena
+
+- Unico dataset strutturato sulle opere strategiche in Italia
+- 20 anni di serie storica (report annuali dal 2004)
+- Colonna CUP per join incrociati
+
+## Output minimo atteso
+
+- Dataset pulito e interrogabile via SQL
+- Risposta alla Discussion #286 con dati verificati

--- a/candidates/silos-infrastrutture/dataset.yml
+++ b/candidates/silos-infrastrutture/dataset.yml
@@ -8,18 +8,26 @@ schema_version: 1
 dataset:
   name: "silos_infrastrutture"
   source_id: "dati_camera"
+  # Il file contiene la fotografia al 31/08/2024 ma la serie storica parte dal 2004
   years: [2024]
+  time_coverage:
+    start_year: 2004
+    end_year: 2024
 
 raw:
   extractor:
     type: "unzip_first_csv"
   output_policy: overwrite
   sources:
-    - name: "silos_http_zip"
-      type: "http_file"
+    - name: "silos_download"
+      # Script di download: l'IP di GitHub Actions è bloccato da dati.camera.it.
+      # Il fallback proxy del toolkit (BLOCKED_SOURCE_PROXY) non basta perché la Camera
+      # risponde 200 con HTML invece di 403 — lo script forza il proxy via curl.
+      type: "script"
       args:
-        url: "https://dati.camera.it/ocd/dump/silos/PISRapportoCSV2024.zip"
+        command: "bash scripts/download_silos.sh"
         filename: "PISRapportoCSV2024.zip"
+        output: "PISRapportoCSV2024.zip"
       primary: true
 
 clean:

--- a/candidates/silos-infrastrutture/dataset.yml
+++ b/candidates/silos-infrastrutture/dataset.yml
@@ -1,0 +1,56 @@
+# SILOS — Infrastrutture strategiche e prioritarie (Camera dei Deputati)
+# Fonte: dati.camera.it — CC BY-SA 4.0
+# Report annuale 2024 del Servizio Studi
+
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "silos_infrastrutture"
+  source_id: "dati_camera"
+  years: [2024]
+
+raw:
+  extractor:
+    type: "unzip_first_csv"
+  output_policy: overwrite
+  sources:
+    - name: "silos_http_zip"
+      type: "http_file"
+      args:
+        url: "https://dati.camera.it/ocd/dump/silos/PISRapportoCSV2024.zip"
+        filename: "PISRapportoCSV2024.zip"
+      primary: true
+
+clean:
+  read:
+    delim: ";"
+    encoding: "utf-8"
+    header: true
+    strict_mode: false
+    ignore_errors: true
+    null_padding: true
+    sample_size: -1
+    columns:
+      "Link alla scheda": "VARCHAR"
+      "Progressivo": "VARCHAR"
+      "Livello": "VARCHAR"
+      "Commissariate o PNRR-PNC": "VARCHAR"
+      "Sistema infrastrutturale": "VARCHAR"
+      "Cup": "VARCHAR"
+      "Denominazione": "VARCHAR"
+      "Soggetto competente": "VARCHAR"
+      "Luogo lavori": "VARCHAR"
+      "Stato di attuazione": "VARCHAR"
+      "Ultimazione lavori al 31/08/2024": "VARCHAR"
+      "Costi al 31/08/2024": "VARCHAR"
+      "Disponibilità al 31/08/2024": "VARCHAR"
+      "Fabbisogno al 31/08/2024": "VARCHAR"
+  read_mode: strict
+  required_columns: ["progressivo", "sistema_infrastrutturale", "denominazione"]
+  sql: "sql/clean.sql"
+
+mart:
+  tables:
+    - name: "silos_infrastrutture"
+      sql: "sql/mart.sql"

--- a/candidates/silos-infrastrutture/notes.md
+++ b/candidates/silos-infrastrutture/notes.md
@@ -1,0 +1,14 @@
+## Tecnico
+
+-
+- Granularita rilevata: non_determinato
+
+## Analitico
+
+-
+
+## Cautele
+
+- La serie storica e omogenea su tutti gli anni?
+- Ci sono discontinuita dichiarate dalla fonte?
+- I valori nulli sono zero reale o dato mancante?

--- a/candidates/silos-infrastrutture/notes.md
+++ b/candidates/silos-infrastrutture/notes.md
@@ -1,14 +1,17 @@
 ## Tecnico
 
--
-- Granularita rilevata: non_determinato
-
-## Analitico
-
--
+- Granularità: singolo intervento con CUP, denominazione, localizzazione (luogo_lavori)
+- Formato: CSV in ZIP (estratto con `unzip_first_csv`)
+- Encoding: UTF-8 con BOM, delim `;`, decimali `,` (formato italiano)
+- Anni CSV disponibili su dati.camera.it: 2016, 2018, 2019, 2020, 2021, 2022, 2024
+- Schema drift significativo tra anni: nomi colonna cambiano, colonne aggiunte/rimosse, 2018 senza CUP
+- `read_mode: strict` con colonne VARCHAR esplicite + parsing manuale dei numeri in clean.sql
 
 ## Cautele
 
-- La serie storica e omogenea su tutti gli anni?
-- Ci sono discontinuita dichiarate dalla fonte?
-- I valori nulli sono zero reale o dato mancante?
+- **2023 non disponibile** come CSV — solo PDF del rapporto
+- **Serie storica cross-anno non omogenea**: colonne cambiano nome e struttura ogni anno (Costi al 31/08/2024 vs Costi al 31 maggio 2018 (b), ecc.)
+- **Stato di attuazione non sempre popolato**: ~742 righe su 3.527 hanno stato null (sono nodi aggregati di livello superiore)
+- **Costi nulli** sui lotti costruttivi di dettaglio (livello 6) — i valori sono aggregati al livello superiore
+- **Join con `mit_opere_incompiute_2020`**: possibile via CUP, ma verificare overlap (SILOS ha opere strategiche/prioritarie, MIT ha opere incompiute)
+- **Non tutti gli interventi hanno CUP**: ~40% mancante

--- a/candidates/silos-infrastrutture/scripts/download_silos.sh
+++ b/candidates/silos-infrastrutture/scripts/download_silos.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Download rapporto SILOS (Camera dei Deputati) attraverso il proxy VM.
+# Necessario perché l'IP di GitHub Actions è bloccato da dati.camera.it.
+# Il proxy VM (BLOCKED_SOURCE_PROXY) fa da tramite.
+set -euo pipefail
+
+OUTPUT="${1:-PISRapportoCSV2024.zip}"
+ZIP_URL="https://dati.camera.it/ocd/dump/silos/PISRapportoCSV2024.zip"
+UA="Mozilla/5.0 (compatible; DataCivicLab/1.0; +https://dataciviclab.github.io)"
+PROXY="${BLOCKED_SOURCE_PROXY:-}"
+
+CURL_ARGS=(-sSL --fail --retry 3 --retry-delay 5 -H "User-Agent: $UA")
+
+if [ -n "$PROXY" ]; then
+    CURL_ARGS+=(-x "$PROXY")
+fi
+
+curl "${CURL_ARGS[@]}" "$ZIP_URL" -o "$OUTPUT"
+echo "Scaricato: $OUTPUT ($(wc -c < "$OUTPUT") bytes)" >&2

--- a/candidates/silos-infrastrutture/sql/clean.sql
+++ b/candidates/silos-infrastrutture/sql/clean.sql
@@ -1,0 +1,27 @@
+-- SILOS — Infrastrutture strategiche e prioritarie
+-- Report Camera dei Deputati 2024
+-- Tutte le colonne lette come VARCHAR da all_varchar, con parsing dei numeri in formato italiano
+
+SELECT
+    {year}::INTEGER AS anno,
+    TRIM("Link alla scheda") AS link_scheda,
+    TRY_CAST("Progressivo" AS INTEGER) AS progressivo,
+    TRY_CAST("Livello" AS INTEGER) AS livello,
+    TRIM("Commissariate o PNRR-PNC") AS flag_commissariato_pnrr,
+    TRIM("Sistema infrastrutturale") AS sistema_infrastrutturale,
+    TRIM("Cup") AS cup,
+    TRIM("Denominazione") AS denominazione,
+    TRIM("Soggetto competente") AS soggetto_competente,
+    TRIM("Luogo lavori") AS luogo_lavori,
+    TRIM("Stato di attuazione") AS stato_attuazione,
+    TRY_CAST(NULLIF(TRIM("Ultimazione lavori al 31/08/2024"), '') AS INTEGER) AS anno_ultimazione_previsto,
+    TRY_CAST(
+        REPLACE(REPLACE(NULLIF(TRIM("Costi al 31/08/2024"), ''), '.', ''), ',', '.')
+    AS DOUBLE) AS costi_mln_euro,
+    TRY_CAST(
+        REPLACE(REPLACE(NULLIF(TRIM("Disponibilità al 31/08/2024"), ''), '.', ''), ',', '.')
+    AS DOUBLE) AS disponibilita_mln_euro,
+    TRY_CAST(
+        REPLACE(REPLACE(NULLIF(TRIM("Fabbisogno al 31/08/2024"), ''), '.', ''), ',', '.')
+    AS DOUBLE) AS fabbisogno_mln_euro
+FROM raw_input

--- a/candidates/silos-infrastrutture/sql/mart.sql
+++ b/candidates/silos-infrastrutture/sql/mart.sql
@@ -1,0 +1,45 @@
+-- MART: aggregazioni principali per analisi territoriale e settoriale
+-- Conserva la granularità originale (singola voce/intervento)
+
+SELECT
+    anno,
+    sistema_infrastrutturale,
+    denominazione,
+    soggetto_competente,
+    luogo_lavori,
+    stato_attuazione,
+    anno_ultimazione_previsto,
+    costi_mln_euro,
+    disponibilita_mln_euro,
+    fabbisogno_mln_euro,
+    cup,
+    link_scheda,
+    progressivo,
+    livello,
+    flag_commissariato_pnrr,
+    -- gap finanziario
+    CASE
+        WHEN costi_mln_euro IS NOT NULL AND disponibilita_mln_euro IS NOT NULL
+        THEN costi_mln_euro - disponibilita_mln_euro
+        ELSE NULL
+    END AS gap_finanziario_mln_euro,
+    -- rapporto copertura
+    CASE
+        WHEN costi_mln_euro IS NOT NULL AND costi_mln_euro > 0
+        THEN ROUND(disponibilita_mln_euro / costi_mln_euro * 100, 1)
+        ELSE NULL
+    END AS pct_copertura,
+    -- classificazione macro-stato
+    CASE
+        WHEN stato_attuazione = 'Lavori conclusi' THEN 'concluso'
+        WHEN stato_attuazione IN ('Lavori in corso', 'Opere con esecutore individuato', 'Gara aggiudicata',
+                                   'Gara non aggiudicata', 'Opere con bando di gara per la realizzazione pubblicato')
+            THEN 'in corso'
+        WHEN stato_attuazione IN ('Progettazione preliminare', 'Progettazione definitiva', 'Progettazione esecutiva',
+                                   'Studio di fattibilità')
+            THEN 'progettazione'
+        WHEN stato_attuazione IN ('Contratto rescisso', 'Lavori sospesi', 'Procedimento interrotto')
+            THEN 'bloccato'
+        ELSE 'non indicato'
+    END AS macro_stato
+FROM clean_input


### PR DESCRIPTION
## Intake candidate: silos-infrastrutture

**Fonte**: Camera dei Deputati — dati.camera.it (SILOS)
**Licenza**: CC BY-SA 4.0
**Issue**: closes #374
**Discussion**: dataciviclab#286

### Shape
- **3.527 righe**, 15 colonne
- Copertura: 2024 (report annuale, serie storica dal 2004)
- 13 sistemi infrastrutturali
- Costi, disponibilità e fabbisogno in **milioni di euro** per singola opera
- Joinabile con `mit_opere_incompiute_2020` via CUP o localizzazione

### Pipeline
- RAW → CLEAN → MART: ✅ **passed**
- `type: script` per download attraverso proxy VM (Camera blocca IP GitHub)
- `unzip_first_csv` per estrazione ZIP da script output
- `read_mode: strict` con colonne VARCHAR esplicite + parsing formato italiano
- MART con macro_stato, gap_finanziario, pct_copertura

### Cosa contiene
- Singolo intervento con CUP, denominazione, soggetto competente, regione
- Stato di attuazione (progettazione, in corso, concluso, bloccato)
- Costi totali, disponibilità finanziaria e fabbisogno residuo