### PR TITLE
chore(post-merge): aggiorna registry per PR #658

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -11469,6 +11469,84 @@
           "type": "DOUBLE",
           "role": "metric",
           "description": "IMU/TASI standard FSC (€)"
+        },
+        {
+          "name": "siope_entrate",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "siope_uscite",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "siope_avanzo",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "siope_personale",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "siope_investimenti",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "siope_imposte_proprie",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "siope_fondi_perequativi",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "dipendenti_totali",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "dipendenti_assunti",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "dipendenti_cessati",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "dipendenti_saldo",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pnrr_progetti",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pnrr_fin_totale",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -11277,7 +11277,7 @@
       "slug": "unified_comuni",
       "name": "Unified Comuni — metriche multi-dominio",
       "description": "Dataset composito che unisce popolazione, redditi IRPEF, rifiuti urbani, consumo suolo e Fondo Solidarietà Comunale per comune italiano. Ogni riga = comune × anno. Fonte: JOIN tra dataset clean del DataCivicLab via comuni_master.",
-      "source": "DataCivicLab — dataset composito",
+      "source": "DataCivICLab — dataset composito (ISTAT, MEF, ISPRA, OpenCivitas)",
       "source_id": "dataciviclab_composite",
       "period": {
         "start": 2026,
@@ -11474,79 +11474,79 @@
           "name": "siope_entrate",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Entrate correnti SIOPE (€)"
         },
         {
           "name": "siope_uscite",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Uscite correnti SIOPE (€)"
         },
         {
           "name": "siope_avanzo",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Avanzo/disavanzo SIOPE entrate - uscite (€)"
         },
         {
           "name": "siope_personale",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Spese per personale SIOPE (€)"
         },
         {
           "name": "siope_investimenti",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Spese per investimenti SIOPE (€)"
         },
         {
           "name": "siope_imposte_proprie",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Entrate da imposte proprie SIOPE (€)"
         },
         {
           "name": "siope_fondi_perequativi",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Entrate da fondi perequativi SIOPE (€)"
         },
         {
           "name": "dipendenti_totali",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Dipendenti PA totali"
         },
         {
           "name": "dipendenti_assunti",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Dipendenti PA assunti nell'anno"
         },
         {
           "name": "dipendenti_cessati",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Dipendenti PA cessati nell'anno"
         },
         {
           "name": "dipendenti_saldo",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Saldo dipendenti PA assunti - cessati"
         },
         {
           "name": "pnrr_progetti",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Numero progetti PNRR"
         },
         {
           "name": "pnrr_fin_totale",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Finanziamento totale PNRR (€)"
         }
       ],
       "location": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1464,24 +1464,6 @@
       }
     },
     {
-      "id": "unified-comuni",
-      "source_id": "dataciviclab_composite",
-      "status": "ok",
-      "label": "unified-comuni",
-      "detail": "anno 2026 — fonte: comuni_master — mart: sì",
-      "action": "",
-      "sample_run": {
-        "status": "passed",
-        "run_id": "27906300471",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27906300471",
-        "checked_at": "2026-06-21",
-        "years": [
-          2026
-        ],
-        "config_path": "candidates/unified-comuni/dataset.yml"
-      }
-    },
-    {
       "id": "bdap-anagrafe-enti",
       "source_id": "openbdap",
       "status": "ok",
@@ -1732,6 +1714,24 @@
       "label": "compose:malasanita-compose",
       "detail": "anno 2022 — fonti: a, c — mart: sì",
       "action": ""
+    },
+    {
+      "id": "compose:unified-comuni",
+      "source_id": "dataciviclab_composite",
+      "status": "ok",
+      "label": "compose:unified-comuni",
+      "detail": "anno 2026 — fonte: ? — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "29422446973",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/29422446973",
+        "checked_at": "2026-07-15",
+        "years": [
+          2026
+        ],
+        "config_path": "compose/unified-comuni/dataset.yml"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #658 — fix(unified-comuni): ripristina CTE SIOPE, dipendenti, PNRR + fix join testuali

Changed candidate/support roots:

- `unified-comuni` (candidate, `candidates/unified-comuni`)
- `unified-comuni` (compose, `compose/unified-comuni`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `compose/unified-comuni/dataset.yml` -> artifact `sample-run-unified-comuni`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
