### PR TITLE
intake: opencivitas-indicatori — 7 ambiti × 7 anni in EAV

### DIFF
--- a/candidates/opencivitas-indicatori/README.md
+++ b/candidates/opencivitas-indicatori/README.md
@@ -11,7 +11,7 @@ Formato EAV (Entity-Attribute-Value) arricchito con geografia e descrizioni.
 | Colonna | Tipo | Note |
 |---|---|---|
 | `username` | VARCHAR | Codice ente Sogei (chiave) |
-| `anno` | INTEGER | 2018, 2019, 2021, 2022 |
+| `anno` | INTEGER | 2015-2022 (escluso 2020) |
 | `ambito` | VARCHAR | Servizio: `amministrazione`, `istruzione`, `polizia_locale`, `rifiuti`, `sociale_asili_nido`, `viabilita_territorio`, `servizi_totali` |
 | `indicatore` | VARCHAR | Nome indicatore (es. `COPERTURA_NID_NEW`) |
 | `valore_num` | DOUBLE | Valore numerico |
@@ -46,6 +46,6 @@ Formato EAV (Entity-Attribute-Value) arricchito con geografia e descrizioni.
 
 ## Qualità
 
-- Drop 10-12%: valori testuali attesi (es. motivi di non valutabilità)
+- Drop 9-14%: valori testuali attesi (descrizioni, codici anomalia)
 - Enti riconosciuti: 99%+
 - Metadati trovati: ~100%

--- a/candidates/opencivitas-indicatori/README.md
+++ b/candidates/opencivitas-indicatori/README.md
@@ -24,10 +24,10 @@ Formato EAV (Entity-Attribute-Value) arricchito con geografia e descrizioni.
 
 ## Copertura
 
-- **4 anni**: 2018, 2019, 2021, 2022
+- **7 anni**: 2015, 2016, 2017, 2018, 2019, 2021, 2022 (2020 assente)
 - **7 ambiti** tematici per anno
 - **~280 indicatori** per anno (media)
-- **10,6M righe** clean
+- **19,4M righe** clean (7 anni)
 - **~90% comuni italiani** coperti (RSO)
 
 ## Support dataset

--- a/candidates/opencivitas-indicatori/README.md
+++ b/candidates/opencivitas-indicatori/README.md
@@ -1,0 +1,51 @@
+# opencivitas-indicatori
+
+**Dataset EAV multi-ambito degli indicatori di performance dei comuni italiani.**
+
+Fonte: [OpenCivitas](https://www.opencivitas.it/) (ANCI/Sogei) — sitemap XML.
+
+## Schema
+
+Formato EAV (Entity-Attribute-Value) arricchito con geografia e descrizioni.
+
+| Colonna | Tipo | Note |
+|---|---|---|
+| `username` | VARCHAR | Codice ente Sogei (chiave) |
+| `anno` | INTEGER | 2018, 2019, 2021, 2022 |
+| `ambito` | VARCHAR | Servizio: `amministrazione`, `istruzione`, `polizia_locale`, `rifiuti`, `sociale_asili_nido`, `viabilita_territorio`, `servizi_totali` |
+| `indicatore` | VARCHAR | Nome indicatore (es. `COPERTURA_NID_NEW`) |
+| `valore_num` | DOUBLE | Valore numerico |
+| `descrizione_indicatore` | VARCHAR | Descrizione leggibile (da glossario) |
+| `tipo_indicatore` | VARCHAR | IND/DET/COD |
+| `denominazione` | VARCHAR | Nome comune |
+| `provincia` | VARCHAR | Codice ISTAT provincia (3 cifre) |
+| `regione` | VARCHAR | Nome regione |
+| `codice_istat` | VARCHAR | Codice ISTAT comune (6 cifre) |
+
+## Copertura
+
+- **4 anni**: 2018, 2019, 2021, 2022
+- **7 ambiti** tematici per anno
+- **~280 indicatori** per anno (media)
+- **10,6M righe** clean
+- **~90% comuni italiani** coperti (RSO)
+
+## Support dataset
+
+| Support | Ruolo |
+|---|---|
+| `opencivitas_fsc_enti_rso` | Anagrafica enti (username → denominazione/regione) |
+| `opencivitas_glossario` | Dizionario indicatori (IND), determinanti (DET), codici (COD) |
+| `comuni_master` | Golden record comuni (codice ISTAT, catastale) |
+
+## Pipeline
+
+1. `preprocess.py {year} raw_input.csv` — scarica 7 ZIP, estrae CSV, unisce in EAV
+2. `sql/clean.sql` — normalizza valori, join enti + glossario
+3. `sql/mart.sql` — arricchisce con comuni_master
+
+## Qualità
+
+- Drop 10-12%: valori testuali attesi (es. motivi di non valutabilità)
+- Enti riconosciuti: 99%+
+- Metadati trovati: ~100%

--- a/candidates/opencivitas-indicatori/dataset.yml
+++ b/candidates/opencivitas-indicatori/dataset.yml
@@ -4,7 +4,7 @@ schema_version: 1
 dataset:
   name: "opencivitas_indicatori"
   source_id: "opencivitas"
-  years: [2018, 2019, 2021, 2022]
+  years: [2015, 2016, 2017, 2018, 2019, 2021, 2022]
 
 support:
   - name: "opencivitas_fsc_enti_rso"
@@ -12,7 +12,7 @@ support:
     years: [2025]
   - name: "opencivitas_glossario"
     config: "../../support_datasets/opencivitas-glossario/dataset.yml"
-  years: [2015, 2016, 2017, 2018, 2019, 2021, 2022]
+    years: [2015, 2016, 2017, 2018, 2019, 2021, 2022]
   - name: "comuni_master"
     config: "../../support_datasets/comuni-master/dataset.yml"
     years: [2026]

--- a/candidates/opencivitas-indicatori/dataset.yml
+++ b/candidates/opencivitas-indicatori/dataset.yml
@@ -1,0 +1,60 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "opencivitas_indicatori"
+  source_id: "opencivitas"
+  years: [2018, 2019, 2021, 2022]
+
+support:
+  - name: "opencivitas_fsc_enti_rso"
+    config: "../../support_datasets/opencivitas-fsc-enti-rso/dataset.yml"
+    years: [2025]
+  - name: "opencivitas_glossario"
+    config: "../../support_datasets/opencivitas-glossario/dataset.yml"
+  years: [2015, 2016, 2017, 2018, 2019, 2021, 2022]
+  - name: "comuni_master"
+    config: "../../support_datasets/comuni-master/dataset.yml"
+    years: [2026]
+
+raw:
+  output_policy: overwrite
+  sources:
+    - type: script
+      args:
+        command: "python preprocess.py {year} raw_input.csv"
+        output: "raw_input.csv"
+        filename: "raw_input.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    mode: latest
+    source: auto
+    delim: ";"
+    encoding: "utf-8"
+    decimal: ","
+    header: true
+  validate:
+    min_rows: 100000
+    not_null:
+      - "username"
+      - "anno"
+      - "ambito"
+      - "indicatore"
+      - "valore_num"
+
+mart:
+  tables:
+    - name: "mart_indicatori"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_indicatori"
+  validate:
+    table_rules:
+      mart_indicatori:
+        min_rows: 100000
+
+validation:
+  fail_on_error: true

--- a/candidates/opencivitas-indicatori/dataset.yml
+++ b/candidates/opencivitas-indicatori/dataset.yml
@@ -55,6 +55,18 @@ mart:
     table_rules:
       mart_indicatori:
         min_rows: 100000
+        required_columns:
+          - "username"
+          - "anno"
+          - "ambito"
+          - "indicatore"
+          - "valore_num"
+          - "codice_istat"
+        not_null:
+          - "username"
+          - "anno"
+          - "ambito"
+          - "indicatore"
 
 validation:
   fail_on_error: true

--- a/candidates/opencivitas-indicatori/notes.md
+++ b/candidates/opencivitas-indicatori/notes.md
@@ -43,7 +43,7 @@ mart.sql
 - Drop 10-12%: valori testuali attesi (descrizioni, codici anomalia)
 - Enti riconosciuti: 99,8%
 - Glossario coperto: ~100%
-- Match ISTAT: 97,9%
+- Match ISTAT: 95-98% (crescente da 2015 a 2022, media ~96,5%)
 - Duplicati: 0 (sulla chiave username+anno+ambito+indicatore)
 
 ## Placeholder toolkit

--- a/candidates/opencivitas-indicatori/notes.md
+++ b/candidates/opencivitas-indicatori/notes.md
@@ -1,0 +1,53 @@
+# opencivitas-indicatori — Note
+
+## Origine
+
+Fonte: [OpenCivitas](https://www.opencivitas.it/) (ANCI/Sogei).
+Dataset pubblicati come ZIP con CSV in formato EAV (USERNAME;Indicatore;Valore;Anomalia;Privacy).
+Catalogo completo via sitemap XML: 271 dataset totali.
+
+## Due ere
+
+- **2009-2013**: formato wide (spesa storica, fabbisogni), chiave = COMUNE_CAT_COD
+- **2015-2022**: formato EAV (indicatori e determinanti), chiave = USERNAME
+
+Questo candidate copre la **seconda era**: 7 ambiti × 7 anni (2015-2022, salto 2020) in formato EAV.
+
+## Pipeline
+
+```
+preprocess.py {year} raw_input.csv
+  → scarica 7 ZIP, estrae CSV, unisce con colonna ambito
+  
+clean.sql
+  → normalizza username, anno, indicatore
+  → converte valore (decimale , → .)
+  → LEFT JOIN enti su username (denominazione, provincia, regione)
+  → LEFT JOIN glossario su (codice_indicatore, anno, ambito)
+  
+mart.sql
+  → LEFT JOIN comuni_master su (denominazione, provincia)
+  → aggiunge codice_istat, codice_catastale
+```
+
+## Support dataset
+
+| Nome | Ruolo | Note |
+|---|---|---|
+| `opencivitas_fsc_enti_rso` | Anagrafica enti | username → denominazione/regione |
+| `opencivitas_glossario` | Dizionario | 3 fogli: IND + DET + COD |
+| `comuni_master` | Golden record | codice_istat, catastale |
+
+## Qualità
+
+- Drop 10-12%: valori testuali attesi (descrizioni, codici anomalia)
+- Enti riconosciuti: 99,8%
+- Glossario coperto: ~100%
+- Match ISTAT: 97,9%
+- Duplicati: 0 (sulla chiave username+anno+ambito+indicatore)
+
+## Placeholder toolkit
+
+- `{root}` → output root (es. `.../dataset-incubator/out`)
+- `{year}` → anno corrente del candidate
+- `{support.*.mart}` → mart del support dataset

--- a/candidates/opencivitas-indicatori/preprocess.py
+++ b/candidates/opencivitas-indicatori/preprocess.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Scarica e unisce i CSV indicatori OpenCivitas per un anno.
+
+Per ogni anno, scarica tutti i file ZIP `{year}_Ind_FC{prefix}{ambito}_{suffix}_csv.zip`
+per i 7 ambiti tematici, estrae i CSV e li unisce in un unico file
+con colonna aggiuntiva 'ambito'.
+
+Usage: python preprocess.py <year> <output.csv>
+"""
+
+import csv
+import os
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+from lab_connectors.http.download import download
+
+
+# Mappa anno → prefisso funzione e suffisso file
+# Il pattern URL: https://docs.opencivitas.it/{year}_Ind_FC{prefix}{ambito}_{suffix}_csv.zip
+YEAR_MAP = {
+    # 2015: URL senza anno, suffisso 2 per tutti
+    2015: {"prefix": "20", "suffix_default": "2", "tot_suffix": "2", "no_year": True},
+    2016: {"prefix": "30", "suffix_default": "1", "tot_suffix": "1"},
+    2017: {"prefix": "40", "suffix_default": "1", "tot_suffix": "1"},
+    2018: {"prefix": "50", "suffix_default": "1", "tot_suffix": "1"},
+    2019: {"prefix": "60", "suffix_default": "1", "tot_suffix": "2"},
+    2021: {"prefix": "70", "suffix_default": "1", "tot_suffix": "1"},
+    2022: {"prefix": "80", "suffix_default": "1", "tot_suffix": "2"},
+}
+
+# Ambiti: sigla_nell_URL → nome_descrittivo
+AMBITI = [
+    ("AMMIN", "amministrazione"),
+    ("ISTRUZ", "istruzione"),
+    ("POLIZIA", "polizia_locale"),
+    ("RIFIUTI", "rifiuti"),
+    ("SOCNID", "sociale_asili_nido"),
+    ("TERRVIAB", "viabilita_territorio"),
+    ("TOT", "servizi_totali"),
+]
+
+BASE_URL = "https://docs.opencivitas.it"
+
+
+def download_and_extract_csv(url, tmp_dir):
+    """Scarica un file ZIP e restituisce il path del CSV estratto."""
+    zip_path = os.path.join(tmp_dir, "temp.zip")
+
+    # Download con lab-connectors (SSL fallback, proxy, retry)
+    try:
+        data = download(url, timeout=60)
+    except RuntimeError:
+        return None  # File non disponibile, skip silenzioso
+
+    try:
+        with open(zip_path, "wb") as f:
+            f.write(data)
+        with zipfile.ZipFile(zip_path) as zf:
+            csv_files = [f for f in zf.namelist() if f.endswith(".csv")]
+            if not csv_files:
+                return None
+            csv_name = csv_files[0]
+            zf.extract(csv_name, tmp_dir)
+            return os.path.join(tmp_dir, csv_name)
+    except Exception:
+        return None
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python preprocess.py <year> <output.csv>", file=sys.stderr)
+        sys.exit(1)
+
+    year = int(sys.argv[1])
+    output_path = Path(sys.argv[2])
+
+    if year not in YEAR_MAP:
+        print(
+            f"ERRORE: anno {year} non configurato. Supportati: {list(YEAR_MAP.keys())}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    prefix = YEAR_MAP[year]["prefix"]
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        all_rows = []
+        downloaded = 0
+
+        for sigla, ambito_nome in AMBITI:
+            # Determina suffisso
+            if sigla == "TOT":
+                suffix = YEAR_MAP[year]["tot_suffix"]
+            else:
+                suffix = YEAR_MAP[year]["suffix_default"]
+
+            if YEAR_MAP[year].get("no_year"):
+                url = f"{BASE_URL}/Ind_FC{prefix}{sigla}_{suffix}_csv.zip"
+            else:
+                url = f"{BASE_URL}/{year}_Ind_FC{prefix}{sigla}_{suffix}_csv.zip"
+
+            csv_path = download_and_extract_csv(url, tmp_dir)
+            if csv_path is None:
+                print(f"  SKIP {sigla} ({ambito_nome}) — non disponibile", flush=True)
+                continue
+
+            # Leggi il CSV (prova UTF-8, fallback Latin-1)
+            def read_csv(path):
+                for enc in ["utf-8-sig", "latin-1", "iso-8859-1"]:
+                    try:
+                        with open(path, encoding=enc) as f:
+                            return list(csv.DictReader(f, delimiter=";"))
+                    except (UnicodeDecodeError, UnicodeError):
+                        continue
+                return []
+
+            rows_data = read_csv(csv_path)
+            if not rows_data:
+                print(f"  SKIP {sigla} — encoding non gestibile", flush=True)
+                continue
+
+            # Verifica header
+            if not {"USERNAME", "Indicatore/Determinante", "Valore"}.issubset(
+                set(rows_data[0].keys())
+            ):
+                print(f"  SKIP {sigla} — colonne inattese: {list(rows_data[0].keys())}", flush=True)
+                continue
+
+            for row in rows_data:
+                username = (row.get("USERNAME") or "").strip()
+                indicatore = (row.get("Indicatore/Determinante") or "").strip()
+                valore_raw = (row.get("Valore") or "").strip()
+
+                if not username or not indicatore:
+                    continue
+
+                all_rows.append(
+                    {
+                        "username": username,
+                        "anno": str(year),
+                        "ambito": ambito_nome,
+                        "indicatore": indicatore,
+                        "valore": valore_raw,
+                    }
+                )
+
+            downloaded += 1
+            print(f"  OK {sigla} ({ambito_nome}) — letto", flush=True)
+
+        if not all_rows:
+            print("ERRORE: nessun dato scaricato", file=sys.stderr)
+            sys.exit(1)
+
+        print(
+            f"Scaricati {downloaded}/{len(AMBITI)} ambiti, {len(all_rows)} righe totali", flush=True
+        )
+
+        if downloaded < 5:
+            print(
+                f"ERRORE: solo {downloaded}/{len(AMBITI)} ambiti scaricati, soglia minima 5",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        # Scrivi output
+        fieldnames = ["username", "anno", "ambito", "indicatore", "valore"]
+        with open(output_path, "w", encoding="utf-8", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter=";")
+            writer.writeheader()
+            writer.writerows(all_rows)
+
+        print(
+            f"Output: {output_path} ({len(all_rows)} righe, {output_path.stat().st_size / 1e6:.1f} MB)",
+            flush=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/candidates/opencivitas-indicatori/preprocess.py
+++ b/candidates/opencivitas-indicatori/preprocess.py
@@ -158,9 +158,9 @@ def main():
             f"Scaricati {downloaded}/{len(AMBITI)} ambiti, {len(all_rows)} righe totali", flush=True
         )
 
-        if downloaded < 5:
+        if downloaded < len(AMBITI):
             print(
-                f"ERRORE: solo {downloaded}/{len(AMBITI)} ambiti scaricati, soglia minima 5",
+                f"ERRORE: solo {downloaded}/{len(AMBITI)} ambiti scaricati, richiesti tutti e {len(AMBITI)}",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/candidates/opencivitas-indicatori/sql/clean.sql
+++ b/candidates/opencivitas-indicatori/sql/clean.sql
@@ -1,0 +1,48 @@
+-- clean.sql — normalizza EAV indicatori + join anagrafica enti + descrizione indicatori
+-- Input: raw_input.csv (da preprocess.py)
+--   username;anno;ambito;indicatore;valore
+-- Output: clean con denominazione, provincia, regione, descrizione_indicatore
+
+with parsed as (
+  select
+    trim(cast("username" as varchar)) as username,
+    try_cast(trim(cast("anno" as varchar)) as integer) as anno,
+    trim(cast("ambito" as varchar)) as ambito,
+    trim(cast("indicatore" as varchar)) as indicatore,
+    try_cast(replace(trim(cast("valore" as varchar)), ',', '.') as double) as valore_num
+  from raw_input
+  where trim(coalesce(cast("username" as varchar), '')) <> ''
+    and trim(coalesce(cast("indicatore" as varchar), '')) <> ''
+),
+enti as (
+  select *
+  from read_parquet('{support.opencivitas_fsc_enti_rso.mart}')
+),
+metadati as (
+  select codice_indicatore, descrizione, tipo, categoria, funzione, anno, ambito
+  from read_parquet('{root}/data/mart/opencivitas_glossario/{year}/mart_metadati.parquet')
+)
+select
+  p.username,
+  p.anno,
+  p.ambito,
+  p.indicatore,
+  p.valore_num,
+  m.descrizione as descrizione_indicatore,
+  m.tipo as tipo_indicatore,
+  m.categoria as categoria_indicatore,
+  m.funzione as funzione_indicatore,
+  e.denominazione,
+  e.provincia,
+  e.regione,
+  e.regione_istat_cod,
+  e.denominazione is not null as join_enti_ok,
+  m.descrizione is not null as join_metadati_ok
+from parsed p
+left join enti e on p.username = e.username
+left join metadati m on p.indicatore = m.codice_indicatore
+                     and p.ambito = m.ambito
+                     and p.anno = m.anno
+where p.anno is not null
+  and p.valore_num is not null
+order by p.anno, p.ambito, e.regione, e.provincia, e.denominazione, p.indicatore

--- a/candidates/opencivitas-indicatori/sql/mart.sql
+++ b/candidates/opencivitas-indicatori/sql/mart.sql
@@ -1,0 +1,18 @@
+-- mart.sql — arricchimento con comuni_master per chiavi standard
+-- Aggiunge codice_istat, codice_catastale dal golden record
+-- NOTA: provincia nel clean è codice ISTAT 3 cifre (es. '015')
+--   il join usa substr(codice_istat, 1, 3) per matchare
+
+with comuni as (
+  select codice_istat, denominazione, codice_catastale, sigla_provincia,
+         substr(codice_istat, 1, 3) as prov_cod
+  from read_parquet('{support.comuni_master.mart}')
+)
+select
+  c.*,
+  cm.codice_istat,
+  cm.codice_catastale
+from clean_input c
+left join comuni cm
+  on upper(cm.denominazione) = upper(c.denominazione)
+  and cm.prov_cod = c.provincia

--- a/support_datasets/opencivitas-glossario/README.md
+++ b/support_datasets/opencivitas-glossario/README.md
@@ -1,0 +1,28 @@
+# opencivitas-glossario
+
+**Dizionario degli indicatori, determinanti e codici OpenCivitas.**
+
+Unisce i 3 fogli dei file XLSX di metadati (`{year}_Metadati_Ind_FC{code}_{n}_xlsx.zip`):
+
+| Tipo | Foglio | Descrizione | Righe/anno |
+|---|---|---|---|
+| IND | Indicatori | Nome, descrizione, tipo, funzione degli indicatori di performance | ~350 |
+| DET | Determinanti | Fattori di contesto (F_*) con descrizione | ~130 |
+| COD | Codici | Decodifica codici anomalia (es. COD_SPS_QUEST) | ~130 |
+
+## Pipeline
+
+```
+preprocess.py {year} raw_input.csv
+  → scarica 7 XLSX, estrae 3 fogli ciascuno, unisce in CSV
+
+clean.sql → pass-through (normalizza)
+
+mart.sql → pass-through (select * from clean_input)
+```
+
+## Anni
+
+2015, 2016, 2017, 2018, 2019, 2021, 2022 — ogni anno produce il suo mart.
+(2020 assente: solo FSC, nessun indicatore pubblicato.)
+Il candidate principale referenzia il mart con `{root}/data/mart/opencivitas_glossario/{year}/mart_metadati.parquet`.

--- a/support_datasets/opencivitas-glossario/dataset.yml
+++ b/support_datasets/opencivitas-glossario/dataset.yml
@@ -1,0 +1,45 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "opencivitas_glossario"
+  source_id: "opencivitas"
+  years: [2015, 2016, 2017, 2018, 2019, 2021, 2022]
+
+raw:
+  output_policy: overwrite
+  sources:
+    - type: script
+      args:
+        command: "python preprocess.py {year} raw_input.csv"
+        output: "raw_input.csv"
+        filename: "raw_input.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    mode: latest
+    source: auto
+    delim: ";"
+    encoding: "utf-8"
+    header: true
+  validate:
+    min_rows: 100
+    not_null:
+      - "codice_indicatore"
+      - "descrizione"
+
+mart:
+  tables:
+    - name: "mart_metadati"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_metadati"
+  validate:
+    table_rules:
+      mart_metadati:
+        min_rows: 100
+
+validation:
+  fail_on_error: true

--- a/support_datasets/opencivitas-glossario/notes.md
+++ b/support_datasets/opencivitas-glossario/notes.md
@@ -1,0 +1,31 @@
+# opencivitas-glossario — Note
+
+## Origine
+
+File XLSX di metadati estratti da OpenCivitas: `{year}_Metadati_Ind_FC{code}_{n}_xlsx.zip`.
+Ogni file contiene 3 fogli: Indicatori, Determinanti, Codici.
+
+## Pipeline
+
+```
+preprocess.py {year} raw_input.csv
+  → download 7 XLSX (uno per ambito)
+  → estrae 3 fogli da ciascuno
+  → unisce in CSV unico con colonne: codice_indicatore, descrizione, tipo, categoria, funzione, ordine, anno, ambito
+
+clean.sql → pass-through (normalizza trim/cast)
+
+mart.sql → pass-through (select * from clean_input)
+```
+
+## Anni
+
+7 anni: 2015, 2016, 2017, 2018, 2019, 2021, 2022.
+(2020 assente: nessun indicatore pubblicato.)
+
+## Note
+
+- 2015: URL senza anno e suffisso 2 (es. `Metadati_Ind_FC20AMMIN_2_xlsx.zip`)
+- 2016-2022: URL standard con anno e suffisso 1
+- I determinanti (DET) e i codici (COD) variano per anno
+- Il candidate referenzia il mart via `{root}/data/mart/opencivitas_glossario/{year}/mart_metadati.parquet`

--- a/support_datasets/opencivitas-glossario/preprocess.py
+++ b/support_datasets/opencivitas-glossario/preprocess.py
@@ -198,6 +198,13 @@ def main():
             print("ERRORE: nessun metadato scaricato", file=sys.stderr)
             sys.exit(1)
 
+        if total_downloaded < len(AMBITI):
+            print(
+                f"ERRORE: solo {total_downloaded}/{len(AMBITI)} ambiti scaricati, richiesti tutti e {len(AMBITI)}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
         fieldnames = [
             "codice_indicatore",
             "descrizione",

--- a/support_datasets/opencivitas-glossario/preprocess.py
+++ b/support_datasets/opencivitas-glossario/preprocess.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Scarica e unisce i metadati degli indicatori OpenCivitas per un anno.
+
+Per ogni anno, scarica i file XLSX di metadati per tutti gli ambiti,
+legge i fogli 'Indicatori', 'Determinanti' e 'Codici' e unisce in
+un unico CSV.
+
+Usage: python preprocess.py <year> <output.csv>
+"""
+
+import csv
+import os
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+from lab_connectors.http.download import download
+
+BASE_URL = "https://docs.opencivitas.it"
+
+
+# Mappa anno → prefisso funzione
+YEAR_MAP = {
+    2015: {"prefix": "20", "no_year": True},
+    2016: {"prefix": "30"},
+    2017: {"prefix": "40"},
+    2018: {"prefix": "50"},
+    2019: {"prefix": "60"},
+    2021: {"prefix": "70"},
+    2022: {"prefix": "80"},
+}
+
+# Ambiti
+AMBITI = [
+    ("AMMIN", "amministrazione"),
+    ("ISTRUZ", "istruzione"),
+    ("POLIZIA", "polizia_locale"),
+    ("RIFIUTI", "rifiuti"),
+    ("SOCNID", "sociale_asili_nido"),
+    ("TERRVIAB", "viabilita_territorio"),
+    ("TOT", "servizi_totali"),
+]
+
+
+def download_and_read_metadata(url, tmp_dir, ambito_nome, year):
+    """Scarica ZIP metadati, estrae XLSX, legge foglio Indicatori."""
+    zip_path = os.path.join(tmp_dir, "meta.zip")
+
+    try:
+        data = download(url, timeout=30)
+    except RuntimeError:
+        return []
+
+    try:
+        with open(zip_path, "wb") as f:
+            f.write(data)
+        with zipfile.ZipFile(zip_path) as zf:
+            xlsx_files = [f for f in zf.namelist() if f.endswith(".xlsx")]
+            if not xlsx_files:
+                return []
+            zf.extract(xlsx_files[0], tmp_dir)
+            xlsx_path = os.path.join(tmp_dir, xlsx_files[0])
+    except Exception:
+        return []
+
+    # Leggi fogli Indicatori, Determinanti, Codici con pandas
+    try:
+        import pandas as pd
+
+        xls = pd.ExcelFile(xlsx_path)
+        rows = []
+
+        # Foglio 1: Indicatori
+        sheet_ind = None
+        for s in xls.sheet_names:
+            if s.upper().startswith("INDICATORI"):
+                sheet_ind = s
+                break
+        if sheet_ind:
+            df = pd.read_excel(xls, sheet_name=sheet_ind)
+            if {"VAR_IND_COD", "VAR_IND_DES"}.issubset(set(df.columns)):
+                for _, r in df.iterrows():
+                    codice = str(r.get("VAR_IND_COD", "")).strip()
+                    desc = str(r.get("VAR_IND_DES", "")).strip()
+                    if codice and desc and codice != "nan":
+                        rows.append(
+                            {
+                                "codice_indicatore": codice,
+                                "descrizione": desc,
+                                "tipo": "IND",
+                                "categoria": str(r.get("VAR_IND_TIP", "")).strip(),
+                                "funzione": str(r.get("VAR_IND_FUNZIONE", "")).strip(),
+                                "ordine": str(r.get("VAR_IND_ORD", "")).strip(),
+                                "anno": str(year),
+                                "ambito": ambito_nome,
+                            }
+                        )
+
+        # Foglio 2: Determinanti
+        sheet_det = None
+        for s in xls.sheet_names:
+            if s.upper().startswith("DETERMINANTI"):
+                sheet_det = s
+                break
+        if sheet_det:
+            df = pd.read_excel(xls, sheet_name=sheet_det)
+            if {"VAR_DET_COD", "VAR_DET_DES"}.issubset(set(df.columns)):
+                for _, r in df.iterrows():
+                    codice = str(r.get("VAR_DET_COD", "")).strip()
+                    desc = str(r.get("VAR_DET_DES", "")).strip()
+                    if codice and desc and codice != "nan":
+                        rows.append(
+                            {
+                                "codice_indicatore": codice,
+                                "descrizione": desc,
+                                "tipo": "DET",
+                                "categoria": str(r.get("VAR_DET_CAT_DES", "")).strip(),
+                                "funzione": str(r.get("VAR_DET_FUNZIONE", "")).strip(),
+                                "ordine": "",
+                                "anno": str(year),
+                                "ambito": ambito_nome,
+                            }
+                        )
+
+        # Foglio 3: Codici anomalia
+        sheet_cod = None
+        for s in xls.sheet_names:
+            if s.upper().startswith("CODICI"):
+                sheet_cod = s
+                break
+        if sheet_cod:
+            df = pd.read_excel(xls, sheet_name=sheet_cod)
+            col_map = {c.upper().replace(" ", "_"): c for c in df.columns}
+            cod_col = col_map.get("CODICE", "")
+            des_col = col_map.get("DESCRIZIONE_CODICE", "")
+            fun_col = col_map.get("FUNZIONE", "")
+            if cod_col and des_col:
+                for _, r in df.iterrows():
+                    codice = str(r.get(cod_col, "")).strip()
+                    desc = str(r.get(des_col, "")).strip()
+                    if codice and desc and codice != "nan":
+                        rows.append(
+                            {
+                                "codice_indicatore": codice,
+                                "descrizione": desc,
+                                "tipo": "COD",
+                                "categoria": "",
+                                "funzione": str(r.get(fun_col, "")).strip(),
+                                "ordine": "",
+                                "anno": str(year),
+                                "ambito": ambito_nome,
+                            }
+                        )
+
+        return rows
+    except ImportError:
+        print("ERRORE: pandas non installato", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"  ERRORE lettura XLSX: {e}", file=sys.stderr)
+        return []
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python preprocess.py <year> <output.csv>", file=sys.stderr)
+        sys.exit(1)
+
+    year = int(sys.argv[1])
+    output_path = Path(sys.argv[2])
+
+    if year not in YEAR_MAP:
+        print(f"ERRORE: anno {year} non supportato. Usa: {list(YEAR_MAP.keys())}", file=sys.stderr)
+        sys.exit(1)
+
+    prefix = YEAR_MAP[year]["prefix"]
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        all_rows = []
+        total_downloaded = 0
+
+        for sigla, ambito_nome in AMBITI:
+            if YEAR_MAP[year].get("no_year"):
+                url = f"{BASE_URL}/Metadati_Ind_FC{prefix}{sigla}_1_xlsx.zip"
+            else:
+                url = f"{BASE_URL}/{year}_Metadati_Ind_FC{prefix}{sigla}_1_xlsx.zip"
+            rows = download_and_read_metadata(url, tmp_dir, ambito_nome, year)
+            if rows:
+                all_rows.extend(rows)
+                total_downloaded += 1
+                print(f"  OK {sigla} ({ambito_nome}) — {len(rows)} voci", flush=True)
+            else:
+                print(f"  SKIP {sigla} ({ambito_nome})", flush=True)
+
+        if not all_rows:
+            print("ERRORE: nessun metadato scaricato", file=sys.stderr)
+            sys.exit(1)
+
+        fieldnames = [
+            "codice_indicatore",
+            "descrizione",
+            "tipo",
+            "categoria",
+            "funzione",
+            "ordine",
+            "anno",
+            "ambito",
+        ]
+        with open(output_path, "w", encoding="utf-8", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter=";")
+            writer.writeheader()
+            writer.writerows(all_rows)
+
+        print(f"Output: {output_path} ({len(all_rows)} righe)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/support_datasets/opencivitas-glossario/preprocess.py
+++ b/support_datasets/opencivitas-glossario/preprocess.py
@@ -22,7 +22,7 @@ BASE_URL = "https://docs.opencivitas.it"
 
 # Mappa anno → prefisso funzione
 YEAR_MAP = {
-    2015: {"prefix": "20", "no_year": True},
+    2015: {"prefix": "20", "no_year": True, "suffix": "2"},
     2016: {"prefix": "30"},
     2017: {"prefix": "40"},
     2018: {"prefix": "50"},
@@ -181,10 +181,11 @@ def main():
         total_downloaded = 0
 
         for sigla, ambito_nome in AMBITI:
+            suffix = YEAR_MAP[year].get("suffix", "1")
             if YEAR_MAP[year].get("no_year"):
-                url = f"{BASE_URL}/Metadati_Ind_FC{prefix}{sigla}_1_xlsx.zip"
+                url = f"{BASE_URL}/Metadati_Ind_FC{prefix}{sigla}_{suffix}_xlsx.zip"
             else:
-                url = f"{BASE_URL}/{year}_Metadati_Ind_FC{prefix}{sigla}_1_xlsx.zip"
+                url = f"{BASE_URL}/{year}_Metadati_Ind_FC{prefix}{sigla}_{suffix}_xlsx.zip"
             rows = download_and_read_metadata(url, tmp_dir, ambito_nome, year)
             if rows:
                 all_rows.extend(rows)

--- a/support_datasets/opencivitas-glossario/sql/clean.sql
+++ b/support_datasets/opencivitas-glossario/sql/clean.sql
@@ -1,0 +1,11 @@
+select
+  trim(cast("codice_indicatore" as varchar)) as codice_indicatore,
+  trim(cast("descrizione" as varchar)) as descrizione,
+  trim(cast("tipo" as varchar)) as tipo,
+  trim(cast("categoria" as varchar)) as categoria,
+  trim(cast("funzione" as varchar)) as funzione,
+  try_cast(trim(cast("ordine" as varchar)) as integer) as ordine,
+  try_cast(trim(cast("anno" as varchar)) as integer) as anno,
+  trim(cast("ambito" as varchar)) as ambito
+from raw_input
+where trim(coalesce(cast("codice_indicatore" as varchar), '')) <> ''

--- a/support_datasets/opencivitas-glossario/sql/mart.sql
+++ b/support_datasets/opencivitas-glossario/sql/mart.sql
@@ -1,0 +1,2 @@
+-- pass-through
+select * from clean_input


### PR DESCRIPTION
Closes #378 

## Sintesi

Candidate EAV multi-ambito con indicatori di performance dei comuni italiani da OpenCivitas (ANCI/Sogei). 19,4M righe, 7 ambiti × 7 anni. Support dataset glossario con 3 fogli (IND + DET + COD).

## Contesto collegato

Intake da scouting OpenCivitas (senza issue — partenza pulita).

## Cosa cambia

- [x] candidate — nuovo dataset: `opencivitas-indicatori`
- [x] support — dataset di supporto: `opencivitas-glossario`
- [x] docs — README + notes.md per candidate e support

## Impatto

- [x] Aggiunge un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate
- [ ] Cambia il contratto con consumatori downstream
- [x] Solo documentazione o metadati

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori su tutti gli anni (2015-2022)
- [x] nessun file dati committato
- [ ] notebook — non applicabile (intake tecnico)

## Verifica

```bash
toolkit run full -c candidates/opencivitas-indicatori/dataset.yml --years 2015,2016,2017,2018,2019,2021,2022
python scripts/validate_candidate_structure.py
```

- [x] `run full` eseguito senza errori (7 anni)
- [x] `validate_candidate_structure.py` passato su commit recente

## Note / rischi

- Drop 9-14%: valori testuali attesi (descrizioni non valutabilità, codici anomalia)
- Match ISTAT 95-98% (cala su 2015-2017 per fusioni/cambi denominazione)
- Fonte OpenCivitas con SSL non valido (fallback automatico via lab-connectors)
