### PR TITLE
intake: candidate mur-iscritti (#629) — via dataciviclab (vars accessibili)

### DIFF
--- a/candidates/mur-iscritti/README.md
+++ b/candidates/mur-iscritti/README.md
@@ -1,0 +1,16 @@
+# MUR — Iscritti Universitari
+
+**Fonte**: Ministero dell'Università e della Ricerca, Ufficio Statistico (USTAT)
+
+**Dataset**: Iscritti per ateneo (2000/01 – 2024/25)
+
+**URL**: http://dati.ustat.miur.it/
+
+**Colonne**: AnnoA, AteneoNOME, AteneoCOD, SESSO, Isc
+
+**Encoding**: latin-1, delimitatore `;`
+
+## Note
+
+- Portale CKAN instabile, accesso via HTTP (non HTTPS). Usato `http_file` con URL CSV diretto.
+- API DataStore spesso restituisce 404 per risorse CSV. Download diretto via HTTPS funziona.

--- a/candidates/mur-iscritti/dataset.yml
+++ b/candidates/mur-iscritti/dataset.yml
@@ -1,0 +1,44 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "mur_iscritti"
+  source_id: "mur_ustat"
+  years: [2025]
+  time_coverage:
+    mode: full_series
+    start_year: 2000
+    end_year: 2025
+
+raw:
+  sources:
+    - type: http_file
+      args:
+        url: "https://dati-ustat.mur.gov.it/dataset/3dd9ca7f-9cc9-4a1a-915c-e569b181dbd5/resource/32d26e28-a0b5-45f3-9152-6072164f3e63/download/02_iscrittixateneo.csv"
+        filename: "input.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    mode: latest
+    source: auto
+    delim: ";"
+    encoding: "latin-1"
+    header: true
+  validate:
+    min_rows: 3000
+
+mart:
+  tables:
+    - name: "mart_iscritti"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_iscritti"
+  validate:
+    table_rules:
+      mart_iscritti:
+        min_rows: 500
+
+validation:
+  fail_on_error: true

--- a/candidates/mur-iscritti/notes.md
+++ b/candidates/mur-iscritti/notes.md
@@ -1,0 +1,25 @@
+# MUR Iscritti — Note Implementative
+
+## Approccio
+
+Stessa strategia di `mur_immatricolati`: `http_file` con URL CSV diretto invece del plugin CKAN.
+
+## Risorsa scelta
+
+`Iscritti per ateneo` — la più semplice e stabile:
+- 25 anni accademici (2000/01 – 2024/25)
+- 4.356 righe
+- Colonne: AnnoA, AteneoNOME, AteneoCOD, SESSO, Isc
+
+## Encoding
+
+Il CSV è in latin-1. Specificato `encoding: "latin-1"` in dataset.yml.
+
+## Altre risorse disponibili
+
+Il CKAN espone 24 risorse per `iscritti`. Tra le più interessanti:
+- `Iscritti per classe` — per classe di laurea (sconsigliato: API DataStore 404)
+- `Iscritti per ateneo e gruppo` — per gruppo disciplinare
+- `Iscritti per corso di studi` — per corso, anni più limitati (2010-2025)
+
+Per v0 si tiene solo `Iscritti per ateneo`. Future espansioni possono aggiungere altre risorse.

--- a/candidates/mur-iscritti/sql/clean.sql
+++ b/candidates/mur-iscritti/sql/clean.sql
@@ -1,0 +1,11 @@
+SELECT
+    CAST(SUBSTR(AnnoA, 1, 4) AS INTEGER) AS anno,
+    CAST(AteneoCOD AS VARCHAR) AS ateneo_cod,
+    CAST(AteneoNOME AS VARCHAR) AS ateneo_nome,
+    CAST(SESSO AS VARCHAR) AS sesso,
+    TRY_CAST(Isc AS INTEGER) AS iscritti
+FROM raw_input
+WHERE
+    TRY_CAST(SUBSTR(AnnoA, 1, 4) AS INTEGER) IS NOT NULL
+    AND TRY_CAST(Isc AS INTEGER) IS NOT NULL
+    AND Isc >= 0

--- a/candidates/mur-iscritti/sql/mart.sql
+++ b/candidates/mur-iscritti/sql/mart.sql
@@ -1,0 +1,9 @@
+SELECT
+    anno,
+    ateneo_cod,
+    ateneo_nome,
+    sesso,
+    SUM(iscritti) AS iscritti
+FROM clean_input
+GROUP BY anno, ateneo_cod, ateneo_nome, sesso
+ORDER BY anno, ateneo_cod, sesso

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # lab-connectors[gcs] per script che usano GCS direttamente (toolkit porta solo [duckdb])
 
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.44.3
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.44.4
 
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # lab-connectors[gcs] per script che usano GCS direttamente (toolkit porta solo [duckdb])
-
+lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
 dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.44.4
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 # lab-connectors[gcs] per script che usano GCS direttamente (toolkit porta solo [duckdb])
-lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git  # da43879  # da43879 — proxy fallback su timeout
 
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.44.1
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.44.3
 
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0


### PR DESCRIPTION
## Sintesi

Candidate **mur-iscritti**: iscritti universitari per ateneo (2000–2025). Fonte: MUR USTAT.

Stessa identica candidate di Andrea (#646) ma su branch dataciviclab per avere accesso a `BLOCKED_SOURCE_PROXY`.

## Cosa cambia

- [x] candidate — nuovo dataset

## Note

- `type: http_file` + toolkit v1.44.4 (curl fallback su timeout + BLOCKED_SOURCE_PROXY)
- Squid proxy sulla VM (sostituisce tinyproxy)
