### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -433,9 +433,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "28500870772",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28500870772",
-        "checked_at": "2026-07-01",
+        "run_id": "28939377890",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28939377890",
+        "checked_at": "2026-07-08",
         "years": [
           2018,
           2019,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `elezioni-regionali` (candidate, `candidates/elezioni-regionali`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/elezioni-regionali/dataset.yml` -> artifact `sample-run-elezioni-regionali`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
