### PR TITLE
intake: candidate elezioni-politiche — Camera+Senato 1948-2022

### DIFF
--- a/candidates/elezioni-politiche/.gitignore
+++ b/candidates/elezioni-politiche/.gitignore
@@ -1,0 +1,2 @@
+cache/
+raw_input.csv

--- a/candidates/elezioni-politiche/README.md
+++ b/candidates/elezioni-politiche/README.md
@@ -1,0 +1,60 @@
+# Elezioni Politiche 1948-2022 — risultati per comune
+
+Risultati delle elezioni politiche (Camera dei Deputati e Senato della Repubblica) a livello comunale per tutte le 19 tornate dal 1948 al 2022.
+
+**38 file ZIP** (19 Camera + 19 Senato) dall'Archivio storico elettorale del DAIT.
+
+## Schema unificato
+
+| Colonna | Tipo | Descrizione |
+|---|---|---|
+| `data_elezione` | DATE | Data del voto |
+| `camera_senato` | VARCHAR | 'C' = Camera, 'S' = Senato |
+| `circoscrizione` | VARCHAR | Circoscrizione elettorale |
+| `provincia` | VARCHAR | Provincia (solo Camera proporzionale/Porcellum e Senato Porcellum) |
+| `comune` | VARCHAR | Denominazione comune |
+| `collegio_plurinominale` | VARCHAR | Collegio plurinominale |
+| `collegio_uninominale` | VARCHAR | Collegio uninominale |
+| `elettori_totali` | BIGINT | Elettori iscritti totali |
+| `elettori_maschi` | BIGINT | Elettori maschi |
+| `votanti_totali` | BIGINT | Votanti totali |
+| `votanti_maschi` | BIGINT | Votanti maschi |
+| `schede_biache` | BIGINT | Schede bianche |
+| `lista` | VARCHAR | Lista o desrizione coalizione |
+| `voti_lista` | BIGINT | Voti alla lista |
+| `desr_lista` | VARCHAR | Desrizione estesa lista (solo Rosatellum) |
+| `onome` | VARCHAR | Cognome candidato uninominale |
+| `nome` | VARCHAR | Nome candidato uninominale |
+| `luogo_nascita` | VARCHAR | Luogo di nascita candidato |
+| `data_nascita` | DATE | Data di nascita candidato |
+| `sesso` | VARCHAR | Sesso candidato ('M'/'F') |
+| `voti_andidato` | BIGINT | Voti al candidato uninominale |
+
+## Epoche elettorali
+
+| Periodo | Sistema | Candidati uninominali | Collegi |
+|---|---|---|---|
+| 1948-1992 | Proporzionale puro | No | No |
+| 1994-2001 | Mattarellum (misto) | Si | Plurinominale + Uninominale |
+| 2006-2013 | Porcellum (proporzionale con premio) | No | No |
+| 2018-2022 | Rosatellum (misto) | Si | Plurinominale + Uninominale |
+
+## Fonte
+
+**Eligendo** — Archivio storico elettorale del DAIT (Ministero dell'Interno)
+URL: https://elezionistorico.interno.gov.it/eligendo/opendata.php
+Licenza: CC BY 4.0
+
+## Issue
+
+DataCivicLab/dataset-incubator#523
+
+## Cross con altri dataset del Lab
+
+| Dataset | Chiave | Domanda |
+|---|---|---|
+| `irpef_comunale` | comune | I comuni ricchi votano diversamente? |
+| `dait_amministratori_locali` | comune | Il colore dell'amministrazione corrisponde al voto? |
+| `popolazione_istat_comunale` | comune | L'astensione è correlata all'età della popolazione? |
+| `ispra_ru_base` | comune | I comuni virtuosi nell'ambiente votano verde? |
+| `consip_consumi_convenzione` | comune | La spesa pubblica correla col voto? |

--- a/candidates/elezioni-politiche/dataset.yml
+++ b/candidates/elezioni-politiche/dataset.yml
@@ -28,6 +28,7 @@ clean:
     delim: ","
     encoding: "utf-8"
     header: true
+    quote: '"'
   validate:
     min_rows: 50000
 

--- a/candidates/elezioni-politiche/dataset.yml
+++ b/candidates/elezioni-politiche/dataset.yml
@@ -1,0 +1,46 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "elezioni_politiche"
+  source_id: "ministero_interno_dait"
+  years: [2022]
+  time_coverage:
+    mode: full_series
+    start_year: 1948
+    end_year: 2022
+
+raw:
+  output_policy: overwrite
+  sources:
+    - type: script
+      args:
+        command: "python preprocess.py {year} raw_input.csv"
+        output: "raw_input.csv"
+        filename: "raw_input.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    mode: latest
+    source: auto
+    delim: ","
+    encoding: "utf-8"
+    header: true
+  validate:
+    min_rows: 50000
+
+mart:
+  tables:
+    - name: "mart_voti_elezioni_politiche"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_voti_elezioni_politiche"
+  validate:
+    table_rules:
+      mart_voti_elezioni_politiche:
+        min_rows: 10000
+
+validation:
+  fail_on_error: true

--- a/candidates/elezioni-politiche/notes.md
+++ b/candidates/elezioni-politiche/notes.md
@@ -1,0 +1,101 @@
+# elezioni-politiche — Note tecniche
+
+## Issue
+DataCivicLab/dataset-incubator#523
+
+## Approccio
+Script source (preprocess.py) invece di per-source http_file.
+
+Motivo: 38 sorgenti ZIP con estrazione e unificazione necessaria.
+Il toolkit processa solo la sorgente primary attraverso clean → mart.
+Con http_file per-source, solo 1 ZIP verrebbe estratto.
+
+preprocess.py scarica tutti i 38 ZIP, estrae i CSV/TXT e produce
+un CSV unico con schema unificato.
+
+## Fonte
+Eligendo — Archivio storico elettorale DAIT (Ministero dell'Interno)
+https://elezionistorico.interno.gov.it/eligendo/opendata.php
+
+## URL pattern ZIP
+Camera:  https://dait.interno.gov.it/documenti/opendata/camera/camera-{YYYYMMDD}.zip
+Senato: https://dait.interno.gov.it/documenti/opendata/senato/senato-{YYYYMMDD}.zip
+
+## 19 tornate (38 ZIP)
+| Anno | Data | Sistema | File interno Camera | File interno Senato |
+|------|------|---------|--------------------|--------------------|
+| 1948 | 18-04 | Proporzionale | camera-19480418.txt | senato-19480418.txt |
+| 1953 | 07-06 | Proporzionale | camera-19530607.txt | senato-19530607.txt |
+| 1958 | 25-05 | Proporzionale | camera-19580525.txt | senato-19580525.txt |
+| 1963 | 28-04 | Proporzionale | camera-19630428.txt | senato-19630428.txt |
+| 1968 | 19-05 | Proporzionale | camera-19680519.txt | senato-19680519.txt |
+| 1972 | 07-05 | Proporzionale | camera-19720507.txt | senato-19720507.txt |
+| 1976 | 20-06 | Proporzionale | camera-19760620.txt | senato-19760620.txt |
+| 1979 | 03-06 | Proporzionale | camera-19790603.txt | senato-19790603.txt |
+| 1983 | 26-06 | Proporzionale | camera-19830626.txt | senato-19830626.txt |
+| 1987 | 14-06 | Proporzionale | camera-19870614.txt | senato-19870614.txt |
+| 1992 | 05-04 | Proporzionale | camera-19920405.txt | senato-19920405.txt |
+| 1994 | 27-03 | Mattarellum | camera-19940327_Proporzionale.txt + Camera_19940327_Uninom_Cand&Contr.txt + Camera_19940327_Uninom_Scrutini.txt | senato-19940327.txt |
+| 1996 | 21-04 | Mattarellum | camera-19960421_Proporzionale.txt + Camera_19960421_Uninom_Cand&Contr.txt + Camera_19960421_Uninom_Scrutini.txt | senato-19960421.txt |
+| 2001 | 13-05 | Mattarellum | camera-20010513_Proporzionale.txt + Camera_20010513_Uninom_Cand&Contr.txt + Camera_20010513_Uninom_Scrutini.txt | senato-20010513.txt |
+| 2006 | 09-04 | Porcellum | camera_italia-20060409.txt | senato_italia-20060409.txt |
+| 2008 | 13-04 | Porcellum | camera_italia-20080413.txt | senato_italia-20080413.txt |
+| 2013 | 24-02 | Porcellum | camera_italia-20130224.txt | senato_italia-20130224.txt |
+| 2018 | 04-03 | Rosatellum | Camera2018_livComune.txt | Senato2018_livComune.txt |
+| 2022 | 25-09 | Rosatellum | camera2022_Italia_LivComune.csv | Senato_Italia_LivComune.csv |
+
+## Schemi verificati (file interni ZIP)
+
+### Camera — Epoca 1 (1948-1992)
+`camera-YYYYMMDD.txt` — 10 colonne:
+CIRCOSCRIZIONE; PROVINCIA; COMUNE; ELETTORI; ELETTORI_MASCHI; VOTANTI; VOTANTI_MASCHI; SCHEDE_BIANCHE; LISTA; VOTI_LISTA
+
+### Camera — Epoca 2 Mattarellum (1994-2001)
+Proporzionale `camera-YYYYMMDD_Proporzionale.txt` — 10 colonne:
+CIRCOSCRIZIONE; COLLEGIO; COMUNE; ELETTORI; ELETTORI_MASCHI; VOTANTI; VOTANTI_MASCHI; SCHEDE_BIANCHE; LISTA; VOTI_LISTA
+
+Uninom candidati `Camera_YYYYMMDD_Uninom_Cand&Contr.txt` — 10 colonne:
+circ; coll; comune; cognome; nome; datanascita; luogonascita; sesso; TOTVOTI; descrcontrass
+
+### Camera — Epoca 3 Porcellum (2006-2013)
+`camera_italia-YYYYMMDD.txt` — stesse 10 colonne epoca 1
+
+### Camera — Epoca 4 Rosatellum (2018)
+`Camera2018_livComune.txt` — 17 colonne:
+CIRCOSCRIZIONE; COLLEGIOPLURINOMINALE; COLLEGIOUNINOMINALE; COMUNE; ELETTORI; ELETTORI_MASCHI; VOTANTI; VOTANTI_MASCHI; SCHEDE_BIANCHE; COGNOME; NOME; DATA_NASCITA; LUOGO_NASCITA; SESSO; VOTI_CANDIDATO; LISTA; VOTI_LISTA
+
+### Camera — Epoca 5 Rosatellum (2022)
+`camera2022_Italia_LivComune.csv` — 19 colonne:
+DATAELEZIONE; CODTIPOELEZIONE; CIRC-REG; COLLPLURI; COLLUNINOM; COMUNE; ELETTORITOT; ELETTORIM; VOTANTITOT; VOTANTIM; SKBIANCHE; VOTILISTA; DESCRLISTA; COGNOME; NOME; LUOGONASCITA; DATANASCITA; SESSO; VOTICANDIDATO
+
+### Senato — Epoca 1 (1948-1992)
+`senato-YYYYMMDD.txt` — 10 colonne:
+REGIONE; COLLEGIO; COMUNE; ELETTORI; ELETTORI_MASCHI; VOTANTI; VOTANTI_MASCHI; SCHEDE_BIANCHE; LISTA; VOTI_LISTA
+
+### Senato — Epoca 2 (1994-2001)
+`senato-YYYYMMDD.txt` — 10 colonne (stessa struttura epoca 1)
+
+### Senato — Epoca 3 Porcellum (2006-2013)
+`senato_italia-YYYYMMDD.txt` — 10 colonne:
+REGIONE; PROVINCIA; COMUNE; ELETTORI_TOTALI; ELETTORI_MASCHI; VOTANTI_TOTALI; VOTANTI_MASCHI; SCHEDE_BIANCHE; LISTA; VOTI_LISTA
+
+### Senato — Epoca 4 Rosatellum (2018)
+`Senato2018_livComune.txt` — 17 colonne:
+REGIONE; COLLEGIOPLURINOMINALE; COLLEGIOUNINOMINALE; COMUNE; ELETTORI; ELETTORI_MASCHI; VOTANTI; VOTANTI_MASCHI; SCHEDE_BIANCHE; COGNOME; NOME; DATA_NASCITA; LUOGO_NASCITA; SESSO; VOTI_CANDIDATO; LISTA; VOTI_LISTA
+
+### Senato — Epoca 5 Rosatellum (2022)
+`Senato_Italia_LivComune.csv` — 19 colonne:
+DATAELEZIONE; CODTIPOELEZIONE; CIRC-REG; COLLPLURI; COLLUNINOM; COMUNE; ELETTORITOT; ELETTORIM; VOTANTITOT; VOTANTIM; SKBIANCHE; VOTILISTA; DESCRLISTA; COGNOME; NOME; LUOGONASCITA; DATANASCITA; SESSO; VOTICANDIDATO
+
+## Note
+- Delimitatore CSV: `;`, encoding UTF-8, header in prima riga
+- Nomi comuni in MAIUSCOLO — normalizzare per join
+- Codice ISTAT non presente — serve lookup table
+- Camera 1994 II turno (19940529) NON disponibile come ZIP → 404
+
+## Cross dataset
+- irpef_comunale (comune) — voto vs reddito
+- dait_amministratori_locali (comune) — colore politico vs voto
+- popolazione_istat_comunale (comune) — astensione vs demografia
+- ispra_ru_base (comune) — voto vs ambiente
+- consip_consumi_convenzione (comune) — voto vs spesa pubblica

--- a/candidates/elezioni-politiche/preprocess.py
+++ b/candidates/elezioni-politiche/preprocess.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Scarica, estrae e unifica risultati elezioni politiche (Camera+Senato 1948-2022)."""
+
+import csv
+import shutil
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+CACHE_DIR = Path(__file__).resolve().parent / "cache"
+HEADER = [
+    "data_elezione",
+    "camera_senato",
+    "circoscrizione",
+    "provincia",
+    "comune",
+    "collegio_plurinominale",
+    "collegio_uninominale",
+    "elettori_totali",
+    "elettori_maschi",
+    "votanti_totali",
+    "votanti_maschi",
+    "schede_biache",
+    "lista",
+    "voti_lista",
+    "descr_lista",
+    "cognome",
+    "nome",
+    "luogo_nascita",
+    "data_nascita",
+    "sesso",
+    "voti_candidato",
+]
+
+ELECTIONS = [
+    (1948, "18-04", "19480418"),
+    (1953, "07-06", "19530607"),
+    (1958, "25-05", "19580525"),
+    (1963, "28-04", "19630428"),
+    (1968, "19-05", "19680519"),
+    (1972, "07-05", "19720507"),
+    (1976, "20-06", "19760620"),
+    (1979, "03-06", "19790603"),
+    (1983, "26-06", "19830626"),
+    (1987, "14-06", "19870614"),
+    (1992, "05-04", "19920405"),
+    (1994, "27-03", "19940327"),
+    (1996, "21-04", "19960421"),
+    (2001, "13-05", "20010513"),
+    (2006, "09-04", "20060409"),
+    (2008, "13-04", "20080413"),
+    (2013, "24-02", "20130224"),
+    (2018, "04-03", "20180304"),
+    (2022, "25-09", "20220925"),
+]
+
+
+def _int(val):
+    if val and val.replace("-", "").strip().isdigit():
+        return int(val)
+    return None
+
+
+def _dload(url, dest):
+    if dest.exists():
+        return
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    curl = shutil.which("curl")
+    if curl:
+        subprocess.run(
+            [curl, "-k", "-sS", "-L", "--max-time", "120", "-o", str(dest), url],
+            check=True,
+            timeout=120,
+        )
+        return
+    import ssl
+    import urllib.request
+
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req, timeout=120, context=ctx) as r:
+        dest.write_bytes(r.read())
+
+
+def _extract(zip_path, out_dir):
+    if not zip_path.exists():
+        return
+    with zipfile.ZipFile(zip_path) as z:
+        for name in z.namelist():
+            if name.lower().endswith((".csv", ".txt")):
+                d = out_dir / Path(name).name
+                if not d.exists():
+                    z.extract(name, out_dir)
+
+
+def _rows(fp, row_fn, de, delim=";", encoding="utf-8"):
+    if not fp.exists():
+        # fallback case-insensitive (es. Camera- vs camera- nel 1987)
+        parent = fp.parent
+        if parent.is_dir():
+            for child in parent.iterdir():
+                if child.name.lower() == fp.name.lower():
+                    fp = child
+                    break
+        if not fp.exists():
+            return []
+    out = []
+    with open(fp, encoding=encoding, errors="replace") as f:
+        for r in csv.DictReader(f, delimiter=delim):
+            r = {k.strip(): v.strip() if v else None for k, v in r.items()}
+            rec = row_fn(r, de)
+            if rec.get("lista") or rec.get("voti_lista") is not None:
+                out.append(rec)
+    return out
+
+
+def _base(de, cs):
+    return {
+        "data_elezione": de,
+        "camera_senato": cs,
+        "circoscrizione": None,
+        "provincia": None,
+        "comune": None,
+        "collegio_plurinominale": None,
+        "collegio_uninominale": None,
+        "elettori_totali": None,
+        "elettori_maschi": None,
+        "votanti_totali": None,
+        "votanti_maschi": None,
+        "schede_biache": None,
+        "lista": None,
+        "voti_lista": None,
+        "descr_lista": None,
+        "cognome": None,
+        "nome": None,
+        "luogo_nascita": None,
+        "data_nascita": None,
+        "sesso": None,
+        "voti_candidato": None,
+    }
+
+
+def r_cam_ep1(row, de):
+    r = _base(de, "C")
+    r.update(
+        circoscrizione=row["CIRCOSCRIZIONE"],
+        provincia=row["PROVINCIA"],
+        comune=row["COMUNE"],
+        elettori_totali=_int(row["ELETTORI"]),
+        elettori_maschi=_int(row["ELETTORI_MASCHI"]),
+        votanti_totali=_int(row["VOTANTI"]),
+        votanti_maschi=_int(row["VOTANTI_MASCHI"]),
+        schede_biache=_int(row["SCHEDE_BIANCHE"]),
+        lista=row["LISTA"],
+        voti_lista=_int(row["VOTI_LISTA"]),
+    )
+    return r
+
+
+def r_cam_porc(row, de):
+    r = _base(de, "C")
+    r.update(
+        circoscrizione=row["CIRCOSCRIZIONE"],
+        provincia=row["PROVINCIA"],
+        comune=row["COMUNE"],
+        elettori_totali=_int(row["ELETTORI"]),
+        elettori_maschi=_int(row["ELETTORI_MASCHI"]),
+        votanti_totali=_int(row["VOTANTI"]),
+        votanti_maschi=_int(row["VOTANTI_MASCHI"]),
+        schede_biache=_int(row["SCHEDE_BIANCHE"]),
+        lista=row["LISTA"],
+        voti_lista=_int(row.get("VOTI_LISTA") or row.get("VOTILISTA")),
+    )
+    return r
+
+
+def r_sen_ep1(row, de):
+    r = _base(de, "S")
+    r.update(
+        circoscrizione=row["REGIONE"],
+        comune=row["COMUNE"],
+        collegio_plurinominale=row["COLLEGIO"],
+        elettori_totali=_int(row["ELETTORI"]),
+        elettori_maschi=_int(row["ELETTORI_MASCHI"]),
+        votanti_totali=_int(row["VOTANTI"]),
+        votanti_maschi=_int(row["VOTANTI_MASCHI"]),
+        schede_biache=_int(row["SCHEDE_BIANCHE"]),
+        lista=row["LISTA"],
+        voti_lista=_int(row["VOTI_LISTA"]),
+    )
+    return r
+
+
+def r_sen_porc(row, de):
+    r = _base(de, "S")
+    r.update(
+        circoscrizione=row["REGIONE"],
+        provincia=row["PROVINCIA"],
+        comune=row["COMUNE"],
+        elettori_totali=_int(row.get("ELETTORI_TOTALI") or row.get("ELETTORI")),
+        elettori_maschi=_int(row["ELETTORI_MASCHI"]),
+        votanti_totali=_int(row.get("VOTANTI_TOTALI") or row.get("VOTANTI")),
+        votanti_maschi=_int(row["VOTANTI_MASCHI"]),
+        schede_biache=_int(row["SCHEDE_BIANCHE"]),
+        lista=row["LISTA"],
+        voti_lista=_int(row["VOTI_LISTA"]),
+    )
+    return r
+
+
+def r_matt_prop(row, de):
+    r = _base(de, "C")
+    r.update(
+        circoscrizione=row["CIRCOSCRIZIONE"],
+        comune=row["COMUNE"],
+        collegio_plurinominale=row["COLLEGIO"],
+        elettori_totali=_int(row["ELETTORI"]),
+        elettori_maschi=_int(row["ELETTORI_MASCHI"]),
+        votanti_totali=_int(row["VOTANTI"]),
+        votanti_maschi=_int(row["VOTANTI_MASCHI"]),
+        schede_biache=_int(row["SCHEDE_BIANCHE"]),
+        lista=row["LISTA"],
+        voti_lista=_int(row["VOTI_LISTA"]),
+    )
+    return r
+
+
+def r_matt_uni(row, de):
+    r = _base(de, "C")
+    r.update(
+        circoscrizione=row["circ"],
+        comune=row["comune"],
+        collegio_plurinominale=row["coll"],
+        lista=row["descrcontrass"],
+        voti_lista=_int(row["TOTVOTI"]),
+        descr_lista=row["descrcontrass"],
+        cognome=row["cognome"],
+        nome=row["nome"],
+        luogo_nascita=row["luogonascita"],
+        data_nascita=row["datanascita"],
+        sesso=row["sesso"],
+        voti_candidato=_int(row["TOTVOTI"]),
+    )
+    return r
+
+
+def r_sen_matt(row, de):
+    r = _base(de, "S")
+    r.update(
+        circoscrizione=row["REGIONE"],
+        comune=row["COMUNE"],
+        collegio_plurinominale=row["COLLEGIO"],
+        elettori_totali=_int(row["ELETTORI"]),
+        elettori_maschi=_int(row["ELETTORI_MASCHI"]),
+        votanti_totali=_int(row["VOTANTI"]),
+        votanti_maschi=_int(row["VOTANTI_MASCHI"]),
+        schede_biache=_int(row["SCHEDE_BIANCHE"]),
+        lista=row["LISTA"],
+        voti_lista=_int(row["VOTI_LISTA"]),
+    )
+    return r
+
+
+def r_ros18(row, de, cs):
+    r = _base(de, cs)
+    r.update(
+        circoscrizione=row.get("CIRCOSCRIZIONE") or row.get("REGIONE"),
+        comune=row["COMUNE"],
+        collegio_plurinominale=row["COLLEGIOPLURINOMINALE"],
+        collegio_uninominale=row["COLLEGIOUNINOMINALE"],
+        elettori_totali=_int(row["ELETTORI"]),
+        elettori_maschi=_int(row["ELETTORI_MASCHI"]),
+        votanti_totali=_int(row["VOTANTI"]),
+        votanti_maschi=_int(row["VOTANTI_MASCHI"]),
+        schede_biache=_int(row["SCHEDE_BIANCHE"]),
+        lista=row["LISTA"],
+        voti_lista=_int(row["VOTI_LISTA"]),
+        cognome=row["COGNOME"],
+        nome=row["NOME"],
+        luogo_nascita=row["LUOGO_NASCITA"],
+        data_nascita=row["DATA_NASCITA"],
+        sesso=row["SESSO"],
+        voti_candidato=_int(row["VOTI_CANDIDATO"]),
+    )
+    return r
+
+
+def r_ros22(row, de, cs):
+    r = _base(de, cs)
+    r.update(
+        circoscrizione=row["CIRC-REG"],
+        comune=row["COMUNE"],
+        collegio_plurinominale=row["COLLPLURI"],
+        collegio_uninominale=row["COLLUNINOM"],
+        elettori_totali=_int(row["ELETTORITOT"]),
+        elettori_maschi=_int(row["ELETTORIM"]),
+        votanti_totali=_int(row["VOTANTITOT"]),
+        votanti_maschi=_int(row["VOTANTIM"]),
+        schede_biache=_int(row["SKBIANCHE"]),
+        lista=row["DESCRLISTA"],
+        voti_lista=_int(row["VOTILISTA"]),
+        descr_lista=row["DESCRLISTA"],
+        cognome=row["COGNOME"],
+        nome=row["NOME"],
+        luogo_nascita=row["LUOGONASCITA"],
+        data_nascita=row["DATANASCITA"],
+        sesso=row["SESSO"],
+        voti_candidato=_int(row["VOTICANDIDATO"]),
+    )
+    return r
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Uso: python preprocess.py <year> <output.csv>", file=sys.stderr)
+        sys.exit(1)
+    output_path = Path(sys.argv[2])
+    tmp = CACHE_DIR / "extracted"
+    tmp.mkdir(parents=True, exist_ok=True)
+    all_rows = []
+
+    for anno, date_str, ymd in ELECTIONS:
+        cz = CACHE_DIR / f"cam-{ymd}.zip"
+        _dload(f"https://dait.interno.gov.it/documenti/opendata/camera/camera-{ymd}.zip", cz)
+        cd = tmp / "cam" / ymd
+        cd.mkdir(parents=True, exist_ok=True)
+        _extract(cz, cd)
+        sz = CACHE_DIR / f"sen-{ymd}.zip"
+        _dload(f"https://dait.interno.gov.it/documenti/opendata/senato/senato-{ymd}.zip", sz)
+        sd = tmp / "sen" / ymd
+        sd.mkdir(parents=True, exist_ok=True)
+        _extract(sz, sd)
+
+        dd, mm = date_str.split("-")
+        de = f"{anno}-{mm}-{dd}"
+        rows = []
+
+        if anno <= 1992:
+            rows += _rows(cd / f"camera-{ymd}.txt", r_cam_ep1, de)
+            rows += _rows(sd / f"senato-{ymd}.txt", r_sen_ep1, de)
+        elif anno <= 2001:
+            rows += _rows(cd / f"camera-{ymd}_Proporzionale.txt", r_matt_prop, de)
+            rows += _rows(cd / f"Camera_{ymd}_Uninom_Cand&Contr.txt", r_matt_uni, de)
+            rows += _rows(sd / f"senato-{ymd}.txt", r_sen_matt, de)
+        elif anno <= 2013:
+            rows += _rows(cd / f"camera_italia-{ymd}.txt", r_cam_porc, de)
+            rows += _rows(sd / f"senato_italia-{ymd}.txt", r_sen_porc, de)
+        elif anno == 2018:
+            rows += _rows(cd / "Camera2018_livComune.txt", lambda r, d: r_ros18(r, d, "C"), de)
+            rows += _rows(sd / "Senato2018_livComune.txt", lambda r, d: r_ros18(r, d, "S"), de)
+        elif anno == 2022:
+            rows += _rows(
+                cd / "camera2022_Italia_LivComune.csv",
+                lambda r, d: r_ros22(r, d, "C"),
+                de,
+                delim=";",
+            )
+            rows += _rows(
+                sd / "Senato_Italia_LivComune.csv", lambda r, d: r_ros22(r, d, "S"), de, delim=";"
+            )
+
+        all_rows += rows
+        print(f"  {anno}: {len(rows)} righe", flush=True)
+
+    if not all_rows:
+        print("ERRORE: nessun dato estratto", file=sys.stderr)
+        sys.exit(1)
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=HEADER)
+        w.writeheader()
+        w.writerows(all_rows)
+    print(f"\nFatto: {len(all_rows)} righe scritte in {output_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/candidates/elezioni-politiche/sql/clean.sql
+++ b/candidates/elezioni-politiche/sql/clean.sql
@@ -1,0 +1,27 @@
+SELECT
+    TRY_CAST(data_elezione AS DATE) AS data_elezione,
+    CAST(camera_senato AS VARCHAR) AS camera_senato,
+    CAST(circoscrizione AS VARCHAR) AS circoscrizione,
+    CAST(provincia AS VARCHAR) AS provincia,
+    CAST(comune AS VARCHAR) AS comune,
+    CAST(collegio_plurinominale AS VARCHAR) AS collegio_plurinominale,
+    CAST(collegio_uninominale AS VARCHAR) AS collegio_uninominale,
+    TRY_CAST(elettori_totali AS BIGINT) AS elettori_totali,
+    TRY_CAST(elettori_maschi AS BIGINT) AS elettori_maschi,
+    TRY_CAST(votanti_totali AS BIGINT) AS votanti_totali,
+    TRY_CAST(votanti_maschi AS BIGINT) AS votanti_maschi,
+    TRY_CAST(schede_biache AS BIGINT) AS schede_biache,
+    CAST(lista AS VARCHAR) AS lista,
+    TRY_CAST(voti_lista AS BIGINT) AS voti_lista,
+    CAST(descr_lista AS VARCHAR) AS descr_lista,
+    CAST(cognome AS VARCHAR) AS cognome,
+    CAST(nome AS VARCHAR) AS nome,
+    CAST(luogo_nascita AS VARCHAR) AS luogo_nascita,
+    CAST(data_nascita AS VARCHAR) AS data_nascita,
+    CAST(sesso AS VARCHAR) AS sesso,
+    TRY_CAST(voti_candidato AS BIGINT) AS voti_candidato
+FROM raw_input
+WHERE
+    TRY_CAST(data_elezione AS DATE) IS NOT NULL
+    AND camera_senato IN ('C', 'S')
+    AND comune IS NOT NULL

--- a/candidates/elezioni-politiche/sql/mart.sql
+++ b/candidates/elezioni-politiche/sql/mart.sql
@@ -1,0 +1,14 @@
+SELECT
+    data_elezione,
+    camera_senato,
+    circoscrizione,
+    comune,
+    lista,
+    SUM(voti_lista) AS tot_voti_lista,
+    MAX(elettori_totali) AS elettori_totali,
+    MAX(votanti_totali) AS votanti_totali,
+    MAX(schede_biache) AS schede_biache
+FROM clean_input
+WHERE voti_lista IS NOT NULL AND voti_lista >= 0
+GROUP BY data_elezione, camera_senato, circoscrizione, comune, lista
+ORDER BY data_elezione, camera_senato, circoscrizione, comune, tot_voti_lista DESC


### PR DESCRIPTION
Candidate **elezioni-politiche**: risultati elezioni politiche a livello comunale (1948-2022).

- **19 tornate** × 2 camere = 38 ZIP da Eligendo DAIT
- **Schema unificato**: data, camera/senato, circoscrizione, comune, elettori/votanti, lista/voti, candidati uninominali
- **Script preprocess.py**: download, estrazione ZIP, parsing per epoca elettorale (proporzionale/Mattarellum/Porcellum/Rosatellum)
- **time_coverage**: full_series 1948-2022