### PR TITLE
chore(post-merge): aggiorna registry per PR #618

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-07-03",
+  "updated_at": "2026-07-04",
   "datasets": [
     {
       "slug": "ade_cinque_per_mille",
@@ -10132,6 +10132,56 @@
       "location": {
         "type": "gcs",
         "path": "gs://dataciviclab-clean/terna_capacita_rinnovabile/*/terna_capacita_rinnovabile_*_clean.parquet",
+        "multi_file": true
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "terna_electrical_energy_by_sector",
+      "name": "Terna Electrical Energy By Sector",
+      "description": "",
+      "source": "",
+      "source_id": "terna_opendata",
+      "period": {
+        "start": 2015,
+        "end": 2024
+      },
+      "columns": [
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "regione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "provincia",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "settore",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "consumo_gwh",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/terna_electrical_energy_by_sector/*/terna_electrical_energy_by_sector_*_clean.parquet",
         "multi_file": true
       },
       "stage": "published",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -10139,9 +10139,9 @@
     },
     {
       "slug": "terna_electrical_energy_by_sector",
-      "name": "Terna Electrical Energy By Sector",
-      "description": "",
-      "source": "",
+      "name": "Consumi elettrici per settore e provincia (GWh)",
+      "description": "Consumi di energia elettrica in Italia per settore economico (Domestico, Industria, Servizi, Agricoltura) e provincia. Dati annuali 2015-2024 da TERNA.",
+      "source": "TERNA S.p.A. — Download Center",
       "source_id": "terna_opendata",
       "period": {
         "start": 2015,
@@ -10151,32 +10151,32 @@
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di riferimento"
         },
         {
           "name": "regione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Regione"
         },
         {
           "name": "provincia",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Provincia"
         },
         {
           "name": "settore",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Settore economico: Domestico, Industria, Servizi, Agricoltura"
         },
         {
           "name": "consumo_gwh",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Consumo di energia elettrica in GWh"
         }
       ],
       "location": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-03",
+  "generated_at": "2026-07-04",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 73,
+    "total": 74,
     "by_status": {
-      "ok": 73,
+      "ok": 74,
       "warn": 0,
       "error": 0
     }
@@ -1218,6 +1218,33 @@
           2024
         ],
         "config_path": "candidates/terna-capacita-rinnovabile/dataset.yml"
+      }
+    },
+    {
+      "id": "terna-electrical-energy-by-sector",
+      "source_id": "terna_opendata",
+      "status": "ok",
+      "label": "terna-electrical-energy-by-sector",
+      "detail": "anni 2015-2024 — fonte: terna_electrical_energy_xlsx — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "28709665937",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28709665937",
+        "checked_at": "2026-07-04",
+        "years": [
+          2015,
+          2016,
+          2017,
+          2018,
+          2019,
+          2020,
+          2021,
+          2022,
+          2023,
+          2024
+        ],
+        "config_path": "candidates/terna-electrical-energy-by-sector/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #618 — feat(terna-electrical-energy-by-sector): candidate — consumi elettrici per settore e provincia (GWh)

Changed candidate/support roots:

- `terna-electrical-energy-by-sector` (candidate, `candidates/terna-electrical-energy-by-sector`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/terna-electrical-energy-by-sector/dataset.yml` -> artifact `sample-run-terna-electrical-energy-by-sector`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
