### PR TITLE
chore(post-merge): aggiorna registry per PR #649

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -7187,9 +7187,9 @@
     },
     {
       "slug": "mur_immatricolati",
-      "name": "Mur Immatricolati",
-      "description": "",
-      "source": "",
+      "name": "Immatricolati Universitari",
+      "description": "Immatricolati nelle università italiane per classe di laurea, sesso e anno accademico (1998-2025). Fonte: MUR USTAT.",
+      "source": "MUR — USTAT (Ufficio Statistica e Studi)",
       "source_id": "mur_ustat",
       "period": {
         "start": 1998,
@@ -7199,32 +7199,32 @@
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno accademico normalizzato (es. 2025 per 2025/2026)"
         },
         {
           "name": "classe_cod",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice classe di laurea (es. L-36, LM-56)"
         },
         {
           "name": "classe_nome",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione classe di laurea"
         },
         {
           "name": "sesso",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Sesso (M=maschi, F=femmine)"
         },
         {
           "name": "immatricolati",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero di immatricolati"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-07-13",
+  "updated_at": "2026-07-14",
   "datasets": [
     {
       "slug": "aci_prime_iscrizioni_autovetture",
@@ -7183,6 +7183,56 @@
         "multi_file": true
       },
       "stage": "incubating",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "mur_immatricolati",
+      "name": "Mur Immatricolati",
+      "description": "",
+      "source": "",
+      "source_id": "mur_ustat",
+      "period": {
+        "start": 1998,
+        "end": 2025
+      },
+      "columns": [
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "classe_cod",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "classe_nome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "sesso",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "immatricolati",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/mur_immatricolati/2025/mur_immatricolati_2025_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
       "registry_source": "derive_auto"
     },
     {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-13",
+  "generated_at": "2026-07-14",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 81,
+    "total": 82,
     "by_status": {
-      "ok": 81,
+      "ok": 82,
       "warn": 0,
       "error": 0
     }
@@ -972,6 +972,24 @@
           2024
         ],
         "config_path": "candidates/mur-contribuzione-universitaria/dataset.yml"
+      }
+    },
+    {
+      "id": "mur-immatricolati",
+      "source_id": "mur_ustat",
+      "status": "ok",
+      "label": "mur-immatricolati",
+      "detail": "anno 2025 — fonte: ? — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "29332061786",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/29332061786",
+        "checked_at": "2026-07-14",
+        "years": [
+          2025
+        ],
+        "config_path": "candidates/mur-immatricolati/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #649 — intake: candidate mur-immatricolati (#628)

Changed candidate/support roots:

- `mur-immatricolati` (candidate, `candidates/mur-immatricolati`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/mur-immatricolati/dataset.yml` -> artifact `sample-run-mur-immatricolati`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
