### PR TITLE
intake: anac-partecipanti — Partecipanti alle gare pubbliche (support)

### DIFF
--- a/support_datasets/anac-partecipanti/README.md
+++ b/support_datasets/anac-partecipanti/README.md
@@ -1,0 +1,45 @@
+# ANAC — Partecipanti (support)
+
+**Dataset**: `anac_partecipanti`
+**Tipo**: support — anagrafica partecipanti alle gare pubbliche
+**Fonte**: ANAC — Autorità Nazionale Anticorruzione
+**Protocollo**: CKAN (via dati.gov.it)
+**Licenza**: CC BY 4.0
+
+## Contenuto
+
+Anagrafica dei soggetti che partecipano alle gare pubbliche (non solo i vincitori). Ogni riga rappresenta un partecipante associato a un CIG.
+
+A differenza di `anac_aggiudicatari` (solo vincitori), qui ci sono TUTTI i partecipanti: permette analisi di concorrenza, esclusioni, concentrazione.
+
+## Copertura
+
+| Metrica | Valore |
+|---|---|
+| Righe | ~8M |
+| CIG distinti | ~4,7M |
+| Partecipanti distinti | ~578K |
+| Match con anac_aggiudicazioni | 95% |
+
+## Schema (5 colonne)
+
+| Colonna | Tipo | Descrizione |
+|---|---|---|
+| `cig` | VARCHAR | CIG (join con `anac_bandi_gara`, `anac_aggiudicazioni`) |
+| `ruolo` | VARCHAR | Ruolo del partecipante |
+| `codice_fiscale` | VARCHAR | CF / P.IVA del partecipante |
+| `denominazione` | VARCHAR | Ragione sociale |
+| `tipo_soggetto` | VARCHAR | Tipo (IMPRESA, DITTA INDIVIDUALE, ecc.) |
+
+## Join chain
+
+```
+partecipanti (cig) → anac_bandi_gara (cig)
+partecipanti (cig) → anac_aggiudicazioni (cig)
+partecipanti (codice_fiscale) → anac_aggiudicatari (codice_fiscale)
+```
+
+## Limiti
+
+- Stessa struttura di `anac_aggiudicatari` ma include anche i non vincitori
+- Full dump non rigenerato frequentemente (file cumulativo 2023+ delta)

--- a/support_datasets/anac-partecipanti/dataset.yml
+++ b/support_datasets/anac-partecipanti/dataset.yml
@@ -1,0 +1,54 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "anac_partecipanti"
+  source_id: "anac"
+  years: [2026]
+  time_coverage:
+    start_year: 2023
+    end_year: 2026
+
+raw:
+  sources:
+    - name: "partecipanti"
+      type: "ckan"
+      extractor:
+        type: "unzip_first_csv"
+      client:
+        user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+      args:
+        portal_url: "https://dati.anticorruzione.it/opendata"
+        dataset_id: "partecipanti"
+        resource_name: "partecipanti_csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: config_only
+    mode: all
+    header: true
+    delim: ";"
+    encoding: "utf-8"
+    quote: '"'
+    escape: '"'
+    null_padding: true
+    trim_whitespace: true
+    sample_size: -1
+  required_columns:
+    - "cig"
+  validate:
+    not_null:
+      - "cig"
+    min_rows: 100000
+
+mart:
+  tables:
+    - name: "mart_partecipanti"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_partecipanti"
+
+validation:
+  fail_on_error: true

--- a/support_datasets/anac-partecipanti/notes.md
+++ b/support_datasets/anac-partecipanti/notes.md
@@ -1,0 +1,46 @@
+# Note tecniche — anac-partecipanti (support)
+
+## Struttura fonte
+
+CKAN dataset `partecipanti` su dati.gov.it (harvesting ANAC):
+- Full dump: risorsa `partecipanti_csv` (~1GB ZIP)
+- Delta mensili: risorse `YYYYMMDD-partecipanti_csv` (non inclusi)
+- Stesso pattern di `anac_aggiudicatari`: 5 colonne, delim `;`
+
+Config: `resource_name: "partecipanti_csv"` + extractor `unzip_first_csv`.
+
+## Schema (5 colonne)
+
+| Colonna | Tipo | Descrizione |
+|---|---|---|
+| `cig` | VARCHAR | CIG della gara |
+| `ruolo` | VARCHAR | Ruolo del partecipante |
+| `codice_fiscale` | VARCHAR | CF/P.IVA del partecipante |
+| `denominazione` | VARCHAR | Ragione sociale |
+| `tipo_soggetto` | VARCHAR | Tipo soggetto |
+
+## Differenza con anac_aggiudicatari
+
+`anac_aggiudicatari` contiene solo gli **operatori che hanno vinto** la gara.
+`anac_partecipanti` contiene **tutti i partecipanti**, vincitori e non.
+
+Join via `codice_fiscale` per incrociare chi partecipa e chi vince.
+
+## Qualità dati (run 2026-07-18)
+
+| Metrica | Valore |
+|---|---|
+| Righe totali | 8.044.052 |
+| CIG distinti | 4.746.047 |
+| Partecipanti distinti (CF) | ~578K |
+| CF nulli | 0 ✅ |
+| CIG nulli | 0 ✅ |
+| Righe per CIG (media) | 1,7 |
+| Match con anac_aggiudicazioni | 7.673.210 (95%) |
+| Match con anac_bandi_gara 2025 | 1.793.021 |
+
+## Anomalie note
+
+- `ruolo` spesso nullo (dal delta osservato, la colonna era vuota)
+- Full dump non rigenerato frequentemente (2023 + delta cumulativi)
+- 1,7 partecipanti/CIG di media — valori più alti possibile per gare con molte offerte

--- a/support_datasets/anac-partecipanti/sql/clean.sql
+++ b/support_datasets/anac-partecipanti/sql/clean.sql
@@ -1,0 +1,7 @@
+SELECT
+    cig,
+    ruolo,
+    codice_fiscale,
+    denominazione,
+    tipo_soggetto
+FROM raw_input

--- a/support_datasets/anac-partecipanti/sql/mart.sql
+++ b/support_datasets/anac-partecipanti/sql/mart.sql
@@ -1,0 +1,1 @@
+SELECT * FROM clean_input


### PR DESCRIPTION
## Sintesi

Support dataset con i partecipanti alle gare pubbliche (non solo vincitori). 8M righe, join via `cig` con `anac_bandi_gara` e `anac_aggiudicazioni`, via `codice_fiscale` con `anac_aggiudicatari`.

**Novità**: `anac_aggiudicatari` ha solo chi vince, qui ci sono TUTTI i partecipanti → analisi concorrenza.

## Contesto collegato

Closes #676

## Cosa cambia

- [x] support — dataset di supporto

## Verifica

```bash
toolkit run full --config support_datasets/anac-partecipanti/dataset.yml --years 2026
```

**Esito:**
```
raw:   ✅ qs=100
clean: ✅ qs=100  8.044.052 righe  5 colonne
mart:  ✅ qs=100  1/1 tabelle
```

**Join verificati:**
- 7.673.210 match con `anac_aggiudicazioni` (95%)
- 1.793.021 match con `anac_bandi_gara` 2025

## Dati di qualità

| Metrica | Valore |
|---|---|
| Righe | 8.044.052 |
| CIG distinti | 4.746.047 |
| Partecipanti distinti (CF) | ~578K |
| CIG / CF nulli | 0 ✅ |

## Schema

| Colonna | Tipo | Ruolo |
|---|---|---|
| `cig` | VARCHAR | join con bandi, aggiudicazioni |
| `ruolo` | VARCHAR | Ruolo del partecipante |
| `codice_fiscale` | VARCHAR | CF / P.IVA |
| `denominazione` | VARCHAR | Ragione sociale |
| `tipo_soggetto` | VARCHAR | Tipo soggetto |
