### PR TITLE
fix(post-merge): usa github.token per PR da fork (LAB_OPS_TOKEN non disponibile)

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Detect changed candidate/support roots
         id: detect
         env:
-          GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           SLUG_INPUT: ${{ inputs.slug }}
         run: |
@@ -226,7 +226,7 @@ jobs:
 
       - name: Create draft registry PR
         env:
-          GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN }}
+          GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN || github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PIPELINE_SIGNALS_CHANGED: ${{ steps.diff.outputs.changed }}
         run: |


### PR DESCRIPTION
## Sintesi

Fix per il workflow `post-merge-candidate.yml` che fallisce quando la PR proviene da un fork. `secrets.LAB_OPS_TOKEN` non è disponibile per PR da fork → `GH_TOKEN` vuoto → `gh pr view` crasha.

## Contesto collegato

Closes # (bug emerso con PR #611 da fork Andreacnt)

## Cosa cambia

- [x] workflow o CI

## Impatto

- [x] Nessun impatto visibile per chi usa il repository

## Verifica

Il workflow ora usa `github.token` nel job `detect` (lettura PR files) e `secrets.LAB_OPS_TOKEN || github.token` in `build-and-pr` (creazione registry PR). `github.token` è sempre disponibile anche per PR da fork.

```yaml
# detect job: lettura PR — github.token basta
GH_TOKEN: ${{ github.token }}

# build-and-pr job: registry PR — LAB_OPS_TOKEN con fallback
GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN || github.token }}
```

## Note / rischi

- `secrets.LAB_OPS_TOKEN` potrebbe essere necessario se in futuro il job `build-and-pr` deve pushare su altri repo. Per ora `github.token` con permessi `contents: write` + `pull-requests: write` è sufficiente.
