### PR TITLE
chore(post-merge): aggiorna registry per PR #661

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-07-16",
+  "updated_at": "2026-07-18",
   "datasets": [
     {
       "slug": "aci_prime_iscrizioni_autovetture",
@@ -7795,6 +7795,184 @@
         "multi_file": false
       },
       "stage": "incubating",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "opencivitas_glossario",
+      "name": "Opencivitas Glossario",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2015,
+        "end": 2022
+      },
+      "columns": [
+        {
+          "name": "codice_indicatore",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "descrizione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "tipo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "categoria",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "funzione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "ordine",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "ambito",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/opencivitas_glossario/*/opencivitas_glossario_*_clean.parquet",
+        "multi_file": true
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "opencivitas_indicatori",
+      "name": "Opencivitas Indicatori",
+      "description": "",
+      "source": "",
+      "source_id": "opencivitas",
+      "period": {
+        "start": 2015,
+        "end": 2022
+      },
+      "columns": [
+        {
+          "name": "username",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "ambito",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "indicatore",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "valore_num",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "descrizione_indicatore",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "tipo_indicatore",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "categoria_indicatore",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "funzione_indicatore",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "denominazione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "provincia",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "regione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "regione_istat_cod",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "join_enti_ok",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "join_metadati_ok",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/opencivitas_indicatori/*/opencivitas_indicatori_*_clean.parquet",
+        "multi_file": true
+      },
+      "stage": "published",
       "registry_source": "derive_auto"
     },
     {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -7799,10 +7799,10 @@
     },
     {
       "slug": "opencivitas_glossario",
-      "name": "Opencivitas Glossario",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "name": "Glossario indicatori OpenCivitas",
+      "description": "Dizionario degli indicatori (IND), determinanti (DET) e codici anomalia (COD) OpenCivitas. 3 fogli XLSX uniti: nome, descrizione, tipo e funzione per ogni codice.",
+      "source": "OpenCivitas / Sogei",
+      "source_id": "opencivitas",
       "period": {
         "start": 2015,
         "end": 2022
@@ -7812,49 +7812,49 @@
           "name": "codice_indicatore",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice dell'indicatore/determinante/codice (es. COPERTURA_NID_NEW, F_DEPRIVAZIONE_MEAN, COD_SPS_QUEST)"
         },
         {
           "name": "descrizione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione leggibile del codice"
         },
         {
           "name": "tipo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipologia: IND (indicatore), DET (determinante), COD (codice anomalia)"
         },
         {
           "name": "categoria",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Categoria (es. FS, LQP, NAVIGA, INDICATORI per IND; DEMOGRAFIA per DET)"
         },
         {
           "name": "funzione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Funzione di appartenenza"
         },
         {
           "name": "ordine",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Ordine di presentazione nel questionario"
         },
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di riferimento del metadato"
         },
         {
           "name": "ambito",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Ambito tematico (es. amministrazione, sociale_asili_nido)"
         }
       ],
       "location": {
@@ -7867,9 +7867,9 @@
     },
     {
       "slug": "opencivitas_indicatori",
-      "name": "Opencivitas Indicatori",
-      "description": "",
-      "source": "",
+      "name": "Indicatori di performance dei comuni",
+      "description": "Indicatori di performance dei comuni italiani (2015-2022): copertura asili nido, spesa sociale, efficienza polizia locale, raccolta rifiuti, istruzione. 7 ambiti tematici, ~280 indicatori per anno. Fonte: OpenCivitas (ANCI/Sogei).",
+      "source": "OpenCivitas / Sogei",
       "source_id": "opencivitas",
       "period": {
         "start": 2015,
@@ -7885,86 +7885,86 @@
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di riferimento (2015-2022, escluso 2020)"
         },
         {
           "name": "ambito",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Ambito tematico: amministrazione, istruzione, polizia_locale, rifiuti, sociale_asili_nido, viabilita_territorio, servizi_totali"
         },
         {
           "name": "indicatore",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice indicatore (es. COPERTURA_NID_NEW, SPESA_STORICA_PROAB)"
         },
         {
           "name": "valore_num",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Valore numerico dell'indicatore"
         },
         {
           "name": "descrizione_indicatore",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione leggibile dell'indicatore (dal glossario)"
         },
         {
           "name": "tipo_indicatore",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipologia: IND (indicatore), DET (determinante), COD (codice anomalia)"
         },
         {
           "name": "categoria_indicatore",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Categoria dell'indicatore (es. FS, LQP, NAVIGA, INDICATORI)"
         },
         {
           "name": "funzione_indicatore",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Funzione di riferimento dell'indicatore"
         },
         {
           "name": "denominazione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione del comune"
         },
         {
           "name": "provincia",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT provincia (3 cifre)"
         },
         {
           "name": "regione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Nome della regione"
         },
         {
           "name": "regione_istat_cod",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Codice ISTAT regione"
         },
         {
           "name": "join_enti_ok",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Indica se il join con l'anagrafica enti è riuscito"
         },
         {
           "name": "join_metadati_ok",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Indica se il join con il glossario è riuscito"
         }
       ],
       "location": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-16",
+  "generated_at": "2026-07-18",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 86,
+    "total": 88,
     "by_status": {
-      "ok": 86,
+      "ok": 88,
       "warn": 0,
       "error": 0
     }
@@ -1033,6 +1033,30 @@
       }
     },
     {
+      "id": "opencivitas-indicatori",
+      "source_id": "opencivitas",
+      "status": "ok",
+      "label": "opencivitas-indicatori",
+      "detail": "anni 2015-2022 — fonte: ? — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "29637176868",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/29637176868",
+        "checked_at": "2026-07-18",
+        "years": [
+          2015,
+          2016,
+          2017,
+          2018,
+          2019,
+          2021,
+          2022
+        ],
+        "config_path": "candidates/opencivitas-indicatori/dataset.yml"
+      }
+    },
+    {
       "id": "opencoesione-progetti",
       "source_id": "opencoesione",
       "status": "ok",
@@ -1641,6 +1665,30 @@
           2025
         ],
         "config_path": "support_datasets/opencivitas-fsc-enti-rso/dataset.yml"
+      }
+    },
+    {
+      "id": "opencivitas-glossario",
+      "source_id": "opencivitas",
+      "status": "ok",
+      "label": "opencivitas-glossario",
+      "detail": "anni: ? — fonte: ? — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "29637176868",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/29637176868",
+        "checked_at": "2026-07-18",
+        "years": [
+          2015,
+          2016,
+          2017,
+          2018,
+          2019,
+          2021,
+          2022
+        ],
+        "config_path": "support_datasets/opencivitas-glossario/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #661 — intake: opencivitas-indicatori — 7 ambiti × 7 anni in EAV

Changed candidate/support roots:

- `opencivitas-indicatori` (candidate, `candidates/opencivitas-indicatori`)
- `opencivitas-glossario` (support_dataset, `support_datasets/opencivitas-glossario`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/opencivitas-indicatori/dataset.yml` -> artifact `sample-run-opencivitas-indicatori`
- `support_datasets/opencivitas-glossario/dataset.yml` -> artifact `sample-run-opencivitas-glossario`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
