### PR TITLE
Intake: ga-ordinanze e ga-decreti — 31 sedi (OpenGA)

### DIFF
--- a/candidates/ga-decreti/README.md
+++ b/candidates/ga-decreti/README.md
@@ -1,19 +1,42 @@
 # ga-decreti — Decreti Giustizia Amministrativa (OpenGA)
 
-Dataset unificato delle decreti del Consiglio di Stato e dei Tribunali Amministrativi Regionali, proveniente dal portale [OpenGA](https://openga.giustizia-amministrativa.it).
+Dataset unificato dei decreti del Consiglio di Stato e dei Tribunali Amministrativi Regionali, proveniente dal portale [OpenGA](https://openga.giustizia-amministrativa.it) della Giustizia Amministrativa.
 
 ## Copertura
 
-- **31 sedi**: CdS, CGA Sicilia, 27 TAR, 2 TRGA
-- **4 anni**: 2023–2026 (aggiornamento MONTHLY)
+- **31 sedi**: CdS (appello), CGA Sicilia, 27 TAR, 2 TRGA (Bolzano, Trento)
+- **4 anni**: 2023, 2024, 2025, 2026 (aggiornamento MONTHLY)
+- **~7.500 decreti** totali
 
-## Schema
+## Schema clean (17 colonne)
 
-Stesso schema identico di `ga-sentenze` (17 colonne). Chiave `NUMERO_RICORSO` per join.
+| Colonna | Tipo | Note |
+|---|---|---|
+| `anno` | BIGINT | Anno pubblicazione |
+| `codice_sede` | BIGINT | Codice sede giudiziaria |
+| `nome_sede` | VARCHAR | Nome sede (es. TAR LAZIO - ROMA) |
+| `codice_sezione` | VARCHAR | Sezione interna |
+| `nome_sezione` | VARCHAR | Nome sezione |
+| `numero_provvedimento` | BIGINT | PK del provvedimento |
+| `numero_ricorso` | BIGINT | **Chiave di join** con sentenze, ordinanze, appalti |
+| `data_pubblicazione` | DATE | Data pubblicazione decreto |
+| `mese_pubblicazione` | BIGINT | Mese pubblicazione (formato YYYYMM) |
+| `esito_provvedimento` | VARCHAR | Esito |
+| `flg_definisce` | VARCHAR | Flag che definisce il ricorso |
+| `data_deposito_ricorso` | DATE | Data deposito ricorso |
+| `oggetto_ricorso` | VARCHAR | Descrizione del caso |
+| `tipo_ricorso` | VARCHAR | Rito |
+| `tipo_udienza` | VARCHAR | Pubblica, Camera di Consiglio |
+| `num_membri_collegio` | BIGINT | Numero giudici |
+| `tipo_provvedimento` | VARCHAR | Tipo (DECRETO) |
+
+## Chiavi di join
+
+- `NUMERO_RICORSO` ↔ `ga-sentenze`, `ga-ordinanze`, `openga-ricorsi-appalto`
 
 ## Mart
 
 | Tabella | Descrizione |
 |---|---|
-| mart_esiti_per_sede | Esiti per sede/anno |
-| mart_esiti_per_tipo | Esiti per tipo ricorso/anno |
+| `mart_esiti_per_sede` | Esiti per sede/anno |
+| `mart_esiti_per_tipo` | Esiti per tipo ricorso/anno |

--- a/candidates/ga-decreti/README.md
+++ b/candidates/ga-decreti/README.md
@@ -1,0 +1,19 @@
+# ga-decreti — Decreti Giustizia Amministrativa (OpenGA)
+
+Dataset unificato delle decreti del Consiglio di Stato e dei Tribunali Amministrativi Regionali, proveniente dal portale [OpenGA](https://openga.giustizia-amministrativa.it).
+
+## Copertura
+
+- **31 sedi**: CdS, CGA Sicilia, 27 TAR, 2 TRGA
+- **4 anni**: 2023–2026 (aggiornamento MONTHLY)
+
+## Schema
+
+Stesso schema identico di `ga-sentenze` (17 colonne). Chiave `NUMERO_RICORSO` per join.
+
+## Mart
+
+| Tabella | Descrizione |
+|---|---|
+| mart_esiti_per_sede | Esiti per sede/anno |
+| mart_esiti_per_tipo | Esiti per tipo ricorso/anno |

--- a/candidates/ga-decreti/dataset.yml
+++ b/candidates/ga-decreti/dataset.yml
@@ -1,0 +1,280 @@
+root: ../../out
+schema_version: 1
+
+dataset:
+  name: ga_decreti
+  source_id: openga
+  years: [2023, 2024, 2025, 2026]
+  time_coverage:
+    start_year: 2023
+    end_year: 2026
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: cds
+      type: ckan
+      primary: true
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: cds-decreti
+        resource_name: "CDS - Decreti - {year}"
+        filename: "cds-decreti-{year}.csv"
+    - name: cga_sicilia
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: cga-sicilia-decreti
+        resource_name: "CGA Sicilia - Decreti - {year}"
+        filename: "cga-sicilia-decreti-{year}.csv"
+    - name: tar_abruzzo_l_aquila
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-abruzzo-l-aquila-decreti
+        resource_name: "TAR Abruzzo - L’Aquila - Decreti - {year}"
+        filename: "tar-abruzzo-l-aquila-decreti-{year}.csv"
+    - name: tar_abruzzo_pescara
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-abruzzo-pescara-decreti
+        resource_name: "TAR Abruzzo - Pescara - Decreti - {year}"
+        filename: "tar-abruzzo-pescara-decreti-{year}.csv"
+    - name: tar_basilicata
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-basilicata-decreti
+        resource_name: "TAR Basilicata - Decreti - {year}"
+        filename: "tar-basilicata-decreti-{year}.csv"
+    - name: tar_calabria_catanzaro
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-calabria-catanzaro-decreti
+        resource_name: "TAR Calabria - Catanzaro - Decreti - {year}"
+        filename: "tar-calabria-catanzaro-decreti-{year}.csv"
+    - name: tar_calabria_reggio_calabria
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-calabria-reggio-calabria-decreti
+        resource_name: "TAR Calabria - Reggio Calabria - Decreti - {year}"
+        filename: "tar-calabria-reggio-calabria-decreti-{year}.csv"
+    - name: tar_campania_napoli
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-campania-napoli-decreti
+        resource_name: "TAR Campania - Napoli - Decreti - {year}"
+        filename: "tar-campania-napoli-decreti-{year}.csv"
+    - name: tar_campania_salerno
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-campania-salerno-decreti
+        resource_name: "TAR Campania - Salerno - Decreti - {year}"
+        filename: "tar-campania-salerno-decreti-{year}.csv"
+    - name: tar_emilia_romagna_bologna
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-emilia-romagna-bologna-decreti
+        resource_name: "TAR Emilia Romagna - Bologna - Decreti - {year}"
+        filename: "tar-emilia-romagna-bologna-decreti-{year}.csv"
+    - name: tar_emilia_romagna_parma
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-emilia-romagna-parma-decreti
+        resource_name: "TAR Emilia Romagna - Parma - Decreti - {year}"
+        filename: "tar-emilia-romagna-parma-decreti-{year}.csv"
+    - name: tar_friuli_venezia_giulia
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-friuli-venezia-giulia-decreti
+        resource_name: "TAR Friuli Venezia Giulia - Decreti - {year}"
+        filename: "tar-friuli-venezia-giulia-decreti-{year}.csv"
+    - name: tar_lazio_latina
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-lazio-latina-decreti
+        resource_name: "TAR Lazio - Latina - Decreti - {year}"
+        filename: "tar-lazio-latina-decreti-{year}.csv"
+    - name: tar_lazio_roma
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-lazio-roma-decreti
+        resource_name: "TAR Lazio - Roma - Decreti - {year}"
+        filename: "tar-lazio-roma-decreti-{year}.csv"
+    - name: tar_liguria
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-liguria-decreti
+        resource_name: "TAR Liguria - Decreti - {year}"
+        filename: "tar-liguria-decreti-{year}.csv"
+    - name: tar_lombardia_brescia
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-lombardia-brescia-decreti
+        resource_name: "TAR Lombardia - Brescia - Decreti - {year}"
+        filename: "tar-lombardia-brescia-decreti-{year}.csv"
+    - name: tar_lombardia_milano
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-lombardia-milano-decreti
+        resource_name: "TAR Lombardia - Milano - Decreti - {year}"
+        filename: "tar-lombardia-milano-decreti-{year}.csv"
+    - name: tar_marche
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-marche-decreti
+        resource_name: "TAR Marche - Decreti - {year}"
+        filename: "tar-marche-decreti-{year}.csv"
+    - name: tar_molise
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-molise-decreti
+        resource_name: "TAR Molise - Decreti - {year}"
+        filename: "tar-molise-decreti-{year}.csv"
+    - name: tar_piemonte
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-piemonte-decreti
+        resource_name: "TAR Piemonte - Decreti - {year}"
+        filename: "tar-piemonte-decreti-{year}.csv"
+    - name: tar_puglia_bari
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-puglia-bari-decreti
+        resource_name: "TAR Puglia - Bari - Decreti - {year}"
+        filename: "tar-puglia-bari-decreti-{year}.csv"
+    - name: tar_puglia_lecce
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-puglia-lecce-decreti
+        resource_name: "TAR Puglia - Lecce - Decreti - {year}"
+        filename: "tar-puglia-lecce-decreti-{year}.csv"
+    - name: tar_sardegna
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-sardegna-decreti
+        resource_name: "TAR Sardegna - Decreti - {year}"
+        filename: "tar-sardegna-decreti-{year}.csv"
+    - name: tar_sicilia_catania
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-sicilia-catania-decreti
+        resource_name: "TAR Sicilia - Catania - Decreti - {year}"
+        filename: "tar-sicilia-catania-decreti-{year}.csv"
+    - name: tar_sicilia_palermo
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-sicilia-palermo-decreti
+        resource_name: "TAR Sicilia - Palermo - Decreti - {year}"
+        filename: "tar-sicilia-palermo-decreti-{year}.csv"
+    - name: tar_toscana
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-toscana-decreti
+        resource_name: "TAR Toscana - Decreti - {year}"
+        filename: "tar-toscana-decreti-{year}.csv"
+    - name: tar_umbria
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-umbria-decreti
+        resource_name: "TAR Umbria - Decreti - {year}"
+        filename: "tar-umbria-decreti-{year}.csv"
+    - name: tar_valle_d_aosta
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-valle-d-aosta-decreti
+        resource_name: "TAR Valle d’Aosta - Decreti - {year}"
+        filename: "tar-valle-d-aosta-decreti-{year}.csv"
+    - name: tar_veneto
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-veneto-decreti
+        resource_name: "TAR Veneto - Decreti - {year}"
+        filename: "tar-veneto-decreti-{year}.csv"
+    - name: trga_bolzano
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: trga-bolzano-decreti
+        resource_name: "TRGA - Bolzano - Decreti - {year}"
+        filename: "trga-bolzano-decreti-{year}.csv"
+    - name: trga_trento
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: trga-trento-decreti
+        resource_name: "TRGA - Trento - Decreti - {year}"
+        filename: "trga-trento-decreti-{year}.csv"
+
+clean:
+  read:
+    delim: ","
+    encoding: utf-8
+    header: true
+  required_columns:
+    - anno
+    - codice_sede
+    - nome_sede
+    - numero_ricorso
+    - esito_provvedimento
+  sql: sql/clean.sql
+  validate:
+    min_rows: 100
+    not_null:
+      - numero_ricorso
+      - data_pubblicazione
+    primary_key: [codice_sede, numero_provvedimento, numero_ricorso]
+
+mart:
+  tables:
+    - name: mart_esiti_per_sede
+      sql: sql/mart_esiti_sede.sql
+    - name: mart_esiti_per_tipo
+      sql: sql/mart_esiti_tipo.sql
+  required_tables:
+    - mart_esiti_per_sede
+  validate:
+    table_rules:
+      mart_esiti_per_sede:
+        required_columns:
+          - anno
+          - codice_sede
+          - nome_sede
+          - esito_provvedimento
+          - totale
+        min_rows: 5
+      mart_esiti_per_tipo:
+        required_columns:
+          - anno
+          - tipo_ricorso
+          - esito_provvedimento
+          - totale
+        min_rows: 5
+
+validation:
+  fail_on_error: true

--- a/candidates/ga-decreti/notes.md
+++ b/candidates/ga-decreti/notes.md
@@ -1,0 +1,11 @@
+# ga-decreti — Note tecniche
+
+## Architettura
+
+31 source CKAN paralleli, schema identico. clean.sql usa `FROM raw_input` (merge automatico multi-file del toolkit).
+
+## Run
+
+```
+toolkit run full --config candidates/ga-decreti/dataset.yml --years 2024
+```

--- a/candidates/ga-decreti/notes.md
+++ b/candidates/ga-decreti/notes.md
@@ -2,10 +2,27 @@
 
 ## Architettura
 
-31 source CKAN paralleli, schema identico. clean.sql usa `FROM raw_input` (merge automatico multi-file del toolkit).
+31 source CKAN paralleli, uno per sede. clean.sql usa `FROM raw_input` — il toolkit gestisce il merge multi-file con `read_csv([paths], union_by_name=true)`.
+
+## Resource name matching
+
+Il toolkit CKAN matcha `resource_name` come substring case-insensitive. Per le sedi con apostrofo Unicode (`L'Aquila`, `Valle d'Aosta`), il nome va scritto con U+2019.
 
 ## Run
 
 ```
 toolkit run full --config candidates/ga-decreti/dataset.yml --years 2024
 ```
+
+## Volumi
+
+| Anno | Decreti | Sedi |
+|---|---|---|
+| 2023 | 2.601 | 31 |
+| 2024 | 2.230 | 31 |
+| 2025 | 1.727 | 31 |
+| 2026 | 926 | 31 |
+
+## Copertura mensile
+
+OpenGA aggiorna i dataset ogni mese. Per l'aggiornamento schedulato, rieseguire il run full su tutti gli anni.

--- a/candidates/ga-decreti/sql/clean.sql
+++ b/candidates/ga-decreti/sql/clean.sql
@@ -1,0 +1,19 @@
+SELECT
+    cast_bigint("ANNO_PUBBLICAZIONE") AS anno,
+    cast_bigint("CODICE_SEDE") AS codice_sede,
+    normalize_string("NOME_SEDE") AS nome_sede,
+    normalize_string("CODICE_SEZIONE") AS codice_sezione,
+    normalize_string("NOME_SEZIONE") AS nome_sezione,
+    cast_bigint("NUMERO_PROVVEDIMENTO") AS numero_provvedimento,
+    cast_bigint("NUMERO_RICORSO") AS numero_ricorso,
+    TRY_CAST("DATA_PUBBLICAZIONE" AS DATE) AS data_pubblicazione,
+    cast_bigint("MESE_PUBBLICAZIONE") AS mese_pubblicazione,
+    normalize_string("ESITO_PROVVEDIMENTO") AS esito_provvedimento,
+    normalize_string("FLG_DEFINISCE") AS flg_definisce,
+    TRY_CAST("DATA_DEPOSITO_RICORSO" AS DATE) AS data_deposito_ricorso,
+    normalize_string("OGGETTO_RICORSO") AS oggetto_ricorso,
+    normalize_string("TIPO_RICORSO") AS tipo_ricorso,
+    normalize_string("TIPO_UDIENZA") AS tipo_udienza,
+    cast_bigint("NUM_MEMBRI_COLLEGIO") AS num_membri_collegio,
+    normalize_string("TIPO_PROVVEDIMENTO") AS tipo_provvedimento
+FROM raw_input

--- a/candidates/ga-decreti/sql/mart_esiti_sede.sql
+++ b/candidates/ga-decreti/sql/mart_esiti_sede.sql
@@ -1,0 +1,11 @@
+SELECT
+    anno,
+    codice_sede,
+    nome_sede,
+    esito_provvedimento,
+    COUNT(*) AS totale,
+    COUNT(DISTINCT numero_ricorso) AS ricorsi_distinti
+FROM clean_input
+WHERE esito_provvedimento IS NOT NULL
+GROUP BY anno, codice_sede, nome_sede, esito_provvedimento
+ORDER BY anno, nome_sede, totale DESC

--- a/candidates/ga-decreti/sql/mart_esiti_tipo.sql
+++ b/candidates/ga-decreti/sql/mart_esiti_tipo.sql
@@ -1,0 +1,10 @@
+SELECT
+    anno,
+    tipo_ricorso,
+    esito_provvedimento,
+    COUNT(*) AS totale,
+    COUNT(DISTINCT numero_ricorso) AS ricorsi_distinti
+FROM clean_input
+WHERE esito_provvedimento IS NOT NULL AND tipo_ricorso IS NOT NULL
+GROUP BY anno, tipo_ricorso, esito_provvedimento
+ORDER BY anno, tipo_ricorso, totale DESC

--- a/candidates/ga-ordinanze/README.md
+++ b/candidates/ga-ordinanze/README.md
@@ -1,0 +1,19 @@
+# ga-ordinanze — Ordinanze Giustizia Amministrativa (OpenGA)
+
+Dataset unificato delle ordinanze del Consiglio di Stato e dei Tribunali Amministrativi Regionali, proveniente dal portale [OpenGA](https://openga.giustizia-amministrativa.it).
+
+## Copertura
+
+- **31 sedi**: CdS, CGA Sicilia, 27 TAR, 2 TRGA
+- **4 anni**: 2023–2026 (aggiornamento MONTHLY)
+
+## Schema
+
+Stesso schema identico di `ga-sentenze` (17 colonne). Chiave `NUMERO_RICORSO` per join.
+
+## Mart
+
+| Tabella | Descrizione |
+|---|---|
+| mart_esiti_per_sede | Esiti per sede/anno |
+| mart_esiti_per_tipo | Esiti per tipo ricorso/anno |

--- a/candidates/ga-ordinanze/README.md
+++ b/candidates/ga-ordinanze/README.md
@@ -1,19 +1,47 @@
 # ga-ordinanze — Ordinanze Giustizia Amministrativa (OpenGA)
 
-Dataset unificato delle ordinanze del Consiglio di Stato e dei Tribunali Amministrativi Regionali, proveniente dal portale [OpenGA](https://openga.giustizia-amministrativa.it).
+Dataset unificato delle ordinanze del Consiglio di Stato e dei Tribunali Amministrativi Regionali, proveniente dal portale [OpenGA](https://openga.giustizia-amministrativa.it) della Giustizia Amministrativa.
 
 ## Copertura
 
-- **31 sedi**: CdS, CGA Sicilia, 27 TAR, 2 TRGA
-- **4 anni**: 2023–2026 (aggiornamento MONTHLY)
+- **31 sedi**: CdS (appello), CGA Sicilia, 27 TAR, 2 TRGA (Bolzano, Trento)
+- **4 anni**: 2023, 2024, 2025, 2026 (aggiornamento MONTHLY)
+- **~15.000 ordinanze** totali
 
-## Schema
+## Schema clean (17 colonne)
 
-Stesso schema identico di `ga-sentenze` (17 colonne). Chiave `NUMERO_RICORSO` per join.
+| Colonna | Tipo | Note |
+|---|---|---|
+| `anno` | BIGINT | Anno pubblicazione |
+| `codice_sede` | BIGINT | Codice sede giudiziaria |
+| `nome_sede` | VARCHAR | Nome sede (es. TAR LAZIO - ROMA, CdS GIURISDIZIONALE - ROMA) |
+| `codice_sezione` | VARCHAR | Sezione interna |
+| `nome_sezione` | VARCHAR | Nome sezione |
+| `numero_provvedimento` | BIGINT | PK del provvedimento |
+| `numero_ricorso` | BIGINT | **Chiave di join** con sentenze, appalti e ANAC |
+| `data_pubblicazione` | DATE | Data pubblicazione ordinanza |
+| `mese_pubblicazione` | BIGINT | Mese pubblicazione (formato YYYYMM) |
+| `esito_provvedimento` | VARCHAR | Esito (ACCOGLIE, RESPINGE, ecc.) |
+| `flg_definisce` | VARCHAR | Flag che definisce il ricorso |
+| `data_deposito_ricorso` | DATE | Data deposito ricorso |
+| `oggetto_ricorso` | VARCHAR | Descrizione del caso |
+| `tipo_ricorso` | VARCHAR | Rito (ORDINARIO, RITO APPALTI, ecc.) |
+| `tipo_udienza` | VARCHAR | Pubblica, Camera di Consiglio |
+| `num_membri_collegio` | BIGINT | Numero giudici |
+| `tipo_provvedimento` | VARCHAR | Tipo (ORDINANZA) |
+
+## Chiavi di join
+
+- `NUMERO_RICORSO` ↔ `ga-sentenze`, `ga-decreti`, `openga-ricorsi-appalto`
+- `NUMERO_RICORSO` è univoco a livello nazionale, non per sede
+
+## Fonti
+
+31 dataset CKAN dal portale OpenGA, uno per sede giudiziaria. Schema identico al 100%.
 
 ## Mart
 
 | Tabella | Descrizione |
 |---|---|
-| mart_esiti_per_sede | Esiti per sede/anno |
-| mart_esiti_per_tipo | Esiti per tipo ricorso/anno |
+| `mart_esiti_per_sede` | Esiti per sede/anno |
+| `mart_esiti_per_tipo` | Esiti per tipo ricorso/anno |

--- a/candidates/ga-ordinanze/dataset.yml
+++ b/candidates/ga-ordinanze/dataset.yml
@@ -1,0 +1,280 @@
+root: ../../out
+schema_version: 1
+
+dataset:
+  name: ga_ordinanze
+  source_id: openga
+  years: [2023, 2024, 2025, 2026]
+  time_coverage:
+    start_year: 2023
+    end_year: 2026
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: cds
+      type: ckan
+      primary: true
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: cds-ordinanze
+        resource_name: "CDS - Ordinanze - {year}"
+        filename: "cds-ordinanze-{year}.csv"
+    - name: cga_sicilia
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: cga-sicilia-ordinanze
+        resource_name: "CGA Sicilia - Ordinanze - {year}"
+        filename: "cga-sicilia-ordinanze-{year}.csv"
+    - name: tar_abruzzo_l_aquila
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-abruzzo-l-aquila-ordinanze
+        resource_name: "TAR Abruzzo - L’Aquila - Ordinanze - {year}"
+        filename: "tar-abruzzo-l-aquila-ordinanze-{year}.csv"
+    - name: tar_abruzzo_pescara
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-abruzzo-pescara-ordinanze
+        resource_name: "TAR Abruzzo - Pescara - Ordinanze - {year}"
+        filename: "tar-abruzzo-pescara-ordinanze-{year}.csv"
+    - name: tar_basilicata
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-basilicata-ordinanze
+        resource_name: "TAR Basilicata - Ordinanze - {year}"
+        filename: "tar-basilicata-ordinanze-{year}.csv"
+    - name: tar_calabria_catanzaro
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-calabria-catanzaro-ordinanze
+        resource_name: "TAR Calabria - Catanzaro - Ordinanze - {year}"
+        filename: "tar-calabria-catanzaro-ordinanze-{year}.csv"
+    - name: tar_calabria_reggio_calabria
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-calabria-reggio-calabria-ordinanze
+        resource_name: "TAR Calabria - Reggio Calabria - Ordinanze - {year}"
+        filename: "tar-calabria-reggio-calabria-ordinanze-{year}.csv"
+    - name: tar_campania_napoli
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-campania-napoli-ordinanze
+        resource_name: "TAR Campania - Napoli - Ordinanze - {year}"
+        filename: "tar-campania-napoli-ordinanze-{year}.csv"
+    - name: tar_campania_salerno
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-campania-salerno-ordinanze
+        resource_name: "TAR Campania - Salerno - Ordinanze - {year}"
+        filename: "tar-campania-salerno-ordinanze-{year}.csv"
+    - name: tar_emilia_romagna_bologna
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-emilia-romagna-bologna-ordinanze
+        resource_name: "TAR Emilia Romagna - Bologna - Ordinanze - {year}"
+        filename: "tar-emilia-romagna-bologna-ordinanze-{year}.csv"
+    - name: tar_emilia_romagna_parma
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-emilia-romagna-parma-ordinanze
+        resource_name: "TAR Emilia Romagna - Parma - Ordinanze - {year}"
+        filename: "tar-emilia-romagna-parma-ordinanze-{year}.csv"
+    - name: tar_friuli_venezia_giulia
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-friuli-venezia-giulia-ordinanze
+        resource_name: "TAR Friuli Venezia Giulia - Ordinanze - {year}"
+        filename: "tar-friuli-venezia-giulia-ordinanze-{year}.csv"
+    - name: tar_lazio_latina
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-lazio-latina-ordinanze
+        resource_name: "TAR Lazio - Latina - Ordinanze - {year}"
+        filename: "tar-lazio-latina-ordinanze-{year}.csv"
+    - name: tar_lazio_roma
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-lazio-roma-ordinanze
+        resource_name: "TAR Lazio - Roma - Ordinanze - {year}"
+        filename: "tar-lazio-roma-ordinanze-{year}.csv"
+    - name: tar_liguria
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-liguria-ordinanze
+        resource_name: "TAR Liguria - Ordinanze - {year}"
+        filename: "tar-liguria-ordinanze-{year}.csv"
+    - name: tar_lombardia_brescia
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-lombardia-brescia-ordinanze
+        resource_name: "TAR Lombardia - Brescia - Ordinanze - {year}"
+        filename: "tar-lombardia-brescia-ordinanze-{year}.csv"
+    - name: tar_lombardia_milano
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-lombardia-milano-ordinanze
+        resource_name: "TAR Lombardia - Milano - Ordinanze - {year}"
+        filename: "tar-lombardia-milano-ordinanze-{year}.csv"
+    - name: tar_marche
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-marche-ordinanze
+        resource_name: "TAR Marche - Ordinanze - {year}"
+        filename: "tar-marche-ordinanze-{year}.csv"
+    - name: tar_molise
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-molise-ordinanze
+        resource_name: "TAR Molise - Ordinanze - {year}"
+        filename: "tar-molise-ordinanze-{year}.csv"
+    - name: tar_piemonte
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-piemonte-ordinanze
+        resource_name: "TAR Piemonte - Ordinanze - {year}"
+        filename: "tar-piemonte-ordinanze-{year}.csv"
+    - name: tar_puglia_bari
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-puglia-bari-ordinanze
+        resource_name: "TAR Puglia - Bari - Ordinanze - {year}"
+        filename: "tar-puglia-bari-ordinanze-{year}.csv"
+    - name: tar_puglia_lecce
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-puglia-lecce-ordinanze
+        resource_name: "TAR Puglia - Lecce - Ordinanze - {year}"
+        filename: "tar-puglia-lecce-ordinanze-{year}.csv"
+    - name: tar_sardegna
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-sardegna-ordinanze
+        resource_name: "TAR Sardegna - Ordinanze - {year}"
+        filename: "tar-sardegna-ordinanze-{year}.csv"
+    - name: tar_sicilia_catania
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-sicilia-catania-ordinanze
+        resource_name: "TAR Sicilia - Catania - Ordinanze - {year}"
+        filename: "tar-sicilia-catania-ordinanze-{year}.csv"
+    - name: tar_sicilia_palermo
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-sicilia-palermo-ordinanze
+        resource_name: "TAR Sicilia - Palermo - Ordinanze - {year}"
+        filename: "tar-sicilia-palermo-ordinanze-{year}.csv"
+    - name: tar_toscana
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-toscana-ordinanze
+        resource_name: "TAR Toscana - Ordinanze - {year}"
+        filename: "tar-toscana-ordinanze-{year}.csv"
+    - name: tar_umbria
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-umbria-ordinanze
+        resource_name: "TAR Umbria - Ordinanze - {year}"
+        filename: "tar-umbria-ordinanze-{year}.csv"
+    - name: tar_valle_d_aosta
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-valle-d-aosta-ordinanze
+        resource_name: "TAR Valle d’Aosta - Ordinanze - {year}"
+        filename: "tar-valle-d-aosta-ordinanze-{year}.csv"
+    - name: tar_veneto
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: tar-veneto-ordinanze
+        resource_name: "TAR Veneto - Ordinanze - {year}"
+        filename: "tar-veneto-ordinanze-{year}.csv"
+    - name: trga_bolzano
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: trga-bolzano-ordinanze
+        resource_name: "TRGA - Bolzano - Ordinanze - {year}"
+        filename: "trga-bolzano-ordinanze-{year}.csv"
+    - name: trga_trento
+      type: ckan
+      args:
+        portal_url: https://openga.giustizia-amministrativa.it
+        dataset_id: trga-trento-ordinanze
+        resource_name: "TRGA - Trento - Ordinanze - {year}"
+        filename: "trga-trento-ordinanze-{year}.csv"
+
+clean:
+  read:
+    delim: ","
+    encoding: utf-8
+    header: true
+  required_columns:
+    - anno
+    - codice_sede
+    - nome_sede
+    - numero_ricorso
+    - esito_provvedimento
+  sql: sql/clean.sql
+  validate:
+    min_rows: 100
+    not_null:
+      - numero_ricorso
+      - data_pubblicazione
+    primary_key: [codice_sede, numero_provvedimento, numero_ricorso]
+
+mart:
+  tables:
+    - name: mart_esiti_per_sede
+      sql: sql/mart_esiti_sede.sql
+    - name: mart_esiti_per_tipo
+      sql: sql/mart_esiti_tipo.sql
+  required_tables:
+    - mart_esiti_per_sede
+  validate:
+    table_rules:
+      mart_esiti_per_sede:
+        required_columns:
+          - anno
+          - codice_sede
+          - nome_sede
+          - esito_provvedimento
+          - totale
+        min_rows: 5
+      mart_esiti_per_tipo:
+        required_columns:
+          - anno
+          - tipo_ricorso
+          - esito_provvedimento
+          - totale
+        min_rows: 5
+
+validation:
+  fail_on_error: true

--- a/candidates/ga-ordinanze/notes.md
+++ b/candidates/ga-ordinanze/notes.md
@@ -1,0 +1,11 @@
+# ga-ordinanze — Note tecniche
+
+## Architettura
+
+31 source CKAN paralleli, schema identico. clean.sql usa `FROM raw_input` (merge automatico multi-file del toolkit).
+
+## Run
+
+```
+toolkit run full --config candidates/ga-ordinanze/dataset.yml --years 2024
+```

--- a/candidates/ga-ordinanze/notes.md
+++ b/candidates/ga-ordinanze/notes.md
@@ -2,10 +2,27 @@
 
 ## Architettura
 
-31 source CKAN paralleli, schema identico. clean.sql usa `FROM raw_input` (merge automatico multi-file del toolkit).
+31 source CKAN paralleli, uno per sede. clean.sql usa `FROM raw_input` — il toolkit gestisce il merge multi-file con `read_csv([paths], union_by_name=true)`.
+
+## Resource name matching
+
+Il toolkit CKAN matcha `resource_name` come substring case-insensitive. Per le sedi con apostrofo Unicode (`L'Aquila`, `Valle d'Aosta`), il nome va scritto con U+2019 (RIGHT SINGLE QUOTATION MARK), non ASCII.
 
 ## Run
 
 ```
 toolkit run full --config candidates/ga-ordinanze/dataset.yml --years 2024
 ```
+
+## Volumi
+
+| Anno | Ordinanze | Sedi |
+|---|---|---|
+| 2023 | 4.796 | 31 |
+| 2024 | 4.327 | 31 |
+| 2025 | 3.970 | 31 |
+| 2026 | 1.961 | 31 |
+
+## Copertura mensile
+
+OpenGA aggiorna i dataset ogni mese. Per l'aggiornamento schedulato, rieseguire il run full su tutti gli anni.

--- a/candidates/ga-ordinanze/sql/clean.sql
+++ b/candidates/ga-ordinanze/sql/clean.sql
@@ -1,0 +1,19 @@
+SELECT
+    cast_bigint("ANNO_PUBBLICAZIONE") AS anno,
+    cast_bigint("CODICE_SEDE") AS codice_sede,
+    normalize_string("NOME_SEDE") AS nome_sede,
+    normalize_string("CODICE_SEZIONE") AS codice_sezione,
+    normalize_string("NOME_SEZIONE") AS nome_sezione,
+    cast_bigint("NUMERO_PROVVEDIMENTO") AS numero_provvedimento,
+    cast_bigint("NUMERO_RICORSO") AS numero_ricorso,
+    TRY_CAST("DATA_PUBBLICAZIONE" AS DATE) AS data_pubblicazione,
+    cast_bigint("MESE_PUBBLICAZIONE") AS mese_pubblicazione,
+    normalize_string("ESITO_PROVVEDIMENTO") AS esito_provvedimento,
+    normalize_string("FLG_DEFINISCE") AS flg_definisce,
+    TRY_CAST("DATA_DEPOSITO_RICORSO" AS DATE) AS data_deposito_ricorso,
+    normalize_string("OGGETTO_RICORSO") AS oggetto_ricorso,
+    normalize_string("TIPO_RICORSO") AS tipo_ricorso,
+    normalize_string("TIPO_UDIENZA") AS tipo_udienza,
+    cast_bigint("NUM_MEMBRI_COLLEGIO") AS num_membri_collegio,
+    normalize_string("TIPO_PROVVEDIMENTO") AS tipo_provvedimento
+FROM raw_input

--- a/candidates/ga-ordinanze/sql/mart_esiti_sede.sql
+++ b/candidates/ga-ordinanze/sql/mart_esiti_sede.sql
@@ -1,0 +1,11 @@
+SELECT
+    anno,
+    codice_sede,
+    nome_sede,
+    esito_provvedimento,
+    COUNT(*) AS totale,
+    COUNT(DISTINCT numero_ricorso) AS ricorsi_distinti
+FROM clean_input
+WHERE esito_provvedimento IS NOT NULL
+GROUP BY anno, codice_sede, nome_sede, esito_provvedimento
+ORDER BY anno, nome_sede, totale DESC

--- a/candidates/ga-ordinanze/sql/mart_esiti_tipo.sql
+++ b/candidates/ga-ordinanze/sql/mart_esiti_tipo.sql
@@ -1,0 +1,10 @@
+SELECT
+    anno,
+    tipo_ricorso,
+    esito_provvedimento,
+    COUNT(*) AS totale,
+    COUNT(DISTINCT numero_ricorso) AS ricorsi_distinti
+FROM clean_input
+WHERE esito_provvedimento IS NOT NULL AND tipo_ricorso IS NOT NULL
+GROUP BY anno, tipo_ricorso, esito_provvedimento
+ORDER BY anno, tipo_ricorso, totale DESC


### PR DESCRIPTION
## Sintesi

Due nuovi candidate che completano la copertura GA:
- **ga-ordinanze**: 15.054 ordinanze, 31 sedi, 2023-2026
- **ga-decreti**: 7.484 decreti, 31 sedi, 2023-2026

Stesso schema di `ga-sentenze` (17 colonne, chiave `numero_ricorso`).

## Contesto

Closes #702

## Verifica

| Dataset | 2023 | 2024 | 2025 | 2026 | Totale | Sedi |
|---|---|---|---|---|---|---|
| ga-ordinanze | 4.796 | 4.327 | 3.970 | 1.961 | 15.054 | 31 |
| ga-decreti | 2.601 | 2.230 | 1.727 | 926 | 7.484 | 31 |
