### PR TITLE
chore(post-merge): aggiorna registry per PR #652

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -7248,6 +7248,56 @@
       "registry_source": "derive_auto"
     },
     {
+      "slug": "mur_iscritti",
+      "name": "Mur Iscritti",
+      "description": "",
+      "source": "",
+      "source_id": "mur_ustat",
+      "period": {
+        "start": 2000,
+        "end": 2025
+      },
+      "columns": [
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "ateneo_cod",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "ateneo_nome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "sesso",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "iscritti",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/mur_iscritti/2025/mur_iscritti_2025_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
       "slug": "opencivitas_fsc_2025_rso",
       "name": "Opencivitas Fsc 2025 Rso",
       "description": "Fondo di Solidarietà Comunale 2022-2025 — 6 componenti FSC per comune RSO con geografia. Multi-anno: 2022-2025.",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -7249,9 +7249,9 @@
     },
     {
       "slug": "mur_iscritti",
-      "name": "Mur Iscritti",
-      "description": "",
-      "source": "",
+      "name": "Iscritti Universitari per Ateneo",
+      "description": "Iscritti nelle università italiane per ateneo, sesso e anno accademico (2000-2025). Fonte: MUR USTAT.",
+      "source": "MUR — USTAT (Ufficio Statistica e Studi)",
       "source_id": "mur_ustat",
       "period": {
         "start": 2000,
@@ -7261,32 +7261,32 @@
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno accademico normalizzato"
         },
         {
           "name": "ateneo_cod",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice identificativo ateneo"
         },
         {
           "name": "ateneo_nome",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione ateneo"
         },
         {
           "name": "sesso",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Sesso (M=maschi, F=femmine)"
         },
         {
           "name": "iscritti",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero iscritti"
         }
       ],
       "location": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -396,24 +396,6 @@
       }
     },
     {
-      "id": "elezioni-politiche-2022",
-      "source_id": "eligendo",
-      "status": "ok",
-      "label": "elezioni-politiche-2022",
-      "detail": "anno 2022 — fonti: camera_livcomune, senato_livcomune — mart: sì",
-      "action": "",
-      "sample_run": {
-        "status": "passed",
-        "run_id": "27900677822",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27900677822",
-        "checked_at": "2026-06-21",
-        "years": [
-          2022
-        ],
-        "config_path": "candidates/elezioni-politiche-2022/dataset.yml"
-      }
-    },
-    {
       "id": "elezioni-referendum",
       "source_id": "eligendo",
       "status": "ok",
@@ -1008,6 +990,24 @@
           2025
         ],
         "config_path": "candidates/mur-immatricolati/dataset.yml"
+      }
+    },
+    {
+      "id": "mur-iscritti",
+      "source_id": "mur_ustat",
+      "status": "ok",
+      "label": "mur-iscritti",
+      "detail": "anno 2025 — fonte: ? — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "29348191635",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/29348191635",
+        "checked_at": "2026-07-14",
+        "years": [
+          2025
+        ],
+        "config_path": "candidates/mur-iscritti/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #652 — intake: candidate mur-iscritti (#629) — via dataciviclab (vars accessibili)

Changed candidate/support roots:

- `mur-iscritti` (candidate, `candidates/mur-iscritti`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/mur-iscritti/dataset.yml` -> artifact `sample-run-mur-iscritti`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
