### PR TITLE
intake: anac-aggiudicazioni — Aggiudicazioni appalti pubblici ANAC

### DIFF
--- a/candidates/anac-aggiudicazioni/README.md
+++ b/candidates/anac-aggiudicazioni/README.md
@@ -25,10 +25,10 @@ Dataset cumulativo full — storico completo delle aggiudicazioni fino alla data
 
 | Metrica | Valore |
 |---|---|
-| Righe (full 2026-07) | ~6.0M |
-| Peso CSV zippato | ~759 MB |
+| Righe (full dump 2026-01) | ~4.86M |
+| Peso CSV zippato (full) | ~759 MB |
 | Peso CSV scomposto | ~2-3 GB |
-| Aggiornamento | Mensile (delta) |
+| Aggiornamento | Mensile (full dump sostituito, delta non inclusi) |
 | Anni con copertura solida | 2007-2026 |
 
 ## Schema clean (28 colonne)
@@ -56,6 +56,16 @@ Dataset cumulativo full — storico completo delle aggiudicazioni fino alla data
 |---|---|---|
 | `anac_bandi_gara` | `cig` | Bando di gara → aggiudicazione |
 | `anac_aggiudicatari` (futuro) | `id_aggiudicazione` | Aggiudicazione → vincitore |
+
+## Mart
+
+Due tabelle mart disponibili:
+
+- **`mart_aggiudicazioni_annuale`** — aggregazione per anno/mese/esito/criterio/flag (analisi trend)
+  - Colonna: importo_totale, importo_medio/mediano, n_aggiudicazioni, ribasso_medio, offerte
+- **`mart_aggiudicazioni_dettaglio`** — row-level con chiavi per join
+  - Preserva `cig`, `id_aggiudicazione`, `importo_aggiudicazione`, `data`, `esito`, `flag_subappalto`
+  - Join diretto con `anac_bandi_gara` via `cig`
 
 ## Limiti
 

--- a/candidates/anac-aggiudicazioni/README.md
+++ b/candidates/anac-aggiudicazioni/README.md
@@ -21,18 +21,21 @@ Informazioni di aggiudicazione relative agli appalti ordinari pubblicati dalle s
 
 Dataset cumulativo full — storico completo delle aggiudicazioni fino alla data di pubblicazione del dump.
 
+**Copertura temporale**: 2000-2026 (dati consistenti da 2007, pre-2007 sporadici)
+
 | Metrica | Valore |
 |---|---|
-| Righe (full 2026-01) | ~4.86M |
+| Righe (full 2026-07) | ~6.0M |
 | Peso CSV zippato | ~759 MB |
-| Peso CSV scomposto (stimato) | ~2-3 GB |
+| Peso CSV scomposto | ~2-3 GB |
 | Aggiornamento | Mensile (delta) |
+| Anni con copertura solida | 2007-2026 |
 
 ## Schema clean (28 colonne)
 
 | Colonna | Tipo | Descrizione |
 |---|---|---|
-| `cig` | VARCHAR | Codice Identificativo Gara (PK) |
+| `cig` | VARCHAR | Codice Identificativo Gara (chiave di join con `anac_bandi_gara`; non univoco — uno stesso CIG può avere più lotti/aggiudicazioni) |
 | `data_aggiudicazione_definitiva` | DATE | Data aggiudicazione definitiva |
 | `esito` | VARCHAR | Esito aggiudicazione |
 | `criterio_aggiudicazione` | VARCHAR | Criterio di aggiudicazione |

--- a/candidates/anac-aggiudicazioni/README.md
+++ b/candidates/anac-aggiudicazioni/README.md
@@ -1,0 +1,61 @@
+# ANAC — Aggiudicazioni
+
+**Dataset**: `anac_aggiudicazioni`
+**Fonte**: ANAC — Autorità Nazionale Anticorruzione, portale [dati.anticorruzione.it](https://dati.anticorruzione.it/)
+**Protocollo**: CKAN (via dati.gov.it + API diretta)
+**Licenza**: CC BY 4.0 (Creative Commons Attribuzione 4.0 Internazionale)
+
+## Contenuto
+
+Informazioni di aggiudicazione relative agli appalti ordinari pubblicati dalle stazioni appaltanti italiane. Ogni riga rappresenta un'aggiudicazione identificata da CIG (Codice Identificativo Gara) con:
+
+- **Importo**: importo di aggiudicazione, ribasso
+- **Tempi**: data aggiudicazione definitiva, data comunicazione esito
+- **Partecipazione**: numero offerte ammesse/escluse, imprese offerenti/richiedenti/invitate
+- **Asta elettronica**: flag, modalità
+- **Esito**: cod_esito, criterio di aggiudicazione
+- **Subappalto**: flag subappalto
+- **Collegamento**: id_aggiudicazione (per join con `aggiudicatari`)
+
+## Copertura
+
+Dataset cumulativo full — storico completo delle aggiudicazioni fino alla data di pubblicazione del dump.
+
+| Metrica | Valore |
+|---|---|
+| Righe (full 2026-01) | ~4.86M |
+| Peso CSV zippato | ~759 MB |
+| Peso CSV scomposto (stimato) | ~2-3 GB |
+| Aggiornamento | Mensile (delta) |
+
+## Schema clean (28 colonne)
+
+| Colonna | Tipo | Descrizione |
+|---|---|---|
+| `cig` | VARCHAR | Codice Identificativo Gara (PK) |
+| `data_aggiudicazione_definitiva` | DATE | Data aggiudicazione definitiva |
+| `esito` | VARCHAR | Esito aggiudicazione |
+| `criterio_aggiudicazione` | VARCHAR | Criterio di aggiudicazione |
+| `data_comunicazione_esito` | DATE | Data comunicazione esito |
+| `numero_offerte_ammesse` | INTEGER | Offerte ammesse |
+| `numero_offerte_escluse` | INTEGER | Offerte escluse |
+| `importo_aggiudicazione` | DOUBLE | Importo di aggiudicazione |
+| `ribasso_aggiudicazione` | DOUBLE | Ribasso percentuale |
+| `num_imprese_offerenti` | INTEGER | Imprese offerenti |
+| `flag_subappalto` | BOOLEAN | Flag subappalto |
+| `id_aggiudicazione` | BIGINT | ID aggiudicazione (join con `aggiudicatari`) |
+| `cod_esito` | INTEGER | Codice esito |
+| ... | | Altre colonne raw |
+
+## Join possibili
+
+| Dataset | Chiave | Descrizione |
+|---|---|---|
+| `anac_bandi_gara` | `cig` | Bando di gara → aggiudicazione |
+| `anac_aggiudicatari` (futuro) | `id_aggiudicazione` | Aggiudicazione → vincitore |
+
+## Limiti
+
+- Dataset cumulativo: aggiornamento mensile con dump full sostituito periodicamente
+- WAF sul portale ANAC: necessario User-Agent browser (via `client.user_agent` in dataset.yml)
+- `aggiudicatari` (vincitori) non ancora integrato — disponibile come dataset ANAC separato

--- a/candidates/anac-aggiudicazioni/dataset.yml
+++ b/candidates/anac-aggiudicazioni/dataset.yml
@@ -49,12 +49,3 @@ mart:
 
 validation:
   fail_on_error: true
-  required_columns:
-    - "cig"
-    - "id_aggiudicazione"
-  min_rows: 100000
-  table_rules:
-    mart_aggiudicazioni_annuale:
-      min_rows: 100
-    mart_aggiudicazioni_dettaglio:
-      min_rows: 100000

--- a/candidates/anac-aggiudicazioni/dataset.yml
+++ b/candidates/anac-aggiudicazioni/dataset.yml
@@ -25,6 +25,9 @@ raw:
 
 clean:
   sql: "sql/clean.sql"
+  required_columns:
+    - "cig"
+    - "id_aggiudicazione"
   read:
     source: config_only
     mode: all
@@ -36,6 +39,11 @@ clean:
     null_padding: true
     trim_whitespace: true
     sample_size: -1
+  validate:
+    not_null:
+      - "cig"
+      - "id_aggiudicazione"
+    min_rows: 100000
 
 mart:
   tables:
@@ -46,6 +54,19 @@ mart:
   required_tables:
     - "mart_aggiudicazioni_annuale"
     - "mart_aggiudicazioni_dettaglio"
+  validate:
+    table_rules:
+      mart_aggiudicazioni_annuale:
+        required_columns:
+          - "anno_aggiudicazione"
+          - "importo_totale"
+        min_rows: 100
+      mart_aggiudicazioni_dettaglio:
+        required_columns:
+          - "cig"
+          - "id_aggiudicazione"
+          - "importo_aggiudicazione"
+        min_rows: 100000
 
 validation:
   fail_on_error: true

--- a/candidates/anac-aggiudicazioni/dataset.yml
+++ b/candidates/anac-aggiudicazioni/dataset.yml
@@ -1,0 +1,36 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "anac_aggiudicazioni"
+  source_id: "anac"
+  years: [2026]
+
+raw:
+  sources:
+    - name: "aggiudicazioni"
+      type: "ckan"
+      client:
+        user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+      args:
+        portal_url: "https://dati.anticorruzione.it/opendata"
+        dataset_id: "aggiudicazioni"
+        download_all: true
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: config_only
+    mode: all
+    header: true
+    delim: ";"
+    encoding: "utf-8"
+    quote: '"'
+    escape: '"'
+    null_padding: true
+    trim_whitespace: true
+    sample_size: -1
+
+validation:
+  fail_on_error: true

--- a/candidates/anac-aggiudicazioni/dataset.yml
+++ b/candidates/anac-aggiudicazioni/dataset.yml
@@ -5,17 +5,22 @@ dataset:
   name: "anac_aggiudicazioni"
   source_id: "anac"
   years: [2026]
+  time_coverage:
+    start_year: 2000
+    end_year: 2026
 
 raw:
   sources:
     - name: "aggiudicazioni"
       type: "ckan"
+      extractor:
+        type: "unzip_first_csv"
       client:
         user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
       args:
         portal_url: "https://dati.anticorruzione.it/opendata"
         dataset_id: "aggiudicazioni"
-        download_all: true
+        resource_name: "aggiudicazioni_csv"
       primary: true
 
 clean:
@@ -32,5 +37,24 @@ clean:
     trim_whitespace: true
     sample_size: -1
 
+mart:
+  tables:
+    - name: "mart_aggiudicazioni_annuale"
+      sql: "sql/mart.sql"
+    - name: "mart_aggiudicazioni_dettaglio"
+      sql: "sql/mart_dettaglio.sql"
+  required_tables:
+    - "mart_aggiudicazioni_annuale"
+    - "mart_aggiudicazioni_dettaglio"
+
 validation:
   fail_on_error: true
+  required_columns:
+    - "cig"
+    - "id_aggiudicazione"
+  min_rows: 100000
+  table_rules:
+    mart_aggiudicazioni_annuale:
+      min_rows: 100
+    mart_aggiudicazioni_dettaglio:
+      min_rows: 100000

--- a/candidates/anac-aggiudicazioni/notes.md
+++ b/candidates/anac-aggiudicazioni/notes.md
@@ -42,8 +42,6 @@ Già risolto in anac-bandi-gara con `client.user_agent` config.
 
 | Metrica | Valore |
 |---|---|
-| Metrica | Valore |
-|---|---|
 | Righe totali | 4.862.077 |
 | CIG distinti | 4.849.388 |
 | Con importo | 4.838.224 (99,5%) |

--- a/candidates/anac-aggiudicazioni/notes.md
+++ b/candidates/anac-aggiudicazioni/notes.md
@@ -7,8 +7,8 @@ CKAN dataset `aggiudicazioni` su dati.anticorruzione.it:
 - Delta mensili: risorse `YYYYMMDD-aggiudicazioni_csv` (XXX MB)
 - Senza DataStore — download diretto CSV via filesystem API
 
-Config scelta: solo full dump via `resource_name: "aggiudicazioni_csv"`.
-Delta mensili da gestire in fase di manutenzione (scaricare delta + append).
+Config scelta: solo full dump via `resource_name: "aggiudicazioni_csv"` + extractor `unzip_first_csv`.
+Delta mensili esclusi: il full dump è cumulativo, scaricando anche i delta si avrebbero duplicati.
 
 ## Schema osservato
 
@@ -42,19 +42,21 @@ Già risolto in anac-bandi-gara con `client.user_agent` config.
 
 | Metrica | Valore |
 |---|---|
-| Righe totali | 6.015.309 |
-| CIG distinti | 5.510.729 |
-| Con importo | 5.925.677 (98,5%) |
-| Con data valida | 5.916.782 (98,4%) |
-| Importo totale | €4.897 Mld |
-| Importo mediano | €45.000 |
-| CIG nulli | 0 ✅ |
+| Metrica | Valore |
+|---|---|
+| Righe totali | 4.862.077 |
+| CIG distinti | 4.849.388 |
+| Con importo | 4.838.224 (99,5%) |
+| Con data valida | 4.819.598 (99,1%) |
+| Importo totale (aggiudicato) | €3.934 Mld |
+| Importo mediano | €50.000 |
+| CIG / id_aggiudicazione nulli | 0 ✅ |
 
 **Anomalie note (non bloccanti):**
 - 2.221 date fuori range (anno < 2000 o > 2026) — date malformate nel sorgente
 - 369 importi negativi — probabili storni/rettifiche
 - 34.314 importi zero con esito "AGGIUDICATA" — aggiudicazioni senza importo comunicato
-- 504.580 CIG con più righe (8,4%) — uno stesso CIG può avere più lotti/aggiudicazioni
+- 12.689 CIG con più righe (0,3%) — uno stesso CIG può avere più lotti/aggiudicazioni
 - 69% dei record senza criterio di aggiudicazione (NULL)
 - Discontinuità 2024+: esplosione volumi (382K → 1,2M), crollo subappalti dichiarati — probabile cambio normativo (D.Lgs 36/2023) o metodologia ANAC
 

--- a/candidates/anac-aggiudicazioni/notes.md
+++ b/candidates/anac-aggiudicazioni/notes.md
@@ -38,8 +38,24 @@ aggiudicazioni senza corrispondenza in anagrafica aggiudicatari.
 Il portale dati.anticorruzione.it blocca richieste senza User-Agent browser.
 Già risolto in anac-bandi-gara con `client.user_agent` config.
 
-## Da verificare
+## Qualità dati (run 2026-07-18)
 
-- [ ] Il full dump ha stesso schema del delta? Verificare con schema_diff.
-- [ ] Separatore decimale: "." nel delta — confermare nel full dump.
-- [ ] Flag booleani: "true"/"false" stringa o "1"/"0"?
+| Metrica | Valore |
+|---|---|
+| Righe totali | 6.015.309 |
+| CIG distinti | 5.510.729 |
+| Con importo | 5.925.677 (98,5%) |
+| Con data valida | 5.916.782 (98,4%) |
+| Importo totale | €4.897 Mld |
+| Importo mediano | €45.000 |
+| CIG nulli | 0 ✅ |
+
+**Anomalie note (non bloccanti):**
+- 2.221 date fuori range (anno < 2000 o > 2026) — date malformate nel sorgente
+- 369 importi negativi — probabili storni/rettifiche
+- 34.314 importi zero con esito "AGGIUDICATA" — aggiudicazioni senza importo comunicato
+- 504.580 CIG con più righe (8,4%) — uno stesso CIG può avere più lotti/aggiudicazioni
+- 69% dei record senza criterio di aggiudicazione (NULL)
+- Discontinuità 2024+: esplosione volumi (382K → 1,2M), crollo subappalti dichiarati — probabile cambio normativo (D.Lgs 36/2023) o metodologia ANAC
+
+**Schema verificato**: full dump conforme al delta osservato. Separatore decimale "." (già processabile da DuckDB). Flag booleani in formato stringa "true"/"false".

--- a/candidates/anac-aggiudicazioni/notes.md
+++ b/candidates/anac-aggiudicazioni/notes.md
@@ -1,0 +1,45 @@
+# Note tecniche — anac-aggiudicazioni
+
+## Struttura fonte
+
+CKAN dataset `aggiudicazioni` su dati.anticorruzione.it:
+- Full dump: risorsa `aggiudicazioni_csv` (~759MB ZIP)
+- Delta mensili: risorse `YYYYMMDD-aggiudicazioni_csv` (XXX MB)
+- Senza DataStore — download diretto CSV via filesystem API
+
+Config scelta: solo full dump via `resource_name: "aggiudicazioni_csv"`.
+Delta mensili da gestire in fase di manutenzione (scaricare delta + append).
+
+## Schema osservato
+
+Dal delta CSV `20260701-aggiudicazioni_csv.csv` (190.829 righe):
+
+Colonne raw (CSV, delim `;`, quoted `"`):
+cig, data_aggiudicazione_definitiva, esito, criterio_aggiudicazione,
+data_comunicazione_esito, numero_offerte_ammesse, numero_offerte_escluse,
+importo_aggiudicazione, ribasso_aggiudicazione, num_imprese_offerenti,
+flag_subappalto, id_aggiudicazione, cod_esito, num_imprese_richiedenti,
+asta_elettronica, num_imprese_invitate, massimo_ribasso, minimo_ribasso,
+FLAG_SCOMPUTO, COD_PRESTAZIONI_COMPRESE, PRESTAZIONI_COMPRESE,
+CIG_PROG_ESTERNA, DATA_INCARICO_PROG, DATA_CONS_PROG,
+COD_MODO_RIAGGIUDICAZIONE, MODO_RIAGGIUDICAZIONE,
+FLAG_PROC_ACCELERATA, N_MANIF_INTERESSE
+
+## Join chain
+
+anac_bandi_gara (cig) ←→ anac_aggiudicazioni (cig)
+anac_aggiudicazioni (id_aggiudicazione) ←→ aggiudicatari (id_aggiudicazione)
+
+Note: id_aggiudicazione con valori negativi (-1, -2xxxx) indica
+aggiudicazioni senza corrispondenza in anagrafica aggiudicatari.
+
+## Warning ANAC WAF
+
+Il portale dati.anticorruzione.it blocca richieste senza User-Agent browser.
+Già risolto in anac-bandi-gara con `client.user_agent` config.
+
+## Da verificare
+
+- [ ] Il full dump ha stesso schema del delta? Verificare con schema_diff.
+- [ ] Separatore decimale: "." nel delta — confermare nel full dump.
+- [ ] Flag booleani: "true"/"false" stringa o "1"/"0"?

--- a/candidates/anac-aggiudicazioni/sql/clean.sql
+++ b/candidates/anac-aggiudicazioni/sql/clean.sql
@@ -1,0 +1,37 @@
+SELECT
+    cig,
+    TRY_CAST(data_aggiudicazione_definitiva AS DATE) AS data_aggiudicazione_definitiva,
+    esito,
+    criterio_aggiudicazione,
+    TRY_CAST(data_comunicazione_esito AS DATE) AS data_comunicazione_esito,
+    TRY_CAST(numero_offerte_ammesse AS INTEGER) AS numero_offerte_ammesse,
+    TRY_CAST(numero_offerte_escluse AS INTEGER) AS numero_offerte_escluse,
+    TRY_CAST(importo_aggiudicazione AS DOUBLE) AS importo_aggiudicazione,
+    TRY_CAST(ribasso_aggiudicazione AS DOUBLE) AS ribasso_aggiudicazione,
+    TRY_CAST(num_imprese_offerenti AS INTEGER) AS num_imprese_offerenti,
+    CASE WHEN flag_subappalto::VARCHAR IN ('1', 'true', 'TRUE', 'S') THEN TRUE
+         WHEN flag_subappalto::VARCHAR IN ('0', 'false', 'FALSE', 'N') THEN FALSE
+         ELSE NULL END AS flag_subappalto,
+    TRY_CAST(id_aggiudicazione AS BIGINT) AS id_aggiudicazione,
+    TRY_CAST(cod_esito AS INTEGER) AS cod_esito,
+    TRY_CAST(num_imprese_richiedenti AS INTEGER) AS num_imprese_richiedenti,
+    CASE WHEN asta_elettronica::VARCHAR IN ('1', 'true', 'TRUE', 'S') THEN TRUE
+         WHEN asta_elettronica::VARCHAR IN ('0', 'false', 'FALSE', 'N') THEN FALSE
+         ELSE NULL END AS asta_elettronica,
+    TRY_CAST(num_imprese_invitate AS INTEGER) AS num_imprese_invitate,
+    TRY_CAST(massimo_ribasso AS DOUBLE) AS massimo_ribasso,
+    TRY_CAST(minimo_ribasso AS DOUBLE) AS minimo_ribasso,
+    -- raw columns pass-through (nullable, schema variabile)
+    FLAG_SCOMPUTO,
+    TRY_CAST(COD_PRESTAZIONI_COMPRESE AS DOUBLE) AS COD_PRESTAZIONI_COMPRESE,
+    PRESTAZIONI_COMPRESE,
+    CIG_PROG_ESTERNA,
+    TRY_CAST(DATA_INCARICO_PROG AS DATE) AS DATA_INCARICO_PROG,
+    TRY_CAST(DATA_CONS_PROG AS DATE) AS DATA_CONS_PROG,
+    TRY_CAST(COD_MODO_RIAGGIUDICAZIONE AS DOUBLE) AS COD_MODO_RIAGGIUDICAZIONE,
+    MODO_RIAGGIUDICAZIONE,
+    CASE WHEN FLAG_PROC_ACCELERATA::VARCHAR IN ('1', 'true', 'TRUE', 'S') THEN TRUE
+         WHEN FLAG_PROC_ACCELERATA::VARCHAR IN ('0', 'false', 'FALSE', 'N') THEN FALSE
+         ELSE NULL END AS FLAG_PROC_ACCELERATA,
+    TRY_CAST(N_MANIF_INTERESSE AS INTEGER) AS N_MANIF_INTERESSE
+FROM raw_input

--- a/candidates/anac-aggiudicazioni/sql/mart.sql
+++ b/candidates/anac-aggiudicazioni/sql/mart.sql
@@ -1,0 +1,33 @@
+SELECT
+    year(data_aggiudicazione_definitiva) AS anno_aggiudicazione,
+    month(data_aggiudicazione_definitiva) AS mese_aggiudicazione,
+    esito,
+    criterio_aggiudicazione,
+    flag_subappalto,
+    asta_elettronica,
+    CASE WHEN importo_aggiudicazione > 0 THEN TRUE ELSE FALSE END AS flag_importo_positivo,
+    COUNT(*) AS n_aggiudicazioni,
+    COUNT(DISTINCT cig) AS n_cig_distinti,
+    COUNT(DISTINCT id_aggiudicazione) AS n_id_aggiudicazione_distinti,
+    SUM(importo_aggiudicazione) AS importo_totale,
+    AVG(importo_aggiudicazione) AS importo_medio,
+    MEDIAN(importo_aggiudicazione) AS importo_mediano,
+    MAX(importo_aggiudicazione) AS importo_massimo,
+    MIN(importo_aggiudicazione) AS importo_minimo,
+    AVG(ribasso_aggiudicazione) AS ribasso_medio,
+    MEDIAN(ribasso_aggiudicazione) AS ribasso_mediano,
+    SUM(numero_offerte_ammesse) AS offerte_ammesse_totale,
+    SUM(numero_offerte_escluse) AS offerte_escluse_totale,
+    AVG(num_imprese_offerenti) AS imprese_offerenti_medie,
+    AVG(num_imprese_invitate) AS imprese_invitate_medie
+FROM clean_input
+WHERE data_aggiudicazione_definitiva IS NOT NULL
+  AND year(data_aggiudicazione_definitiva) BETWEEN 2005 AND 2026
+GROUP BY
+    year(data_aggiudicazione_definitiva),
+    month(data_aggiudicazione_definitiva),
+    esito,
+    criterio_aggiudicazione,
+    flag_subappalto,
+    asta_elettronica,
+    CASE WHEN importo_aggiudicazione > 0 THEN TRUE ELSE FALSE END

--- a/candidates/anac-aggiudicazioni/sql/mart_dettaglio.sql
+++ b/candidates/anac-aggiudicazioni/sql/mart_dettaglio.sql
@@ -1,0 +1,19 @@
+-- Mart dettaglio: preserva righe e chiavi per join con anac_bandi_gara
+SELECT
+    cig,
+    id_aggiudicazione,
+    data_aggiudicazione_definitiva,
+    data_comunicazione_esito,
+    esito,
+    criterio_aggiudicazione,
+    importo_aggiudicazione,
+    ribasso_aggiudicazione,
+    numero_offerte_ammesse,
+    numero_offerte_escluse,
+    num_imprese_offerenti,
+    num_imprese_invitate,
+    flag_subappalto,
+    asta_elettronica,
+    cod_esito
+FROM clean_input
+WHERE cig IS NOT NULL


### PR DESCRIPTION
## Sintesi

Nuovo candidate `anac-aggiudicazioni`: dataset cumulativo delle aggiudicazioni degli appalti ordinari pubblicati da ANAC. ~4.86M righe con importi, criteri, partecipazione — join via CIG con `anac_bandi_gara` già pubblicato.

## Contesto collegato

Closes #666

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento
- [ ] support — dataset di supporto
- [ ] docs — struttura candidate, README, template
- [ ] cleanup — refactoring, rimozioni, allineamento
- [ ] workflow o CI
- [ ] altro

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
- [ ] Solo documentazione o metadati
- [ ] Nessun impatto visibile per chi usa il repository

## Checklist candidate

- [x] `dataset.yml` presente con `name`, `years` e `time_coverage`
- [x] toolkit run full eseguito senza errori (raw ✅ clean ✅ mart ✅)
- [x] nessun file dati committato nella root del candidate
- [x] output immagini cleared dal notebook (N/A)
- [x] notebook nominato `{slug}_v0.ipynb` (N/A — notebook in follow-up)
- [x] issue di intake collegata (#666)

## Verifica

```bash
toolkit run full --config candidates/anac-aggiudicazioni/dataset.yml --years 2026
```

**Esito run:**
```
raw:   ✅ qs=100  encoding=utf-8  delim=;
clean: ✅ qs=95  4.862.077 righe  28 colonne
mart:  ✅ qs=90  2/2 tabelle
```

**Mart disponibili:**
- `mart_aggiudicazioni_annuale` — aggregato per anno/mese/criterio (analisi trend)
- `mart_aggiudicazioni_dettaglio` — row-level con `cig`, `id_aggiudicazione` (join con `anac_bandi_gara`)

## Dati di qualità (su config finale, solo full dump)

| Metrica | Valore |
|---|---|
| Righe totali | 4.862.077 |
| CIG distinti | 4.849.388 |
| Con importo | 4.838.224 (99,5%) |
| Con data valida | 4.819.598 (99,1%) |
| Importo complessivo | ~€3.934 Mld |
| Importo mediano | €50.000 |
| CIG / id_aggiudicazione nulli | 0 ✅ |

Anomalie note documentate in `notes.md` (date fuori range, importi negativi, discontinuità 2024+).

## Note / rischi

- Dump cumulativo unico (~760MB ZIP) — `time_coverage: 2000-2026`
- Scaricata solo risorsa `aggiudicazioni_csv` (full dump), delta mensili esclusi per evitare duplicati
- Aggiudicatari (vincitori) non inclusi: dataset ANAC separato `aggiudicatari`, da intakare in seguito
- WAF su dati.anticorruzione.it: gestito con `client.user_agent` + extractor `unzip_first_csv`
- Discontinuità nei volumi dal 2024: possibile effetto D.Lgs 36/2023
