### PR TITLE
intake: candidate istat_asia_ul (#413)

### DIFF
--- a/candidates/istat-asia-ul/README.md
+++ b/candidates/istat-asia-ul/README.md
@@ -1,0 +1,21 @@
+# ASIA UL — Unità Locali e Addetti delle imprese attive
+
+Fonte: **ISTAT** — Archivo Statistico delle Imprese Attive (ASIA), Unità Locali (UL).
+
+Dataset DBnomics: `ISTAT/183_1163_DF_DICA_ASIAULP_TERRIFDATA_3`
+
+Contiene il numero di **unità locali** (LU) e **addetti** (AENTEMPDAA, media annua) per comune,
+sezione ATECO 2007 e classe di addetti, anni 2018-2020.
+
+## Dimensione territoriale
+
+La versione `_3` del dataset contiene dati a livello comunale (codice ISTAT 6 cifre).
+La versione `_1` (Key data, 2018-2023) contiene solo classi di ampiezza demografica.
+
+## Note
+
+- Anni disponibili: 2018-2020 (dati territoriali completi)
+- Per anni successivi (2021-2023) usare la versione Key data `_1` o attendere il rilascio
+  del dato territoriale completo
+- I codici ATECO sono le sezioni A-S della classificazione ATECO 2007 + 0010 (totale economia)
+- La classe di addetti è TOTAL (totale, senza suddivisione per classe dimensionale)

--- a/candidates/istat-asia-ul/dataset.yml
+++ b/candidates/istat-asia-ul/dataset.yml
@@ -1,0 +1,46 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "istat_asia_ul"
+  source_id: "istat_dbnomics"
+  years: [2020]
+  time_coverage:
+    mode: full_series
+    start_year: 2018
+    end_year: 2020
+
+raw:
+  output_policy: overwrite
+  sources:
+    - type: script
+      args:
+        command: "python preprocess.py {year} raw_input.csv"
+        output: "raw_input.csv"
+        filename: "raw_input.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: "auto"
+    mode: "latest"
+    delim: ","
+    encoding: "utf-8"
+    header: true
+  validate:
+    min_rows: 100000
+
+mart:
+  tables:
+    - name: "mart_asia_ul_comuni"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_asia_ul_comuni"
+  validate:
+    table_rules:
+      mart_asia_ul_comuni:
+        min_rows: 100000
+
+validation:
+  fail_on_error: true

--- a/candidates/istat-asia-ul/notes.md
+++ b/candidates/istat-asia-ul/notes.md
@@ -1,0 +1,23 @@
+# Note tecniche — istat-asia-ul
+
+## SDMX ISTAT (esploradati.istat.it) non raggiungibile
+
+L'API SDMX di ISTAT su esploradati.istat.it non risponde (timeout).
+Usiamo DBnomics come proxy per accedere ai dati ISTAT.
+
+## Dataflow revisioni DBnomics
+
+- `_1` (latest): Key data, REF_AREA = classi ampiezza demografica, anni 2018-2023
+- `_3`: Dati territoriali completi, REF_AREA = comuni (6 cifre), anni 2018-2020
+- `_4`: Solo livello paese (IT), anni 2018-2021
+
+## API limitazioni
+
+- DBnomics API restituisce max 1.000 serie per chiamata
+- Il preprocess usa paginazione con offset per scaricare tutte le serie
+- Limiti di rate non documentati; in caso di errore 429 attendere prima di riprovare
+
+## Dimensioni stimate
+
+- ~40 combinazioni ATECO × DATA_TYPE × circa 7.700 comuni × 3 anni ≈ 925.000 righe
+- ~150-200 chiamate API totali

--- a/candidates/istat-asia-ul/preprocess.py
+++ b/candidates/istat-asia-ul/preprocess.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Scarica Unità Locali ASIA da DBnomics API (parallelo).
+
+Uso: python preprocess.py {year} {output.csv}
+
+Dataset: ISTAT/183_1163_DF_DICA_ASIAULP_TERRIFDATA_3
+Dati a livello comunale, anni 2018-2020.
+"""
+
+import csv
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+DATASET = "ISTAT/183_1163_DF_DICA_ASIAULP_TERRIFDATA_3"
+PAGE_SIZE = 1000
+
+ATECO = [
+    "0010",
+    "B",
+    "C",
+    "D",
+    "E",
+    "F",
+    "G",
+    "H",
+    "I",
+    "J",
+    "K",
+    "L",
+    "M",
+    "N",
+    "P",
+    "Q",
+    "R",
+    "S",
+]
+
+DATA_TYPE = "LU"
+SIZE_CLASS = "TOTAL"
+FREQ = "A"
+
+
+def api_request(data_type: str, ateco: str, offset: int = 0) -> dict:
+    dims = json.dumps(
+        {
+            "FREQ": [FREQ],
+            "PERS_EMPL_SIZE_CLASS": [SIZE_CLASS],
+            "DATA_TYPE": [data_type],
+            "ECON_ACTIVITY_NACE_2007": [ateco],
+        }
+    )
+    params = urllib.parse.urlencode(
+        {
+            "dimensions": dims,
+            "observations": "1",
+            "limit": str(PAGE_SIZE),
+            "offset": str(offset),
+        }
+    )
+    url = f"https://api.db.nomics.world/v22/series/{DATASET}?{params}"
+    req = urllib.request.Request(url)
+    resp = urllib.request.urlopen(req, timeout=120)
+    return json.loads(resp.read())
+
+
+def fetch_ateco(ateco: str) -> list[list]:
+    """Scarica tutte le pagine per un singolo ATECO, restituisce righe."""
+    rows = []
+    try:
+        resp = api_request(DATA_TYPE, ateco, 0)
+    except Exception as e:
+        print(f"  {ateco}: ERR {e}", flush=True)
+        return rows
+
+    num_found = resp["series"]["num_found"]
+    if num_found == 0:
+        return rows
+
+    print(f"  {ateco}: {num_found} series", flush=True)
+    offset = 0
+    while offset < num_found:
+        if offset > 0:
+            try:
+                resp = api_request(DATA_TYPE, ateco, offset)
+            except Exception as e:
+                print(f"    {ateco} offset={offset}: ERR {e}", flush=True)
+                break
+        docs = resp["series"].get("docs", [])
+        for d in docs:
+            dims_info = d.get("dimensions", {})
+            ref_area = dims_info.get("REF_AREA", "")
+            period_list = d.get("period", [])
+            value_list = d.get("value", [])
+            for p, v in zip(period_list, value_list):
+                if v is not None:
+                    rows.append([ref_area, int(p), ateco, float(v)])
+        if len(docs) < PAGE_SIZE:
+            break
+        offset += PAGE_SIZE
+    return rows
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Uso: python preprocess.py <year> <output.csv>", file=sys.stderr)
+        sys.exit(1)
+    output_path = sys.argv[2]
+
+    all_rows = []
+    print("Download ASIA UL (parallelo)...", flush=True)
+    with ThreadPoolExecutor(max_workers=6) as pool:
+        futuri = {pool.submit(fetch_ateco, a): a for a in ATECO}
+        for f in as_completed(futuri):
+            all_rows.extend(f.result())
+
+    if not all_rows:
+        print("ERRORE: nessun dato scaricato", flush=True)
+        sys.exit(1)
+
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["ref_area", "anno", "ateco_sezione", "valore"])
+        w.writerows(all_rows)
+
+    print(f"\nFatto: {len(all_rows)} righe scritte in {output_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/candidates/istat-asia-ul/sql/clean.sql
+++ b/candidates/istat-asia-ul/sql/clean.sql
@@ -1,0 +1,13 @@
+SELECT
+    CAST(ref_area AS VARCHAR(6))            AS codice_comune,
+    CAST(anno AS INTEGER)                   AS anno,
+    CAST(ateco_sezione AS VARCHAR(5))       AS ateco_sezione,
+    CAST(valore AS DOUBLE)                  AS unita_locali
+FROM raw_input
+WHERE
+    LENGTH(ref_area) = 6
+    AND TRY_CAST(ref_area AS INTEGER) IS NOT NULL
+    AND anno IS NOT NULL
+    AND anno BETWEEN 2018 AND 2020
+    AND valore >= 0
+    AND valore IS NOT NULL

--- a/candidates/istat-asia-ul/sql/mart.sql
+++ b/candidates/istat-asia-ul/sql/mart.sql
@@ -1,0 +1,11 @@
+SELECT
+    codice_comune,
+    anno,
+    ateco_sezione,
+    ROUND(unita_locali, 0) AS unita_locali
+FROM clean_input
+WHERE
+    codice_comune IS NOT NULL
+    AND anno IS NOT NULL
+    AND ateco_sezione IS NOT NULL
+    AND unita_locali IS NOT NULL


### PR DESCRIPTION
## Descrizione

Intake del dataset **Unità Locali e Addetti delle imprese attive** (ASIA UL) da ISTAT.

### Fonte
- **DBnomics**: \ISTAT/183_1163_DF_DICA_ASIAULP_TERRIFDATA_3\
- SDMX ISTAT non raggiungibile (timeout), usato DBnomics come proxy
- Dati a livello comunale (codice ISTAT 6 cifre), anni 2018-2020

### Struttura

| File | Descrizione |
|------|-------------|
| \preprocess.py\ | Download via DBnomics API con paginazione |
| \sql/clean.sql\ | Filtra codici ISTAT 6 cifre, valori validi |
| \sql/mart.sql\ | Tabella finale \mart_asia_ul_comuni\ |
| \dataset.yml\ | Configurazione pipeline |
| \README.md\ / \
otes.md\ | Documentazione |

### Note
- Solo indicatori **UL** (unità locali) disponibili a livello comunale nella revisione \_3\
- Addetti (\AENTEMPDAA\) non presenti in \_3\; disponibili solo nella versione Key data (\_1\) aggregata per classe demografica
- Per ATECO: sezioni A (Agricoltura) e O (PA) non hanno unità locali

### TODO
- [x] Preprocess da DBnomics
- [ ] Eseguire download completo (richiede ~150 chiamate API, ~3-5 minuti)
- [ ] Valutare fonte alternativa per addetti a livello comunale

Closes #413