### PR TITLE
intake: anac-aggiudicatari — Anagrafica operatori economici aggiudicatari (support)

### DIFF
--- a/support_datasets/anac-aggiudicatari/README.md
+++ b/support_datasets/anac-aggiudicatari/README.md
@@ -10,6 +10,15 @@
 
 Anagrafica degli operatori economici che si sono aggiudicati appalti ordinari pubblicati su dati.anticorruzione.it. Ogni riga rappresenta un operatore economico associato a un'aggiudicazione.
 
+## Copertura
+
+| Metrica | Valore |
+|---|---|
+| Righe (full dump) | ~5,4M |
+| Operatori economici distinti | ~505K |
+| Copertura temporale | 2000-2026 |
+| Aggiornamento | Mensile (full dump sostituito periodicamente) |
+
 ## Schema (6 colonne)
 
 | Colonna | Tipo | Descrizione |

--- a/support_datasets/anac-aggiudicatari/README.md
+++ b/support_datasets/anac-aggiudicatari/README.md
@@ -1,0 +1,37 @@
+# ANAC — Aggiudicatari (support)
+
+**Dataset**: `anac_aggiudicatari`
+**Tipo**: support — anagrafica operatori economici aggiudicatari di appalti pubblici
+**Fonte**: ANAC — Autorità Nazionale Anticorruzione
+**Protocollo**: CKAN (via dati.gov.it)
+**Licenza**: CC BY 4.0
+
+## Contenuto
+
+Anagrafica degli operatori economici che si sono aggiudicati appalti ordinari pubblicati su dati.anticorruzione.it. Ogni riga rappresenta un operatore economico associato a un'aggiudicazione.
+
+## Schema (6 colonne)
+
+| Colonna | Tipo | Descrizione |
+|---|---|---|
+| `cig` | VARCHAR | CIG (join con `anac_bandi_gara`, `anac_aggiudicazioni`) |
+| `ruolo` | VARCHAR | Ruolo (OPERATORE ECONOMICO MONOSOGGETTIVO, IMPRESA AUSILIARIA, ecc.) |
+| `codice_fiscale` | VARCHAR | Partita IVA / CF dell'operatore |
+| `denominazione` | VARCHAR | Ragione sociale |
+| `tipo_soggetto` | VARCHAR | Tipo (IMPRESA, DITTA INDIVIDUALE, STAZIONE APPALTANTE, ecc.) |
+| `id_aggiudicazione` | BIGINT | ID aggiudicazione (join con `anac_aggiudicazioni`) |
+
+## Join chain
+
+```
+anac_bandi_gara (cig) → anac_aggiudicazioni (cig)
+anac_aggiudicazioni (id_aggiudicazione) → anac_aggiudicatari (id_aggiudicazione)
+```
+
+Join diretto via `cig` anche con `anac_bandi_gara`.
+
+## Limiti
+
+- `codice_fiscale` può essere nullo per operatori esteri
+- `id_aggiudicazione` negativo (-1) indica aggiudicazioni senza corrispondenza anagrafica
+- `denominazione` può contenere spazi extra o maiuscole incoerenti

--- a/support_datasets/anac-aggiudicatari/dataset.yml
+++ b/support_datasets/anac-aggiudicatari/dataset.yml
@@ -1,0 +1,56 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "anac_aggiudicatari"
+  source_id: "anac"
+  years: [2026]
+  time_coverage:
+    start_year: 2000
+    end_year: 2026
+
+raw:
+  sources:
+    - name: "aggiudicatari"
+      type: "ckan"
+      extractor:
+        type: "unzip_first_csv"
+      client:
+        user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+      args:
+        portal_url: "https://dati.anticorruzione.it/opendata"
+        dataset_id: "aggiudicatari"
+        resource_name: "aggiudicatari_csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: config_only
+    mode: all
+    header: true
+    delim: ";"
+    encoding: "utf-8"
+    quote: '"'
+    escape: '"'
+    null_padding: true
+    trim_whitespace: true
+    sample_size: -1
+  required_columns:
+    - "cig"
+    - "id_aggiudicazione"
+  validate:
+    not_null:
+      - "cig"
+      - "id_aggiudicazione"
+    min_rows: 100000
+
+mart:
+  tables:
+    - name: "mart_aggiudicatari"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_aggiudicatari"
+
+validation:
+  fail_on_error: true

--- a/support_datasets/anac-aggiudicatari/notes.md
+++ b/support_datasets/anac-aggiudicatari/notes.md
@@ -32,8 +32,10 @@ anac_aggiudicazioni (id_aggiudicazione) → anac_aggiudicatari (id_aggiudicazion
 | Metrica | Valore |
 |---|---|
 | Righe totali | 5.437.334 |
-| Join con anac_aggiudicazioni via id_aggiudicazione | 9.424.624 match |
+| id_aggiudicazione distinti | 4.764.335 |
+| id_aggiudicazione con più righe | 265.354 |
 | Operatori economici distinti (denominazione) | ~505K |
+| Join con anac_aggiudicazioni via id_aggiudicazione | 9.424.624 righe risultanti (molti-a-molti) |
 
 **Anomalie note (non bloccanti):**
 - `codice_fiscale` nullo per operatori non censiti in anagrafe o esteri

--- a/support_datasets/anac-aggiudicatari/notes.md
+++ b/support_datasets/anac-aggiudicatari/notes.md
@@ -1,0 +1,41 @@
+# Note tecniche — anac-aggiudicatari (support)
+
+## Struttura fonte
+
+CKAN dataset `aggiudicatari` su dati.gov.it (harvesting ANAC):
+- Full dump: risorsa `aggiudicatari_csv` (~800MB ZIP, ~5.4M righe)
+- Delta mensili: risorse `YYYYMMDD-aggiudicatari_csv` (non inclusi)
+- Senza DataStore — download diretto CSV via filesystem API
+
+Config: `resource_name: "aggiudicatari_csv"` + extractor `unzip_first_csv`.
+Stessa identica strategia di `anac-aggiudicazioni`.
+
+## Schema osservato
+
+Da delta JSON `20260701-aggiudicatari_json.json` (2.242 righe):
+- `cig` — VARCHAR, CIG
+- `ruolo` — VARCHAR (OPERATORE ECONOMICO MONOSOGGETTIVO, IMPRESA AUSILIARIA, ecc.)
+- `codice_fiscale` — VARCHAR (può essere null per operatori esteri)
+- `denominazione` — VARCHAR (ragione sociale, a volte con spazi extra)
+- `tipo_soggetto` — VARCHAR (IMPRESA, DITTA INDIVIDUALE, NON PRESENTE IN ANAGRAFE, ecc.)
+- `id_aggiudicazione` — BIGINT (negativo = senza corrispondenza in anagrafica)
+
+## Join chain
+
+```
+anac_bandi_gara (cig) → anac_aggiudicazioni (cig)
+anac_aggiudicazioni (id_aggiudicazione) → anac_aggiudicatari (id_aggiudicazione)
+```
+
+## Qualità dati (run 2026-07-18)
+
+| Metrica | Valore |
+|---|---|
+| Righe totali | 5.437.334 |
+| Join con anac_aggiudicazioni via id_aggiudicazione | 9.424.624 match |
+| Operatori economici distinti (denominazione) | ~505K |
+
+**Anomalie note (non bloccanti):**
+- `codice_fiscale` nullo per operatori non censiti in anagrafe o esteri
+- `id_aggiudicazione` negativo (-1, -2xxxx) indica assenza di corrispondenza anagrafica
+- `denominazione` con spazi extra o case incoerente (es. "IMPRESA INESISTENTE")

--- a/support_datasets/anac-aggiudicatari/sql/clean.sql
+++ b/support_datasets/anac-aggiudicatari/sql/clean.sql
@@ -1,0 +1,8 @@
+SELECT
+    cig,
+    ruolo,
+    codice_fiscale,
+    denominazione,
+    tipo_soggetto,
+    TRY_CAST(id_aggiudicazione AS BIGINT) AS id_aggiudicazione
+FROM raw_input

--- a/support_datasets/anac-aggiudicatari/sql/mart.sql
+++ b/support_datasets/anac-aggiudicatari/sql/mart.sql
@@ -1,0 +1,1 @@
+SELECT * FROM clean_input


### PR DESCRIPTION
## Sintesi

Support dataset con l'anagrafica degli operatori economici aggiudicatari di appalti pubblici italiani. 5.4M righe, join via `id_aggiudicazione` con `anac_aggiudicazioni` e via `cig` con `anac_bandi_gara`.

## Contesto collegato

Closes #670

## Cosa cambia

- [x] support — dataset di supporto

## Verifica

```bash
toolkit run full --config support_datasets/anac-aggiudicatari/dataset.yml --years 2026
```

**Esito:**
```
raw:   ✅ qs=100
clean: ✅ qs=100  5.437.334 righe  6 colonne
mart:  ✅ qs=100  1/1 tabelle
```

**Join con `anac_aggiudicazioni`**: 9.424.624 righe risultanti (join molti-a-molti via `id_aggiudicazione`, atteso: una aggiudicazione può avere più operatori)

## Dati di qualità

| Metrica | Valore |
|---|---|
| Righe | 5.437.334 |
| id_aggiudicazione distinti | 4.764.335 |
| id_aggiudicazione con più righe | 265.354 |
| Operatori economici distinti | ~505K |
| CIG / id_aggiudicazione nulli | 0 ✅ |

## Schema

| Colonna | Tipo | Ruolo |
|---|---|---|
| `cig` | VARCHAR | join con anac_bandi_gara, anac_aggiudicazioni |
| `ruolo` | VARCHAR | OPERATORE ECONOMICO MONOSOGGETTIVO, ecc. |
| `codice_fiscale` | VARCHAR | CF / P.IVA |
| `denominazione` | VARCHAR | Ragione sociale |
| `tipo_soggetto` | VARCHAR | IMPRESA, DITTA INDIVIDUALE, ecc. |
| `id_aggiudicazione` | BIGINT | join con anac_aggiudicazioni |
