### PR TITLE
feat: siope-bilancio-unificato — bilancio consolidato SIOPE

### DIFF
--- a/candidates/siope-bilancio-unificato/README.md
+++ b/candidates/siope-bilancio-unificato/README.md
@@ -1,0 +1,35 @@
+# siope-bilancio-unificato
+
+Bilancio consolidato entrate/uscite di tutti i comparti SIOPE (PRO, REG, SAN, UNI).
+Dato mensile con arricchimento territoriale e classificazione per macro-categoria.
+
+## Fonte
+
+Parquet pubblicato su GCS dal progetto [open-siope](https://github.com/dataciviclab/open-siope),
+che scarica i bulk CSV da [SIOPE](https://www.siope.it) e produce il dataset pulito.
+
+## Copertura
+
+- 2021-2026
+- 16+ comparti: PRO (comuni/province), REG (regioni), SAN (ASL/AO/IRCCS), UNI (università),
+  MON (comunita' montane), CDC (camere di commercio), e altri enti pubblici
+- ~18.000 enti
+- Granularità: mensile (periodo 01..12)
+
+## Colonne principali
+
+| Colonna | Descrizione |
+|---|---|
+| `lato` | entrate / uscite |
+| `codice_comparto` | PRO, REG, SAN, UNI |
+| `anno` | 2021-2026 |
+| `periodo` | 01..12 (mese) |
+| `codice_ente` | codice SIOPE dell'ente |
+| `codice_istat_comune` | codice ISTAT del comune (sede dell'ente) |
+| `codice_provincia` / `provincia` / `regione` | territorio |
+| `importo` | centesimi di euro |
+| `importo_eur` | euro |
+| `is_titolo_9` | true = partite di giro (da escludere dai totali) |
+| `macro_categoria_v2` | entrate: Imposte proprie, Fondi perequativi, ... |
+| `macro_categoria` | uscite: Personale, Acquisto beni, Investimenti, ... |
+| `macro_area` | uscite: Spese correnti, Conto capitale, ... |

--- a/candidates/siope-bilancio-unificato/dataset.yml
+++ b/candidates/siope-bilancio-unificato/dataset.yml
@@ -1,0 +1,103 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "siope_bilancio_unificato"
+  source_id: "siope"
+  years: [2021, 2022, 2023, 2024, 2025, 2026]
+
+raw:
+  sources:
+    - name: "siope_bilancio_unificato_gcs"
+      type: "http_file"
+      args:
+        url: "https://storage.googleapis.com/dataciviclab-mart/siope/siope_cross_comparto/{year}/siope_bilancio_unificato.parquet"
+        filename: "siope_bilancio_unificato_{year}.parquet"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    mode: "latest"
+    header: true
+  required_columns:
+    - lato
+    - codice_comparto
+    - anno
+    - periodo
+    - codice_ente
+    - codice_voce
+    - denominazione_ente
+    - tipo_ente
+    - codice_istat_comune
+    - codice_provincia
+    - provincia
+    - regione
+    - codice_sottocomparto
+    - descrizione_sottocomparto
+    - descrizione_comparto
+    - is_titolo_9
+    - descrizione_codice
+    - has_codgest_match
+    - importo
+    - importo_eur
+  validate:
+    min_rows: 500000
+    primary_key:
+      [
+        "lato",
+        "codice_comparto",
+        "anno",
+        "periodo",
+        "codice_ente",
+        "codice_voce",
+      ]
+    not_null:
+      - lato
+      - codice_comparto
+      - anno
+      - periodo
+      - codice_ente
+      - importo
+
+mart:
+  tables:
+    - name: "siope_bilancio_unificato"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "siope_bilancio_unificato"
+  validate:
+    table_rules:
+      siope_bilancio_unificato:
+        min_rows: 500000
+        required_columns:
+          - lato
+          - codice_comparto
+          - anno
+          - periodo
+          - codice_ente
+          - codice_voce
+          - denominazione_ente
+          - tipo_ente
+          - codice_istat_comune
+          - codice_provincia
+          - provincia
+          - regione
+          - descrizione_comparto
+          - is_titolo_9
+          - descrizione_codice
+          - has_codgest_match
+          - importo
+          - importo_eur
+        primary_key:
+          [
+            "lato",
+            "codice_comparto",
+            "anno",
+            "periodo",
+            "codice_ente",
+            "codice_voce",
+          ]
+
+validation:
+  fail_on_error: true

--- a/candidates/siope-bilancio-unificato/notes.md
+++ b/candidates/siope-bilancio-unificato/notes.md
@@ -1,0 +1,34 @@
+# Note tecniche — siope-bilancio-unificato
+
+## Fonte
+
+Parquet generato da [open-siope](https://github.com/dataciviclab/open-siope),
+pubblicato su GCS pubblico:
+`https://storage.googleapis.com/dataciviclab-mart/siope/siope_cross_comparto/{year}/siope_bilancio_unificato.parquet`
+
+Il dato upstream proviene dai download open di [SIOPE](https://www.siope.it).
+
+## Perimetro
+
+- 2021-2026
+- Entrate + uscite di tutti i comparti SIOPE
+- ~18.000 enti, ~13M righe/anno
+- Granularità mensile (periodo 01..12)
+
+## Join e arricchimento
+
+Tutti i join (territorio, comparto, classificazione voci) sono già stati
+eseguiti a monte in open-siope. Il dato downstream è già arricchito.
+
+## Rischi
+
+- Il path GCS (`dataciviclab-mart/siope/siope_cross_comparto/`) è un contratto
+  con open-siope. Se cambia, il candidate si rompe.
+- I dati SIOPE vengono aggiornati mensilmente dalla fonte. Il candidate va
+  rieseguito periodicamente per avere i dati freschi.
+
+## Decisioni
+
+- Clean e mart sono pass-through: il dato è già pulito a monte.
+- Non ci sono notebook perche' il dataset e' già analitico (si puo' interrogare
+  direttamente via clean-query).

--- a/candidates/siope-bilancio-unificato/sql/clean.sql
+++ b/candidates/siope-bilancio-unificato/sql/clean.sql
@@ -1,0 +1,1 @@
+select * from raw_input;

--- a/candidates/siope-bilancio-unificato/sql/mart.sql
+++ b/candidates/siope-bilancio-unificato/sql/mart.sql
@@ -1,0 +1,1 @@
+select * from clean_input;


### PR DESCRIPTION
## Sintesi

Candidate del bilancio consolidato SIOPE: entrate e uscite mensili di tutti i comparti (PRO, REG, SAN, UNI, MON, CDC, ecc.), ~18.000 enti, 2021-2026. Fonte: parquet pubblicato su GCS da [open-siope](https://github.com/dataciviclab/open-siope).

## Contesto collegato

Prodotto dal progetto open-siope dopo audit, ottimizzazioni e pulizia. Il cross `siope_bilancio_unificato` unifica entrate/uscite in un unico schema con arricchimento territoriale e classificazione voci.

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori (smoke: RAW→CLEAN→MART)
- [x] nessun file dati committato

## Verifica

```bash
python -m toolkit.cli.app run all --config candidates/siope-bilancio-unificato/dataset.yml --year 2025 --sample-rows 1000
```

- [x] `run all` eseguito senza errori (smoke passato)
- [x] Dato upstream (open-siope) testato con pipeline CI completa per 2021-2026

## Note / rischi

- Il candidate legge il parquet da GCS (`gs://dataciviclab-mart/siope/siope_cross_comparto/`). Se il path upstream cambia, il candidate si rompe.
- Il dato è già arricchito a monte (join territoriali fatti in open-siope). Clean e mart sono pass-through.
