### PR TITLE
compose: who-is-who-pa — ente, uffici, responsabili, contatti

### DIFF
--- a/compose/who-is-who-pa/README.md
+++ b/compose/who-is-who-pa/README.md
@@ -1,0 +1,59 @@
+# who-is-who-pa
+
+Compose del filone **struttura della PA**. Unisce 3 support dataset in un'unica vista: per ogni unità organizzativa (UO), il contesto dell'ente, il responsabile, i contatti e l'area organizzativa.
+
+## Domanda
+
+Chi è il responsabile di un ufficio specifico nella PA? Quali sono i suoi contatti (email, PEC, telefono)? A che area organizzativa appartiene? Qual è il vertice dell'ente?
+
+## Fonti
+
+| ID | Dataset | Fonte | Output |
+|---|---|---|---|
+| Enti | `support_datasets/ipa-enti` | AgID — IndicePA | Anagrafica enti, categorie, vertici |
+| UO | `support_datasets/ipa-unita-organizzative` | AgID — IndicePA | Uffici, gerarchia, responsabili, contatti |
+| AOO | `support_datasets/ipa-aree-organizzative-omogenee` | AgID — IndicePA | Aree organizzative, protocollo |
+
+## Output
+
+Singolo mart `who_is_who_pa` con **122.470 righe** e **36 colonne**:
+
+| Blocco | Colonne principali |
+|---|---|
+| **Ente** | codice_ipa, denominazione_ente, codice_categoria, tipologia, acronimo |
+| **Vertice ente** | vertice_ente_titolo, vertice_ente_nome, vertice_ente_cognome |
+| **Unità organizzativa** | codice_uni_uo, descrizione_uo, codice_uni_uo_padre |
+| **Responsabile UO** | uo_resp_nome, uo_resp_cognome, uo_resp_email, uo_resp_telefono |
+| **Contatti UO** | uo_mail, uo_tipo_mail (Pec/Altro), uo_mail2 |
+| **Area organizzativa** | denominazione_aoo, aoo_resp_nome, aoo_mail, protocollo_informatico |
+| **Sede** | codice_comune_istat, cap, indirizzo |
+
+## Esempio
+
+```sql
+SELECT denominazione_ente, descrizione_uo,
+       uo_resp_nome, uo_resp_cognome, uo_resp_email, uo_mail, uo_tipo_mail
+FROM who_is_who_pa
+WHERE denominazione_ente = 'Comune di Abbiategrasso'
+ORDER BY descrizione_uo;
+```
+
+Risultato: 7 uffici del comune, con responsabile (nome+cognome), email diretta e PEC istituzionale.
+
+## Esecuzione
+
+```bash
+toolkit run full --config compose/who-is-who-pa/dataset.yml
+```
+
+I parquet upstream sono letti direttamente da GCS via DuckDB `read_parquet()` — nessuna estensione httpfs necessaria.
+
+## Join graph
+
+```
+ipa_enti ──codice_ipa──┐
+                        ├──→ who_is_who_pa
+ipa_unita_org. ────────┘
+       │
+       └──codice_uni_aoo──→ ipa_aree_organizzative_omogenee
+```

--- a/compose/who-is-who-pa/dataset.yml
+++ b/compose/who-is-who-pa/dataset.yml
@@ -1,0 +1,37 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "who_is_who_pa"
+  source_id: "dataciviclab_composite"
+  years: [2026]
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "ipa_enti_ref"
+      type: "http_file"
+      args:
+        url: "https://storage.googleapis.com/dataciviclab-clean/ipa_enti/2026/ipa_enti_2026_clean.parquet"
+        filename: "ipa_enti_ref.parquet"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: "config_only"
+    mode: "latest"
+  validate:
+    min_rows: 100000
+
+mart:
+  tables:
+    - name: "who_is_who_pa"
+      sql: "sql/mart.sql"
+  validate:
+    table_rules:
+      who_is_who_pa:
+        min_rows: 100000
+
+validation:
+  fail_on_error: true

--- a/compose/who-is-who-pa/notes.md
+++ b/compose/who-is-who-pa/notes.md
@@ -1,0 +1,27 @@
+# Note — who-is-who-pa
+
+## Stato tecnico
+
+Compose puro con `read_parquet()` diretto da GCS. DuckDB 1.5.4+ legge `https://storage.googleapis.com/` nativamente. Il raw layer è un placeholder (scarica ipa_enti ma non viene usato nel clean).
+
+## Join verificati
+
+- `uo.codice_ipa → enti.codice_ipa`: 23.530 enti su 23.709 hanno UO (99,2% coverage)
+- `uo.codice_uni_aoo → aoo.codice_uni_aoo`: join parziale (non tutte le UO hanno AOO associata)
+- `uo.codice_uni_uo_padre` → self-join per gerarchia (disponibile ma non espanso nel compose)
+
+## Schema
+
+Tutte le colonne sono VARCHAR (CAST esplicito nei support upstream). Il compose preserva i tipi così come arrivano dai parquet upstream.
+
+## Limiti
+
+- **DAIT non integrato**: il join con `dait_amministratori_locali` (sindaci, assessori) richiede una mappatura tra codice ISTAT (ipa_enti) e codifica DAIT (regione+comune). Il formato dei codici differisce. Soluzione: passare da `comuni_master` come bridge table.
+- **MEF partecipazioni non integrato**: join possibile via denominazione ente o codice fiscale, ma non fa parte del perimetro v0.
+- **Gerarchia non espansa**: il campo `codice_uni_uo_padre` è preservato ma non è applicata una CTE ricorsiva. L'utente può farlo nella propria query.
+- **Uff_eFatturaPA**: ~20k UO sono uffici fittizi per fatturazione elettronica, non corrispondono a uffici reali.
+
+## Policy aggiornamento
+
+Quando i dataset upstream cambiano anno, aggiornare gli URL in `sql/clean.sql`. Il pattern è:
+`https://storage.googleapis.com/dataciviclab-clean/{slug}/{anno}/{slug}_{anno}_clean.parquet`

--- a/compose/who-is-who-pa/sql/clean.sql
+++ b/compose/who-is-who-pa/sql/clean.sql
@@ -1,0 +1,69 @@
+-- Clean: who-is-who-pa
+-- Compose da ipa_enti + ipa_unita_organizzative + ipa_aree_organizzative_omogenee
+-- Ogni riga = un'unità organizzativa con contesto ente e responsabile
+-- DuckDB 1.5.4+ legge https://storage.googleapis.com/ nativamente
+--
+-- TODO: join con dait_amministratori_locali via comuni_master (mappatura codice)
+-- Policy: aggiornare gli URL se cambia l'anno dei dataset upstream
+
+WITH enti AS (
+    SELECT * FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/ipa_enti/2026/ipa_enti_2026_clean.parquet')
+),
+
+uo AS (
+    SELECT * FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/ipa_unita_organizzative/2026/ipa_unita_organizzative_2026_clean.parquet')
+),
+
+aoo AS (
+    SELECT * FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/ipa_aree_organizzative_omogenee/2026/ipa_aree_organizzative_omogenee_2026_clean.parquet')
+)
+
+SELECT
+    -- Ente
+    e.codice_ipa,
+    e.denominazione_ente,
+    e.codice_fiscale_ente,
+    e.codice_categoria,
+    e.tipologia,
+    e.codice_istat,
+    e.acronimo,
+    e.titolo_responsabile AS vertice_ente_titolo,
+    e.nome_responsabile AS vertice_ente_nome,
+    e.cognome_responsabile AS vertice_ente_cognome,
+    e.sito_istituzionale,
+
+    -- UO
+    uo.codice_uni_uo,
+    uo.descrizione_uo,
+    uo.codice_uni_uo_padre,
+    uo.data_istituzione AS uo_data_istituzione,
+    uo.nome_responsabile AS uo_resp_nome,
+    uo.cognome_responsabile AS uo_resp_cognome,
+    uo.mail_responsabile AS uo_resp_email,
+    uo.telefono_responsabile AS uo_resp_telefono,
+    uo.mail1 AS uo_mail,
+    uo.tipo_mail1 AS uo_tipo_mail,
+    uo.mail2 AS uo_mail2,
+    uo.tipo_mail2 AS uo_tipo_mail2,
+
+    -- AOO
+    aoo.codice_uni_aoo,
+    aoo.denominazione_aoo,
+    aoo.nome_responsabile AS aoo_resp_nome,
+    aoo.cognome_responsabile AS aoo_resp_cognome,
+    aoo.mail1 AS aoo_mail,
+    aoo.tipo_mail1 AS aoo_tipo_mail,
+    aoo.protocollo_informatico,
+    aoo.uri_protocollo_informatico,
+
+    -- Sede
+    uo.codice_comune_istat,
+    uo.codice_catastale_comune,
+    uo.cap,
+    uo.indirizzo,
+    e.codice_comune_istat AS ente_codice_comune_istat
+
+FROM uo
+LEFT JOIN enti e ON uo.codice_ipa = e.codice_ipa
+LEFT JOIN aoo ON uo.codice_uni_aoo = aoo.codice_uni_aoo
+ORDER BY e.denominazione_ente, uo.descrizione_uo

--- a/compose/who-is-who-pa/sql/mart.sql
+++ b/compose/who-is-who-pa/sql/mart.sql
@@ -1,0 +1,5 @@
+-- Mart: who-is-who-pa — pass-through
+-- Serve come tabella dimensionale completa per navigazione ente→ufficio→responsabile
+
+SELECT * FROM clean_input
+ORDER BY denominazione_ente, descrizione_uo


### PR DESCRIPTION
## Compose: who-is-who-pa

Unisce `ipa_enti` + `ipa_unita_organizzative` + `ipa_aree_organizzative_omogenee` in un'unica vista: **122.470 righe, 36 colonne**.

Ogni riga ha: ente → ufficio → responsabile (nome, email, telefono) → contatti (PEC) → AOO → sede.

### Cosa contiene

| Blocco | Colonne |
|---|---|
| Ente | codice_ipa, denominazione, categoria, tipologia, vertice |
| Ufficio | descrizione, gerarchia padre, data istituzione |
| Responsabile UO | nome, cognome, email, telefono |
| Contatti | mail (con tipo: Pec/Altro) |
| AOO | denominazione, responsabile, protocollo |
| Sede | comune ISTAT, CAP, indirizzo |

### Esempio d'uso

```sql
SELECT denominazione_ente, descrizione_uo,
       uo_resp_nome, uo_resp_cognome, uo_resp_email, uo_mail
FROM who_is_who_pa
WHERE denominazione_ente = 'Comune di Abbiategrasso';
```

→ 7 uffici, ciascuno con nome del responsabile e contatto diretto.

### Note tecniche

- DuckDB `read_parquet()` diretto da GCS (nessuna estensione)
- Run full verificato: raw ✅ clean ✅ mart ✅
- Join DAIT non incluso (mappatura codice ISTAT da risolvere)

### Issue collegate

- #654 — intake dataset UO + AOO
- PR #655 — merged
- PR #656 — merged (post-merge registry)
