### PR TITLE
candidate(aci-prime-iscrizioni-autovetture): intake #494 — prime iscrizioni autovetture per comune e alimentazione (2017-2024)

### DIFF
--- a/candidates/aci-prime-iscrizioni-autovetture/README.md
+++ b/candidates/aci-prime-iscrizioni-autovetture/README.md
@@ -1,0 +1,18 @@
+# aci-prime-iscrizioni-autovetture
+
+Prime iscrizioni di autovetture nuove in Italia per comune e tipo alimentazione (2017-2024).
+
+**Fonte**: ACI - Automobile Club Italia ([dati.gov.it](https://www.dati.gov.it/))
+**Licenza**: CC-BY 4.0
+
+## Domanda guida
+
+Come sta cambiando il parco auto italiano? Quante auto nuove elettriche/ibride vengono immatricolate ogni anno per comune?
+
+## Dataset
+
+- **Copertura**: 2017-2024 (8 anni)
+- **Granularità**: comunale per tipo alimentazione
+- **Righe**: ~301.000
+- **Colonne**: 6 (anno, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, prime_iscrizioni)
+- **Immatricolazioni totali**: ~53,4 milioni

--- a/candidates/aci-prime-iscrizioni-autovetture/README.md
+++ b/candidates/aci-prime-iscrizioni-autovetture/README.md
@@ -7,12 +7,12 @@ Prime iscrizioni di autovetture nuove in Italia per comune e tipo alimentazione 
 
 ## Domanda guida
 
-Come sta cambiando il parco auto italiano? Quante auto nuove elettriche/ibride vengono immatricolate ogni anno per comune?
+Come sta cambiando il parco auto italiano? Quante auto nuove elettriche/ibride vengono immatricolate ogni anno per comune? La transizione energetica nei trasporti è omogenea sul territorio?
 
 ## Dataset
 
 - **Copertura**: 2017-2024 (8 anni)
 - **Granularità**: comunale per tipo alimentazione
 - **Righe**: ~301.000
-- **Colonne**: 6 (anno, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, prime_iscrizioni)
+- **Colonne**: 5 (anno, comune, provincia, alimentazione, prime_iscrizioni)
 - **Immatricolazioni totali**: ~53,4 milioni

--- a/candidates/aci-prime-iscrizioni-autovetture/dataset.yml
+++ b/candidates/aci-prime-iscrizioni-autovetture/dataset.yml
@@ -1,0 +1,71 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "aci_prime_iscrizioni_autovetture"
+  years: [2024]
+  time_coverage:
+    mode: "full_series"
+    start_year: 2017
+    end_year: 2024
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "aci_2017"
+      type: "http_file"
+      primary: true
+      args:
+        url: "http://lod.aci.it/sites/default/files/Prime_iscrizioni_veicoli_nuovi_nel_2017-autovetture_per_ente_territoriale_e_alimentazione_1.csv"
+        filename: "aci_2017.csv"
+    - name: "aci_2018"
+      type: "http_file"
+      args:
+        url: "http://lod.aci.it/sites/default/files/Prime_iscrizioni_veicoli_nuovi_nel_2018-autovetture_per_ente_territoriale_e_alimentazione%20.csv"
+        filename: "aci_2018.csv"
+    - name: "aci_2019"
+      type: "http_file"
+      args:
+        url: "http://lod.aci.it/sites/default/files/Prime%20iscrizioni%20veicoli%20nuovi%20nel%202019%20-%20autovetture%20per%20ente%20territoriale%20e%20alimentazione.csv"
+        filename: "aci_2019.csv"
+    - name: "aci_2020"
+      type: "http_file"
+      args:
+        url: "http://lod.aci.it/sites/default/files/Prime%20iscrizioni%20veicoli%20nuovi%20nel%202020%20%E2%80%93%20autovetture%20per%20ente%20territoriale%20e%20alimentazione.csv"
+        filename: "aci_2020.csv"
+    - name: "aci_2021"
+      type: "http_file"
+      args:
+        url: "http://lod.aci.it/sites/default/files/Prime%20iscrizioni%20veicoli%20nuovi%20nel%202021%20%E2%80%93%20autovetture%20per%20ente%20territoriale%20e%20alimentazione.csv"
+        filename: "aci_2021.csv"
+    - name: "aci_2022"
+      type: "http_file"
+      args:
+        url: "http://lod.aci.it/sites/default/files/Prime%20iscrizioni%20veicoli%20nuovi%20nel%202022%20%E2%80%93%20autovetture%20per%20ente%20territoriale%20e%20alimentazione.csv"
+        filename: "aci_2022.csv"
+    - name: "aci_2023"
+      type: "http_file"
+      args:
+        url: "http://lod.aci.it/sites/default/files/Prime%20iscrizioni%20veicoli%20nuovi%20nel%202023%20%E2%80%93%20autovetture%20per%20ente%20territoriale%20e%20alimentazione.csv"
+        filename: "aci_2023.csv"
+    - name: "aci_2024"
+      type: "http_file"
+      args:
+        url: "http://lod.aci.it/sites/default/files/statistiche_prime_iscrizioni_2024.csv"
+        filename: "aci_2024.csv"
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: config_only
+    mode: all
+    header: true
+    delim: ","
+    encoding: "utf-8"
+    trim_whitespace: true
+  validate: {}
+
+mart:
+  tables:
+    - name: "mart_anno_alimentazione"
+      sql: "sql/mart.sql"

--- a/candidates/aci-prime-iscrizioni-autovetture/notebooks/aci_prime_iscrizioni_autovetture_v0.ipynb
+++ b/candidates/aci-prime-iscrizioni-autovetture/notebooks/aci_prime_iscrizioni_autovetture_v0.ipynb
@@ -1,0 +1,121 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "\n",
+    "sns.set_theme(style='whitegrid')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+    "source": [
+     "import os\n",
+     "os.chdir('../../..')\n",
+     "\n",
+     "# Carica dati clean\n",
+     "df = pd.read_parquet('out/data/clean/aci_prime_iscrizioni_autovetture/2024/aci_prime_iscrizioni_autovetture_2024_clean.parquet')",
+     "print(f'Righe totali: {len(df)}')"
+    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Colonne:', list(df.columns))\n",
+    "print()\n",
+    "print(df.dtypes)\n",
+    "print()\n",
+    "print('Anni:', sorted(df['anno'].unique()))\n",
+    "print('Alimentazioni:', sorted(df['alimentazione'].unique()))\n",
+    "print('Regioni/province:', df['provincia'].nunique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Totali per anno\n",
+    "annuale = df.groupby('anno')['prime_iscrizioni'].sum()\n",
+    "print(annuale.to_string())\n",
+    "\n",
+    "plt.figure(figsize=(12, 4))\n",
+    "sns.barplot(x=annuale.index, y=annuale.values)\n",
+    "plt.title('Immatricolazioni auto nuove per anno (2017-2024)')\n",
+    "plt.ylabel('Prime iscrizioni')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Per tipo alimentazione\n",
+    "alim = df.groupby(['anno', 'alimentazione'])['prime_iscrizioni'].sum().reset_index()\n",
+    "\n",
+    "plt.figure(figsize=(14, 5))\n",
+    "sns.lineplot(data=alim, x='anno', y='prime_iscrizioni', hue='alimentazione', marker='o')\n",
+    "plt.title('Immatricolazioni per tipo alimentazione (2017-2024)')\n",
+    "plt.ylabel('Prime iscrizioni')\n",
+    "plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Quota elettrico + ibrido sul totale\n",
+    "elettrificato = alim[alim['alimentazione'].str.contains('Elettrica|Ibrido BE|Ibrido GE', na=False)]\n",
+    "elettr_annuale = elettrificato.groupby('anno')['prime_iscrizioni'].sum()\n",
+    "quota = (elettr_annuale / annuale * 100).reset_index()\n",
+    "quota.columns = ['anno', 'quota_perc']\n",
+    "print(quota.to_string(index=False))\n",
+    "\n",
+    "plt.figure(figsize=(10, 4))\n",
+    "sns.lineplot(data=quota, x='anno', y='quota_perc', marker='o')\n",
+    "plt.title('Quota elettrico+ibrido sulle immatricolazioni (%)')\n",
+    "plt.ylabel('%')\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv (3.14.3.final.0)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/candidates/aci-prime-iscrizioni-autovetture/notes.md
+++ b/candidates/aci-prime-iscrizioni-autovetture/notes.md
@@ -7,8 +7,11 @@ DataCivicLab/dataset-incubator#494
 ACI - Automobile Club Italia via dati.gov.it e lod.aci.it
 http://lod.aci.it/
 
-## Schema
+## Schema raw
 5 colonne: tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, primeIscrizioni
+
+## Schema clean
+5 colonne: anno, comune, provincia, alimentazione, prime_iscrizioni (solo Comuni)
 
 ## Note
 - CSV gia' in formato tidy, encoding UTF-8

--- a/candidates/aci-prime-iscrizioni-autovetture/notes.md
+++ b/candidates/aci-prime-iscrizioni-autovetture/notes.md
@@ -1,0 +1,18 @@
+# aci-prime-iscrizioni-autovetture
+
+## Issue
+DataCivicLab/dataset-incubator#494
+
+## Fonte dati
+ACI - Automobile Club Italia via dati.gov.it e lod.aci.it
+http://lod.aci.it/
+
+## Schema
+5 colonne: tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, primeIscrizioni
+
+## Note
+- CSV gia' in formato tidy, encoding UTF-8
+- URL verificati con toolkit scout-url su tutti gli 8 anni
+- 2024 ha nome file diverso (statistiche_prime_iscrizioni_2024.csv)
+- Solo versione "con alimentazione" per v0
+- ~24.000 righe/anno, ~190.000 totali

--- a/candidates/aci-prime-iscrizioni-autovetture/sql/clean.sql
+++ b/candidates/aci-prime-iscrizioni-autovetture/sql/clean.sql
@@ -1,23 +1,34 @@
-SELECT 2017 AS anno, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER) AS prime_iscrizioni
-FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2017.csv')
-UNION ALL
-SELECT 2018, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
-FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2018.csv')
-UNION ALL
-SELECT 2019, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
-FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2019.csv')
-UNION ALL
-SELECT 2020, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
-FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2020.csv')
-UNION ALL
-SELECT 2021, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
-FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2021.csv')
-UNION ALL
-SELECT 2022, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
-FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2022.csv')
-UNION ALL
-SELECT 2023, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
-FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2023.csv')
-UNION ALL
-SELECT 2024, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
-FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2024.csv')
+SELECT anno, comune, provincia, alimentazione, prime_iscrizioni
+FROM (
+  SELECT 2017 AS anno, enteTerritoriale AS comune, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER) AS prime_iscrizioni
+  FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2017.csv')
+  WHERE tipoEnteTerritoriale = 'Comune'
+  UNION ALL
+  SELECT 2018, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
+  FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2018.csv')
+  WHERE tipoEnteTerritoriale = 'Comune'
+  UNION ALL
+  SELECT 2019, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
+  FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2019.csv')
+  WHERE tipoEnteTerritoriale = 'Comune'
+  UNION ALL
+  SELECT 2020, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
+  FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2020.csv')
+  WHERE tipoEnteTerritoriale = 'Comune'
+  UNION ALL
+  SELECT 2021, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
+  FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2021.csv')
+  WHERE tipoEnteTerritoriale = 'Comune'
+  UNION ALL
+  SELECT 2022, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
+  FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2022.csv')
+  WHERE tipoEnteTerritoriale = 'Comune'
+  UNION ALL
+  SELECT 2023, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
+  FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2023.csv')
+  WHERE tipoEnteTerritoriale = 'Comune'
+  UNION ALL
+  SELECT 2024, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
+  FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2024.csv')
+  WHERE tipoEnteTerritoriale = 'Comune'
+)

--- a/candidates/aci-prime-iscrizioni-autovetture/sql/clean.sql
+++ b/candidates/aci-prime-iscrizioni-autovetture/sql/clean.sql
@@ -1,0 +1,23 @@
+SELECT 2017 AS anno, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER) AS prime_iscrizioni
+FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2017.csv')
+UNION ALL
+SELECT 2018, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
+FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2018.csv')
+UNION ALL
+SELECT 2019, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
+FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2019.csv')
+UNION ALL
+SELECT 2020, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
+FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2020.csv')
+UNION ALL
+SELECT 2021, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
+FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2021.csv')
+UNION ALL
+SELECT 2022, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
+FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2022.csv')
+UNION ALL
+SELECT 2023, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
+FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2023.csv')
+UNION ALL
+SELECT 2024, tipoEnteTerritoriale, enteTerritoriale, provincia, alimentazione, TRY_CAST(primeIscrizioni AS INTEGER)
+FROM READ_CSV_AUTO('{root}/data/raw/aci_prime_iscrizioni_autovetture/2024/aci_2024.csv')

--- a/candidates/aci-prime-iscrizioni-autovetture/sql/mart.sql
+++ b/candidates/aci-prime-iscrizioni-autovetture/sql/mart.sql
@@ -1,0 +1,7 @@
+SELECT
+  anno,
+  alimentazione,
+  SUM(prime_iscrizioni) AS prime_iscrizioni
+FROM clean_input
+GROUP BY anno, alimentazione
+ORDER BY anno, alimentazione


### PR DESCRIPTION
Nuovo candidate `aci-prime-iscrizioni-autovetture` per l'intake #494.

Otto fonti HTTP da ACI (lod.aci.it) per le prime iscrizioni di
autovetture nuove nei comuni italiani, per tipo alimentazione,
dal 2017 al 2024.

Schema clean: anno, comune, provincia, alimentazione, prime_iscrizioni
(solo comuni). Singolo mart per anno/alimentazione. Notebook v0 con
validazione e grafici.

Run completato: ~64.000 righe clean.