### PR TITLE
intake: candidate mur-immatricolati (#628)

### DIFF
--- a/candidates/mur-immatricolati/.gitignore
+++ b/candidates/mur-immatricolati/.gitignore
@@ -1,0 +1,2 @@
+cache/
+raw_input.csv

--- a/candidates/mur-immatricolati/README.md
+++ b/candidates/mur-immatricolati/README.md
@@ -1,0 +1,22 @@
+# mur-immatricolati
+
+Immatricolati universitari in Italia per classe di laurea e sesso (1998-2025).
+
+**Fonte**: MUR — USTAT ([dati-ustat.mur.gov.it](https://dati-ustat.mur.gov.it/dataset/immatricolati))
+**Licenza**: CC BY 3.0 IT
+
+## Domanda guida
+
+Quanti studenti si iscrivono all'università ogni anno in Italia? Come si distribuiscono tra classi di laurea e generi? Come evolve la domanda di istruzione superiore?
+
+## Dataset
+
+- **Copertura**: 1998–2025 (28 anni accademici)
+- **Granularità**: classe di laurea × sesso
+- **Righe**: 3.233 (clean)
+- **Colonne**: 5 (anno, classe_cod, classe_nome, sesso, immatricolati)
+- **Immatricolati 2025**: ~356.000 (M=158K F=198K)
+
+## Stato
+
+`candidate` — run verificato su source CKAN singola (risorsa più granulare: classe di laurea).

--- a/candidates/mur-immatricolati/dataset.yml
+++ b/candidates/mur-immatricolati/dataset.yml
@@ -13,11 +13,11 @@ dataset:
 raw:
   output_policy: overwrite
   sources:
-    - type: ckan
+    - type: script
       args:
-        portal_url: "https://dati-ustat.mur.gov.it"
-        resource_id: "9bb0cf6d-1d4e-47f3-8ae9-0c665617b158"
-        filename: "input.csv"
+        command: "python preprocess.py {year} raw_input.csv"
+        output: "raw_input.csv"
+        filename: "raw_input.csv"
       primary: true
 
 clean:

--- a/candidates/mur-immatricolati/dataset.yml
+++ b/candidates/mur-immatricolati/dataset.yml
@@ -1,0 +1,46 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "mur_immatricolati"
+  source_id: "mur_ustat"
+  years: [2025]
+  time_coverage:
+    mode: full_series
+    start_year: 1998
+    end_year: 2025
+
+raw:
+  output_policy: overwrite
+  sources:
+    - type: ckan
+      args:
+        portal_url: "https://dati-ustat.mur.gov.it"
+        resource_id: "9bb0cf6d-1d4e-47f3-8ae9-0c665617b158"
+        filename: "input.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    mode: latest
+    source: auto
+    delim: ","
+    encoding: "utf-8"
+    header: true
+  validate:
+    min_rows: 3000
+
+mart:
+  tables:
+    - name: "mart_immatricolati"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_immatricolati"
+  validate:
+    table_rules:
+      mart_immatricolati:
+        min_rows: 500
+
+validation:
+  fail_on_error: true

--- a/candidates/mur-immatricolati/notes.md
+++ b/candidates/mur-immatricolati/notes.md
@@ -1,0 +1,21 @@
+# Note tecniche — mur_immatricolati
+
+## Portale CKAN
+
+- URL base API: `https://dati-ustat.mur.gov.it/api/3/action`
+- Redirect HTTP → HTTPS
+- Dataset contiene 20 risorse (CSV + 1 XLSX informativo)
+- Encoding: latin-1 (ISO-8859-1)
+
+## Perimetro v0
+
+Risorse selezionate:
+- **ateneo**: immatricolati per ateneo, sesso (4.811 righe, 28 anni × ~86 atenei × 2 sessi)
+- **gruppo**: immatricolati per gruppo disciplinare, sesso (840 righe)
+- **classe**: immatricolati per classe di laurea, sesso (3.233 righe)
+
+## Estensioni future
+
+- Aggiungere risorse per: anno di nascita, residenza, tipo diploma, voto
+- Aggiungere risorse internazionali (paese, ateneo, classe)
+- Arricchire atenei con regione/provincia (da COD ateneo → lookup MUR)

--- a/candidates/mur-immatricolati/preprocess.py
+++ b/candidates/mur-immatricolati/preprocess.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Scarica immatricolati MUR via CKAN DataStore API.
+
+Usa lab_connectors.http.HttpClient con proxy esplicito
+(BLOCKED_SOURCE_PROXY) per funzionare da GHA.
+"""
+
+import csv
+import os
+import sys
+from pathlib import Path
+
+from lab_connectors.http import HttpClient
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Uso: python preprocess.py <year> <output.csv>", file=sys.stderr)
+        sys.exit(1)
+
+    output_path = Path(sys.argv[2])
+
+    proxy_url = os.environ.get("BLOCKED_SOURCE_PROXY")
+    proxies = {"http": proxy_url, "https": proxy_url} if proxy_url else None
+    client = HttpClient(timeout=120, max_retries=2)
+
+    # Scarica CSV via DataStore search (dump non disponibile su MUR CKAN)
+    url = (
+        "https://dati-ustat.mur.gov.it/api/3/action/datastore_search"
+        "?resource_id=9bb0cf6d-1d4e-47f3-8ae9-0c665617b158&limit=5000"
+    )
+    print(f"Download {url} ...", flush=True)
+
+    if proxies:
+        print(f"  con proxy {proxy_url}", flush=True)
+
+    result = client.get(url, proxies=proxies)
+    if not result.is_ok or not result.response:
+        print(f"ERRORE download: {result.err}", file=sys.stderr)
+        sys.exit(1)
+
+    # Scrivi output come CSV
+    data = result.response.json()
+    records = data.get("result", {}).get("records", [])
+    if not records:
+        print("ERRORE: nessun record nel risultato", file=sys.stderr)
+        sys.exit(1)
+
+    fieldnames = list(records[0].keys())
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        w.writerows(records)
+
+    print(f"Fatto: {len(records)} righe scritte in {output_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/candidates/mur-immatricolati/scripts/download_mur.sh
+++ b/candidates/mur-immatricolati/scripts/download_mur.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+OUTPUT="${2:-input.csv}"
+CSV_URL="https://dati-ustat.mur.gov.it/dataset/14aeb712-4665-4311-9e90-3e13639e8f50/resource/9bb0cf6d-1d4e-47f3-8ae9-0c665617b158/download/17_immatricolatixclasse.csv"
+UA="Mozilla/5.0 (compatible; DataCivicLab/1.0; +https://dataciviclab.github.io)"
+PROXY="${BLOCKED_SOURCE_PROXY:-http://152.70.15.192:8888}"
+CURL_ARGS=(-sSL --fail --retry 3 --retry-delay 5 --tlsv1.2 -H "User-Agent: $UA")
+[ -n "$PROXY" ] && CURL_ARGS+=(-x "$PROXY")
+curl "${CURL_ARGS[@]}" "$CSV_URL" -o "$OUTPUT"

--- a/candidates/mur-immatricolati/scripts/download_mur.sh
+++ b/candidates/mur-immatricolati/scripts/download_mur.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-OUTPUT="${2:-input.csv}"
-CSV_URL="https://dati-ustat.mur.gov.it/dataset/14aeb712-4665-4311-9e90-3e13639e8f50/resource/9bb0cf6d-1d4e-47f3-8ae9-0c665617b158/download/17_immatricolatixclasse.csv"
-UA="Mozilla/5.0 (compatible; DataCivicLab/1.0; +https://dataciviclab.github.io)"
-PROXY="${BLOCKED_SOURCE_PROXY:-http://152.70.15.192:8888}"
-CURL_ARGS=(-sSL --fail --retry 3 --retry-delay 5 --tlsv1.2 -H "User-Agent: $UA")
-[ -n "$PROXY" ] && CURL_ARGS+=(-x "$PROXY")
-curl "${CURL_ARGS[@]}" "$CSV_URL" -o "$OUTPUT"

--- a/candidates/mur-immatricolati/sql/clean.sql
+++ b/candidates/mur-immatricolati/sql/clean.sql
@@ -9,4 +9,3 @@ WHERE
     TRY_CAST(SUBSTR(AnnoA, 1, 4) AS INTEGER) IS NOT NULL
     AND TRY_CAST(Immatricolati AS INTEGER) IS NOT NULL
     AND Immatricolati >= 0
--- DROP _id: CKAN internal row id, non utile

--- a/candidates/mur-immatricolati/sql/clean.sql
+++ b/candidates/mur-immatricolati/sql/clean.sql
@@ -9,3 +9,4 @@ WHERE
     TRY_CAST(SUBSTR(AnnoA, 1, 4) AS INTEGER) IS NOT NULL
     AND TRY_CAST(Immatricolati AS INTEGER) IS NOT NULL
     AND Immatricolati >= 0
+-- DROP _id: CKAN internal row id, non utile

--- a/candidates/mur-immatricolati/sql/clean.sql
+++ b/candidates/mur-immatricolati/sql/clean.sql
@@ -1,0 +1,11 @@
+SELECT
+    CAST(SUBSTR(AnnoA, 1, 4) AS INTEGER) AS anno,
+    CAST(ClasseNUMERO AS VARCHAR) AS classe_cod,
+    CAST(ClasseNOME AS VARCHAR) AS classe_nome,
+    CAST(Sesso AS VARCHAR) AS sesso,
+    TRY_CAST(Immatricolati AS INTEGER) AS immatricolati
+FROM raw_input
+WHERE
+    TRY_CAST(SUBSTR(AnnoA, 1, 4) AS INTEGER) IS NOT NULL
+    AND TRY_CAST(Immatricolati AS INTEGER) IS NOT NULL
+    AND Immatricolati >= 0

--- a/candidates/mur-immatricolati/sql/mart.sql
+++ b/candidates/mur-immatricolati/sql/mart.sql
@@ -1,0 +1,9 @@
+SELECT
+    anno,
+    classe_cod,
+    classe_nome,
+    sesso,
+    SUM(immatricolati) AS immatricolati
+FROM clean_input
+GROUP BY anno, classe_cod, classe_nome, sesso
+ORDER BY anno, classe_cod, sesso


### PR DESCRIPTION
## Sintesi

Candidate **mur-immatricolati**: immatricolati universitari in Italia per classe di laurea e sesso (1998-2025). Fonte: MUR USTAT via CKAN.

## Contesto collegato

Closes #628

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori su tutti gli anni dichiarati
- [x] nessun file dati committato nella root del candidate
- [x] issue di intake collegata (#628)

## Verifica

```bash
toolkit run all -c candidates/mur-immatricolati/dataset.yml
```

- [x] `run all` eseguito senza errori (3233 righe clean, qs 90/100)

## Note

- Resource CKAN: `9bb0cf6d` (Immatricolati per classe di laurea)
- TLS 1.2 gestito da lab-connectors #67 (appena mergiato)
- La PR sostituisce la vecchia #643 su fork (file vuoti per nostro errore)
