### PR TITLE
intake: anac-subappalti — Subappalti e filiera esecutiva (support)

### DIFF
--- a/support_datasets/anac-subappalti/README.md
+++ b/support_datasets/anac-subappalti/README.md
@@ -1,0 +1,38 @@
+# ANAC — Subappalti (support)
+
+**Dataset**: `anac_subappalti`
+**Tipo**: support — subappalti e filiera esecutiva
+**Fonte**: ANAC — Autorità Nazionale Anticorruzione
+**Protocollo**: CKAN (via dati.gov.it)
+**Licenza**: CC BY 4.0
+
+## Contenuto
+
+Autorizzazioni al subappalto comunicate all'ANAC. Colma il gap tra `flag_subappalto` (che dice solo SE c'è subappalto) e l'effettiva filiera: chi subappalta a chi, per quali lavori, in quali categorie.
+
+## Schema (15 colonne)
+
+| Colonna | Tipo | Descrizione |
+|---|---|---|
+| `cig` | VARCHAR | CIG del contratto principale |
+| `id_subappalto` | VARCHAR | ID univoco subappalto |
+| `cf_subappaltante` | VARCHAR | CF dell'aggiudicatario che subappalta |
+| `data_autorizzazione` | DATE | Data autorizzazione |
+| `oggetto` | VARCHAR | Oggetto del subappalto |
+| `cod_categoria` | VARCHAR | Categoria lavori |
+| `cod_cpv` | VARCHAR | CPV del subappalto |
+| `codice_fiscale` | VARCHAR | CF del subappaltatore |
+| `denominazione` | VARCHAR | Ragione sociale subappaltatore |
+| `tipo_soggetto` | VARCHAR | Tipo soggetto |
+
+## Join chain
+
+- `subappalti (cig)` → `anac_bandi_gara (cig)` / `anac_aggiudicazioni (cig)`
+- `subappalti (cf_subappaltante)` → `anac_aggiudicatari (codice_fiscale)` — SA subappaltanti
+- `subappalti (codice_fiscale)` → `anac_aggiudicatari (codice_fiscale)` — subappaltatori che vincono anche gare dirette
+
+## Limiti
+
+- Copertura parziale: solo gare dove il subappalto è stato dichiarato e autorizzato
+- `cf_subappaltante` spesso nullo
+- Frequenza annuale

--- a/support_datasets/anac-subappalti/dataset.yml
+++ b/support_datasets/anac-subappalti/dataset.yml
@@ -1,0 +1,55 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "anac_subappalti"
+  source_id: "anac"
+  years: [2026]
+  time_coverage:
+    start_year: 2020
+    end_year: 2026
+
+raw:
+  sources:
+    - name: "subappalti"
+      type: "ckan"
+      extractor:
+        type: "unzip_first_csv"
+      client:
+        user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+      args:
+        portal_url: "https://dati.anticorruzione.it/opendata"
+        dataset_id: "subappalti"
+        resource_name: "subappalti_csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: config_only
+    mode: all
+    header: true
+    delim: ";"
+    encoding: "utf-8"
+    quote: '"'
+    escape: '"'
+    null_padding: true
+    trim_whitespace: true
+    sample_size: -1
+  required_columns:
+    - "cig"
+    - "id_subappalto"
+  validate:
+    not_null:
+      - "cig"
+    min_rows: 10000
+
+mart:
+  tables:
+    - name: "mart_subappalti"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_subappalti"
+
+validation:
+  fail_on_error: true

--- a/support_datasets/anac-subappalti/notes.md
+++ b/support_datasets/anac-subappalti/notes.md
@@ -1,0 +1,24 @@
+# Note tecniche — anac-subappalti (support)
+
+## Struttura fonte
+
+CKAN dataset `subappalti` su dati.gov.it (harvesting ANAC):
+- Full dump: risorsa `subappalti_csv` (~122MB ZIP)
+- Delta: risorse YYYYMMDD-subappalti_csv (6-15MB)
+- Frequenza: ANNUALE
+- Stessa identica configurazione di `anac_partecipanti`
+
+## Qualità dati (run 2026-07-19)
+
+| Metrica | Valore |
+|---|---|
+| Righe | 334.301 |
+| Con cf_subappaltante | dati da verificare |
+| CIG nulli | 0 ✅ |
+| Match con anac_aggiudicazioni | da verificare |
+
+## Note
+
+- `classe_importo` è VARCHAR nel CSV (es. "null" o valori testuali)
+- `cf_subappaltante` può essere nullo (subappalti dove non è stato indicato l'affidatario principale)
+- I CIG qui sono CIG ordinari (numerici), joinabili con bandi/aggiudicazioni

--- a/support_datasets/anac-subappalti/sql/clean.sql
+++ b/support_datasets/anac-subappalti/sql/clean.sql
@@ -1,0 +1,17 @@
+SELECT
+    cig,
+    id_subappalto,
+    cf_subappaltante,
+    TRY_CAST(data_autorizzazione AS DATE) AS data_autorizzazione,
+    oggetto,
+    cod_categoria,
+    descrizione_categoria,
+    classe_importo,
+    descrizione_tipo_categoria,
+    cod_cpv,
+    descrizione_cpv,
+    codice_fiscale,
+    denominazione,
+    ruolo,
+    tipo_soggetto
+FROM raw_input

--- a/support_datasets/anac-subappalti/sql/mart.sql
+++ b/support_datasets/anac-subappalti/sql/mart.sql
@@ -1,0 +1,1 @@
+SELECT * FROM clean_input


### PR DESCRIPTION
## Sintesi

Support dataset con i subappalti autorizzati negli appalti pubblici. 334K righe, join via `cig` con `anac_bandi_gara`/`anac_aggiudicazioni`, via `codice_fiscale` con `anac_aggiudicatari`.

## Contesto collegato

Closes #677

## Cosa cambia

- [x] support — dataset di supporto

## Verifica

```bash
toolkit run full --config support_datasets/anac-subappalti/dataset.yml --years 2026
```

**Esito:**
```
raw:   ✅ qs=100
clean: ✅ qs=95  334.301 righe  15 colonne
mart:  ✅ qs=100  1/1 tabelle
```

**Match verificati:**
- 121K CIG con `anac_aggiudicazioni`
- 121K CIG con `anac_aggiudicatari`
- 73K CIG con `anac_bandi_gara`

## Schema

| Colonna | Tipo | Ruolo |
|---|---|---|
| `cig` | VARCHAR | CIG del contratto principale |
| `id_subappalto` | VARCHAR | ID univoco subappalto |
| `cf_subappaltante` | VARCHAR | CF di chi subappalta (join con aggiudicatari) |
| `data_autorizzazione` | DATE | Data autorizzazione |
| `cod_categoria` | VARCHAR | Categoria lavori |
| `cod_cpv` | VARCHAR | CPV del subappalto |
| `codice_fiscale` | VARCHAR | CF dell'esecutore subappalto |
| `denominazione` | VARCHAR | Ragione sociale esecutore |

**Nota**: 66% dei record ha `cf_subappaltante` nullo — non sempre è noto chi tra gli aggiudicatari ha subappaltato.
