### PR TITLE
intake(sbarchi-migranti-italia): candidate #596 — arrivi via mare (onData)

### DIFF
--- a/candidates/sbarchi-migranti-italia/README.md
+++ b/candidates/sbarchi-migranti-italia/README.md
@@ -1,0 +1,22 @@
+# sbarchi-migranti-italia
+
+Arrivi giornalieri di migranti via mare in Italia (2019-2025).
+
+**Fonte**: [ondata/liberiamoli-tutti](https://github.com/ondata/liberiamoli-tutti/tree/main/sbarchi-migranti/dati) — dati estratti da PDF del Ministero dell'Interno.
+**Licenza**: CC-BY 4.0 (onData)
+
+## Domanda guida
+
+Quante persone arrivano via mare in Italia ogni giorno? Come evolve il fenomeno anno per anno?
+
+## Dataset
+
+- **Copertura**: settembre 2019 – settembre 2025 (7 anni)
+- **Granularità**: giornaliera
+- **Righe**: 4.348 (giorni con almeno un arrivo)
+- **Arrivi totali**: ~689.000
+- **Colonne**: 4 (data, valore, note, fonte)
+
+## Stato
+
+`candidate` — run verificato su snapshot 2025 (file unico multi-anno).

--- a/candidates/sbarchi-migranti-italia/dataset.yml
+++ b/candidates/sbarchi-migranti-italia/dataset.yml
@@ -1,0 +1,34 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "sbarchi_migranti_italia"
+  years: [2025]
+  time_coverage:
+    mode: "full_series"
+    start_year: 2019
+    end_year: 2025
+
+raw:
+  sources:
+    - name: "sbarchi_per_giorno"
+      type: "http_file"
+      args:
+        url: "https://raw.githubusercontent.com/ondata/liberiamoli-tutti/main/sbarchi-migranti/dati/sbarchi-per-giorno.csv"
+        filename: "sbarchi-per-giorno.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    delim: ","
+    encoding: "utf-8"
+    header: true
+    trim_whitespace: true
+    mode: all
+  validate: {}
+
+mart:
+  tables:
+    - name: "mart_sbarchi_mensili"
+      sql: "sql/mart_sbarchi.sql"

--- a/candidates/sbarchi-migranti-italia/notebooks/sbarchi_migranti_italia_v0.ipynb
+++ b/candidates/sbarchi-migranti-italia/notebooks/sbarchi_migranti_italia_v0.ipynb
@@ -1,0 +1,309 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# sbarchi_migranti_italia - notebook v0\n",
+    "\n",
+    "Validazione rapida + analisi esplorativa della pipeline **raw \u2192 clean \u2192 mart**.\n",
+    "\n",
+    "- i check tecnici (righe, null, readiness) sono delegati al toolkit\n",
+    "- le SQL sono la fonte di verita: leggile prima di interpretare i numeri\n",
+    "- il notebook serve l'analisi, non sostituisce la validazione della pipeline\n",
+    "- evitare output pesanti o immagini embeddate nel commit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json, subprocess, sys, duckdb, yaml\n",
+    "from pathlib import Path\n",
+    "\n",
+    "SLUG = \"sbarchi_migranti_italia\"\n",
+    "\n",
+    "_start = Path.cwd().resolve()\n",
+    "for probe in [_start, *_start.parents]:\n",
+    "    if (probe / \"dataset.yml\").exists():\n",
+    "        CANDIDATE_DIR = probe\n",
+    "        break\n",
+    "else:\n",
+    "    raise FileNotFoundError(f\"dataset.yml non trovato risalendo da {_start}\")\n",
+    "\n",
+    "CFG_PATH = CANDIDATE_DIR / \"dataset.yml\"\n",
+    "SQL_DIR = CANDIDATE_DIR / \"sql\"\n",
+    "_cfg_raw = yaml.safe_load(CFG_PATH.read_text())\n",
+    "ANNO = _cfg_raw[\"dataset\"][\"years\"][-1]\n",
+    "\n",
+    "def tk(*args: str) -> dict:\n",
+    "    cmd = [\"toolkit\", *args, \"-c\", str(CFG_PATH), \"--json\"]\n",
+    "    r = subprocess.run(cmd, capture_output=True, text=True)\n",
+    "    if r.returncode != 0:\n",
+    "        print(r.stderr, file=sys.stderr)\n",
+    "        r.check_returncode()\n",
+    "    return json.loads(r.stdout) if r.stdout.strip() else {}\n",
+    "\n",
+    "def tk_year(*args: str) -> dict:\n",
+    "    return tk(*args, \"--year\", str(ANNO))\n",
+    "\n",
+    "def tk_schema(layer: str) -> dict:\n",
+    "    cmd = [\"toolkit\", \"inspect\", \"schema\", \"-l\", layer,\n",
+    "           str(CFG_PATH), \"--json\", \"--year\", str(ANNO)]\n",
+    "    r = subprocess.run(cmd, capture_output=True, text=True)\n",
+    "    if r.returncode:\n",
+    "        print(r.stderr, file=sys.stderr)\n",
+    "        return {\"columns\": 0, \"schema\": []}\n",
+    "    return json.loads(r.stdout) if r.stdout.strip() else {}\n",
+    "\n",
+    "def show(df) -> None:\n",
+    "    try:\n",
+    "        display(df)\n",
+    "    except NameError:\n",
+    "        print(df.to_string())\n",
+    "\n",
+    "WORKSPACE_ROOT = CANDIDATE_DIR.parent.parent\n",
+    "def _rel(p: Path) -> str:\n",
+    "    try: return str(p.relative_to(WORKSPACE_ROOT))\n",
+    "    except ValueError: return str(p)\n",
+    "\n",
+    "print(f\"slug: {SLUG}    anno: {ANNO}\")\n",
+    "print(f\"config: {_rel(CFG_PATH)}\")\n",
+    "\n",
+    "paths = tk_year(\"inspect\", \"paths\")\n",
+    "P = paths.get(\"paths\", {})\n",
+    "RAW_DIR = Path(P.get(\"raw\", {}).get(\"dir\", \"\"))\n",
+    "CLEAN_DIR = Path(P.get(\"clean\", {}).get(\"dir\", \"\"))\n",
+    "MART_DIR = Path(P.get(\"mart\", {}).get(\"dir\", \"\"))\n",
+    "print(f\"raw:   {_rel(RAW_DIR)}\")\n",
+    "print(f\"clean: {_rel(CLEAN_DIR)}\")\n",
+    "print(f\"mart:  {_rel(MART_DIR)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-sql",
+   "metadata": {},
+   "source": [
+    "## SQL di riferimento\n",
+    "\n",
+    "Le SQL sono la fonte di verita per capire cosa deve contenere ogni layer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "sql-show",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for sql_file in sorted(SQL_DIR.glob(\"*.sql\")):\n",
+    "    print(f\"{'='*60}\")\n",
+    "    print(f\"  {sql_file.name}\")\n",
+    "    print(f\"{'='*60}\")\n",
+    "    print(sql_file.read_text())\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-gates",
+   "metadata": {},
+   "source": [
+    "## Quality gates\n",
+    "\n",
+    "Riassunto del run e validazione."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "gates",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_info = paths.get(\"latest_run\", {})\n",
+    "print(f\"Ultimo run: {run_info.get('status','?')}  (ID: {run_info.get('run_id','?')})\")\n",
+    "print()\n",
+    "\n",
+    "schema_clean = tk_schema(\"clean\")\n",
+    "cols_clean = schema_clean.get(\"schema\", [])\n",
+    "print(f\"Clean: {schema_clean.get('columns', 0)} colonne\")\n",
+    "for c in cols_clean[:7]:\n",
+    "    print(f\"  {c.get('name','?'):30s} {c.get('type','?')}\")\n",
+    "if len(cols_clean) > 7: print(f\"  ... ({len(cols_clean)} totali)\")\n",
+    "print()\n",
+    "\n",
+    "profiles = paths.get(\"layer_profiles\", {})\n",
+    "clean_prof = profiles.get(\"clean_output\", {})\n",
+    "if clean_prof:\n",
+    "    print(f\"Clean: {clean_prof.get('row_count','?')} righe, {clean_prof.get('columns_count','?')} colonne\")\n",
+    "for tbl in profiles.get(\"mart_tables\", []):\n",
+    "    print(f\"Mart: {tbl.get('row_count','?')} righe ({tbl.get('name','?')})\")\n",
+    "for trans in profiles.get(\"clean_to_mart\", []):\n",
+    "    print(f\"Transizione: {trans.get('source_row_count','?')} -> {trans.get('target_row_count','?')} righe\")\n",
+    "print()\n",
+    "\n",
+    "rh = paths.get(\"raw_hints\", {})\n",
+    "print(f\"Raw: {rh.get('primary_output_file','?')}  |  encoding={rh.get('encoding','?')}  delim={rh.get('delim','?')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-analysis",
+   "metadata": {},
+   "source": [
+    "## Analisi dati\n",
+    "\n",
+    "Caricamento del mart e analisi esplorativa.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "analysis-setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con = duckdb.connect()\n",
+    "\n",
+    "mart_files = list(MART_DIR.glob(\"*.parquet\")) if MART_DIR.exists() else []\n",
+    "for mf in sorted(mart_files):\n",
+    "    table_name = mf.stem\n",
+    "    p = str(mf).replace(\"'\", \"''\")\n",
+    "    con.execute(f\"CREATE OR REPLACE VIEW {table_name} AS SELECT * FROM read_parquet('{p}')\")\n",
+    "    cnt = con.execute(f\"SELECT count(*) FROM {table_name}\").fetchone()[0]\n",
+    "    print(f\"{table_name}: {cnt} righe\")\n",
+    "\n",
+    "if not mart_files:\n",
+    "    print(\"Nessun mart disponibile. Esegui: toolkit run mart\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "analysis-sbarchi",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"=== mart_sbarchi_mensili: ultimi 12 mesi ===\")\n",
+    "df = con.execute(\"\"\"\n",
+    "    SELECT * FROM mart_sbarchi_mensili\n",
+    "    ORDER BY mese DESC LIMIT 12\n",
+    "\"\"\").fetchdf()\n",
+    "show(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "analysis-nulls-profile",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for tbl_name in ['mart_sbarchi_mensili']:\n",
+    "    if tbl_name not in con.execute(\"SELECT table_name FROM information_schema.tables\").fetchdf()['table_name'].values:\n",
+    "        continue\n",
+    "    cols = con.execute(f\"DESCRIBE {tbl_name}\").fetchall()\n",
+    "    exprs = []\n",
+    "    for c in cols[:8]:\n",
+    "        safe = c[0].replace('\"', '\"\"')\n",
+    "        exprs.append(f'round(100.0 * sum(CASE WHEN \"{safe}\" IS NULL THEN 1 ELSE 0 END) / count(*), 2) as \"null_{c[0]}\"')\n",
+    "    if exprs:\n",
+    "        q = f\"SELECT count(*) as tot, {', '.join(exprs)} FROM {tbl_name}\"\n",
+    "        nulls = con.execute(q).fetchdf()\n",
+    "        print(f\"\\n--- {tbl_name} ---\")\n",
+    "        show(nulls)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-boundary",
+   "metadata": {},
+   "source": [
+    "## Boundary e note\n",
+    "\n",
+    "Perimetro, esclusioni, anomalie note."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "boundary",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PERIMETRO = \"Arrivi via mare 2019-2025 (onData)\"\n",
+    "\n",
+    "print(f\"Slug      : {SLUG}\")\n",
+    "print(f\"Anno run  : {ANNO}\")\n",
+    "print(f\"Perimetro : {PERIMETRO}\")\n",
+    "print()\n",
+    "print(\"Note boundary:\")\n",
+    "print(\"  - onData si e' fermato a settembre 2025 (gap 2025-2026)\")\n",
+    "print(\"  - dati estratti da PDF del Ministero dell'Interno\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "header-verdict",
+   "metadata": {},
+   "source": [
+    "## Verdetto\n",
+    "\n",
+    "Riepilogo end-to-end della pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "verdict-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_info = paths.get(\"latest_run\", {})\n",
+    "run_status = run_info.get(\"status\", \"?\")\n",
+    "profiles = paths.get(\"layer_profiles\", {})\n",
+    "clean_p = profiles.get(\"clean_output\", {})\n",
+    "mart_tables = profiles.get(\"mart_tables\", [])\n",
+    "transitions = profiles.get(\"clean_to_mart\", [])\n",
+    "\n",
+    "status_icon = {'SUCCESS': 'OK', 'FAILED': 'FAIL', 'IN_PROGRESS': '...'}.get(run_status, '?')\n",
+    "print(f\"Pipeline  : {status_icon} {run_status}\")\n",
+    "print()\n",
+    "if clean_p:\n",
+    "    print(f\"  Clean: {clean_p.get('row_count', '?'):>8} righe, {clean_p.get('columns_count', '?')} colonne\")\n",
+    "for tbl in mart_tables:\n",
+    "    print(f\"  Mart:  {tbl.get('row_count', '?'):>8} righe ({tbl.get('name', '?')})\")\n",
+    "for t in transitions:\n",
+    "    print(f\"  Transizione: {t.get('source_row_count','?')} -> {t.get('target_row_count','?')} righe\")\n",
+    "print()\n",
+    "print(\"Notebook v0 completato.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/candidates/sbarchi-migranti-italia/notes.md
+++ b/candidates/sbarchi-migranti-italia/notes.md
@@ -1,0 +1,18 @@
+# sbarchi-migranti-italia
+
+## Issue
+DataCivicLab/dataset-incubator#596
+
+## Fonte dati
+Repository GitHub ondata/liberiamoli-tutti → `sbarchi-migranti/dati/`
+https://github.com/ondata/liberiamoli-tutti/tree/main/sbarchi-migranti/dati
+
+## File raw
+- `sbarchi-per-giorno.csv`: arrivi giornalieri (settembre 2019–settembre 2025)
+
+## Encoding
+UTF-8, delimitatore virgola, header presente.
+
+## Note
+I campi Data nel CSV hanno formati misti (YYYY-MM-DD e DD/MM/YYYY).
+TRY_CAST in DuckDB gestisce entrambi automaticamente.

--- a/candidates/sbarchi-migranti-italia/sql/clean.sql
+++ b/candidates/sbarchi-migranti-italia/sql/clean.sql
@@ -1,0 +1,7 @@
+SELECT
+    TRY_CAST(Data AS DATE) AS data_sbarchi,
+    TRY_CAST(Valore AS BIGINT) AS valore,
+    CAST(Note AS VARCHAR) AS note,
+    CAST(Fonte AS VARCHAR) AS fonte
+FROM raw_input
+WHERE TRY_CAST(Valore AS BIGINT) IS NOT NULL

--- a/candidates/sbarchi-migranti-italia/sql/mart_sbarchi.sql
+++ b/candidates/sbarchi-migranti-italia/sql/mart_sbarchi.sql
@@ -1,0 +1,11 @@
+SELECT
+    DATE_TRUNC('month', data_sbarchi) AS mese,
+    COUNT(*) AS giorni_con_sbarchi,
+    SUM(valore) AS tot_sbarchi,
+    AVG(valore) AS media_giornaliera,
+    MAX(valore) AS picco_giornaliero,
+    MIN(valore) AS minimo_giornaliero
+FROM clean_input
+WHERE data_sbarchi IS NOT NULL AND valore IS NOT NULL AND valore > 0
+GROUP BY DATE_TRUNC('month', data_sbarchi)
+ORDER BY mese


### PR DESCRIPTION
nuovo candidate sbarchi-migranti-italia per l'intake #596.

Singola fonte CSV dal progetto onData/liberiamoli-tutti:

sbarchi-per-giorno.csv — arrivi giornalieri via mare (settembre 2019 — settembre 2025)

Pipeline toolkit:
- time_coverage full_series 2019-2025
- clean.sql con TRY_CAST su data e valore (4 colonne)
- Mart: mart_sbarchi_mensili (73 mesi, 6 metriche)
- Notebook v0 con validazione e analisi esplorativa

Run completato con successo: 4.348 righe clean, 73 righe mart.
Quality score: RAW=100, CLEAN=90, MART=95.