### PR TITLE
feat: migrazione macro SQL — batch 1 (13 candidati low-risk)

### DIFF
--- a/candidates/anpr-mobilita-residenziale/sql/clean.sql
+++ b/candidates/anpr-mobilita-residenziale/sql/clean.sql
@@ -2,13 +2,13 @@
 -- Flussi mensili di cambio residenza tra regioni italiane (ANPR)
 
 SELECT
-    CAST(ANNO AS INTEGER)                                       AS anno,
-    CAST(MESE AS INTEGER)                                       AS mese,
-    TRIM(CAST(PARTENZA AS VARCHAR))                              AS partenza,
-    LPAD(TRIM(CAST(COD_ISTAT_REGIONE_DI_PARTENZA AS VARCHAR)), 3, '0') AS cod_regione_partenza,
-    TRIM(CAST(ARRIVO AS VARCHAR))                                AS arrivo,
-    LPAD(TRIM(CAST(COD_ISTAT_REGIONE_DI_ARRIVO AS VARCHAR)), 3, '0')   AS cod_regione_arrivo,
-    CAST(TOTALE AS INTEGER)                                     AS totale
+    cast_int(ANNO)                                       AS anno,
+    cast_int(MESE)                                       AS mese,
+    normalize_string(PARTENZA)                              AS partenza,
+    LPAD(normalize_string(COD_ISTAT_REGIONE_DI_PARTENZA), 3, '0') AS cod_regione_partenza,
+    normalize_string(ARRIVO)                                AS arrivo,
+    LPAD(normalize_string(COD_ISTAT_REGIONE_DI_ARRIVO), 3, '0')   AS cod_regione_arrivo,
+    cast_int(TOTALE)                                     AS totale
 
 FROM raw_input
 WHERE TOTALE IS NOT NULL

--- a/candidates/bdap-entrate-stato/sql/clean.sql
+++ b/candidates/bdap-entrate-stato/sql/clean.sql
@@ -1,5 +1,5 @@
 select
-  try_cast(column00 as integer) as esercizio_finanziario,
+  cast_int(column00) as esercizio_finanziario,
   nullif(trim(column01), '') as codice_titolo,
   nullif(trim(column02), '') as titolo,
   nullif(trim(column03), '') as codice_natura,
@@ -8,7 +8,7 @@ select
   nullif(trim(column06), '') as tipologia,
   nullif(trim(column07), '') as codice_provento,
   nullif(trim(column08), '') as provento,
-  try_cast(column09 as double) as previsioni_definitive_cp,
-  try_cast(column10 as double) as previsioni_definitive_cs
+  cast_double(column09) as previsioni_definitive_cp,
+  cast_double(column10) as previsioni_definitive_cs
 from raw_input
-where try_cast(column00 as integer) is not null
+where cast_int(column00) is not null

--- a/candidates/bdap-spese-stato/sql/clean.sql
+++ b/candidates/bdap-spese-stato/sql/clean.sql
@@ -1,5 +1,5 @@
 select
-  try_cast(column00 as integer) as esercizio_finanziario,
+  cast_int(column00) as esercizio_finanziario,
   nullif(trim(column01), '') as stato_previsione,
   nullif(trim(column02), '') as amministrazione,
   nullif(trim(column03), '') as missione,
@@ -9,7 +9,7 @@ select
   nullif(trim(column07), '') as udv_livello_3,
   nullif(trim(column08), '') as codice_puntato_udv,
   nullif(trim(column09), '') as macroaggregato,
-  try_cast(column10 as double) as previsioni_definitive_cp,
-  try_cast(column11 as double) as previsioni_definitive_cs
+  cast_double(column10) as previsioni_definitive_cp,
+  cast_double(column11) as previsioni_definitive_cs
 from raw_input
-where try_cast(column00 as integer) is not null
+where cast_int(column00) is not null

--- a/candidates/civile-flussi/sql/clean.sql
+++ b/candidates/civile-flussi/sql/clean.sql
@@ -1,16 +1,16 @@
 select
-  try_cast("Anno" as integer) as anno,
-  trim("Fonte") as fonte,
+  cast_int("Anno") as anno,
+  normalize_string("Fonte") as fonte,
   trim("Tipo ufficio") as tipo_ufficio,
-  trim("Distretto") as distretto,
-  trim("Sede") as sede,
-  trim("Macromateria") as macromateria,
-  trim("Materia") as materia,
-  trim("Dettaglio") as dettaglio,
-  try_cast("Sopravvenuti" as double) as sopravvenuti,
+  normalize_string("Distretto") as distretto,
+  normalize_string("Sede") as sede,
+  normalize_string("Macromateria") as macromateria,
+  normalize_string("Materia") as materia,
+  normalize_string("Dettaglio") as dettaglio,
+  cast_double("Sopravvenuti") as sopravvenuti,
   try_cast("Definiti - totale" as double) as definiti_totale,
   try_cast("Definiti con sentenza" as double) as definiti_con_sentenza,
   try_cast("Pendenti finali" as double) as pendenti_finali
 from raw_input
-where try_cast("Anno" as integer) is not null
+where cast_int("Anno") is not null
   and trim(coalesce("Fonte", '')) <> ''

--- a/candidates/giustizia-penale-indicatori/sql/clean.sql
+++ b/candidates/giustizia-penale-indicatori/sql/clean.sql
@@ -2,12 +2,12 @@
 -- Sheet: Tribunali
 -- Fonte: Ministero della Giustizia
 SELECT
-    TRY_CAST("Anno" AS INTEGER)         AS anno,
-    TRIM("Tipo ufficio")                AS tipo_ufficio,
-    TRIM("Distretto")                   AS distretto,
-    TRIM("Sede")                        AS sede,
-    TRIM("Sezione")                     AS sezione,
-    TRY_CAST("Clearance rate" AS DOUBLE)    AS clearance_rate,
-    TRY_CAST("Disposition time" AS DOUBLE) AS disposition_time_gg
+    cast_int("Anno")         AS anno,
+    normalize_string("Tipo ufficio")                AS tipo_ufficio,
+    normalize_string("Distretto")                   AS distretto,
+    normalize_string("Sede")                        AS sede,
+    normalize_string("Sezione")                     AS sezione,
+    cast_double("Clearance rate")    AS clearance_rate,
+    cast_double("Disposition time") AS disposition_time_gg
 FROM raw_input
-WHERE TRY_CAST("Anno" AS INTEGER) IS NOT NULL;
+WHERE cast_int("Anno") IS NOT NULL;

--- a/candidates/ispra-emissioni-ghg/sql/clean.sql
+++ b/candidates/ispra-emissioni-ghg/sql/clean.sql
@@ -4,12 +4,12 @@
 -- Periodo: 1990-2023
 
 SELECT
-    TRY_CAST("anno" AS INTEGER) AS anno,
-    TRY_CAST("industrie_energetiche" AS DOUBLE) AS industrie_energetiche,
-    TRY_CAST("industrie_manifatturiere" AS DOUBLE) AS industrie_manifatturiere,
-    TRY_CAST("residenziale_e_servizi" AS DOUBLE) AS residenziale_e_servizi,
-    TRY_CAST("trasporti" AS DOUBLE) AS trasporti,
-    TRY_CAST("totale" AS DOUBLE) AS totale
+    cast_int("anno") AS anno,
+    cast_double("industrie_energetiche") AS industrie_energetiche,
+    cast_double("industrie_manifatturiere") AS industrie_manifatturiere,
+    cast_double("residenziale_e_servizi") AS residenziale_e_servizi,
+    cast_double("trasporti") AS trasporti,
+    cast_double("totale") AS totale
 FROM raw_input
-WHERE TRY_CAST("anno" AS INTEGER) IS NOT NULL
+WHERE cast_int("anno") IS NOT NULL
 ORDER BY anno

--- a/candidates/istat-asia-ul/sql/clean.sql
+++ b/candidates/istat-asia-ul/sql/clean.sql
@@ -1,12 +1,12 @@
 SELECT
-    CAST(ref_area AS VARCHAR(6))            AS codice_comune,
-    CAST(anno AS INTEGER)                   AS anno,
-    CAST(ateco_sezione AS VARCHAR(5))       AS ateco_sezione,
-    CAST(valore AS DOUBLE)                  AS unita_locali
+    normalize_string(ref_area)            AS codice_comune,
+    cast_int(anno)                   AS anno,
+    normalize_string(ateco_sezione)       AS ateco_sezione,
+    cast_double(valore)                  AS unita_locali
 FROM raw_input
 WHERE
     LENGTH(ref_area) = 6
-    AND TRY_CAST(ref_area AS INTEGER) IS NOT NULL
+    AND TRY_cast_int(ref_area) IS NOT NULL
     AND anno IS NOT NULL
     AND anno BETWEEN 2018 AND 2020
     AND valore >= 0

--- a/candidates/istat-gini-regionale/sql/clean.sql
+++ b/candidates/istat-gini-regionale/sql/clean.sql
@@ -4,7 +4,7 @@ select
     DATA_TYPE as tipo_dato,
     IMPUTED_RENTS as pres_aff_imp,
     TIME_PERIOD as anno,
-    cast(value as double) as gini
+    cast_double(value) as gini
 from raw_input
 where DATA_TYPE = 'DISUG_REDDNET_GINI'
   and IMPUTED_RENTS in ('1', '2')

--- a/candidates/mortalita-istat-evitabile/sql/clean.sql
+++ b/candidates/mortalita-istat-evitabile/sql/clean.sql
@@ -14,20 +14,20 @@
 
 SELECT
     CAST(anno AS INTEGER)                              AS anno,
-    TRIM(CAST("Cod_Territorio" AS VARCHAR))            AS cod_territorio,
-    TRIM("Territorio")                                 AS territorio,
-    CAST("Cod_Sesso" AS INTEGER)                       AS cod_sesso,
-    TRIM("Sesso")                                      AS sesso,
-    CAST("Cod_Classe età" AS INTEGER)                  AS cod_classe_eta,
-    TRIM("Classe età")                                 AS classe_eta,
-    CAST("Cod_Titolo di studio" AS INTEGER)            AS cod_titolo_studio,
-    TRIM("Titolo di studio")                           AS titolo_studio,
-    CAST("Cod_Causa" AS INTEGER)                       AS cod_causa,
-    TRIM("Causa")                                      AS causa,
-    CAST("pop media" AS DOUBLE)                        AS pop_media,
-    CAST("decessi" AS INTEGER)                         AS decessi,
-    CAST("tassi_standardizzati per 10.000" AS DOUBLE)  AS tasso_std_10000
+    normalize_string("Cod_Territorio")            AS cod_territorio,
+    normalize_string("Territorio")                                 AS territorio,
+    cast_int("Cod_Sesso")                       AS cod_sesso,
+    normalize_string("Sesso")                                      AS sesso,
+    cast_int("Cod_Classe età")                  AS cod_classe_eta,
+    normalize_string("Classe età")                                 AS classe_eta,
+    cast_int("Cod_Titolo di studio")            AS cod_titolo_studio,
+    normalize_string("Titolo di studio")                           AS titolo_studio,
+    cast_int("Cod_Causa")                       AS cod_causa,
+    normalize_string("Causa")                                      AS causa,
+    cast_double("pop media")                        AS pop_media,
+    cast_int("decessi")                         AS decessi,
+    cast_double("tassi_standardizzati per 10.000")  AS tasso_std_10000
 FROM raw_input
 WHERE CAST(anno AS INTEGER) = {year}
-  AND CAST("Cod_Territorio" AS INTEGER) BETWEEN 1 AND 22
-  AND CAST("Cod_Territorio" AS INTEGER) <> 4
+  AND cast_int("Cod_Territorio") BETWEEN 1 AND 22
+  AND cast_int("Cod_Territorio") <> 4

--- a/candidates/mur-immatricolati/sql/clean.sql
+++ b/candidates/mur-immatricolati/sql/clean.sql
@@ -1,11 +1,11 @@
 SELECT
-    CAST(SUBSTR(AnnoA, 1, 4) AS INTEGER) AS anno,
-    CAST(ClasseNUMERO AS VARCHAR) AS classe_cod,
-    CAST(ClasseNOME AS VARCHAR) AS classe_nome,
-    CAST(Sesso AS VARCHAR) AS sesso,
-    TRY_CAST(Immatricolati AS INTEGER) AS immatricolati
+    cast_int(SUBSTR(AnnoA, 1, 4)) AS anno,
+    normalize_string(ClasseNUMERO) AS classe_cod,
+    normalize_string(ClasseNOME) AS classe_nome,
+    normalize_string(Sesso) AS sesso,
+    cast_int(Immatricolati) AS immatricolati
 FROM raw_input
 WHERE
-    TRY_CAST(SUBSTR(AnnoA, 1, 4) AS INTEGER) IS NOT NULL
-    AND TRY_CAST(Immatricolati AS INTEGER) IS NOT NULL
+    TRY_cast_int(SUBSTR(AnnoA, 1, 4)) IS NOT NULL
+    AND cast_int(Immatricolati) IS NOT NULL
     AND Immatricolati >= 0

--- a/candidates/mur-iscritti/sql/clean.sql
+++ b/candidates/mur-iscritti/sql/clean.sql
@@ -1,11 +1,11 @@
 SELECT
-    CAST(SUBSTR(AnnoA, 1, 4) AS INTEGER) AS anno,
-    CAST(AteneoCOD AS VARCHAR) AS ateneo_cod,
-    CAST(AteneoNOME AS VARCHAR) AS ateneo_nome,
-    CAST(SESSO AS VARCHAR) AS sesso,
-    TRY_CAST(Isc AS INTEGER) AS iscritti
+    cast_int(SUBSTR(AnnoA, 1, 4)) AS anno,
+    normalize_string(AteneoCOD) AS ateneo_cod,
+    normalize_string(AteneoNOME) AS ateneo_nome,
+    normalize_string(SESSO) AS sesso,
+    cast_int(Isc) AS iscritti
 FROM raw_input
 WHERE
-    TRY_CAST(SUBSTR(AnnoA, 1, 4) AS INTEGER) IS NOT NULL
-    AND TRY_CAST(Isc AS INTEGER) IS NOT NULL
+    TRY_cast_int(SUBSTR(AnnoA, 1, 4)) IS NOT NULL
+    AND cast_int(Isc) IS NOT NULL
     AND Isc >= 0

--- a/candidates/openga-ricorsi-cds/sql/clean.sql
+++ b/candidates/openga-ricorsi-cds/sql/clean.sql
@@ -3,9 +3,9 @@
 
 SELECT
     {year}::INTEGER AS anno,
-    "ANNO_MESE_RIFERIMENTO"::BIGINT AS anno_mese_riferimento,
-    (("ANNO_MESE_RIFERIMENTO"::BIGINT) % 100)::INTEGER AS mese,
-    "CODICE_SEDE"::BIGINT AS codice_sede,
-    "NOME_SEDE"::VARCHAR AS nome_sede,
-    "NUMERO_RICORSI_PENDENTI"::BIGINT AS numero_ricorsi_pendenti
+    cast_bigint("ANNO_MESE_RIFERIMENTO") AS anno_mese_riferimento,
+    (cast_bigint("ANNO_MESE_RIFERIMENTO") % 100)::INTEGER AS mese,
+    cast_bigint("CODICE_SEDE") AS codice_sede,
+    normalize_string("NOME_SEDE") AS nome_sede,
+    cast_bigint("NUMERO_RICORSI_PENDENTI") AS numero_ricorsi_pendenti
 FROM raw_input

--- a/candidates/sbarchi-migranti-italia/sql/clean.sql
+++ b/candidates/sbarchi-migranti-italia/sql/clean.sql
@@ -1,7 +1,7 @@
 SELECT
     TRY_CAST(Data AS DATE) AS data_sbarchi,
-    TRY_CAST(Valore AS BIGINT) AS valore,
-    CAST(Note AS VARCHAR) AS note,
-    CAST(Fonte AS VARCHAR) AS fonte
+    cast_bigint(Valore) AS valore,
+    normalize_string(Note) AS note,
+    normalize_string(Fonte) AS fonte
 FROM raw_input
-WHERE TRY_CAST(Valore AS BIGINT) IS NOT NULL
+WHERE cast_bigint(Valore) IS NOT NULL


### PR DESCRIPTION
## Sintesi

Migrazione di 13 candidati a basso rischio dai pattern manuali (`TRY_CAST`, `CAST`, `TRIM`, `NULLIF(TRIM(...))`) alle macro standard del toolkit v1.45.0.

## Cosa cambia

Ogni `sql/clean.sql` sostituisce:

| Pattern vecchio | Macro nuova | Occorrenze totali |
|---|---|---|
| `TRY_CAST("col" AS INTEGER)` / `CAST(col AS INTEGER)` | `cast_int(col)` | ~20 |
| `TRY_CAST("col" AS BIGINT)` / `::BIGINT` | `cast_bigint(col)` | ~8 |
| `TRY_CAST("col" AS DOUBLE)` / `CAST(col AS DOUBLE)` | `cast_double(col)` | ~25 |
| `TRIM(CAST("col" AS VARCHAR))` / `CAST(col AS VARCHAR)` | `normalize_string(col)` | ~30 |

## Candidati

1. `sbarchi-migranti-italia` — 4 colonne, semplice
2. `mur-iscritti` — 5 colonne, SUBSTR+cast_int
3. `mur-immatricolati` — 5 colonne, stesso pattern
4. `istat-asia-ul` — 4 colonne
5. `ispra-emissioni-ghg` — 6 colonne
6. `istat-gini-regionale` — 6 colonne
7. `openga-ricorsi-cds` — 6 colonne, utilizzava `::BIGINT`
8. `giustizia-penale-indicatori` — 7 colonne
9. `anpr-mobilita-residenziale` — 7 colonne
10. `bdap-entrate-stato` — 12 colonne
11. `bdap-spese-stato` — 12 colonne, stesso pattern
12. `civile-flussi` — 12 colonne
13. `mortalita-istat-evitabile` — 14 colonne

## Perché questi

Candidati a basso rischio: niente REPLACE, niente CASE WHEN complesso, niente window function. Solo cast e trim. CI rapida, rollback facile.

## Non inclusi

- `rna-misure`, `siope-bilancio-unificato` — già `select *`, nessuna modifica
- I rimanenti ~55 candidati — richiedono pattern più complessi (REPLACE numeri italiani, CASE boolean, window function). Batch successivi.

## Verifica

```bash
toolkit run full --config candidates/sbarchi-migranti-italia/dataset.yml --dry-run
# ... stesso per ogni candidato
```

La CI PR eseguirà `toolkit run full --smoke` per ogni candidato modificato.
