### PR TITLE
chore(post-merge): aggiorna registry per PR #678

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -918,6 +918,56 @@
       "registry_source": "derive_auto"
     },
     {
+      "slug": "anac_partecipanti",
+      "name": "Anac Partecipanti",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2026,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "cig",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "ruolo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_fiscale",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "denominazione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "tipo_soggetto",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/anac_partecipanti/2026/anac_partecipanti_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
       "slug": "anpr_mobilita_residenziale",
       "name": "ANPR — Mobilita Residenziale Interregionale (2022-2026)",
       "description": "Flussi mensili di cambio residenza tra regioni italiane, da ANPR (Anagrafe Nazionale della Popolazione Residente). Serie mensile 2022-2026, aggiornata quasi in tempo reale via GitHub Actions.",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -919,12 +919,12 @@
     },
     {
       "slug": "anac_partecipanti",
-      "name": "Anac Partecipanti",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "name": "ANAC Partecipanti",
+      "description": "Anagrafica dei partecipanti alle gare pubbliche (non solo vincitori): denominazione, codice fiscale, ruolo e tipo soggetto. Fonte ANAC. Join via cig con anac_bandi_gara e anac_aggiudicazioni, via codice_fiscale con anac_aggiudicatari.",
+      "source": "ANAC - Autorità Nazionale Anticorruzione",
+      "source_id": "anac",
       "period": {
-        "start": 2026,
+        "start": 2023,
         "end": 2026
       },
       "columns": [
@@ -932,31 +932,31 @@
           "name": "cig",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "CIG della gara — join con anac_bandi_gara e anac_aggiudicazioni"
         },
         {
           "name": "ruolo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Ruolo del partecipante"
         },
         {
           "name": "codice_fiscale",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice fiscale / partita IVA del partecipante"
         },
         {
           "name": "denominazione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Ragione sociale del partecipante"
         },
         {
           "name": "tipo_soggetto",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipo soggetto (IMPRESA, DITTA INDIVIDUALE, ecc.)"
         }
       ],
       "location": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -4,9 +4,9 @@
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 90,
+    "total": 91,
     "by_status": {
-      "ok": 90,
+      "ok": 91,
       "warn": 0,
       "error": 0
     }
@@ -1521,6 +1521,24 @@
           2026
         ],
         "config_path": "support_datasets/anac-aggiudicatari/dataset.yml"
+      }
+    },
+    {
+      "id": "anac-partecipanti",
+      "source_id": "anac",
+      "status": "ok",
+      "label": "anac-partecipanti",
+      "detail": "anni: ? — fonte: ? — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "29655870229",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/29655870229",
+        "checked_at": "2026-07-18",
+        "years": [
+          2026
+        ],
+        "config_path": "support_datasets/anac-partecipanti/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #678 — intake: anac-partecipanti — Partecipanti alle gare pubbliche (support)

Changed candidate/support roots:

- `anac-partecipanti` (support_dataset, `support_datasets/anac-partecipanti`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `support_datasets/anac-partecipanti/dataset.yml` -> artifact `sample-run-anac-partecipanti`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
