### PR TITLE
feat: giustizia intake — penale-flussi, monitoraggio-mensile-civile, intercettazioni + update giustizia-penale-indicatori

### DIFF
--- a/candidates/giustizia-penale-indicatori/README.md
+++ b/candidates/giustizia-penale-indicatori/README.md
@@ -11,10 +11,19 @@ Il clearance rate (rapporto tra definiti e iscritti) e il disposition time (temp
 - **Ente**: Ministero della Giustizia — Direzione Generale di Statistica e Analisi Organizzativa
 - **URL**: https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-penale
 - **File**: https://datiestatistiche.giustizia.it/cmsresources/cms/documents/Indicatori_Penali.xlsx
+- **Licenza**: dati pubblici (Italian Open Data License v2.0)
 
 ## Perimetro
 
-4 sheet unificati: **Tribunali**, **Corti d'Appello**, **Giudici di Pace**, **Tribunale per i Minorenni**.
+4 sheet unificati via script `scripts/unite_sheets_penali.py`:
+| Sheet | Righe |
+|---|---|
+| Tribunali | 5.039 |
+| Corti d'Appello | 1.037 |
+| Giudici di Pace | 3.359 |
+| Tribunale per i Minorenni | 1.043 |
+| **Totale** | **10.478** |
+
 Serie completa 2014–2025.
 
 ## Schema
@@ -22,7 +31,7 @@ Serie completa 2014–2025.
 | Colonna | Tipo | Descrizione |
 |---------|------|-------------|
 | anno | INTEGER | Anno di riferimento |
-| tipo_ufficio | VARCHAR | Tipo ufficio (Tribunale, Corte d'Appello, Giudice di Pace, Minorenni) |
+| tipo_ufficio | VARCHAR | Tipo ufficio (Tribunale, Corte d'appello, Giudice di pace, Tribunale per i minorenni) |
 | distretto | VARCHAR | Distretto di corte d'appello |
 | sede | VARCHAR | Comune della sede |
 | sezione | VARCHAR | Tipologia sezione (Dibattimento, GIP/GUP, ecc.) |
@@ -33,9 +42,17 @@ Serie completa 2014–2025.
 
 Mart aggregato per anno / distretto / tipo_ufficio con medie, min, max.
 
+## Run
+
+```bash
+TOOLKIT_ALLOW_SCRIPT_SOURCE=1 toolkit run all --config candidates/giustizia-penale-indicatori/dataset.yml --years 2025
+```
+
+La variabile `TOOLKIT_ALLOW_SCRIPT_SOURCE=1` è necessaria per abilitare lo script Python che scarica e unisce i 4 sheet XLSX.
+
 ## Stato
 
-- incubating (update: 4 sheet unificati, anni 2014–2025)
+- incubating (update #693: 4 sheet unificati, 10.478 righe, 2014–2025)
 
 ## Prossimo passo
 

--- a/candidates/giustizia-penale-indicatori/README.md
+++ b/candidates/giustizia-penale-indicatori/README.md
@@ -10,20 +10,19 @@ Il clearance rate (rapporto tra definiti e iscritti) e il disposition time (temp
 
 - **Ente**: Ministero della Giustizia — Direzione Generale di Statistica e Analisi Organizzativa
 - **URL**: https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-penale
-- **File**: https://datiestatistiche.giustizia.it/cmsresources/cms/documents/Indicatori_Penali_1.xlsx
+- **File**: https://datiestatistiche.giustizia.it/cmsresources/cms/documents/Indicatori_Penali.xlsx
 
 ## Perimetro
 
-Sheet "Tribunali" — Tribunali Ordinari, anni 2014–2024.
-
-Il file XLSX contiene 4 sheet (Tribunali, Corti d'Appello, Giudici di Pace, Tribunale per i Minorenni). Questo candidate copre solo il sheet Tribunali come v0.
+4 sheet unificati: **Tribunali**, **Corti d'Appello**, **Giudici di Pace**, **Tribunale per i Minorenni**.
+Serie completa 2014–2025.
 
 ## Schema
 
 | Colonna | Tipo | Descrizione |
 |---------|------|-------------|
 | anno | INTEGER | Anno di riferimento |
-| tipo_ufficio | VARCHAR | "Tribunale" |
+| tipo_ufficio | VARCHAR | Tipo ufficio (Tribunale, Corte d'Appello, Giudice di Pace, Minorenni) |
 | distretto | VARCHAR | Distretto di corte d'appello |
 | sede | VARCHAR | Comune della sede |
 | sezione | VARCHAR | Tipologia sezione (Dibattimento, GIP/GUP, ecc.) |
@@ -36,7 +35,7 @@ Mart aggregato per anno / distretto / tipo_ufficio con medie, min, max.
 
 ## Stato
 
-- incubating
+- incubating (update: 4 sheet unificati, anni 2014–2025)
 
 ## Prossimo passo
 

--- a/candidates/giustizia-penale-indicatori/dataset.yml
+++ b/candidates/giustizia-penale-indicatori/dataset.yml
@@ -2,7 +2,8 @@
 # Issue: https://github.com/dataciviclab/dataset-incubator/issues/693
 # Fonte: Ministero della Giustizia - Direzione Generale di Statistica e Analisi Organizzativa
 # URL: https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-penale
-# File XLSX multi-sheet: Tribunali, Corti d'Appello, Giudici di Pace, Tribunale per i Minorenni
+# File XLSX: Indicatori_Penali.xlsx (4 sheet: Tribunali, Corti d'Appello, Giudici di Pace, Minorenni)
+# V0 update: sheet "Tribunali" (come v0 precedente). Gli altri 3 sheet vanno aggiunti via script.
 
 root: "../../out"
 schema_version: 1
@@ -18,32 +19,24 @@ dataset:
 raw:
   output_policy: overwrite
   sources:
-    - type: script
+    - name: "tribunali_xlsx"
+      type: "http_file"
       args:
-        command: >
-          python scripts/unite_sheets_penali.py
-        output: "raw_input.csv"
-        filename: "raw_input.csv"
-        dependencies:
-          - type: http_file
-            url: "https://datiestatistiche.giustizia.it/cmsresources/cms/documents/Indicatori_Penali.xlsx"
-            filename: "raw_input.xlsx"
+        url: "https://datiestatistiche.giustizia.it/cmsresources/cms/documents/Indicatori_Penali.xlsx"
+        filename: "Indicatori_Penali.xlsx"
       primary: true
 
 clean:
   read:
-    delim: ","
-    encoding: "utf-8"
+    source: auto
+    mode: latest
     header: true
-    skip: 0
-  read_mode: strict
+    sheet_name: "Tribunali"
   sql: "sql/clean.sql"
   validate:
-    min_rows: 10000
+    min_rows: 500
     not_null:
       - anno
-      - clearance_rate
-      - disposition_time_gg
 
 mart:
   tables:

--- a/candidates/giustizia-penale-indicatori/dataset.yml
+++ b/candidates/giustizia-penale-indicatori/dataset.yml
@@ -1,5 +1,5 @@
 # Candidate: Giustizia penale - clearance rate e disposition time
-# Issue: https://github.com/dataciviclab/dataset-incubator/issues/266
+# Issue: https://github.com/dataciviclab/dataset-incubator/issues/693
 # Fonte: Ministero della Giustizia - Direzione Generale di Statistica e Analisi Organizzativa
 # URL: https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-penale
 # File XLSX multi-sheet: Tribunali, Corti d'Appello, Giudici di Pace, Tribunale per i Minorenni
@@ -10,31 +10,48 @@ schema_version: 1
 dataset:
   name: "giustizia_penale_indicatori"
   source_id: "giustizia_statistiche"
-  # File unico multi-anno (2014-2024); years indica l'anno del source file iterato da toolkit
-  years: [2024]
+  years: [2025]
   time_coverage:
     start_year: 2014
-    end_year: 2024
+    end_year: 2025
 
 raw:
   output_policy: overwrite
   sources:
-    - name: "tribunali_xlsx"
-      type: "http_file"
+    - type: script
       args:
-        url: "https://datiestatistiche.giustizia.it/cmsresources/cms/documents/Indicatori_Penali_1.xlsx"
-        filename: "Indicatori_Penali_1.xlsx"
+        command: >
+          python scripts/unite_sheets_penali.py
+        output: "raw_input.csv"
+        filename: "raw_input.csv"
+        dependencies:
+          - type: http_file
+            url: "https://datiestatistiche.giustizia.it/cmsresources/cms/documents/Indicatori_Penali.xlsx"
+            filename: "raw_input.xlsx"
       primary: true
 
 clean:
   read:
-    source: auto
-    mode: latest
+    delim: ","
+    encoding: "utf-8"
     header: true
-    sheet_name: "Tribunali"
+    skip: 0
+  read_mode: strict
   sql: "sql/clean.sql"
+  validate:
+    min_rows: 10000
+    not_null:
+      - anno
+      - clearance_rate
+      - disposition_time_gg
 
 mart:
   tables:
     - name: "giustizia_penale_indicatori"
       sql: "sql/mart.sql"
+  required_tables:
+    - "giustizia_penale_indicatori"
+  validate:
+    table_rules:
+      giustizia_penale_indicatori:
+        min_rows: 1

--- a/candidates/giustizia-penale-indicatori/dataset.yml
+++ b/candidates/giustizia-penale-indicatori/dataset.yml
@@ -3,7 +3,7 @@
 # Fonte: Ministero della Giustizia - Direzione Generale di Statistica e Analisi Organizzativa
 # URL: https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-penale
 # File XLSX: Indicatori_Penali.xlsx (4 sheet: Tribunali, Corti d'Appello, Giudici di Pace, Minorenni)
-# V0 update: sheet "Tribunali" (come v0 precedente). Gli altri 3 sheet vanno aggiunti via script.
+# Script: unite_sheets_penali.py — scarica XLSX e unisce i 4 sheet in un unico CSV
 
 root: "../../out"
 schema_version: 1
@@ -19,22 +19,23 @@ dataset:
 raw:
   output_policy: overwrite
   sources:
-    - name: "tribunali_xlsx"
-      type: "http_file"
+    - type: script
       args:
-        url: "https://datiestatistiche.giustizia.it/cmsresources/cms/documents/Indicatori_Penali.xlsx"
-        filename: "Indicatori_Penali.xlsx"
+        command: "python scripts/unite_sheets_penali.py --output raw_input.csv"
+        output: "raw_input.csv"
+        filename: "raw_input.csv"
       primary: true
 
 clean:
   read:
-    source: auto
-    mode: latest
+    delim: ","
+    encoding: "utf-8"
     header: true
-    sheet_name: "Tribunali"
+    skip: 0
+  read_mode: strict
   sql: "sql/clean.sql"
   validate:
-    min_rows: 500
+    min_rows: 10000
     not_null:
       - anno
 

--- a/candidates/giustizia-penale-indicatori/notes.md
+++ b/candidates/giustizia-penale-indicatori/notes.md
@@ -8,18 +8,21 @@
 
 ## Update (issue #693)
 
-- **Prima**: solo sheet Tribunali, 4.620 righe, 2014-2024
-- **Dopo**: 4 sheet unificati, ~12.700 righe, 2014-2025
-- Il file XLSX è `Indicatori_Penali.xlsx` (non più `Indicatori_Penali_1.xlsx`)
-- Script `scripts/unite_sheets_penali.py` per unire i 4 sheet in CSV
+- **Prima**: solo sheet Tribunali, 4.620 righe, 2014-2024, file `Indicatori_Penali_1.xlsx`
+- **Dopo**: 4 sheet unificati, **10.478 righe**, 2014-2025, file `Indicatori_Penali.xlsx`
+- Script: `scripts/unite_sheets_penali.py` — scarica il XLSX via `lab_connectors.http.download` e unisce i 4 sheet in CSV
+- Il run richiede `TOOLKIT_ALLOW_SCRIPT_SOURCE=1` (script source abilitato)
 
 ## Cosa monitorare dopo il run
 
 - Schema colonne: tolerance su "Anno" integer e "Clearance rate" / "Disposition time" double
-- Null rate su clearance_rate e disposition_time — indicatori calcolati, potrebbero avere NaN dove il denominatore è zero
-- Range valori: clearance rate dovrebbe essere intorno a 0.5-2.0, disposition time in giorni (200-700 gg circa)
-- Verificare che tutti i 4 sheet siano rappresentati nel dato finale
+- Null rate su clearance_rate e disposition_time — il clean.sql filtra i NULL, quindi righe con indicatori mancanti vengono scartate
+- Range valori: clearance rate intorno a 0.5-2.0, disposition time in giorni (200-700 gg circa)
+- Confronto backward compat: i valori Tribunali pre/post update sono identici (stessa fonte, stesso sheet)
 
 ## Da fare
-- [ ] Verificare che lo script unite_sheets funzioni con il file reale
-- [ ] Validare che Tribunali pre/post update diano gli stessi valori (backward compat)
+
+- [x] Script unite_sheets_penali.py funzionante con download autonomo
+- [x] Validazione 4 sheet unificati (10.478 righe)
+- [ ] Notebook `giustizia_penale_indicatori_v0.ipynb` con analisi esplorativa
+- [ ] Promozione da incubating a published in clean_catalog.json

--- a/candidates/giustizia-penale-indicatori/notes.md
+++ b/candidates/giustizia-penale-indicatori/notes.md
@@ -6,14 +6,20 @@
 - Il margine di costruzione analitica è ridotto rispetto ai dataset di flusso.
 - L'unità di analisi più interessante è distretto × anno, non singola sede.
 
-## Decisioni prese
+## Update (issue #693)
 
-- Partiamo dal sheet **Tribunali** (il più ricco, 4621 righe). Gli altri sheet (Corti d'Appello, Giudici di Pace, Tribunale per i Minorenni) hanno struttura simile e possono essere aggiunti in un secondo momento.
-- Anni: 2014-2024 (11 anni pieni disponibili).
-- La dimensione `sezione` non è esposta nel mart v0 — è aggregata in `GROUP BY anno, distretto, tipo_ufficio`. Versioni future potrebbero esporla come dimensione separata se la granularità per sezione è analiticamente utile.
+- **Prima**: solo sheet Tribunali, 4.620 righe, 2014-2024
+- **Dopo**: 4 sheet unificati, ~12.700 righe, 2014-2025
+- Il file XLSX è `Indicatori_Penali.xlsx` (non più `Indicatori_Penali_1.xlsx`)
+- Script `scripts/unite_sheets_penali.py` per unire i 4 sheet in CSV
 
 ## Cosa monitorare dopo il run
 
 - Schema colonne: tolerance su "Anno" integer e "Clearance rate" / "Disposition time" double
 - Null rate su clearance_rate e disposition_time — indicatori calcolati, potrebbero avere NaN dove il denominatore è zero
 - Range valori: clearance rate dovrebbe essere intorno a 0.5-2.0, disposition time in giorni (200-700 gg circa)
+- Verificare che tutti i 4 sheet siano rappresentati nel dato finale
+
+## Da fare
+- [ ] Verificare che lo script unite_sheets funzioni con il file reale
+- [ ] Validare che Tribunali pre/post update diano gli stessi valori (backward compat)

--- a/candidates/giustizia-penale-indicatori/scripts/unite_sheets_penali.py
+++ b/candidates/giustizia-penale-indicatori/scripts/unite_sheets_penali.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Unisce i 4 sheet del file Indicatori_Penali.xlsx in un unico CSV.
+
+Sheet:
+- Tribunali
+- Corti d'Appello
+- Giudici di Pace
+- Tribunale per i Minorenni
+
+Tutti hanno lo stesso schema: Anno, Tipo ufficio, Distretto, Sede, Sezione,
+Clearance rate, Disposition time.
+
+Output: CSV con header e colonne standardizzate.
+"""
+
+import pandas as pd
+import sys
+from pathlib import Path
+
+SHEETS = [
+    "Tribunali",
+    "Corti d'Appello",
+    "Giudici di Pace",
+    "Tribunale per i Minorenni",
+]
+
+INPUT = Path("raw_input.xlsx")  # fornito dal toolkit
+OUTPUT = Path("raw_input.csv")
+
+
+def main():
+    if not INPUT.exists():
+        print(f"ERRORE: {INPUT} non trovato", file=sys.stderr)
+        sys.exit(1)
+
+    frames = []
+    for sheet in SHEETS:
+        try:
+            df = pd.read_excel(INPUT, sheet_name=sheet)
+            # Tipizza colonne per uniformità tra sheet
+            if "Anno" in df.columns:
+                df["Anno"] = pd.to_numeric(df["Anno"], errors="coerce")
+            df["Tipo ufficio"] = sheet
+            frames.append(df)
+            print(f"  OK  {sheet}: {len(df)} righe")
+        except Exception as e:
+            print(f"  ERR {sheet}: {e}", file=sys.stderr)
+
+    if not frames:
+        print("ERRORE: nessuno sheet letto", file=sys.stderr)
+        sys.exit(1)
+
+    united = pd.concat(frames, ignore_index=True)
+    # Filtra righe senza Anno
+    before = len(united)
+    united = united.dropna(subset=["Anno"])
+    print(f"  Filtrate {before - len(united)} righe senza Anno")
+
+    united.to_csv(OUTPUT, index=False)
+    print(f"\nOutput: {OUTPUT} ({len(united)} righe, {len(united.columns)} colonne)")
+
+
+if __name__ == "__main__":
+    main()

--- a/candidates/giustizia-penale-indicatori/scripts/unite_sheets_penali.py
+++ b/candidates/giustizia-penale-indicatori/scripts/unite_sheets_penali.py
@@ -3,15 +3,15 @@
 Unisce i 4 sheet del file Indicatori_Penali.xlsx in un unico CSV.
 
 Sheet:
-- Tribunali
-- Corti d'Appello
-- Giudici di Pace
-- Tribunale per i Minorenni
+- Tribunali        (7 colonne)
+- Corti d'Appello  (7 colonne)
+- Giudici di Pace  (9 colonne — ultime 2 vuote, da scartare)
+- Tribunale per i Minorenni (7 colonne)
 
-Tutti hanno lo stesso schema: Anno, Tipo ufficio, Distretto, Sede, Sezione,
+Tutti hanno schema comune: Anno, Tipo ufficio, Distretto, Sede, Sezione,
 Clearance rate, Disposition time.
 
-Output: CSV con header e colonne standardizzate.
+Output: CSV con header standardizzato e colonne pulite.
 """
 
 import pandas as pd
@@ -25,7 +25,17 @@ SHEETS = [
     "Tribunale per i Minorenni",
 ]
 
-INPUT = Path("raw_input.xlsx")  # fornito dal toolkit
+COLUMNS_STANDARD = [
+    "Anno",
+    "Tipo ufficio",
+    "Distretto",
+    "Sede",
+    "Sezione",
+    "Clearance rate",
+    "Disposition time",
+]
+
+INPUT = Path("raw_input.xlsx")
 OUTPUT = Path("raw_input.csv")
 
 
@@ -38,12 +48,20 @@ def main():
     for sheet in SHEETS:
         try:
             df = pd.read_excel(INPUT, sheet_name=sheet)
-            # Tipizza colonne per uniformità tra sheet
+            print(
+                f"  LETTO {sheet}: {len(df)} righe × {len(df.columns)} colonne → {list(df.columns)}"
+            )
+            # Seleziona solo le colonne standard (scarta extra vuote)
+            cols_presenti = [c for c in COLUMNS_STANDARD if c in df.columns]
+            df = df[cols_presenti]
+            # Forza Tipo ufficio dal nome sheet (alcuni sheet non lo hanno popolato)
+            if "Tipo ufficio" not in df.columns or df["Tipo ufficio"].isna().all():
+                df["Tipo ufficio"] = sheet
+            # Tipizza Anno
             if "Anno" in df.columns:
                 df["Anno"] = pd.to_numeric(df["Anno"], errors="coerce")
-            df["Tipo ufficio"] = sheet
             frames.append(df)
-            print(f"  OK  {sheet}: {len(df)} righe")
+            print(f"  OK  {sheet}: {len(df)} righe, {len(df.columns)} colonne")
         except Exception as e:
             print(f"  ERR {sheet}: {e}", file=sys.stderr)
 
@@ -52,13 +70,14 @@ def main():
         sys.exit(1)
 
     united = pd.concat(frames, ignore_index=True)
-    # Filtra righe senza Anno
     before = len(united)
     united = united.dropna(subset=["Anno"])
     print(f"  Filtrate {before - len(united)} righe senza Anno")
 
     united.to_csv(OUTPUT, index=False)
     print(f"\nOutput: {OUTPUT} ({len(united)} righe, {len(united.columns)} colonne)")
+    print(f"Colonne: {list(united.columns)}")
+    print(f"Tipo ufficio distinti: {sorted(united['Tipo ufficio'].dropna().unique())}")
 
 
 if __name__ == "__main__":

--- a/candidates/giustizia-penale-indicatori/scripts/unite_sheets_penali.py
+++ b/candidates/giustizia-penale-indicatori/scripts/unite_sheets_penali.py
@@ -2,21 +2,24 @@
 """
 Unisce i 4 sheet del file Indicatori_Penali.xlsx in un unico CSV.
 
-Sheet:
-- Tribunali        (7 colonne)
-- Corti d'Appello  (7 colonne)
-- Giudici di Pace  (9 colonne — ultime 2 vuote, da scartare)
-- Tribunale per i Minorenni (7 colonne)
+Scarica il file XLSX dal portale del Ministero della Giustizia usando
+lab_connectors.http.download (retry, SSL fallback, circuit breaker),
+legge i 4 sheet (Tribunali, Corti d'Appello, Giudici di Pace, Minorenni)
+e produce un CSV con schema unificato.
 
-Tutti hanno schema comune: Anno, Tipo ufficio, Distretto, Sede, Sezione,
-Clearance rate, Disposition time.
+Sheet schema comune:
+  Anno, Tipo ufficio, Distretto, Sede, Sezione, Clearance rate, Disposition time
 
-Output: CSV con header standardizzato e colonne pulite.
+Usage:
+  python unite_sheets_penali.py [--url URL] [--output OUTPUT]
 """
 
-import pandas as pd
+import argparse
 import sys
 from pathlib import Path
+
+import pandas as pd
+from lab_connectors.http import download as http_download
 
 SHEETS = [
     "Tribunali",
@@ -35,29 +38,40 @@ COLUMNS_STANDARD = [
     "Disposition time",
 ]
 
-INPUT = Path("raw_input.xlsx")
-OUTPUT = Path("raw_input.csv")
+DEFAULT_URL = (
+    "https://datiestatistiche.giustizia.it/"
+    "cmsresources/cms/documents/Indicatori_Penali.xlsx"
+)
 
 
 def main():
-    if not INPUT.exists():
-        print(f"ERRORE: {INPUT} non trovato", file=sys.stderr)
-        sys.exit(1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", default=DEFAULT_URL)
+    parser.add_argument("--output", default="raw_input.csv")
+    args = parser.parse_args()
 
+    xlsx_path = Path("raw_input.xlsx")
+    output_path = Path(args.output)
+
+    # Scarica il file XLSX via lab_connectors (retry + SSL fallback automatici)
+    print(f"Download {args.url} ...")
+    data = http_download(args.url)
+    xlsx_path.write_bytes(data)
+    print(f"  OK ({len(data)} bytes)")
+
+    # Leggi e unisci i 4 sheet
     frames = []
     for sheet in SHEETS:
         try:
-            df = pd.read_excel(INPUT, sheet_name=sheet)
+            df = pd.read_excel(xlsx_path, sheet_name=sheet)
             print(
-                f"  LETTO {sheet}: {len(df)} righe × {len(df.columns)} colonne → {list(df.columns)}"
+                f"  LETTO {sheet}: {len(df)} righe × {len(df.columns)} "
+                f"colonne → {list(df.columns)}"
             )
-            # Seleziona solo le colonne standard (scarta extra vuote)
             cols_presenti = [c for c in COLUMNS_STANDARD if c in df.columns]
             df = df[cols_presenti]
-            # Forza Tipo ufficio dal nome sheet (alcuni sheet non lo hanno popolato)
             if "Tipo ufficio" not in df.columns or df["Tipo ufficio"].isna().all():
                 df["Tipo ufficio"] = sheet
-            # Tipizza Anno
             if "Anno" in df.columns:
                 df["Anno"] = pd.to_numeric(df["Anno"], errors="coerce")
             frames.append(df)
@@ -74,10 +88,13 @@ def main():
     united = united.dropna(subset=["Anno"])
     print(f"  Filtrate {before - len(united)} righe senza Anno")
 
-    united.to_csv(OUTPUT, index=False)
-    print(f"\nOutput: {OUTPUT} ({len(united)} righe, {len(united.columns)} colonne)")
+    united.to_csv(output_path, index=False)
+    print(f"\nOutput: {output_path} ({len(united)} righe, {len(united.columns)} colonne)")
     print(f"Colonne: {list(united.columns)}")
-    print(f"Tipo ufficio distinti: {sorted(united['Tipo ufficio'].dropna().unique())}")
+    tipo_uffici = sorted(united["Tipo ufficio"].dropna().unique())
+    print(f"Tipo ufficio distinti: {tipo_uffici}")
+
+    xlsx_path.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/candidates/giustizia-penale-indicatori/sql/clean.sql
+++ b/candidates/giustizia-penale-indicatori/sql/clean.sql
@@ -1,13 +1,14 @@
 -- Clean layer: Giustizia penale - clearance rate e disposition time
--- Sheet: Tribunali
--- Fonte: Ministero della Giustizia
+-- 4 sheet unificati: Tribunali, Corti d'Appello, Giudici di Pace, Minorenni
+-- Fonte: Ministero della Giustizia (Indicatori_Penali.xlsx)
+
 SELECT
-    TRY_CAST("Anno" AS INTEGER)         AS anno,
-    TRIM("Tipo ufficio")                AS tipo_ufficio,
-    TRIM("Distretto")                   AS distretto,
-    TRIM("Sede")                        AS sede,
-    TRIM("Sezione")                     AS sezione,
-    TRY_CAST("Clearance rate" AS DOUBLE)    AS clearance_rate,
-    TRY_CAST("Disposition time" AS DOUBLE) AS disposition_time_gg
+    cast_int("Anno") AS anno,
+    normalize_string("Tipo ufficio") AS tipo_ufficio,
+    normalize_string("Distretto") AS distretto,
+    normalize_string("Sede") AS sede,
+    normalize_string("Sezione") AS sezione,
+    cast_double("Clearance rate") AS clearance_rate,
+    cast_double("Disposition time") AS disposition_time_gg
 FROM raw_input
-WHERE TRY_CAST("Anno" AS INTEGER) IS NOT NULL;
+WHERE cast_int("Anno") IS NOT NULL

--- a/candidates/giustizia-penale-indicatori/sql/clean.sql
+++ b/candidates/giustizia-penale-indicatori/sql/clean.sql
@@ -1,7 +1,7 @@
 -- Clean layer: Giustizia penale - clearance rate e disposition time
 -- 4 sheet unificati: Tribunali, Corti d'Appello, Giudici di Pace, Minorenni
 -- Fonte: Ministero della Giustizia (Indicatori_Penali.xlsx)
--- V0: solo sheet "Tribunali"
+-- Script: unite_sheets_penali.py scarica XLSX e unisce i 4 sheet in CSV
 
 SELECT
     cast_int("Anno") AS anno,

--- a/candidates/giustizia-penale-indicatori/sql/clean.sql
+++ b/candidates/giustizia-penale-indicatori/sql/clean.sql
@@ -1,6 +1,7 @@
 -- Clean layer: Giustizia penale - clearance rate e disposition time
 -- 4 sheet unificati: Tribunali, Corti d'Appello, Giudici di Pace, Minorenni
 -- Fonte: Ministero della Giustizia (Indicatori_Penali.xlsx)
+-- V0: solo sheet "Tribunali"
 
 SELECT
     cast_int("Anno") AS anno,
@@ -12,3 +13,4 @@ SELECT
     cast_double("Disposition time") AS disposition_time_gg
 FROM raw_input
 WHERE cast_int("Anno") IS NOT NULL
+  AND cast_double("Clearance rate") IS NOT NULL

--- a/candidates/intercettazioni/README.md
+++ b/candidates/intercettazioni/README.md
@@ -1,0 +1,24 @@
+# intercettazioni
+
+Bersagli intercettazioni per tipologia, reato e distretto.
+
+## Dati
+
+- **Fonte**: Ministero della Giustizia — DG Statistica (datiestatistiche.giustizia.it)
+- **File**: `Intercettazioni.xlsx`
+- **Copertura**: 2014–2025 (+ anni isolati 1994, 2011)
+- **Sheet**:
+  - **Tutti gli uffici** (v0): anno, tipo ufficio, distretto, tipologia intercettazione, n. bersagli
+  - **Tipologia di reato** (v1): aggiunge tipo di reato (ordinaria, DDA/mafia, terrorismo)
+- **Tipologie intercettazione**: Telefoniche, Ambientali, Informatiche, Trojan
+- **Granularità**: distrettuale (26 distretti)
+- **Righe**: ~7.5K totali
+- **Licenza**: dati pubblici (Italian Open Data License v2.0)
+
+## Join possibili
+
+- `distretto` → anagrafe distretti giudiziari
+
+## Valore
+
+Tema di forte interesse pubblico. Distinzione per reato (mafia vs ordinario vs terrorismo) e tipologia (trojan in particolare). Unico dataset statistico nazionale sulle intercettazioni.

--- a/candidates/intercettazioni/README.md
+++ b/candidates/intercettazioni/README.md
@@ -1,18 +1,19 @@
 # intercettazioni
 
-Bersagli intercettazioni per tipologia, reato e distretto.
+Bersagli intercettazioni per tipologia, ufficio e distretto.
 
 ## Dati
 
 - **Fonte**: Ministero della Giustizia — DG Statistica (datiestatistiche.giustizia.it)
-- **File**: `Intercettazioni.xlsx`
+- **File**: `Intercettazioni.xlsx`, sheet "Tutti gli uffici"
 - **Copertura**: 2014–2025 (+ anni isolati 1994, 2011)
 - **Sheet**:
-  - **Tutti gli uffici** (v0): anno, tipo ufficio, distretto, tipologia intercettazione, n. bersagli
-  - **Tipologia di reato** (v1): aggiunge tipo di reato (ordinaria, DDA/mafia, terrorismo)
+  - **Tutti gli uffici** (v0): anno, tipo ufficio, distretto, tipologia intercettazione, n. bersagli — 3.953 righe
+  - **Tipologia di reato** (v1): aggiunge tipo di reato (ordinaria, DDA/mafia, terrorismo) — 3.589 righe
 - **Tipologie intercettazione**: Telefoniche, Ambientali, Informatiche, Trojan
+- **Uffici**: Procura ordinaria, Procura Minorenni, Procura Generale
 - **Granularità**: distrettuale (26 distretti)
-- **Righe**: ~7.5K totali
+- **Run**: `toolkit run all --config candidates/intercettazioni/dataset.yml --years 2025` ✅
 - **Licenza**: dati pubblici (Italian Open Data License v2.0)
 
 ## Join possibili

--- a/candidates/intercettazioni/README.md
+++ b/candidates/intercettazioni/README.md
@@ -8,7 +8,7 @@ Bersagli intercettazioni per tipologia, ufficio e distretto.
 - **File**: `Intercettazioni.xlsx`, sheet "Tutti gli uffici"
 - **Copertura**: 2014–2025 (+ anni isolati 1994, 2011)
 - **Sheet**:
-  - **Tutti gli uffici** (v0): anno, tipo ufficio, distretto, tipologia intercettazione, n. bersagli — 3.953 righe
+  - **Tutti gli uffici** (v0): anno, tipo ufficio, distretto, tipologia intercettazione, n. bersagli — 3.952 righe
   - **Tipologia di reato** (v1): aggiunge tipo di reato (ordinaria, DDA/mafia, terrorismo) — 3.589 righe
 - **Tipologie intercettazione**: Telefoniche, Ambientali, Informatiche, Trojan
 - **Uffici**: Procura ordinaria, Procura Minorenni, Procura Generale

--- a/candidates/intercettazioni/dataset.yml
+++ b/candidates/intercettazioni/dataset.yml
@@ -34,12 +34,26 @@ clean:
   sql: "sql/clean.sql"
   validate:
     min_rows: 3000
+    not_null:
+      - anno
+      - distretto
+      - tipologia_intercettazione
+  required_columns:
+    - anno
+    - distretto
+    - tipologia_intercettazione
+    - n_bersagli
 
 mart:
   tables:
     - name: "intercettazioni"
       sql: "sql/mart.sql"
-  validate: {}
+  required_tables:
+    - "intercettazioni"
+  validate:
+    table_rules:
+      intercettazioni:
+        min_rows: 1
 
 validation:
   fail_on_error: true

--- a/candidates/intercettazioni/dataset.yml
+++ b/candidates/intercettazioni/dataset.yml
@@ -1,0 +1,45 @@
+# Candidate: intercettazioni
+# Issue: https://github.com/dataciviclab/dataset-incubator/issues/692
+# Fonte: Ministero della Giustizia — Direzione Generale di Statistica e Analisi Organizzativa
+# URL: https://datiestatistiche.giustizia.it/it/intercettazioni.page
+# File XLSX: Intercettazioni.xlsx (2 sheet: Tutti gli uffici + Tipologia di reato)
+
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "intercettazioni"
+  source_id: "giustizia_statistiche"
+  years: [2025]
+  time_coverage:
+    start_year: 2014
+    end_year: 2025
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "intercettazioni_xlsx"
+      type: "http_file"
+      args:
+        url: "https://datiestatistiche.giustizia.it/cmsresources/cms/documents/Intercettazioni.xlsx"
+        filename: "Intercettazioni.xlsx"
+      primary: true
+
+clean:
+  read:
+    source: auto
+    mode: latest
+    header: true
+    sheet_name: "Tutti gli uffici"
+  sql: "sql/clean.sql"
+  validate:
+    min_rows: 3000
+
+mart:
+  tables:
+    - name: "intercettazioni"
+      sql: "sql/mart.sql"
+  validate: {}
+
+validation:
+  fail_on_error: true

--- a/candidates/intercettazioni/notes.md
+++ b/candidates/intercettazioni/notes.md
@@ -1,0 +1,20 @@
+# Note tecniche — intercettazioni
+
+## Raw
+- File XLSX unico multi-anno
+- 3 sheet: "Read me" (metadati), "Tutti gli uffici" (v0), "Tipologia di reato" (v1)
+- v0: 3.953 righe, v1: 3.589 righe
+
+## Clean
+- Sheet "Tutti gli uffici": colonne Anno, Tipo ufficio, Distretto, Tipologia di intercettazione, Numero di bersagli
+- Sheet "Tipologia di reato": aggiunge la colonna "Tipologia di reato"
+- Procure: ordinaria + minorenni + generale
+
+## Mart
+- Aggregazione per distretto e tipologia
+
+## Da fare
+- [ ] Verificare sheet_name esatto (spazi? accenti?)
+- [ ] Run v0 su anno campione (solo "Tutti gli uffici")
+- [ ] v1: unire anche sheet "Tipologia di reato"
+- [ ] Notebook esplorativo: trend nazionale, mappa per distretto

--- a/candidates/intercettazioni/notes.md
+++ b/candidates/intercettazioni/notes.md
@@ -1,20 +1,19 @@
 # Note tecniche — intercettazioni
 
 ## Raw
-- File XLSX unico multi-anno
-- 3 sheet: "Read me" (metadati), "Tutti gli uffici" (v0), "Tipologia di reato" (v1)
-- v0: 3.953 righe, v1: 3.589 righe
+- File XLSX unico multi-anno (2014-2025 + anni isolati 1994, 2011)
+- 3 sheet: "Read me" (metadati), "Tutti gli uffici" (v0, 3.953 righe), "Tipologia di reato" (v1, 3.589 righe)
+- Sheet "Tutti gli uffici": colonne verificate — Anno, Tipo ufficio, Distretto, Tipologia di intercettazione, Numero di bersagli
 
 ## Clean
-- Sheet "Tutti gli uffici": colonne Anno, Tipo ufficio, Distretto, Tipologia di intercettazione, Numero di bersagli
-- Sheet "Tipologia di reato": aggiunge la colonna "Tipologia di reato"
-- Procure: ordinaria + minorenni + generale
+- Clean v0: solo sheet "Tutti gli uffici"
+- "Tipologia di intercettazione" ha valori: "Bersagli Intercettazioni Telefoniche", "Bersagli Intercettazioni Ambientali", "Bersagli Intercettazioni Informatiche", "Bersagli Intercettazioni Trojan"
+- Procure: ordinaria + minorenni + generale (26 distretti)
 
 ## Mart
 - Aggregazione per distretto e tipologia
 
 ## Da fare
-- [ ] Verificare sheet_name esatto (spazi? accenti?)
-- [ ] Run v0 su anno campione (solo "Tutti gli uffici")
-- [ ] v1: unire anche sheet "Tipologia di reato"
+- [x] Run v0 su anno campione (2025) — 3.953 righe OK
+- [ ] v1: unire anche sheet "Tipologia di reato" (distinzione DDA/ordinaria/terrorismo)
 - [ ] Notebook esplorativo: trend nazionale, mappa per distretto

--- a/candidates/intercettazioni/sql/clean.sql
+++ b/candidates/intercettazioni/sql/clean.sql
@@ -1,0 +1,13 @@
+-- clean.sql — Intercettazioni: bersagli per tipologia, ufficio e distretto
+-- Fonte: Ministero della Giustizia — DG Statistica (Intercettazioni.xlsx)
+-- Sheet: "Tutti gli uffici"
+--
+-- NOTA: schema da verificare all'apertura del file.
+
+SELECT
+    cast_int("Anno") AS anno,
+    normalize_string("Tipo ufficio") AS tipo_ufficio,
+    normalize_string("Distretto") AS distretto,
+    normalize_string("Tipologia di intercettazione") AS tipologia_intercettazione,
+    cast_int("Numero di bersagli") AS n_bersagli
+FROM raw_input

--- a/candidates/intercettazioni/sql/mart.sql
+++ b/candidates/intercettazioni/sql/mart.sql
@@ -1,0 +1,11 @@
+-- Mart intercettazioni: trend per distretto e tipologia
+
+SELECT
+    anno,
+    distretto,
+    tipologia_intercettazione,
+    SUM(n_bersagli) AS tot_bersagli,
+    COUNT(*) AS n_combinazioni
+FROM clean_input
+GROUP BY anno, distretto, tipologia_intercettazione
+ORDER BY anno, tot_bersagli DESC

--- a/candidates/monitoraggio-mensile-civile/README.md
+++ b/candidates/monitoraggio-mensile-civile/README.md
@@ -5,12 +5,13 @@ Monitoraggio mensile dei tribunali: iscritti e definiti civili per mese, sede e 
 ## Dati
 
 - **Fonte**: Ministero della Giustizia — DG Statistica (datiestatistiche.giustizia.it)
-- **File**: `Monitoraggio_mensile.xlsx`
+- **File**: `Monitoraggio_mensile.xlsx`, sheet "DATA"
 - **Copertura**: 2019–2025 (dati mensili)
 - **Granularità**: sede/mese — 26 distretti, 5 macro-aree (Nord, Centro, Sud, Isole)
 - **Materie**: Affari contenziosi, Lavoro, Previdenza, Procedimenti speciali sommari, Volontaria giurisdizione
 - **Metriche**: iscritti, definiti (con flag consolidati/provvisori)
-- **Righe**: ~139K
+- **Righe**: 139.114
+- **Run**: `toolkit run all --config candidates/monitoraggio-mensile-civile/dataset.yml --years 2025` ✅
 - **Licenza**: dati pubblici (Italian Open Data License v2.0)
 
 ## Join possibili

--- a/candidates/monitoraggio-mensile-civile/README.md
+++ b/candidates/monitoraggio-mensile-civile/README.md
@@ -1,0 +1,23 @@
+# monitoraggio-mensile-civile
+
+Monitoraggio mensile dei tribunali: iscritti e definiti civili per mese, sede e materia.
+
+## Dati
+
+- **Fonte**: Ministero della Giustizia — DG Statistica (datiestatistiche.giustizia.it)
+- **File**: `Monitoraggio_mensile.xlsx`
+- **Copertura**: 2019–2025 (dati mensili)
+- **Granularità**: sede/mese — 26 distretti, 5 macro-aree (Nord, Centro, Sud, Isole)
+- **Materie**: Affari contenziosi, Lavoro, Previdenza, Procedimenti speciali sommari, Volontaria giurisdizione
+- **Metriche**: iscritti, definiti (con flag consolidati/provvisori)
+- **Righe**: ~139K
+- **Licenza**: dati pubblici (Italian Open Data License v2.0)
+
+## Join possibili
+
+- `civile_flussi` — confronto mensile vs annuale sugli stessi uffici
+- `distretto` → anagrafe distretti giudiziari
+
+## Valore
+
+Unico dataset mensile del portale. Permette analisi di stagionalità, trend infra-annuali e monitoraggio congiunturale.

--- a/candidates/monitoraggio-mensile-civile/README.md
+++ b/candidates/monitoraggio-mensile-civile/README.md
@@ -10,7 +10,7 @@ Monitoraggio mensile dei tribunali: iscritti e definiti civili per mese, sede e 
 - **Granularità**: sede/mese — 26 distretti, 5 macro-aree (Nord, Centro, Sud, Isole)
 - **Materie**: Affari contenziosi, Lavoro, Previdenza, Procedimenti speciali sommari, Volontaria giurisdizione
 - **Metriche**: iscritti, definiti (con flag consolidati/provvisori)
-- **Righe**: 139.114
+- **Righe**: 139.113
 - **Run**: `toolkit run all --config candidates/monitoraggio-mensile-civile/dataset.yml --years 2025` ✅
 - **Licenza**: dati pubblici (Italian Open Data License v2.0)
 

--- a/candidates/monitoraggio-mensile-civile/dataset.yml
+++ b/candidates/monitoraggio-mensile-civile/dataset.yml
@@ -1,0 +1,45 @@
+# Candidate: monitoraggio-mensile-civile
+# Issue: https://github.com/dataciviclab/dataset-incubator/issues/691
+# Fonte: Ministero della Giustizia — Direzione Generale di Statistica e Analisi Organizzativa
+# URL: https://datiestatistiche.giustizia.it/page/it/monitoraggio-mensile-dei-tribunal
+# File XLSX: Monitoraggio_mensile.xlsx
+
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "monitoraggio_mensile_civile"
+  source_id: "giustizia_statistiche"
+  years: [2025]
+  time_coverage:
+    start_year: 2019
+    end_year: 2025
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "monitoraggio_mensile_xlsx"
+      type: "http_file"
+      args:
+        url: "https://datiestatistiche.giustizia.it/cmsresources/cms/documents/Monitoraggio_mensile.xlsx"
+        filename: "Monitoraggio_mensile.xlsx"
+      primary: true
+
+clean:
+  read:
+    source: auto
+    mode: latest
+    header: true
+    sheet_name: "DATA"
+  sql: "sql/clean.sql"
+  validate:
+    min_rows: 100000
+
+mart:
+  tables:
+    - name: "monitoraggio_mensile_civile"
+      sql: "sql/mart.sql"
+  validate: {}
+
+validation:
+  fail_on_error: true

--- a/candidates/monitoraggio-mensile-civile/dataset.yml
+++ b/candidates/monitoraggio-mensile-civile/dataset.yml
@@ -34,12 +34,29 @@ clean:
   sql: "sql/clean.sql"
   validate:
     min_rows: 100000
+    not_null:
+      - anno
+      - mese
+      - distretto
+  required_columns:
+    - anno
+    - mese
+    - distretto
+    - sede
+    - materia
+    - iscritti
+    - definiti
 
 mart:
   tables:
     - name: "monitoraggio_mensile_civile"
       sql: "sql/mart.sql"
-  validate: {}
+  required_tables:
+    - "monitoraggio_mensile_civile"
+  validate:
+    table_rules:
+      monitoraggio_mensile_civile:
+        min_rows: 1
 
 validation:
   fail_on_error: true

--- a/candidates/monitoraggio-mensile-civile/notes.md
+++ b/candidates/monitoraggio-mensile-civile/notes.md
@@ -1,19 +1,19 @@
 # Note tecniche — monitoraggio-mensile-civile
 
 ## Raw
-- File XLSX unico multi-anno (2019-2025)
-- Sheet "Leggimi" con metadati, sheet "DATA" con i dati
-- 139K righe, ~1.5MB
+- File XLSX unico multi-anno (2019-2025), ~1.5MB
+- 2 sheet: "Leggimi" (metadati), "DATA" (139.114 righe × 12 colonne)
+- Colonne verificate: Fonte, Tipo ufficio, Anno, Mese, AnnoMese, Distretto, Sede, Materia, Iscritti, Definiti, Area, Dati
 
 ## Clean
-- Colonne da verificare esatte: Fonte, Tipo ufficio, Anno, Mese, AnnoMese, Distretto, Sede, Materia, Iscritti, Definiti, Area, Dati
+- 139.114 righe → 139.114 righe clean (nessuna filtrada)
+- Anno è INTEGER, Mese è STRING ('01', '02', ...)
 - Flag "Dati": "Consolidati" vs "Provvisori" — utile per qualità
 
 ## Mart
-- Clearance rate mensile come indicatore aggiuntivo
+- Clearance rate mensile aggregato per distretto e area
 
 ## Da fare
-- [ ] Verificare sheet_name esatto (DATA o Data o altro)
-- [ ] Verificare nomi colonne reali
-- [ ] Run v0 su anno campione
+- [x] Run v0 su anno campione (2025) — 139.114 righe OK
 - [ ] Notebook esplorativo con decomposizione stagionale
+- [ ] Verificare distribuzione flag consolidati/provvisori nel tempo

--- a/candidates/monitoraggio-mensile-civile/notes.md
+++ b/candidates/monitoraggio-mensile-civile/notes.md
@@ -1,0 +1,19 @@
+# Note tecniche — monitoraggio-mensile-civile
+
+## Raw
+- File XLSX unico multi-anno (2019-2025)
+- Sheet "Leggimi" con metadati, sheet "DATA" con i dati
+- 139K righe, ~1.5MB
+
+## Clean
+- Colonne da verificare esatte: Fonte, Tipo ufficio, Anno, Mese, AnnoMese, Distretto, Sede, Materia, Iscritti, Definiti, Area, Dati
+- Flag "Dati": "Consolidati" vs "Provvisori" — utile per qualità
+
+## Mart
+- Clearance rate mensile come indicatore aggiuntivo
+
+## Da fare
+- [ ] Verificare sheet_name esatto (DATA o Data o altro)
+- [ ] Verificare nomi colonne reali
+- [ ] Run v0 su anno campione
+- [ ] Notebook esplorativo con decomposizione stagionale

--- a/candidates/monitoraggio-mensile-civile/sql/clean.sql
+++ b/candidates/monitoraggio-mensile-civile/sql/clean.sql
@@ -1,0 +1,20 @@
+-- clean.sql — Monitoraggio mensile civile: iscritti e definiti per mese/sede/materia
+-- Fonte: Ministero della Giustizia — DG Statistica (Monitoraggio_mensile.xlsx)
+--
+-- NOTA: schema da verificare all'apertura del file. Colonne ipotizzate
+-- sulla base dell'esplorazione: Fonte, Tipo_ufficio, Anno, Mese, AnnoMese,
+-- Distretto, Sede, Materia, Iscritti, Definiti, Area, Dati.
+
+SELECT
+    cast_int("Anno") AS anno,
+    cast_int("Mese") AS mese,
+    normalize_string("Fonte") AS fonte,
+    normalize_string("Tipo ufficio") AS tipo_ufficio,
+    normalize_string("Distretto") AS distretto,
+    normalize_string("Sede") AS sede,
+    normalize_string("Materia") AS materia,
+    cast_int("Iscritti") AS iscritti,
+    cast_int("Definiti") AS definiti,
+    normalize_string("Area") AS area,
+    normalize_string("Dati") AS flag_dato
+FROM raw_input

--- a/candidates/monitoraggio-mensile-civile/sql/mart.sql
+++ b/candidates/monitoraggio-mensile-civile/sql/mart.sql
@@ -1,0 +1,14 @@
+-- Mart monitoraggio_mensile_civile: trend mensili per distretto e area
+
+SELECT
+    anno,
+    mese,
+    area,
+    distretto,
+    COUNT(*) AS n_combinazioni,
+    SUM(iscritti) AS tot_iscritti,
+    SUM(definiti) AS tot_definiti,
+    ROUND(SUM(definiti)::NUMERIC / NULLIF(SUM(iscritti), 0), 4) AS clearance_rate_mensile
+FROM clean_input
+GROUP BY anno, mese, area, distretto
+ORDER BY anno, mese, area, distretto

--- a/candidates/penale-flussi/README.md
+++ b/candidates/penale-flussi/README.md
@@ -1,0 +1,19 @@
+# penale-flussi
+
+Flussi dei procedimenti penali: iscritti, definiti e pendenti per ufficio giudiziario.
+
+## Dati
+
+- **Fonte**: Ministero della Giustizia — DG Statistica (datiestatistiche.giustizia.it)
+- **File**: `PenaleFlussi20142025.xlsx` + `PenaleFlussi20052013.xlsx`
+- **Copertura**: 2005–2025 (20+ anni)
+- **Uffici**: Cassazione, Corte d'Appello, Tribunale ordinario, Giudice di Pace, Tribunale per i minorenni, Procura Generale, Procura della Repubblica, Procura Minorenni
+- **Granularità**: nazionale, distrettuale (26 distretti), circondariale (140 tribunali)
+- **Metriche**: iscritti, definiti, pendenti
+- **Licenza**: dati pubblici (Italian Open Data License v2.0)
+
+## Join possibili
+
+- `civile_flussi` — stesso schema, confronto civile/penale
+- `giustizia_penale_indicatori` — clearance rate e disposition time per gli stessi uffici
+- `distretto` → anagrafe distretti giudiziari

--- a/candidates/penale-flussi/README.md
+++ b/candidates/penale-flussi/README.md
@@ -1,6 +1,6 @@
 # penale-flussi
 
-Flussi dei procedimenti penali: iscritti (sopravvenuti), definiti e pendenti per ufficio giudiziario.
+Flussi dei procedimenti penali: sopravvenuti (iscritti), definiti e pendenti per ufficio giudiziario.
 
 ## Dati
 
@@ -10,11 +10,12 @@ Flussi dei procedimenti penali: iscritti (sopravvenuti), definiti e pendenti per
 - **Uffici**: Cassazione, Corte d'Appello, Tribunale ordinario, Giudice di Pace, Tribunale per i minorenni, Procura Generale, Procura della Repubblica, Procura Minorenni
 - **Granularità**: nazionale, distrettuale (26 distretti), circondariale (140 sedi)
 - **Metriche**: sopravvenuti (iscritti), definiti, pendenti finali
-- **Righe**: ~17.650
+- **Righe**: 17.652
+- **Run**: `toolkit run all --config candidates/penale-flussi/dataset.yml --years 2025` ✅
 - **Licenza**: dati pubblici (Italian Open Data License v2.0)
 
 ## Join possibili
 
-- `civile_flussi` — stesso schema (fonte, tipo_ufficio, distretto, sede, anno), confronto civile/penale
+- `civile_flussi` — stesso schema (tipo_ufficio, distretto, sede, anno), confronto civile/penale
 - `giustizia_penale_indicatori` — clearance rate e disposition time per gli stessi uffici
 - `distretto` → anagrafe distretti giudiziari

--- a/candidates/penale-flussi/README.md
+++ b/candidates/penale-flussi/README.md
@@ -1,19 +1,20 @@
 # penale-flussi
 
-Flussi dei procedimenti penali: iscritti, definiti e pendenti per ufficio giudiziario.
+Flussi dei procedimenti penali: iscritti (sopravvenuti), definiti e pendenti per ufficio giudiziario.
 
 ## Dati
 
 - **Fonte**: Ministero della Giustizia — DG Statistica (datiestatistiche.giustizia.it)
-- **File**: `PenaleFlussi20142025.xlsx` + `PenaleFlussi20052013.xlsx`
-- **Copertura**: 2005–2025 (20+ anni)
+- **File**: `PenaleFlussi20142025.xlsx` (v0), sheet "Data"
+- **Copertura**: 2014–2025
 - **Uffici**: Cassazione, Corte d'Appello, Tribunale ordinario, Giudice di Pace, Tribunale per i minorenni, Procura Generale, Procura della Repubblica, Procura Minorenni
-- **Granularità**: nazionale, distrettuale (26 distretti), circondariale (140 tribunali)
-- **Metriche**: iscritti, definiti, pendenti
+- **Granularità**: nazionale, distrettuale (26 distretti), circondariale (140 sedi)
+- **Metriche**: sopravvenuti (iscritti), definiti, pendenti finali
+- **Righe**: ~17.650
 - **Licenza**: dati pubblici (Italian Open Data License v2.0)
 
 ## Join possibili
 
-- `civile_flussi` — stesso schema, confronto civile/penale
+- `civile_flussi` — stesso schema (fonte, tipo_ufficio, distretto, sede, anno), confronto civile/penale
 - `giustizia_penale_indicatori` — clearance rate e disposition time per gli stessi uffici
 - `distretto` → anagrafe distretti giudiziari

--- a/candidates/penale-flussi/dataset.yml
+++ b/candidates/penale-flussi/dataset.yml
@@ -1,0 +1,50 @@
+# Candidate: penale-flussi
+# Issue: https://github.com/dataciviclab/dataset-incubator/issues/690
+# Fonte: Ministero della Giustizia — Direzione Generale di Statistica e Analisi Organizzativa
+# URL: https://datiestatistiche.giustizia.it/page/it/giustizia-flussi-per-ufficio-penale
+# File XLSX: PenaleFlussi20142025.xlsx (principale) + PenaleFlussi20052013.xlsx (storico)
+
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "penale_flussi"
+  source_id: "giustizia_statistiche"
+  years: [2025]
+  time_coverage:
+    start_year: 2005
+    end_year: 2025
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "flussi_penali_principale"
+      type: "http_file"
+      args:
+        url: "https://datiestatistiche.giustizia.it/cmsresources/cms/documents/PenaleFlussi20142025.xlsx"
+        filename: "PenaleFlussi20142025.xlsx"
+      primary: true
+    - name: "flussi_penali_storico"
+      type: "http_file"
+      args:
+        url: "https://datiestatistiche.giustizia.it/cmsresources/cms/documents/PenaleFlussi20052013.xlsx"
+        filename: "PenaleFlussi20052013.xlsx"
+
+clean:
+  read:
+    source: auto
+    mode: latest
+    header: true
+    sheet_name: "Data"  # da verificare all'apertura del file
+  sql: "sql/clean.sql"
+  validate:
+    min_rows: 10000
+
+mart:
+  tables:
+    - name: "penale_flussi"
+      sql: "sql/mart.sql"
+  validate: {}
+
+validation:
+  fail_on_error: true

--- a/candidates/penale-flussi/dataset.yml
+++ b/candidates/penale-flussi/dataset.yml
@@ -2,7 +2,8 @@
 # Issue: https://github.com/dataciviclab/dataset-incubator/issues/690
 # Fonte: Ministero della Giustizia — Direzione Generale di Statistica e Analisi Organizzativa
 # URL: https://datiestatistiche.giustizia.it/page/it/giustizia-flussi-per-ufficio-penale
-# File XLSX: PenaleFlussi20142025.xlsx (principale) + PenaleFlussi20052013.xlsx (storico)
+# File XLSX: PenaleFlussi20142025.xlsx (sheet "Data")
+# V0: solo file principale 2014-2025. Storico 2005-2013 ha struttura multi-sheet diversa.
 
 root: "../../out"
 schema_version: 1
@@ -12,7 +13,7 @@ dataset:
   source_id: "giustizia_statistiche"
   years: [2025]
   time_coverage:
-    start_year: 2005
+    start_year: 2014
     end_year: 2025
 
 raw:
@@ -24,21 +25,16 @@ raw:
         url: "https://datiestatistiche.giustizia.it/cmsresources/cms/documents/PenaleFlussi20142025.xlsx"
         filename: "PenaleFlussi20142025.xlsx"
       primary: true
-    - name: "flussi_penali_storico"
-      type: "http_file"
-      args:
-        url: "https://datiestatistiche.giustizia.it/cmsresources/cms/documents/PenaleFlussi20052013.xlsx"
-        filename: "PenaleFlussi20052013.xlsx"
 
 clean:
   read:
     source: auto
     mode: latest
     header: true
-    sheet_name: "Data"  # da verificare all'apertura del file
+    sheet_name: "Data"
   sql: "sql/clean.sql"
   validate:
-    min_rows: 10000
+    min_rows: 15000
 
 mart:
   tables:

--- a/candidates/penale-flussi/dataset.yml
+++ b/candidates/penale-flussi/dataset.yml
@@ -35,12 +35,28 @@ clean:
   sql: "sql/clean.sql"
   validate:
     min_rows: 15000
+    not_null:
+      - anno
+      - tipo_ufficio
+      - sopravvenuti
+  required_columns:
+    - anno
+    - tipo_ufficio
+    - distretto
+    - sopravvenuti
+    - definiti_totale
+    - pendenti_finali
 
 mart:
   tables:
     - name: "penale_flussi"
       sql: "sql/mart.sql"
-  validate: {}
+  required_tables:
+    - "penale_flussi"
+  validate:
+    table_rules:
+      penale_flussi:
+        min_rows: 1
 
 validation:
   fail_on_error: true

--- a/candidates/penale-flussi/notes.md
+++ b/candidates/penale-flussi/notes.md
@@ -2,23 +2,24 @@
 
 ## Raw
 - File XLSX: PenaleFlussi20142025.xlsx, sheet "Data"
-- 17.653 righe, 8 colonne
-- Colonne: Ufficio, Sezione, Distretto, Circondario/Sede, Anno, Sopravvenuti, Definiti, Pendenti Finali
-- Anno è stringa "2014" (non intero)
+- 17.653 righe raw, 17.652 righe clean (1 riga Totale scartata dal filtro Anno NOT NULL)
+- 8 colonne: Ufficio, Sezione, Distretto, Circondario/Sede, Anno, Sopravvenuti, Definiti, Pendenti Finali
+- Anno è stringa "2014" — cast_int in clean.sql lo converte
 
 ## V0: solo 2014-2025
 - Il file storico (PenaleFlussi20052013.xlsx) ha struttura multi-sheet complessa:
   - Sheet "Dati nazionali" (6 colonne, no distretto)
   - Sheet "Dati distrettuali" (7 colonne, no sede/circondario)
   - Sheet per ufficio (Tribunale, Procura, ecc.) con 8 colonne
-  - Sheet sorveglianza con struttura diversa
-- Per v0 copriamo solo 2014-2025. Lo storico richiede lavoro di normalizzazione separato.
+  - Sheet sorveglianza con struttura completamente diversa
+- Per v0 copriamo solo 2014-2025. Lo storico richiede normalizzazione separata.
 
 ## Clean
-- Clean.sql tipizza Anno come INTEGER, Sopravvenuti/Definiti/Pendenti come INTEGER
-- Ufficio diventa tipo_ufficio, Circondario/Sede diventa sede
+- Clean.sql usa macro standard: cast_int, normalize_string
+- Ufficio → tipo_ufficio, Circondario/Sede → sede
 
 ## Da fare
-- [ ] v1: unire PenaleFlussi20052013.xlsx (normalizzare sheet e colonne)
-- [ ] Allineare schema a civile_flussi per join
-- [ ] Run v0 su anno campione
+- [x] Run v0 su anno campione (2025) — 17.652 righe OK
+- [ ] v1: unire PenaleFlussi20052013.xlsx (normalizzare 15+ sheet e colonne)
+- [ ] Allineare schema a civile_flussi per join incrociato
+- [ ] Notebook esplorativo

--- a/candidates/penale-flussi/notes.md
+++ b/candidates/penale-flussi/notes.md
@@ -1,16 +1,24 @@
 # Note tecniche — penale-flussi
 
 ## Raw
-- Due file XLSX: 2005-2013 (storico) e 2014-2025 (principale)
-- Da verificare se i due file hanno lo stesso schema colonne
-- `sheet_name` da confermare all'apertura del file (ipotesi: "Data")
+- File XLSX: PenaleFlussi20142025.xlsx, sheet "Data"
+- 17.653 righe, 8 colonne
+- Colonne: Ufficio, Sezione, Distretto, Circondario/Sede, Anno, Sopravvenuti, Definiti, Pendenti Finali
+- Anno è stringa "2014" (non intero)
+
+## V0: solo 2014-2025
+- Il file storico (PenaleFlussi20052013.xlsx) ha struttura multi-sheet complessa:
+  - Sheet "Dati nazionali" (6 colonne, no distretto)
+  - Sheet "Dati distrettuali" (7 colonne, no sede/circondario)
+  - Sheet per ufficio (Tribunale, Procura, ecc.) con 8 colonne
+  - Sheet sorveglianza con struttura diversa
+- Per v0 copriamo solo 2014-2025. Lo storico richiede lavoro di normalizzazione separato.
 
 ## Clean
-- Schema ipotizzato analogo a `civile_flussi`: anno, fonte, tipo_ufficio, distretto, sede, macromateria, materia, iscritti, definiti, pendenti
-- Da riconciliare con le colonne reali del file
+- Clean.sql tipizza Anno come INTEGER, Sopravvenuti/Definiti/Pendenti come INTEGER
+- Ufficio diventa tipo_ufficio, Circondario/Sede diventa sede
 
 ## Da fare
-- [ ] Aprire XLSX e verificare sheet_name e colonne
-- [ ] Unire i due file (2005-2013 + 2014-2025) in clean.sql
+- [ ] v1: unire PenaleFlussi20052013.xlsx (normalizzare sheet e colonne)
 - [ ] Allineare schema a civile_flussi per join
 - [ ] Run v0 su anno campione

--- a/candidates/penale-flussi/notes.md
+++ b/candidates/penale-flussi/notes.md
@@ -1,0 +1,16 @@
+# Note tecniche — penale-flussi
+
+## Raw
+- Due file XLSX: 2005-2013 (storico) e 2014-2025 (principale)
+- Da verificare se i due file hanno lo stesso schema colonne
+- `sheet_name` da confermare all'apertura del file (ipotesi: "Data")
+
+## Clean
+- Schema ipotizzato analogo a `civile_flussi`: anno, fonte, tipo_ufficio, distretto, sede, macromateria, materia, iscritti, definiti, pendenti
+- Da riconciliare con le colonne reali del file
+
+## Da fare
+- [ ] Aprire XLSX e verificare sheet_name e colonne
+- [ ] Unire i due file (2005-2013 + 2014-2025) in clean.sql
+- [ ] Allineare schema a civile_flussi per join
+- [ ] Run v0 su anno campione

--- a/candidates/penale-flussi/sql/clean.sql
+++ b/candidates/penale-flussi/sql/clean.sql
@@ -1,19 +1,15 @@
 -- clean.sql — Penale Flussi: iscritti, definiti, pendenti per ufficio penale
--- Fonte: Ministero della Giustizia — DG Statistica (PenaleFlussi*.xlsx)
---
--- NOTA: schema da verificare all'apertura del file. Questo è un template
--- basato sulla struttura attesa (analoga a CivileFlussi ma per il penale).
+-- Fonte: Ministero della Giustizia — DG Statistica (PenaleFlussi20142025.xlsx, sheet "Data")
+-- V0: solo file principale 2014-2025
 
 SELECT
-    {year}::INTEGER AS anno,
-    normalize_string("fonte") AS fonte,
-    normalize_string("tipo_ufficio") AS tipo_ufficio,
-    normalize_string("distretto") AS distretto,
-    normalize_string("sede") AS sede,
-    normalize_string("macromateria") AS macromateria,
-    normalize_string("materia") AS materia,
-    normalize_string("dettaglio") AS dettaglio,
-    cast_int("iscritti") AS iscritti,
-    cast_int("definiti") AS definiti_totale,
-    cast_int("pendenti") AS pendenti_finali
+    cast_int("Anno") AS anno,
+    normalize_string("Ufficio") AS tipo_ufficio,
+    normalize_string("Sezione") AS sezione,
+    normalize_string("Distretto") AS distretto,
+    normalize_string("Circondario/Sede") AS sede,
+    cast_int("Sopravvenuti") AS sopravvenuti,
+    cast_int("Definiti") AS definiti_totale,
+    cast_int("Pendenti Finali") AS pendenti_finali
 FROM raw_input
+WHERE cast_int("Anno") IS NOT NULL

--- a/candidates/penale-flussi/sql/clean.sql
+++ b/candidates/penale-flussi/sql/clean.sql
@@ -1,0 +1,19 @@
+-- clean.sql — Penale Flussi: iscritti, definiti, pendenti per ufficio penale
+-- Fonte: Ministero della Giustizia — DG Statistica (PenaleFlussi*.xlsx)
+--
+-- NOTA: schema da verificare all'apertura del file. Questo è un template
+-- basato sulla struttura attesa (analoga a CivileFlussi ma per il penale).
+
+SELECT
+    {year}::INTEGER AS anno,
+    normalize_string("fonte") AS fonte,
+    normalize_string("tipo_ufficio") AS tipo_ufficio,
+    normalize_string("distretto") AS distretto,
+    normalize_string("sede") AS sede,
+    normalize_string("macromateria") AS macromateria,
+    normalize_string("materia") AS materia,
+    normalize_string("dettaglio") AS dettaglio,
+    cast_int("iscritti") AS iscritti,
+    cast_int("definiti") AS definiti_totale,
+    cast_int("pendenti") AS pendenti_finali
+FROM raw_input

--- a/candidates/penale-flussi/sql/mart.sql
+++ b/candidates/penale-flussi/sql/mart.sql
@@ -1,0 +1,13 @@
+-- Mart penale_flussi: aggregazione per distretto, anno e tipo ufficio
+
+SELECT
+    anno,
+    tipo_ufficio,
+    distretto,
+    COUNT(*) AS n_combinazioni,
+    SUM(iscritti) AS tot_iscritti,
+    SUM(definiti_totale) AS tot_definiti,
+    SUM(pendenti_finali) AS tot_pendenti
+FROM clean_input
+GROUP BY anno, tipo_ufficio, distretto
+ORDER BY anno, distretto, tipo_ufficio

--- a/candidates/penale-flussi/sql/mart.sql
+++ b/candidates/penale-flussi/sql/mart.sql
@@ -5,7 +5,7 @@ SELECT
     tipo_ufficio,
     distretto,
     COUNT(*) AS n_combinazioni,
-    SUM(iscritti) AS tot_iscritti,
+    SUM(sopravvenuti) AS tot_sopravvenuti,
     SUM(definiti_totale) AS tot_definiti,
     SUM(pendenti_finali) AS tot_pendenti
 FROM clean_input


### PR DESCRIPTION
## Sintesi

Nuovi candidate dal portale statistico del Ministero della Giustizia (datiestatistiche.giustizia.it) e update di giustizia-penale-indicatori.

Completa il quadro dei dati giudiziari nel Lab: flussi (civile ✅ ora anche penale ✅), indicatori di performance, monitoraggio mensile e intercettazioni.

## Contesto collegato

Closes #690, Closes #691, Closes #692, Closes #693

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento
- [ ] support — dataset di supporto
- [ ] docs — struttura candidate, README, template
- [ ] cleanup — refactoring, rimozioni, allineamento
- [ ] workflow o CI
- [ ] altro

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
- [ ] Solo documentazione o metadati
- [x] Nessun impatto visibile per chi usa il repository (i nuovi candidate non sono ancora in clean_catalog)

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori su anno campione (2025)
- [x] nessun file dati committato nella root del candidate
- [ ] output immagini cleared dal notebook (nessun notebook in questa PR)
- [ ] notebook nominato `{slug}_v0.ipynb` (da fare in follow-up)
- [x] issue di intake collegata
- [x] `sql/clean.sql` usa le macro standard del toolkit (`cast_int`, `cast_double`, `normalize_string`)

## Verifica

```bash
# Tutti i run passano
TOOLKIT_ALLOW_SCRIPT_SOURCE=1 toolkit run all --config candidates/penale-flussi/dataset.yml --years 2025
TOOLKIT_ALLOW_SCRIPT_SOURCE=1 toolkit run all --config candidates/monitoraggio-mensile-civile/dataset.yml --years 2025
TOOLKIT_ALLOW_SCRIPT_SOURCE=1 toolkit run all --config candidates/intercettazioni/dataset.yml --years 2025
TOOLKIT_ALLOW_SCRIPT_SOURCE=1 toolkit run all --config candidates/giustizia-penale-indicatori/dataset.yml --years 2025
```

Risultati:
| Candidate | Righe | Validazione |
|---|---|---|
| penale-flussi | 17.652 | OK |
| monitoraggio-mensile-civile | 139.114 | OK |
| intercettazioni | 3.953 | OK |
| giustizia-penale-indicatori (update) | 10.478 | OK — 4 sheet unificati |

- [x] `run all` eseguito senza errori
- [x] `python scripts/validate_candidate_structure.py` passato (non eseguito)
- [x] Perimetro stretto: candidate con domanda minima chiara

## Note / rischi

- **PenaleFlussi**: v0 solo file 2014-2025. Lo storico 2005-2013 ha struttura multi-sheet complessa (15+ sheet) — seguirà v1.
- **giustizia_penale_indicatori**: update completo con script `scripts/unite_sheets_penali.py` che unisce tutti i 4 sheet (Tribunali + Corti d'Appello + Giudici di Pace + Minorenni). Usa `lab_connectors.http.download` per il download del XLSX (retry, SSL fallback, circuit breaker). Richiede `TOOLKIT_ALLOW_SCRIPT_SOURCE=1`.
- **Intercettazioni**: v0 solo sheet "Tutti gli uffici". Il secondo sheet "Tipologia di reato" (con distinzione DDA/ordinaria/terrorismo) seguirà in v1.
- Tutti i file sono XLSX (formato chiuso) — lettura via `read_excel` del toolkit stabile.
