### PR TITLE
chore(post-merge): aggiorna registry per PR #657

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-07-15",
+  "updated_at": "2026-07-16",
   "datasets": [
     {
       "slug": "aci_prime_iscrizioni_autovetture",
@@ -11552,6 +11552,242 @@
       "location": {
         "type": "gcs",
         "path": "gs://dataciviclab-clean/unified_comuni/2026/unified_comuni_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "who_is_who_pa",
+      "name": "Who Is Who Pa",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2026,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "codice_ipa",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "denominazione_ente",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_fiscale_ente",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_categoria",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "tipologia",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_istat",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "acronimo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "vertice_ente_titolo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "vertice_ente_nome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "vertice_ente_cognome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "sito_istituzionale",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_uni_uo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "descrizione_uo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_uni_uo_padre",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "uo_data_istituzione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "uo_resp_nome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "uo_resp_cognome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "uo_resp_email",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "uo_resp_telefono",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "uo_mail",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "uo_tipo_mail",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "uo_mail2",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "uo_tipo_mail2",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_uni_aoo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "denominazione_aoo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "aoo_resp_nome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "aoo_resp_cognome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "aoo_mail",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "aoo_tipo_mail",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "protocollo_informatico",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "uri_protocollo_informatico",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_comune_istat",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_catastale_comune",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cap",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "indirizzo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "ente_codice_comune_istat",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/who_is_who_pa/2026/who_is_who_pa_2026_clean.parquet",
         "multi_file": false
       },
       "stage": "published",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -11559,10 +11559,10 @@
     },
     {
       "slug": "who_is_who_pa",
-      "name": "Who Is Who Pa",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "name": "Who Is Who PA — anagrafica enti, vertici, uffici, contatti",
+      "description": "Anagrafica completa della Pubblica Amministrazione italiana: enti, vertici, unità organizzative, AOO, contatti e protocollo informatico. Fonte: IPA IndicePA.",
+      "source": "AgID — Indice della Pubblica Amministrazione (indicepa.gov.it)",
+      "source_id": "ipa",
       "period": {
         "start": 2026,
         "end": 2026
@@ -11572,217 +11572,217 @@
           "name": "codice_ipa",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice IPA dell'ente"
         },
         {
           "name": "denominazione_ente",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione ufficiale dell'ente"
         },
         {
           "name": "codice_fiscale_ente",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice fiscale dell'ente"
         },
         {
           "name": "codice_categoria",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Categoria IPA (L6=comune, L4=regione, ...)"
         },
         {
           "name": "tipologia",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipologia IPA (PA=PA, GPS=gestore pubblico servizi)"
         },
         {
           "name": "codice_istat",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT del comune (6 cifre)"
         },
         {
           "name": "acronimo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Acronimo dell'ente"
         },
         {
           "name": "vertice_ente_titolo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Titolo del vertice dell'ente (Sindaco, Presidente, ...)"
         },
         {
           "name": "vertice_ente_nome",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Nome del vertice dell'ente"
         },
         {
           "name": "vertice_ente_cognome",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Cognome del vertice dell'ente"
         },
         {
           "name": "sito_istituzionale",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Sito web istituzionale"
         },
         {
           "name": "codice_uni_uo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice unità organizzativa (UNI)"
         },
         {
           "name": "descrizione_uo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione unità organizzativa"
         },
         {
           "name": "codice_uni_uo_padre",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice unità organizzativa padre"
         },
         {
           "name": "uo_data_istituzione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Data istituzione unità organizzativa"
         },
         {
           "name": "uo_resp_nome",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Nome del responsabile UO"
         },
         {
           "name": "uo_resp_cognome",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Cognome del responsabile UO"
         },
         {
           "name": "uo_resp_email",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Email del responsabile UO"
         },
         {
           "name": "uo_resp_telefono",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Telefono del responsabile UO"
         },
         {
           "name": "uo_mail",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Email istituzionale UO"
         },
         {
           "name": "uo_tipo_mail",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipo email UO (certificata/ordinaria)"
         },
         {
           "name": "uo_mail2",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Email secondaria UO"
         },
         {
           "name": "uo_tipo_mail2",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipo email secondaria UO"
         },
         {
           "name": "codice_uni_aoo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice Area Organizzativa Omogenea (AOO)"
         },
         {
           "name": "denominazione_aoo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione AOO"
         },
         {
           "name": "aoo_resp_nome",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Nome del responsabile AOO"
         },
         {
           "name": "aoo_resp_cognome",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Cognome del responsabile AOO"
         },
         {
           "name": "aoo_mail",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Email istituzionale AOO"
         },
         {
           "name": "aoo_tipo_mail",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipo email AOO (certificata/ordinaria)"
         },
         {
           "name": "protocollo_informatico",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Indicatore presenza protocollo informatico"
         },
         {
           "name": "uri_protocollo_informatico",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "URI del protocollo informatico"
         },
         {
           "name": "codice_comune_istat",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT del comune (dati IPA)"
         },
         {
           "name": "codice_catastale_comune",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice catastale del comune"
         },
         {
           "name": "cap",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "CAP della sede"
         },
         {
           "name": "indirizzo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Indirizzo della sede"
         },
         {
           "name": "ente_codice_comune_istat",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT del comune dell'ente"
         }
       ],
       "location": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-15",
+  "generated_at": "2026-07-16",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 85,
+    "total": 86,
     "by_status": {
-      "ok": 85,
+      "ok": 86,
       "warn": 0,
       "error": 0
     }
@@ -1731,6 +1731,24 @@
           2026
         ],
         "config_path": "compose/unified-comuni/dataset.yml"
+      }
+    },
+    {
+      "id": "compose:who-is-who-pa",
+      "source_id": "dataciviclab_composite",
+      "status": "ok",
+      "label": "compose:who-is-who-pa",
+      "detail": "anno 2026 — fonte: ? — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "29491723328",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/29491723328",
+        "checked_at": "2026-07-16",
+        "years": [
+          2026
+        ],
+        "config_path": "compose/who-is-who-pa/dataset.yml"
       }
     }
   ]


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #657 — compose: who-is-who-pa — ente, uffici, responsabili, contatti

Changed candidate/support roots:

- `who-is-who-pa` (compose, `compose/who-is-who-pa`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `compose/who-is-who-pa/dataset.yml` -> artifact `sample-run-who-is-who-pa`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
