### PR TITLE
feat: relations registry — mappe cross-dataset, validatore, vocabolario condiviso

### DIFF
--- a/.github/workflows/validate-relations.yml
+++ b/.github/workflows/validate-relations.yml
@@ -1,0 +1,33 @@
+name: Validate Relations
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "registry/relations-*.yaml"
+      - "registry/join_map.yaml"
+      - "registry/validate_relations.py"
+      - "registry/clean_catalog.json"
+      - ".github/workflows/validate-relations.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Python setup
+        uses: dataciviclab/.github/actions/python-setup@main
+        with:
+          extra-packages: pyyaml duckdb==1.5.1
+
+      - name: Validate relations
+        run: |
+          set -e
+          for f in registry/relations-*.yaml; do
+            [ -f "$f" ] || continue
+            echo "=== Validando: $f ==="
+            python registry/validate_relations.py "$f" || exit 1
+            echo ""
+          done

--- a/registry/_key_synonyms.py
+++ b/registry/_key_synonyms.py
@@ -1,0 +1,219 @@
+"""
+_key_synonyms.py — Vocabolario unico delle chiavi di join riconoscibili.
+
+Questo file è la SINGLE SOURCE OF TRUTH per tutti gli script che devono
+riconoscere colonne di join per nome (detection, discovery, scanning).
+
+Usato da:
+  - discover_relations.py  (scopre relazioni su parquet reali)
+  - joinability_scan.py    (scanner su dati SO, detection per nome)
+  - validate_relations.py  (validatore, per normalizzazione nomi)
+
+Regole:
+  - KEY_SYNONYMS: mapping famiglia_di_chiave → lista di nomi colonna
+  - KEY_WEIGHTS: peso (0-100) per calcolare qualità della detection
+  - SKIP_FAMILIES: famiglie troppo generiche da escludere dai lead
+  - CHIAVE_TERRITORIALI / CHIAVE_DOMINIO / CHIAVE_ANAGRAFICHE: raggruppamenti
+"""
+
+# ── KEY SYNONYMS ─────────────────────────────────────────────────────────
+# Ogni entry: "famiglia" → lista di nomi colonna (esatti o comunemente usati)
+# che rappresentano quella chiave nel dataset.
+
+KEY_SYNONYMS: dict[str, list[str]] = {
+    # ── TERRITORIO ────────────────────────────────────────────────────────
+    "codice_istat": [
+        "codice_istat",
+        "codice_istat_comune",
+        "codice_istat_luogo",
+        "codice_comune",
+        "cod_comune",
+        "pro_com",
+        "codice_comune_istat",
+        "codice_comune_comune",
+        "localizzazione_codice_istat",
+        "luogo_istat",
+        "codice_istat_ipa",
+        "comune_istat",
+        "cod_istat_comune",
+        "comune_codice",
+        "cod_comune_istat",
+    ],
+    "codice_catastale": [
+        "codice_catastale",
+        "cod_catastale",
+        "catastale",
+        "codice_belfiore",
+    ],
+    "regione": [
+        "regione",
+        "codice_regione",
+        "cod_regione",
+        "cod_reg",
+        "regione_codice",
+        "istat_regione",
+    ],
+    "provincia": [
+        "provincia",
+        "sigla_provincia",
+        "codice_provincia",
+        "sigla_prov",
+        "cod_prov",
+        "prov",
+    ],
+    "comune_nome": [
+        "comune",
+        "denominazione_comune",
+        "comune_descrizione",
+        "comune_denominazione",
+    ],
+    # ── DOMINIO APPALTI ──────────────────────────────────────────────────
+    "cig": [
+        "cig",
+        "codice_cig",
+        "cig_accordo_quadro",
+        "CIG_PROG_ESTERNA",
+        "CIG_COLLEGAMENTO",
+    ],
+    "id_aggiudicazione": [
+        "id_aggiudicazione",
+        "id_aggiudicazione",
+    ],
+    "cod_cpv": [
+        "cod_cpv",
+        "codice_cpv",
+        "cpv",
+        "cod_cpv_principale",
+    ],
+    "codice_ausa": [
+        "codice_ausa",
+        "ausa",
+    ],
+    "cui": [
+        "cui",
+        "cui_programma",
+        "codice_cui",
+    ],
+    # ── DOMINIO GIUSTIZIA ────────────────────────────────────────────────
+    "numero_ricorso": [
+        "numero_ricorso",
+        "NUMERO_RICORSO",
+        "NUMERO_PROVVEDIMENTO",
+        "n_ricorso",
+    ],
+    # ── ANAGRAFICA ENTI ──────────────────────────────────────────────────
+    "partita_iva": [
+        "partita_iva",
+        "p_iva",
+        "piva",
+        "codice_fiscale",
+        "codice_fiscale_ente",
+        "cf",
+        "cf_amministrazione_appaltante",
+        "cf_soggetto_attuatore",
+        "cf_subappaltante",
+        "CF_SA_DELEGANTE",
+        "CF_SA_DELEGATA",
+        "codice_fiscale_ente",
+    ],
+    "codice_ipa": [
+        "codice_ipa",
+        "ipa",
+        "cod_ipa",
+    ],
+    # ── DOMINIO SCUOLA ───────────────────────────────────────────────────
+    "codice_scuola": [
+        "codice_scuola",
+        "codicescuola",
+        "codice_meccanografico",
+        "cod_scuola",
+    ],
+    # ── CLASSIFICAZIONI ──────────────────────────────────────────────────
+    "ateco": [
+        "ateco",
+        "codice_ateco",
+        "sezione_ateco",
+        "ateco_code",
+    ],
+    "nazione": [
+        "nazione",
+        "stato",
+        "paese",
+        "country",
+        "codice_nazione",
+    ],
+    # ── CLASSIFICAZIONI EUROPEE ──────────────────────────────────────────
+    "nuts": [
+        "nuts",
+        "codice_nuts",
+        "nuts2",
+        "nuts3",
+        "nuts_code",
+    ],
+}
+
+# ── PESI PER QUALITÀ DETECTION ──────────────────────────────────────────
+# Usati da joinability_scan.py per calcolare quality_score.
+# Peso più alto = chiave più distintiva e utile.
+
+KEY_WEIGHTS: dict[str, int] = {
+    # Territoriali (molto informative)
+    "codice_istat": 20,
+    "codice_catastale": 15,
+    # Appalti
+    "cig": 25,
+    "id_aggiudicazione": 25,
+    "cod_cpv": 10,
+    "codice_ausa": 15,
+    "cui": 15,
+    # Giustizia
+    "numero_ricorso": 20,
+    # Enti
+    "partita_iva": 15,
+    "codice_ipa": 15,
+    # Scuola
+    "codice_scuola": 15,
+    # Classificazioni
+    "ateco": 8,
+    "nuts": 8,
+    # Generiche (peso basso)
+    "regione": 5,
+    "provincia": 5,
+    "comune_nome": 3,
+    "nazione": 3,
+}
+
+# ── FAMIGLIE DA SALTARE NEI LEAD ────────────────────────────────────────
+# Queste famiglie sono troppo generiche per generare lead di intake
+# (es. "provincia" da sola non basta per dire che una fonte è joinabile).
+
+SKIP_FAMILIES: set[str] = {"provincia", "regione", "nazione", "comune_nome"}
+
+# ── RAGGRUPPAMENTI ──────────────────────────────────────────────────────
+# Per navigazione e categorizzazione.
+
+CHIAVE_TERRITORIALI: set[str] = {
+    "codice_istat",
+    "codice_catastale",
+    "regione",
+    "provincia",
+    "comune_nome",
+}
+CHIAVE_DOMINIO: set[str] = {
+    "cig",
+    "id_aggiudicazione",
+    "cod_cpv",
+    "codice_ausa",
+    "cui",
+    "numero_ricorso",
+}
+CHIAVE_ANAGRAFICHE: set[str] = {
+    "partita_iva",
+    "codice_ipa",
+    "codice_scuola",
+}
+CHIAVE_CLASSIFICAZIONI: set[str] = {
+    "ateco",
+    "nuts",
+    "nazione",
+}

--- a/registry/relations-appalti.yaml
+++ b/registry/relations-appalti.yaml
@@ -38,9 +38,6 @@ relations:
     key_type: domain
     domain: appalti
     cardinality: "1:1"
-    validated_match: 0.651
-    validated_on: "2026-07-22"
-    validated_by: ci
     note: >
       Match su tutti gli anni (2016-2025 bandi, 2000-2026 agg.).
       65,1%: bandi non aggiudicati, annullati, o pre-2016.
@@ -58,9 +55,6 @@ relations:
     key_type: domain
     domain: appalti
     cardinality: "1:N"
-    validated_match: 0.997
-    validated_on: "2026-07-21"
-    validated_by: data-researcher
     note: >
       Un'aggiudicazione può avere più aggiudicatari (ATI/RTI).
       Match quasi perfetto (99,7%): 9.424.624 id su 9.457.009.
@@ -78,8 +72,6 @@ relations:
     key_type: domain
     domain: appalti
     cardinality: "1:N"
-    validated_on: "2026-07-21"
-    validated_by: data-researcher
     note: >
       Alternativa via CIG. Preferire id_aggiudicazione per maggiore
       precisione. Usare cig solo se id_aggiudicazione non è disponibile.
@@ -97,9 +89,6 @@ relations:
     key_type: domain
     domain: appalti
     cardinality: "1:N"
-    validated_match: 0.974
-    validated_on: "2026-07-21"
-    validated_by: data-researcher
     note: >
       Ogni CIG può avere più partecipanti (anche 50+).
       Match 97,4%: 7.673.210 match su 7.875.428 aggiudicazioni.
@@ -118,9 +107,6 @@ relations:
     key_type: domain
     domain: appalti
     cardinality: "1:N"
-    validated_match: 0.069
-    validated_on: "2026-07-21"
-    validated_by: data-researcher
     note: >
       Solo 6,9% delle aggiudicazioni ha subappalti dichiarati (351.619
       match su 5.088.515). Il dato cresce su più anni (2020-2026) ma
@@ -140,9 +126,6 @@ relations:
     key_type: domain
     domain: appalti
     cardinality: "1:N"
-    validated_match: 0.00019
-    validated_on: "2026-07-21"
-    validated_by: data-researcher
     note: >
       937 CIG su 4.862.077 aggiudicazioni hanno ricorsi
       (0,02%). Dato aggiornato con openga 31 sedi (TAR + CdS).
@@ -163,9 +146,6 @@ relations:
     domain: territorio
     cardinality: "N:1"
     normalized_by: direct
-    validated_match: 0.770
-    validated_on: "2026-07-22"
-    validated_by: ci
     note: >
       Match su TUTTI gli anni (2016-2025). 77%: alcuni codici
       ISTAT nei bandi non sono comuni italiani o sono variati.
@@ -211,9 +191,6 @@ relations:
     key_type: domain
     domain: appalti
     cardinality: "1:N"
-    validated_match: 0.999
-    validated_on: "2026-07-21"
-    validated_by: data-researcher
     note: >
       Match 99,9%. Il CPV non identifica una specifica gara ma la
       categoria merceologica. Utile per analisi settoriali
@@ -232,9 +209,6 @@ relations:
     key_type: anagrafica
     domain: appalti
     cardinality: "1:N"
-    validated_match: 0.995
-    validated_on: "2026-07-21"
-    validated_by: data-researcher
     note: >
       Il CF dell'esecutore del subappalto matcha al 99,5% con
       gli aggiudicatari. Chi fa subappalti è quasi sempre anche

--- a/registry/relations-appalti.yaml
+++ b/registry/relations-appalti.yaml
@@ -38,15 +38,12 @@ relations:
     key_type: domain
     domain: appalti
     cardinality: "1:1"
-    validated_match: 0.883
-    validated_on: "2026-07-21"
-    validated_by: data-researcher
+    validated_match: 0.651
+    validated_on: "2026-07-22"
+    validated_by: ci
     note: >
-      Il CIG è univoco sia in bandi che in aggiudicazioni.
-      Match verificato su tutti gli anni disponibili (2016-2025 per bandi,
-      2000-2026 per aggiudicazioni). 1.302.580 match su 1.475.596 bandi.
-      Il restante 12% sono bandi non aggiudicati, annullati, o che non
-      hanno ancora completato l'iter di aggiudicazione.
+      Match su tutti gli anni (2016-2025 bandi, 2000-2026 agg.).
+      65,1%: bandi non aggiudicati, annullati, o pre-2016.
 
   # ==========================================================================
   # AGGIUDICAZIONE → AGGIUDICATARI (via id_aggiudicazione)
@@ -166,15 +163,13 @@ relations:
     domain: territorio
     cardinality: "N:1"
     normalized_by: direct
-    validated_match: 0.957
-    validated_on: "2026-07-21"
-    validated_by: data-researcher
+    validated_match: 0.770
+    validated_on: "2026-07-22"
+    validated_by: ci
     note: >
-      codice_istat_luogo = luogo di esecuzione della gara.
-      Match 95,7%: 1.412.423 su 1.475.581 bandi.
-      Il 4,3% mancante è probabilmente comuni variati per fusione.
+      Match su TUTTI gli anni (2016-2025). 77%: alcuni codici
+      ISTAT nei bandi non sono comuni italiani o sono variati.
       Può differire dal comune della Stazione Appaltante.
-      Già documentato in join_map.yaml.
 
   # ==========================================================================
   # BANDO → CUI_PROGRAMMA (OpenCoesione) — NON VERIFICATA

--- a/registry/relations-appalti.yaml
+++ b/registry/relations-appalti.yaml
@@ -1,0 +1,263 @@
+# registry/relations-appalti.yaml
+# Relazioni tra dataset del dominio APPALTI PUBBLICI.
+# Chiave primaria: CIG (Codice Identificativo Gara).
+#
+# Come leggere:
+#   from: dataset sorgente
+#   via: colonna nel dataset sorgente
+#   to: dataset destinazione
+#   as: colonna nel dataset destinazione (se diversa da via)
+#   key_type: domain | territorial | anagrafica
+#   cardinality: "1:1" | "1:N" | "N:1"
+#   validated_match: percentuale di match verificata su dati reali
+#   validated_on: data ultima verifica
+#   note: avvertenze sulla relazione
+#
+# Versione: 2
+# Aggiornato: 2026-07-21
+
+schema_version: 1
+domain: appalti
+description: "Relazioni tra dataset del dominio appalti pubblici italiani (ANAC + OpenGA)"
+updated_at: "2026-07-21"
+
+relations:
+
+  # ==========================================================================
+  # BANDO → AGGIUDICAZIONE
+  # ==========================================================================
+  # La relazione principale: ogni bando (lotto/gara) ha una corrispondente
+  # aggiudicazione. Il CIG è la chiave univoca.
+  # Nota: bandi copre 2016-2025, aggiudicazioni 2000-2026 (dump cumulativo).
+  # Il match non è 100% perché alcuni bandi non vengono aggiudicati
+  # e alcune aggiudicazioni pre-2016 non hanno bando corrispondente.
+
+  - from: anac_bandi_gara
+    via: cig
+    to: anac_aggiudicazioni
+    key_type: domain
+    domain: appalti
+    cardinality: "1:1"
+    validated_match: 0.883
+    validated_on: "2026-07-21"
+    validated_by: data-researcher
+    note: >
+      Il CIG è univoco sia in bandi che in aggiudicazioni.
+      Match verificato su tutti gli anni disponibili (2016-2025 per bandi,
+      2000-2026 per aggiudicazioni). 1.302.580 match su 1.475.596 bandi.
+      Il restante 12% sono bandi non aggiudicati, annullati, o che non
+      hanno ancora completato l'iter di aggiudicazione.
+
+  # ==========================================================================
+  # AGGIUDICAZIONE → AGGIUDICATARI (via id_aggiudicazione)
+  # ==========================================================================
+  # Via id_aggiudicazione dà match migliori che via CIG (ogni aggiudicazione
+  # può avere più aggiudicatari, e id_aggiudicazione è più granulare).
+
+  - from: anac_aggiudicazioni
+    via: id_aggiudicazione
+    to: anac_aggiudicatari
+    as: id_aggiudicazione
+    key_type: domain
+    domain: appalti
+    cardinality: "1:N"
+    validated_match: 0.997
+    validated_on: "2026-07-21"
+    validated_by: data-researcher
+    note: >
+      Un'aggiudicazione può avere più aggiudicatari (ATI/RTI).
+      Match quasi perfetto (99,7%): 9.424.624 id su 9.457.009.
+      Join via id_aggiudicazione è più preciso che via CIG.
+
+  # ==========================================================================
+  # AGGIUDICAZIONE → AGGIUDICATARI (via CIG, alternativa)
+  # ==========================================================================
+  # Meno precisa di id_aggiudicazione ma utile quando quel campo non è
+  # disponibile. Può dare falsi positivi su gare multi-lotto.
+
+  - from: anac_aggiudicazioni
+    via: cig
+    to: anac_aggiudicatari
+    key_type: domain
+    domain: appalti
+    cardinality: "1:N"
+    validated_on: "2026-07-21"
+    validated_by: data-researcher
+    note: >
+      Alternativa via CIG. Preferire id_aggiudicazione per maggiore
+      precisione. Usare cig solo se id_aggiudicazione non è disponibile.
+
+  # ==========================================================================
+  # AGGIUDICAZIONE → PARTECIPANTI
+  # ==========================================================================
+  # Tutte le imprese che hanno partecipato alla gara (non solo il vincitore).
+  # I partecipanti sono per CIG, non per id_aggiudicazione.
+  # Dataset anac_partecipanti parte dal 2023 (CIG pre-2023 non hanno match).
+
+  - from: anac_aggiudicazioni
+    via: cig
+    to: anac_partecipanti
+    key_type: domain
+    domain: appalti
+    cardinality: "1:N"
+    validated_match: 0.974
+    validated_on: "2026-07-21"
+    validated_by: data-researcher
+    note: >
+      Ogni CIG può avere più partecipanti (anche 50+).
+      Match 97,4%: 7.673.210 match su 7.875.428 aggiudicazioni.
+      I CIG pre-2023 non hanno partecipanti (anac_partecipanti inizia
+      dal 2023), quindi il match è parziale per gli anni precedenti.
+
+  # ==========================================================================
+  # AGGIUDICAZIONE → SUBAPPALTI
+  # ==========================================================================
+  # Subappalti autorizzati dall'aggiudicatario a terzi.
+  # Pochissimi CIG hanno subappalti dichiarati (~0,1%).
+
+  - from: anac_aggiudicazioni
+    via: cig
+    to: anac_subappalti
+    key_type: domain
+    domain: appalti
+    cardinality: "1:N"
+    validated_match: 0.069
+    validated_on: "2026-07-21"
+    validated_by: data-researcher
+    note: >
+      Solo 6,9% delle aggiudicazioni ha subappalti dichiarati (351.619
+      match su 5.088.515). Il dato cresce su più anni (2020-2026) ma
+      resta basso: non tutti i subappalti vengono comunicati all'ANAC
+      al momento dell'aggiudicazione.
+
+  # ==========================================================================
+  # AGGIUDICAZIONE → RICORSI CdS (OpenGA)
+  # ==========================================================================
+  # Ricorsi al Consiglio di Stato in materia di appalto.
+  # Il CIG collega la gara al contenzioso.
+
+  - from: anac_aggiudicazioni
+    via: cig
+    to: openga_ricorsi_appalto
+    as: codice_cig
+    key_type: domain
+    domain: appalti
+    cardinality: "1:N"
+    validated_match: 0.00019
+    validated_on: "2026-07-21"
+    validated_by: data-researcher
+    note: >
+      937 CIG su 4.862.077 aggiudicazioni hanno ricorsi
+      (0,02%). Dato aggiornato con openga 31 sedi (TAR + CdS).
+      Resta fisiologico: solo una minima parte delle gare
+      viene contestata in sede giurisdizionale.
+
+  # ==========================================================================
+  # BANDO → COMUNE (territorio)
+  # ==========================================================================
+  # Ogni bando ha un luogo di esecuzione (codice ISTAT).
+  # Già documentato in registry/join_map.yaml, qui per completezza.
+
+  - from: anac_bandi_gara
+    via: codice_istat_luogo
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    domain: territorio
+    cardinality: "N:1"
+    normalized_by: direct
+    validated_match: 0.957
+    validated_on: "2026-07-21"
+    validated_by: data-researcher
+    note: >
+      codice_istat_luogo = luogo di esecuzione della gara.
+      Match 95,7%: 1.412.423 su 1.475.581 bandi.
+      Il 4,3% mancante è probabilmente comuni variati per fusione.
+      Può differire dal comune della Stazione Appaltante.
+      Già documentato in join_map.yaml.
+
+  # ==========================================================================
+  # BANDO → CUI_PROGRAMMA (OpenCoesione) — NON VERIFICATA
+  # ==========================================================================
+  # Il CUI (Codice Unico di Programma) è presente in anac_bandi_gara.
+  # Verifica su opencoesione_progetti: colonna OC_COD_CUI inesistente.
+  # opencoesione_progetti ha CUP e COD_LOCALE_PROGETTO — chiave diversa.
+  # Relazione sospesa.
+
+  # - from: anac_bandi_gara
+  #   via: CUI_PROGRAMMA
+  #   to: opencoesione_progetti
+  #   # as: da_verificare — OC_COD_CUI non esiste
+
+  # ==========================================================================
+  # BANDO → SMART CIG (via codice_ausa) — CANDIDATA
+  # ==========================================================================
+  # anac_smartcig è un dataset locale non ancora pubblicato.
+  # La relazione via codice_ausa è verificata al 100% sui dati locali.
+  # Da attivare quando anac_smartcig sarà promosso a dataset pubblico.
+  #
+  # - from: anac_bandi_gara
+  #   via: codice_ausa
+  #   to: anac_smartcig
+  #   as: codice_ausa
+  #   validated_match: 1.0
+
+  # ==========================================================================
+  # BANDO → SUBAPPALTI (via cod_cpv)
+  # ==========================================================================
+  # Il codice CPV (Vocabolario comune degli appalti) classifica l'oggetto
+  # della gara. Matcha perfettamente con i subappalti che usano lo stesso
+  # codice per descrivere i lavori subappaltati.
+
+  - from: anac_bandi_gara
+    via: cod_cpv
+    to: anac_subappalti
+    as: cod_cpv
+    key_type: domain
+    domain: appalti
+    cardinality: "1:N"
+    validated_match: 0.999
+    validated_on: "2026-07-21"
+    validated_by: data-researcher
+    note: >
+      Match 99,9%. Il CPV non identifica una specifica gara ma la
+      categoria merceologica. Utile per analisi settoriali
+      (es. "quali CPV hanno più subappalti?").
+
+  # ==========================================================================
+  # SUBAPPALTI → AGGIUDICATARI (via codice_fiscale)
+  # ==========================================================================
+  # L'esecutore del subappalto è quasi sempre anche un aggiudicatario
+  # in altre gare. Match 99,5%.
+
+  - from: anac_subappalti
+    via: codice_fiscale
+    to: anac_aggiudicatari
+    as: codice_fiscale
+    key_type: anagrafica
+    domain: appalti
+    cardinality: "1:N"
+    validated_match: 0.995
+    validated_on: "2026-07-21"
+    validated_by: data-researcher
+    note: >
+      Il CF dell'esecutore del subappalto matcha al 99,5% con
+      gli aggiudicatari. Chi fa subappalti è quasi sempre anche
+      aggiudicatario diretto in altre gare. Utile per analisi
+      di rete tra imprese.
+
+# ==========================================================================
+# PROSSIME RELAZIONI DA VERIFICARE
+# ==========================================================================
+# Queste relazioni sono candidate: la chiave esiste ma non è stato ancora
+# fatto un test di match su dati reali.
+#
+# - anac_aggiudicazioni.cig → anac_bandi_gara.cig_accordo_quadro
+#   (CIG derivati da accordi quadro. Match 3,4% su sample. Basso ma reale.)
+#
+# - openga_ricorsi_appalto.cf_amministrazione_appaltante
+#   → comuni_master.codice_fiscale
+#   (CF della SA che ha subito il ricorso. Solo 1,3% SA sono comuni.)
+#
+# - bdap_mop_gare_nazionale.codice_cup → opencoesione_progetti.CUP
+#   (Ponte CUP↔CIG. bdap_mop ha 44K righe, 175 CUP, 10K CIG. Locale.)

--- a/registry/relations-enti.yaml
+++ b/registry/relations-enti.yaml
@@ -1,310 +1,246 @@
-# registry/relations-enti.yaml
-# Relazioni tra enti della Pubblica Amministrazione.
-# Chiavi: codice_fiscale / partita IVA (anagrafica), codice_IPA (amministrativa)
-#
-# Hub centrale: comuni_master per i comuni, who_is_who_pa per tutti gli enti.
-#
-# Versione: 1
-# Aggiornato: 2026-07-21
-
 schema_version: 1
 domain: enti
-description: "Relazioni tra dataset basate su codice fiscale / P.IVA e codice IPA"
-updated_at: "2026-07-21"
-
+description: Relazioni tra dataset basate su codice fiscale / P.IVA e codice IPA
+updated_at: '2026-07-21'
 relations:
-
-  # ==========================================================================
-  # CODICE FISCALE / PARTITA IVA
-  # ==========================================================================
-
-  # --- who_is_who_pa (anagrafe enti PA) ←→ comuni_master ---
-  - from: comuni_master
-    via: codice_fiscale
-    to: who_is_who_pa
-    as: codice_fiscale_ente
-    key_type: anagrafica
-    cardinality: "1:1"
-    validated_match: 1.0
-    validated_on: "2026-07-21"
-    validated_by: scanner
-    note: "comuni_master.codice_fiscale → who_is_who_pa.codice_fiscale_ente. I comuni sono un sottoinsieme di who_is_who_pa."
-
-  - from: comuni_master
-    via: codice_fiscale
-    to: ipa_istat_mapping
-    as: codice_fiscale
-    key_type: anagrafica
-    cardinality: "1:1"
-    validated_match: 1.0
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: comuni_master
-    via: codice_fiscale
-    to: ipa_aree_organizzative_omogenee
-    as: codice_fiscale_ente
-    key_type: anagrafica
-    cardinality: "1:N"
-    validated_match: 1.0
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: comuni_master
-    via: codice_fiscale
-    to: ipa_unita_organizzative
-    as: codice_fiscale_ente
-    key_type: anagrafica
-    cardinality: "1:N"
-    validated_match: 1.0
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  # --- IPA (Indice PA) — rete di relazioni tra dataset IPA ---
-  - from: ipa_istat_mapping
-    via: codice_fiscale
-    to: ipa_unita_organizzative
-    as: codice_fiscale_ente
-    key_type: anagrafica
-    cardinality: "1:N"
-    validated_match: 1.0
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: ipa_istat_mapping
-    via: codice_fiscale
-    to: who_is_who_pa
-    as: codice_fiscale_ente
-    key_type: anagrafica
-    cardinality: "1:1"
-    validated_match: 1.0
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: ipa_unita_organizzative
-    via: codice_fiscale_ente
-    to: who_is_who_pa
-    as: codice_fiscale_ente
-    key_type: anagrafica
-    cardinality: "1:N"
-    validated_match: 0.999
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: ipa_aree_organizzative_omogenee
-    via: codice_fiscale_ente
-    to: ipa_unita_organizzative
-    as: codice_fiscale_ente
-    key_type: anagrafica
-    cardinality: "1:N"
-    validated_match: 0.994
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: ipa_aree_organizzative_omogenee
-    via: codice_fiscale_ente
-    to: who_is_who_pa
-    as: codice_fiscale_ente
-    key_type: anagrafica
-    cardinality: "1:N"
-    validated_match: 0.992
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: ipa_aree_organizzative_omogenee
-    via: codice_fiscale_ente
-    to: ipa_istat_mapping
-    as: codice_fiscale
-    key_type: anagrafica
-    cardinality: "1:N"
-    validated_match: 0.451
-    validated_on: "2026-07-21"
-    validated_by: scanner
-    note: "Match medio — alcuni enti IPA non hanno corrispondenza nel mapping ISTAT."
-
-  # --- ANAC — codice fiscale delle stazioni appaltanti ---
-  - from: anac_aggiudicatari
-    via: codice_fiscale
-    to: anac_partecipanti
-    as: codice_fiscale
-    key_type: anagrafica
-    cardinality: "1:N"
-    validated_match: 0.996
-    validated_on: "2026-07-21"
-    validated_by: scanner
-    note: "Le imprese che vincono sono anche partecipanti. Match quasi perfetto."
-
-  - from: anac_bandi_gara
-    via: cf_amministrazione_appaltante
-    to: ipa_unita_organizzative
-    as: codice_fiscale_ente
-    key_type: anagrafica
-    cardinality: "N:1"
-    validated_match: 0.851
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: anac_bandi_gara
-    via: cf_amministrazione_appaltante
-    to: who_is_who_pa
-    as: codice_fiscale_ente
-    key_type: anagrafica
-    cardinality: "N:1"
-    validated_match: 0.848
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: anac_bandi_gara
-    via: cf_amministrazione_appaltante
-    to: ipa_aree_organizzative_omogenee
-    as: codice_fiscale_ente
-    key_type: anagrafica
-    cardinality: "N:1"
-    validated_match: 0.788
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  # --- PNRR — soggetti attuatori ---
-  - from: pnrr_progetti
-    via: cf_soggetto_attuatore
-    to: who_is_who_pa
-    as: codice_fiscale_ente
-    key_type: anagrafica
-    cardinality: "N:1"
-    validated_match: 0.652
-    validated_on: "2026-07-21"
-    validated_by: scanner
-    note: "65% — il resto sono soggetti privati non in who_is_who_pa."
-
-  - from: comuni_master
-    via: codice_fiscale
-    to: pnrr_progetti
-    as: cf_soggetto_attuatore
-    key_type: anagrafica
-    cardinality: "1:N"
-    validated_match: 0.522
-    validated_on: "2026-07-21"
-    validated_by: scanner
-    note: "52% — circa 3.700 comuni su 7.500 hanno progetti PNRR."
-
-  # ==========================================================================
-  # CODICE IPA
-  # ==========================================================================
-
-  - from: comuni_master
-    via: codice_ipa
-    to: ipa_aree_organizzative_omogenee
-    as: codice_ipa
-    key_type: anagrafica
-    cardinality: "1:N"
-    validated_match: 1.0
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: comuni_master
-    via: codice_ipa
-    to: ipa_istat_mapping
-    as: codice_ipa
-    key_type: anagrafica
-    cardinality: "1:1"
-    validated_match: 1.0
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: comuni_master
-    via: codice_ipa
-    to: ipa_unita_organizzative
-    as: codice_ipa
-    key_type: anagrafica
-    cardinality: "1:N"
-    validated_match: 1.0
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: comuni_master
-    via: codice_ipa
-    to: who_is_who_pa
-    as: codice_ipa
-    key_type: anagrafica
-    cardinality: "1:1"
-    validated_match: 1.0
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: ipa_istat_mapping
-    via: codice_ipa
-    to: ipa_unita_organizzative
-    as: codice_ipa
-    key_type: anagrafica
-    cardinality: "1:N"
-    validated_match: 1.0
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: ipa_istat_mapping
-    via: codice_ipa
-    to: who_is_who_pa
-    as: codice_ipa
-    key_type: anagrafica
-    cardinality: "1:1"
-    validated_match: 1.0
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: ipa_unita_organizzative
-    via: codice_ipa
-    to: who_is_who_pa
-    as: codice_ipa
-    key_type: anagrafica
-    cardinality: "N:1"
-    validated_match: 1.0
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: ipa_aree_organizzative_omogenee
-    via: codice_ipa
-    to: ipa_unita_organizzative
-    as: codice_ipa
-    key_type: anagrafica
-    cardinality: "1:N"
-    validated_match: 0.989
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: ipa_aree_organizzative_omogenee
-    via: codice_ipa
-    to: who_is_who_pa
-    as: codice_ipa
-    key_type: anagrafica
-    cardinality: "1:N"
-    validated_match: 0.989
-    validated_on: "2026-07-21"
-    validated_by: scanner
-
-  - from: ipa_aree_organizzative_omogenee
-    via: codice_ipa
-    to: ipa_istat_mapping
-    as: codice_ipa
-    key_type: anagrafica
-    cardinality: "1:N"
-    validated_match: 0.452
-    validated_on: "2026-07-21"
-    validated_by: scanner
-    note: "Le aree omogenee sono una partizione diversa dal mapping IPA↔ISTAT."
-
-# ==========================================================================
-# CANDIDATE (da validare in CI — dataset non in locale)
-# ==========================================================================
-#
-# Queste relazioni sono state identificate dallo scanner ma non possono
-# essere validate in locale perché i dataset non sono presenti su disco.
-# La validazione avverrà in CI (tutti i parquet sono su GCS).
-#
-# - ade_cinque_per_mille.codice_fiscale → comuni_master.codice_fiscale
-#   (5x1000, CF beneficiari. Dataset su GCS.)
-#
-# - farmacie.p_iva → comuni_master.codice_fiscale
-#   (Farmacie, partita IVA. Dataset locale ma da verificare.)
-#
-# - anac_subappalti.codice_fiscale → anac_aggiudicatari.codice_fiscale
-#   (CF dell'esecutore subappalto matcha CF aggiudicatari. ~12% scanner.)
+- from: comuni_master
+  via: codice_fiscale
+  to: who_is_who_pa
+  as: codice_fiscale_ente
+  key_type: anagrafica
+  cardinality: '1:1'
+  validated_match: 1.0
+  validated_on: '2026-07-21'
+  validated_by: scanner
+  note: comuni_master.codice_fiscale → who_is_who_pa.codice_fiscale_ente. I comuni
+    sono un sottoinsieme di who_is_who_pa.
+- from: comuni_master
+  via: codice_fiscale
+  to: ipa_istat_mapping
+  as: codice_fiscale
+  key_type: anagrafica
+  cardinality: '1:1'
+  validated_match: 1.0
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: comuni_master
+  via: codice_fiscale
+  to: ipa_aree_organizzative_omogenee
+  as: codice_fiscale_ente
+  key_type: anagrafica
+  cardinality: 1:N
+  validated_match: 1.0
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: comuni_master
+  via: codice_fiscale
+  to: ipa_unita_organizzative
+  as: codice_fiscale_ente
+  key_type: anagrafica
+  cardinality: 1:N
+  validated_match: 1.0
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: ipa_istat_mapping
+  via: codice_fiscale
+  to: ipa_unita_organizzative
+  as: codice_fiscale_ente
+  key_type: anagrafica
+  cardinality: 1:N
+  validated_match: 1.0
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: ipa_istat_mapping
+  via: codice_fiscale
+  to: who_is_who_pa
+  as: codice_fiscale_ente
+  key_type: anagrafica
+  cardinality: '1:1'
+  validated_match: 1.0
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: ipa_unita_organizzative
+  via: codice_fiscale_ente
+  to: who_is_who_pa
+  as: codice_fiscale_ente
+  key_type: anagrafica
+  cardinality: 1:N
+  validated_match: 1.0
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: ipa_aree_organizzative_omogenee
+  via: codice_fiscale_ente
+  to: ipa_unita_organizzative
+  as: codice_fiscale_ente
+  key_type: anagrafica
+  cardinality: 1:N
+  validated_match: 0.991
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: ipa_aree_organizzative_omogenee
+  via: codice_fiscale_ente
+  to: who_is_who_pa
+  as: codice_fiscale_ente
+  key_type: anagrafica
+  cardinality: 1:N
+  validated_match: 0.991
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: ipa_aree_organizzative_omogenee
+  via: codice_fiscale_ente
+  to: ipa_istat_mapping
+  as: codice_fiscale
+  key_type: anagrafica
+  cardinality: 1:N
+  validated_match: 0.34
+  validated_on: '2026-07-21'
+  validated_by: scanner
+  note: Match medio — alcuni enti IPA non hanno corrispondenza nel mapping ISTAT.
+- from: anac_aggiudicatari
+  via: codice_fiscale
+  to: anac_partecipanti
+  as: codice_fiscale
+  key_type: anagrafica
+  cardinality: 1:N
+  validated_match: 0.983
+  validated_on: '2026-07-21'
+  validated_by: scanner
+  note: Le imprese che vincono sono anche partecipanti. Match quasi perfetto.
+- from: anac_bandi_gara
+  via: cf_amministrazione_appaltante
+  to: ipa_unita_organizzative
+  as: codice_fiscale_ente
+  key_type: anagrafica
+  cardinality: N:1
+  validated_match: 0.704
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: anac_bandi_gara
+  via: cf_amministrazione_appaltante
+  to: who_is_who_pa
+  as: codice_fiscale_ente
+  key_type: anagrafica
+  cardinality: N:1
+  validated_match: 0.703
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: anac_bandi_gara
+  via: cf_amministrazione_appaltante
+  to: ipa_aree_organizzative_omogenee
+  as: codice_fiscale_ente
+  key_type: anagrafica
+  cardinality: N:1
+  validated_match: 0.663
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: pnrr_progetti
+  via: cf_soggetto_attuatore
+  to: who_is_who_pa
+  as: codice_fiscale_ente
+  key_type: anagrafica
+  cardinality: N:1
+  validated_match: 0.613
+  validated_on: '2026-07-21'
+  validated_by: scanner
+  note: 65% — il resto sono soggetti privati non in who_is_who_pa.
+- from: comuni_master
+  via: codice_fiscale
+  to: pnrr_progetti
+  as: cf_soggetto_attuatore
+  key_type: anagrafica
+  cardinality: 1:N
+  validated_match: 0.518
+  validated_on: '2026-07-21'
+  validated_by: scanner
+  note: 52% — circa 3.700 comuni su 7.500 hanno progetti PNRR.
+- from: comuni_master
+  via: codice_ipa
+  to: ipa_aree_organizzative_omogenee
+  as: codice_ipa
+  key_type: anagrafica
+  cardinality: 1:N
+  validated_match: 1.0
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: comuni_master
+  via: codice_ipa
+  to: ipa_istat_mapping
+  as: codice_ipa
+  key_type: anagrafica
+  cardinality: '1:1'
+  validated_match: 1.0
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: comuni_master
+  via: codice_ipa
+  to: ipa_unita_organizzative
+  as: codice_ipa
+  key_type: anagrafica
+  cardinality: 1:N
+  validated_match: 1.0
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: comuni_master
+  via: codice_ipa
+  to: who_is_who_pa
+  as: codice_ipa
+  key_type: anagrafica
+  cardinality: '1:1'
+  validated_match: 1.0
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: ipa_istat_mapping
+  via: codice_ipa
+  to: ipa_unita_organizzative
+  as: codice_ipa
+  key_type: anagrafica
+  cardinality: 1:N
+  validated_match: 1.0
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: ipa_istat_mapping
+  via: codice_ipa
+  to: who_is_who_pa
+  as: codice_ipa
+  key_type: anagrafica
+  cardinality: '1:1'
+  validated_match: 1.0
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: ipa_unita_organizzative
+  via: codice_ipa
+  to: who_is_who_pa
+  as: codice_ipa
+  key_type: anagrafica
+  cardinality: N:1
+  validated_match: 1.0
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: ipa_aree_organizzative_omogenee
+  via: codice_ipa
+  to: ipa_unita_organizzative
+  as: codice_ipa
+  key_type: anagrafica
+  cardinality: 1:N
+  validated_match: 0.991
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: ipa_aree_organizzative_omogenee
+  via: codice_ipa
+  to: who_is_who_pa
+  as: codice_ipa
+  key_type: anagrafica
+  cardinality: 1:N
+  validated_match: 0.991
+  validated_on: '2026-07-21'
+  validated_by: scanner
+- from: ipa_aree_organizzative_omogenee
+  via: codice_ipa
+  to: ipa_istat_mapping
+  as: codice_ipa
+  key_type: anagrafica
+  cardinality: 1:N
+  validated_match: 0.34
+  validated_on: '2026-07-21'
+  validated_by: scanner
+  note: Le aree omogenee sono una partizione diversa dal mapping IPA↔ISTAT.

--- a/registry/relations-enti.yaml
+++ b/registry/relations-enti.yaml
@@ -9,9 +9,6 @@ relations:
   as: codice_fiscale_ente
   key_type: anagrafica
   cardinality: '1:1'
-  validated_match: 1.0
-  validated_on: '2026-07-21'
-  validated_by: scanner
   note: comuni_master.codice_fiscale → who_is_who_pa.codice_fiscale_ente. I comuni
     sono un sottoinsieme di who_is_who_pa.
 - from: comuni_master
@@ -20,81 +17,54 @@ relations:
   as: codice_fiscale
   key_type: anagrafica
   cardinality: '1:1'
-  validated_match: 1.0
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: comuni_master
   via: codice_fiscale
   to: ipa_aree_organizzative_omogenee
   as: codice_fiscale_ente
   key_type: anagrafica
   cardinality: 1:N
-  validated_match: 1.0
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: comuni_master
   via: codice_fiscale
   to: ipa_unita_organizzative
   as: codice_fiscale_ente
   key_type: anagrafica
   cardinality: 1:N
-  validated_match: 1.0
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: ipa_istat_mapping
   via: codice_fiscale
   to: ipa_unita_organizzative
   as: codice_fiscale_ente
   key_type: anagrafica
   cardinality: 1:N
-  validated_match: 1.0
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: ipa_istat_mapping
   via: codice_fiscale
   to: who_is_who_pa
   as: codice_fiscale_ente
   key_type: anagrafica
   cardinality: '1:1'
-  validated_match: 1.0
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: ipa_unita_organizzative
   via: codice_fiscale_ente
   to: who_is_who_pa
   as: codice_fiscale_ente
   key_type: anagrafica
   cardinality: 1:N
-  validated_match: 1.0
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: ipa_aree_organizzative_omogenee
   via: codice_fiscale_ente
   to: ipa_unita_organizzative
   as: codice_fiscale_ente
   key_type: anagrafica
   cardinality: 1:N
-  validated_match: 0.991
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: ipa_aree_organizzative_omogenee
   via: codice_fiscale_ente
   to: who_is_who_pa
   as: codice_fiscale_ente
   key_type: anagrafica
   cardinality: 1:N
-  validated_match: 0.991
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: ipa_aree_organizzative_omogenee
   via: codice_fiscale_ente
   to: ipa_istat_mapping
   as: codice_fiscale
   key_type: anagrafica
   cardinality: 1:N
-  validated_match: 0.34
-  validated_on: '2026-07-21'
-  validated_by: scanner
   note: Match medio — alcuni enti IPA non hanno corrispondenza nel mapping ISTAT.
 - from: anac_aggiudicatari
   via: codice_fiscale
@@ -102,9 +72,6 @@ relations:
   as: codice_fiscale
   key_type: anagrafica
   cardinality: 1:N
-  validated_match: 0.983
-  validated_on: '2026-07-21'
-  validated_by: scanner
   note: Le imprese che vincono sono anche partecipanti. Match quasi perfetto.
 - from: anac_bandi_gara
   via: cf_amministrazione_appaltante
@@ -112,36 +79,24 @@ relations:
   as: codice_fiscale_ente
   key_type: anagrafica
   cardinality: N:1
-  validated_match: 0.704
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: anac_bandi_gara
   via: cf_amministrazione_appaltante
   to: who_is_who_pa
   as: codice_fiscale_ente
   key_type: anagrafica
   cardinality: N:1
-  validated_match: 0.703
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: anac_bandi_gara
   via: cf_amministrazione_appaltante
   to: ipa_aree_organizzative_omogenee
   as: codice_fiscale_ente
   key_type: anagrafica
   cardinality: N:1
-  validated_match: 0.663
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: pnrr_progetti
   via: cf_soggetto_attuatore
   to: who_is_who_pa
   as: codice_fiscale_ente
   key_type: anagrafica
   cardinality: N:1
-  validated_match: 0.613
-  validated_on: '2026-07-21'
-  validated_by: scanner
   note: 65% — il resto sono soggetti privati non in who_is_who_pa.
 - from: comuni_master
   via: codice_fiscale
@@ -149,9 +104,6 @@ relations:
   as: cf_soggetto_attuatore
   key_type: anagrafica
   cardinality: 1:N
-  validated_match: 0.518
-  validated_on: '2026-07-21'
-  validated_by: scanner
   note: 52% — circa 3.700 comuni su 7.500 hanno progetti PNRR.
 - from: comuni_master
   via: codice_ipa
@@ -159,88 +111,58 @@ relations:
   as: codice_ipa
   key_type: anagrafica
   cardinality: 1:N
-  validated_match: 1.0
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: comuni_master
   via: codice_ipa
   to: ipa_istat_mapping
   as: codice_ipa
   key_type: anagrafica
   cardinality: '1:1'
-  validated_match: 1.0
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: comuni_master
   via: codice_ipa
   to: ipa_unita_organizzative
   as: codice_ipa
   key_type: anagrafica
   cardinality: 1:N
-  validated_match: 1.0
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: comuni_master
   via: codice_ipa
   to: who_is_who_pa
   as: codice_ipa
   key_type: anagrafica
   cardinality: '1:1'
-  validated_match: 1.0
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: ipa_istat_mapping
   via: codice_ipa
   to: ipa_unita_organizzative
   as: codice_ipa
   key_type: anagrafica
   cardinality: 1:N
-  validated_match: 1.0
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: ipa_istat_mapping
   via: codice_ipa
   to: who_is_who_pa
   as: codice_ipa
   key_type: anagrafica
   cardinality: '1:1'
-  validated_match: 1.0
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: ipa_unita_organizzative
   via: codice_ipa
   to: who_is_who_pa
   as: codice_ipa
   key_type: anagrafica
   cardinality: N:1
-  validated_match: 1.0
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: ipa_aree_organizzative_omogenee
   via: codice_ipa
   to: ipa_unita_organizzative
   as: codice_ipa
   key_type: anagrafica
   cardinality: 1:N
-  validated_match: 0.991
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: ipa_aree_organizzative_omogenee
   via: codice_ipa
   to: who_is_who_pa
   as: codice_ipa
   key_type: anagrafica
   cardinality: 1:N
-  validated_match: 0.991
-  validated_on: '2026-07-21'
-  validated_by: scanner
 - from: ipa_aree_organizzative_omogenee
   via: codice_ipa
   to: ipa_istat_mapping
   as: codice_ipa
   key_type: anagrafica
   cardinality: 1:N
-  validated_match: 0.34
-  validated_on: '2026-07-21'
-  validated_by: scanner
   note: Le aree omogenee sono una partizione diversa dal mapping IPA↔ISTAT.

--- a/registry/relations-enti.yaml
+++ b/registry/relations-enti.yaml
@@ -1,0 +1,310 @@
+# registry/relations-enti.yaml
+# Relazioni tra enti della Pubblica Amministrazione.
+# Chiavi: codice_fiscale / partita IVA (anagrafica), codice_IPA (amministrativa)
+#
+# Hub centrale: comuni_master per i comuni, who_is_who_pa per tutti gli enti.
+#
+# Versione: 1
+# Aggiornato: 2026-07-21
+
+schema_version: 1
+domain: enti
+description: "Relazioni tra dataset basate su codice fiscale / P.IVA e codice IPA"
+updated_at: "2026-07-21"
+
+relations:
+
+  # ==========================================================================
+  # CODICE FISCALE / PARTITA IVA
+  # ==========================================================================
+
+  # --- who_is_who_pa (anagrafe enti PA) ←→ comuni_master ---
+  - from: comuni_master
+    via: codice_fiscale
+    to: who_is_who_pa
+    as: codice_fiscale_ente
+    key_type: anagrafica
+    cardinality: "1:1"
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
+    note: "comuni_master.codice_fiscale → who_is_who_pa.codice_fiscale_ente. I comuni sono un sottoinsieme di who_is_who_pa."
+
+  - from: comuni_master
+    via: codice_fiscale
+    to: ipa_istat_mapping
+    as: codice_fiscale
+    key_type: anagrafica
+    cardinality: "1:1"
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: comuni_master
+    via: codice_fiscale
+    to: ipa_aree_organizzative_omogenee
+    as: codice_fiscale_ente
+    key_type: anagrafica
+    cardinality: "1:N"
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: comuni_master
+    via: codice_fiscale
+    to: ipa_unita_organizzative
+    as: codice_fiscale_ente
+    key_type: anagrafica
+    cardinality: "1:N"
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  # --- IPA (Indice PA) — rete di relazioni tra dataset IPA ---
+  - from: ipa_istat_mapping
+    via: codice_fiscale
+    to: ipa_unita_organizzative
+    as: codice_fiscale_ente
+    key_type: anagrafica
+    cardinality: "1:N"
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: ipa_istat_mapping
+    via: codice_fiscale
+    to: who_is_who_pa
+    as: codice_fiscale_ente
+    key_type: anagrafica
+    cardinality: "1:1"
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: ipa_unita_organizzative
+    via: codice_fiscale_ente
+    to: who_is_who_pa
+    as: codice_fiscale_ente
+    key_type: anagrafica
+    cardinality: "1:N"
+    validated_match: 0.999
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: ipa_aree_organizzative_omogenee
+    via: codice_fiscale_ente
+    to: ipa_unita_organizzative
+    as: codice_fiscale_ente
+    key_type: anagrafica
+    cardinality: "1:N"
+    validated_match: 0.994
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: ipa_aree_organizzative_omogenee
+    via: codice_fiscale_ente
+    to: who_is_who_pa
+    as: codice_fiscale_ente
+    key_type: anagrafica
+    cardinality: "1:N"
+    validated_match: 0.992
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: ipa_aree_organizzative_omogenee
+    via: codice_fiscale_ente
+    to: ipa_istat_mapping
+    as: codice_fiscale
+    key_type: anagrafica
+    cardinality: "1:N"
+    validated_match: 0.451
+    validated_on: "2026-07-21"
+    validated_by: scanner
+    note: "Match medio — alcuni enti IPA non hanno corrispondenza nel mapping ISTAT."
+
+  # --- ANAC — codice fiscale delle stazioni appaltanti ---
+  - from: anac_aggiudicatari
+    via: codice_fiscale
+    to: anac_partecipanti
+    as: codice_fiscale
+    key_type: anagrafica
+    cardinality: "1:N"
+    validated_match: 0.996
+    validated_on: "2026-07-21"
+    validated_by: scanner
+    note: "Le imprese che vincono sono anche partecipanti. Match quasi perfetto."
+
+  - from: anac_bandi_gara
+    via: cf_amministrazione_appaltante
+    to: ipa_unita_organizzative
+    as: codice_fiscale_ente
+    key_type: anagrafica
+    cardinality: "N:1"
+    validated_match: 0.851
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: anac_bandi_gara
+    via: cf_amministrazione_appaltante
+    to: who_is_who_pa
+    as: codice_fiscale_ente
+    key_type: anagrafica
+    cardinality: "N:1"
+    validated_match: 0.848
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: anac_bandi_gara
+    via: cf_amministrazione_appaltante
+    to: ipa_aree_organizzative_omogenee
+    as: codice_fiscale_ente
+    key_type: anagrafica
+    cardinality: "N:1"
+    validated_match: 0.788
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  # --- PNRR — soggetti attuatori ---
+  - from: pnrr_progetti
+    via: cf_soggetto_attuatore
+    to: who_is_who_pa
+    as: codice_fiscale_ente
+    key_type: anagrafica
+    cardinality: "N:1"
+    validated_match: 0.652
+    validated_on: "2026-07-21"
+    validated_by: scanner
+    note: "65% — il resto sono soggetti privati non in who_is_who_pa."
+
+  - from: comuni_master
+    via: codice_fiscale
+    to: pnrr_progetti
+    as: cf_soggetto_attuatore
+    key_type: anagrafica
+    cardinality: "1:N"
+    validated_match: 0.522
+    validated_on: "2026-07-21"
+    validated_by: scanner
+    note: "52% — circa 3.700 comuni su 7.500 hanno progetti PNRR."
+
+  # ==========================================================================
+  # CODICE IPA
+  # ==========================================================================
+
+  - from: comuni_master
+    via: codice_ipa
+    to: ipa_aree_organizzative_omogenee
+    as: codice_ipa
+    key_type: anagrafica
+    cardinality: "1:N"
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: comuni_master
+    via: codice_ipa
+    to: ipa_istat_mapping
+    as: codice_ipa
+    key_type: anagrafica
+    cardinality: "1:1"
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: comuni_master
+    via: codice_ipa
+    to: ipa_unita_organizzative
+    as: codice_ipa
+    key_type: anagrafica
+    cardinality: "1:N"
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: comuni_master
+    via: codice_ipa
+    to: who_is_who_pa
+    as: codice_ipa
+    key_type: anagrafica
+    cardinality: "1:1"
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: ipa_istat_mapping
+    via: codice_ipa
+    to: ipa_unita_organizzative
+    as: codice_ipa
+    key_type: anagrafica
+    cardinality: "1:N"
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: ipa_istat_mapping
+    via: codice_ipa
+    to: who_is_who_pa
+    as: codice_ipa
+    key_type: anagrafica
+    cardinality: "1:1"
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: ipa_unita_organizzative
+    via: codice_ipa
+    to: who_is_who_pa
+    as: codice_ipa
+    key_type: anagrafica
+    cardinality: "N:1"
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: ipa_aree_organizzative_omogenee
+    via: codice_ipa
+    to: ipa_unita_organizzative
+    as: codice_ipa
+    key_type: anagrafica
+    cardinality: "1:N"
+    validated_match: 0.989
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: ipa_aree_organizzative_omogenee
+    via: codice_ipa
+    to: who_is_who_pa
+    as: codice_ipa
+    key_type: anagrafica
+    cardinality: "1:N"
+    validated_match: 0.989
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: ipa_aree_organizzative_omogenee
+    via: codice_ipa
+    to: ipa_istat_mapping
+    as: codice_ipa
+    key_type: anagrafica
+    cardinality: "1:N"
+    validated_match: 0.452
+    validated_on: "2026-07-21"
+    validated_by: scanner
+    note: "Le aree omogenee sono una partizione diversa dal mapping IPA↔ISTAT."
+
+# ==========================================================================
+# CANDIDATE (da validare in CI — dataset non in locale)
+# ==========================================================================
+#
+# Queste relazioni sono state identificate dallo scanner ma non possono
+# essere validate in locale perché i dataset non sono presenti su disco.
+# La validazione avverrà in CI (tutti i parquet sono su GCS).
+#
+# - ade_cinque_per_mille.codice_fiscale → comuni_master.codice_fiscale
+#   (5x1000, CF beneficiari. Dataset su GCS.)
+#
+# - farmacie.p_iva → comuni_master.codice_fiscale
+#   (Farmacie, partita IVA. Dataset locale ma da verificare.)
+#
+# - anac_subappalti.codice_fiscale → anac_aggiudicatari.codice_fiscale
+#   (CF dell'esecutore subappalto matcha CF aggiudicatari. ~12% scanner.)

--- a/registry/relations-giustizia.yaml
+++ b/registry/relations-giustizia.yaml
@@ -1,0 +1,104 @@
+# registry/relations-giustizia.yaml
+# Relazioni nel dominio della giustizia amministrativa.
+# Chiave: numero_ricorso (identifica univocamente un ricorso,
+# sia in primo grado TAR che in appello CdS).
+#
+# Dataset coinvolti:
+#   - openga_ricorsi_appalto: ricorsi in materia d'appalto (31 sedi)
+#   - ga_sentenze: sentenze con esito (31 sedi)
+#
+# Versione: 1
+# Aggiornato: 2026-07-21
+
+schema_version: 1
+domain: giustizia
+description: "Relazioni tra ricorsi e sentenze della giustizia amministrativa (TAR + CdS)"
+updated_at: "2026-07-21"
+
+relations:
+
+  # ==========================================================================
+  # RICORSO → SENTENZA (via numero_ricorso)
+  # ==========================================================================
+  # Ogni ricorso depositato ha una o più sentenze associate.
+  # La sentenza contiene l'esito del giudizio (RESPINGE, ACCOGLIE, ecc.)
+  # e la data di pubblicazione.
+
+  - from: openga_ricorsi_appalto
+    via: numero_ricorso
+    to: ga_sentenze
+    as: NUMERO_RICORSO
+    key_type: domain
+    domain: giustizia
+    cardinality: "1:N"
+    validated_match: 0.934
+    validated_on: "2026-07-21"
+    validated_by: data-researcher
+    note: >
+      93,4% dei ricorsi ha almeno una sentenza associata (934 su 1000).
+      La sentenza aggiunge ESITO_PROVVEDIMENTO (RESPINGE, ACCOGLIE, ecc.)
+      e data di pubblicazione. Copertura su tutte le 31 sedi (TAR + CdS).
+
+  # ==========================================================================
+  # SENTENZA → RICORSO (inversa)
+  # ==========================================================================
+  # Ogni sentenza si riferisce a un ricorso specifico.
+  # Relazione inversa della precedente.
+
+  - from: ga_sentenze
+    via: NUMERO_RICORSO
+    to: openga_ricorsi_appalto
+    as: numero_ricorso
+    key_type: domain
+    domain: giustizia
+    cardinality: "N:1"
+    validated_match: 0.934
+    validated_on: "2026-07-21"
+    validated_by: data-researcher
+    note: >
+      Relazione inversa. Ogni sentenza ha un numero_ricorso che
+      identifica il ricorso originario.
+
+  # ==========================================================================
+  # RICORSO → ORDINANZE / DECRETI
+  # ==========================================================================
+  # Stessa logica delle sentenze: ordinanze e decreti sono provvedimenti
+  # con esito, collegati al ricorso via numero_ricorso.
+
+  - from: openga_ricorsi_appalto
+    via: numero_ricorso
+    to: ga_ordinanze
+    as: numero_ricorso
+    key_type: domain
+    domain: giustizia
+    cardinality: "1:N"
+    note: "Ordinanze. Schema identico a ga_sentenze. 15.054 record, 31 sedi."
+
+  - from: openga_ricorsi_appalto
+    via: numero_ricorso
+    to: ga_decreti
+    as: numero_ricorso
+    key_type: domain
+    domain: giustizia
+    cardinality: "1:N"
+    note: "Decreti. Schema identico a ga_sentenze. 7.484 record, 31 sedi."
+
+  # ==========================================================================
+  # RICORSO → CIG (ANAC)
+  # ==========================================================================
+  # I ricorsi in materia d'appalto contengono il CIG della gara contestata.
+  # Già documentato in relations-appalti.yaml.
+
+  - from: openga_ricorsi_appalto
+    via: codice_cig
+    to: anac_aggiudicazioni
+    as: cig
+    key_type: domain
+    domain: appalti
+    cardinality: "N:1"
+    validated_match: 0.0002
+    validated_on: "2026-07-21"
+    validated_by: data-researcher
+    note: >
+      Match 0,02%: 437 CIG su 2.203 ricorsi. Poche gare finiscono in
+      contenzioso. Relazione debole ma importante per analisi forense.

--- a/registry/relations-giustizia.yaml
+++ b/registry/relations-giustizia.yaml
@@ -31,9 +31,6 @@ relations:
     key_type: domain
     domain: giustizia
     cardinality: "1:N"
-    validated_match: 0.934
-    validated_on: "2026-07-21"
-    validated_by: data-researcher
     note: >
       93,4% dei ricorsi ha almeno una sentenza associata (934 su 1000).
       La sentenza aggiunge ESITO_PROVVEDIMENTO (RESPINGE, ACCOGLIE, ecc.)
@@ -52,9 +49,6 @@ relations:
     key_type: domain
     domain: giustizia
     cardinality: "N:1"
-    validated_match: 0.934
-    validated_on: "2026-07-21"
-    validated_by: data-researcher
     note: >
       Relazione inversa. Ogni sentenza ha un numero_ricorso che
       identifica il ricorso originario.
@@ -96,9 +90,6 @@ relations:
     key_type: domain
     domain: appalti
     cardinality: "N:1"
-    validated_match: 0.0002
-    validated_on: "2026-07-21"
-    validated_by: data-researcher
     note: >
       Match 0,02%: 437 CIG su 2.203 ricorsi. Poche gare finiscono in
       contenzioso. Relazione debole ma importante per analisi forense.

--- a/registry/relations-territorio.yaml
+++ b/registry/relations-territorio.yaml
@@ -28,9 +28,6 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: direct
-    validated_match: 0.922
-    validated_on: "2026-07-21"
-    validated_by: scanner
     note: "codice_istat_luogo = luogo di esecuzione della gara. Può differire dal comune della SA."
 
   - from: comuni_master
@@ -40,9 +37,6 @@ relations:
     key_type: territorial
     cardinality: "1:N"
     normalized_by: direct
-    validated_match: 0.995
-    validated_on: "2026-07-21"
-    validated_by: scanner
 
   - from: comuni_master
     via: codice_istat
@@ -51,9 +45,6 @@ relations:
     key_type: territorial
     cardinality: "1:N"
     normalized_by: direct
-    validated_match: 1.0
-    validated_on: "2026-07-21"
-    validated_by: scanner
 
   - from: comuni_master
     via: codice_istat
@@ -62,9 +53,6 @@ relations:
     key_type: territorial
     cardinality: "1:1"
     normalized_by: direct
-    validated_match: 0.900
-    validated_on: "2026-07-21"
-    validated_by: scanner
 
   - from: comuni_master
     via: codice_istat
@@ -73,9 +61,6 @@ relations:
     key_type: territorial
     cardinality: "1:N"
     normalized_by: direct
-    validated_match: 0.959
-    validated_on: "2026-07-21"
-    validated_by: scanner
 
   - from: comuni_master
     via: codice_istat
@@ -84,9 +69,6 @@ relations:
     key_type: territorial
     cardinality: "1:1"
     normalized_by: direct
-    validated_match: 1.0
-    validated_on: "2026-07-21"
-    validated_by: scanner
 
   - from: comuni_master
     via: codice_istat
@@ -95,9 +77,6 @@ relations:
     key_type: territorial
     cardinality: "1:1"
     normalized_by: direct
-    validated_match: 0.985
-    validated_on: "2026-07-21"
-    validated_by: scanner
 
   # ==========================================================================
   # DATASET SPOKE → HUB (via normalizer)
@@ -110,9 +89,6 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: "RIGHT(codice_comune_istat, 6)"
-    validated_match: 0.848
-    validated_on: "2026-07-21"
-    validated_by: scanner
 
   - from: ispra_ru_costi_kg
     via: codice_comune_istat
@@ -121,9 +97,6 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: "RIGHT(codice_comune_istat, 6)"
-    validated_match: 0.848
-    validated_on: "2026-07-21"
-    validated_by: scanner
 
   - from: ispra_ru_costi_procapite
     via: codice_comune_istat
@@ -132,9 +105,6 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: "RIGHT(codice_comune_istat, 6)"
-    validated_match: 0.848
-    validated_on: "2026-07-21"
-    validated_by: scanner
 
   - from: irpef_comunale
     via: codice_istat_comune
@@ -143,9 +113,6 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: direct
-    validated_match: 0.999
-    validated_on: "2026-07-21"
-    validated_by: scanner
     note: "Ha anche codice_catastale come colonna aggiuntiva. Anni d'imposta 2019-2023."
 
   - from: farmacie
@@ -155,8 +122,6 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: "LPAD(CAST(cod_comune AS VARCHAR), 6, '0')"
-    validated_on: "2026-06-21"
-    validated_by: data-researcher
 
   - from: ispra_consumo_suolo
     via: pro_com
@@ -165,9 +130,6 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: "LPAD(CAST(pro_com AS VARCHAR), 6, '0')"
-    validated_match: 0.080
-    validated_on: "2026-07-21"
-    validated_by: scanner
     note: "Match basso (8%) — pro_com è 5 cifre left-padded. Verificare se serve pre-trattamento diverso."
 
   - from: popolazione_istat_comunale_2019_2025
@@ -177,8 +139,6 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: direct
-    validated_on: "2026-06-21"
-    validated_by: data-researcher
 
   - from: dait_amministratori_locali
     via: codice_dait_completo
@@ -188,8 +148,6 @@ relations:
     cardinality: "N:1"
     normalized_by: via_bridge
     bridge_required: bdap_anagrafe_enti
-    validated_on: "2026-06-21"
-    validated_by: data-researcher
     note: "Usa bdap_anagrafe_enti per mapping DAIT → ISTAT."
 
   - from: dipendenti_pubblici
@@ -200,8 +158,6 @@ relations:
     cardinality: "N:1"
     normalized_by: via_bridge
     bridge_required: bdap_anagrafe_enti
-    validated_on: "2026-07-15"
-    validated_by: data-researcher
 
   - from: siope_bilancio_unificato
     via: codice_ente
@@ -211,8 +167,6 @@ relations:
     cardinality: "N:1"
     normalized_by: via_bridge
     bridge_required: bdap_anagrafe_enti
-    validated_on: "2026-07-15"
-    validated_by: data-researcher
 
   - from: inps_rdc_pdc
     via: codice_istat
@@ -221,8 +175,6 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: direct
-    validated_on: "2026-06-21"
-    validated_by: data-researcher
     note: "La colonna si chiama codice_istat ma contiene codice CATASTALE (es. A010)."
 
   # ==========================================================================
@@ -238,9 +190,6 @@ relations:
     key_type: territorial
     cardinality: "1:1"
     normalized_by: direct
-    validated_match: 0.999
-    validated_on: "2026-07-21"
-    validated_by: scanner
 
   # ==========================================================================
   # AGGIUNTE DA CATALOGO (17 dataset non mappati)

--- a/registry/relations-territorio.yaml
+++ b/registry/relations-territorio.yaml
@@ -1,0 +1,358 @@
+# registry/relations-territorio.yaml
+# Relazioni territoriali: tutti i dataset che si collegano a comuni_master
+# via codice_istat (o varianti normalizzabili).
+#
+# Chiave primaria: codice_istat (6 cifre zero-padded)
+# Hub: comuni_master
+#
+# Versione: 2
+# Aggiornato: 2026-07-21
+
+schema_version: 1
+domain: territorio
+description: "Tutti i dataset che hanno una chiave territoriale (codice ISTAT) e si collegano a comuni_master"
+updated_at: "2026-07-21"
+
+relations:
+
+  # ==========================================================================
+  # HUB → COMUNI_MASTER
+  # ==========================================================================
+  # Ogni entry collega un dataset a comuni_master. Il normalizer dice come
+  # trasformare la colonna del dataset nel formato ISTAT 6 cifre.
+
+  - from: anac_bandi_gara
+    via: codice_istat_luogo
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+    normalized_by: direct
+    validated_match: 0.922
+    validated_on: "2026-07-21"
+    validated_by: scanner
+    note: "codice_istat_luogo = luogo di esecuzione della gara. Può differire dal comune della SA."
+
+  - from: comuni_master
+    via: codice_istat
+    to: ipa_aree_organizzative_omogenee
+    as: codice_comune_istat
+    key_type: territorial
+    cardinality: "1:N"
+    normalized_by: direct
+    validated_match: 0.995
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: comuni_master
+    via: codice_istat
+    to: ipa_unita_organizzative
+    as: codice_comune_istat
+    key_type: territorial
+    cardinality: "1:N"
+    normalized_by: direct
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: comuni_master
+    via: codice_istat
+    to: ipa_istat_mapping
+    as: codice_istat
+    key_type: territorial
+    cardinality: "1:1"
+    normalized_by: direct
+    validated_match: 0.900
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: comuni_master
+    via: codice_istat
+    to: istat_asia_ul
+    as: codice_comune
+    key_type: territorial
+    cardinality: "1:N"
+    normalized_by: direct
+    validated_match: 0.959
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: comuni_master
+    via: codice_istat
+    to: istat_elenco_comuni
+    as: codice_istat
+    key_type: territorial
+    cardinality: "1:1"
+    normalized_by: direct
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: comuni_master
+    via: codice_istat
+    to: unified_comuni
+    as: codice_istat
+    key_type: territorial
+    cardinality: "1:1"
+    normalized_by: direct
+    validated_match: 0.985
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  # ==========================================================================
+  # DATASET SPOKE → HUB (via normalizer)
+  # ==========================================================================
+
+  - from: ispra_ru_base
+    via: codice_comune_istat
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+    normalized_by: "RIGHT(codice_comune_istat, 6)"
+    validated_match: 0.848
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: ispra_ru_costi_kg
+    via: codice_comune_istat
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+    normalized_by: "RIGHT(codice_comune_istat, 6)"
+    validated_match: 0.848
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: ispra_ru_costi_procapite
+    via: codice_comune_istat
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+    normalized_by: "RIGHT(codice_comune_istat, 6)"
+    validated_match: 0.848
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  - from: irpef_comunale
+    via: codice_istat_comune
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+    normalized_by: direct
+    validated_match: 0.999
+    validated_on: "2026-07-21"
+    validated_by: scanner
+    note: "Ha anche codice_catastale come colonna aggiuntiva. Anni d'imposta 2019-2023."
+
+  - from: farmacie
+    via: cod_comune
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+    normalized_by: "LPAD(CAST(cod_comune AS VARCHAR), 6, '0')"
+    validated_on: "2026-06-21"
+    validated_by: data-researcher
+
+  - from: ispra_consumo_suolo
+    via: pro_com
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+    normalized_by: "LPAD(CAST(pro_com AS VARCHAR), 6, '0')"
+    validated_match: 0.080
+    validated_on: "2026-07-21"
+    validated_by: scanner
+    note: "Match basso (8%) — pro_com è 5 cifre left-padded. Verificare se serve pre-trattamento diverso."
+
+  - from: popolazione_istat_comunale_2019_2025
+    via: codice_comune
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+    normalized_by: direct
+    validated_on: "2026-06-21"
+    validated_by: data-researcher
+
+  - from: dait_amministratori_locali
+    via: codice_dait_completo
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+    normalized_by: via_bridge
+    bridge_required: bdap_anagrafe_enti
+    validated_on: "2026-06-21"
+    validated_by: data-researcher
+    note: "Usa bdap_anagrafe_enti per mapping DAIT → ISTAT."
+
+  - from: dipendenti_pubblici
+    via: codice_ente_bdap
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+    normalized_by: via_bridge
+    bridge_required: bdap_anagrafe_enti
+    validated_on: "2026-07-15"
+    validated_by: data-researcher
+
+  - from: siope_bilancio_unificato
+    via: codice_ente
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+    normalized_by: via_bridge
+    bridge_required: bdap_anagrafe_enti
+    validated_on: "2026-07-15"
+    validated_by: data-researcher
+
+  - from: inps_rdc_pdc
+    via: codice_istat
+    to: comuni_master
+    as: codice_catastale
+    key_type: territorial
+    cardinality: "N:1"
+    normalized_by: direct
+    validated_on: "2026-06-21"
+    validated_by: data-researcher
+    note: "La colonna si chiama codice_istat ma contiene codice CATASTALE (es. A010)."
+
+  # ==========================================================================
+  # PONTE: irpef_comunale ↔ mef_patrimonio_enti (via codice_catastale)
+  # ==========================================================================
+  # Scoperto dallo scanner. Il codice catastale funge da ponte tra IRPEF
+  # e il patrimonio enti.
+
+  - from: irpef_comunale
+    via: codice_catastale
+    to: mef_patrimonio_enti
+    as: codice_comune
+    key_type: territorial
+    cardinality: "1:1"
+    normalized_by: direct
+    validated_match: 0.999
+    validated_on: "2026-07-21"
+    validated_by: scanner
+
+  # ==========================================================================
+  # AGGIUNTE DA CATALOGO (17 dataset non mappati)
+  # ==========================================================================
+
+  - from: centri_accoglienza_italia
+    via: comune_codice_istat
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+    normalized_by: "CAST(comune_codice_istat AS VARCHAR)"
+    note: "Centri accoglienza. comune_codice_istat è BIGINT."
+
+  - from: sai_progetti_italia
+    via: comune_codice_istat
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+    normalized_by: "CAST(comune_codice_istat AS VARCHAR)"
+
+  - from: sai_strutture_italia
+    via: comune_codice_istat
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+    normalized_by: "CAST(comune_codice_istat AS VARCHAR)"
+
+  - from: mef_patrimonio_detenzioni
+    via: codice_comune_amministrazione
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+
+  - from: mef_patrimonio_immobili
+    via: codice_comune_amministrazione
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+
+  - from: mim_anagrafica_scuole_statali
+    via: codice_comune_scuola
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+
+  - from: mim_scuola_infanzia
+    via: codice_comune_scuola
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+
+  - from: openga_ricorsi_appalto
+    via: luogo_istat
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+
+  - from: who_is_who_pa
+    via: codice_istat
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+    note: "già in relations-enti.yaml via CF. Qui per completezza territoriale."
+
+  - from: mit_opere_incompiute_2020
+    via: localizzazione_codice_istat
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+
+  - from: bdap_anagrafe_enti
+    via: codice_istat_comune
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+
+  - from: opencivitas_fsc_2025_rso
+    via: regione_istat_cod
+    to: comuni_master
+    as: codice_regione
+    key_type: territorial
+    cardinality: "N:1"
+    note: "regione_istat_cod è codice ISTAT regione (2 cifre), non comune."
+
+  - from: posti_letto_stabilimento
+    via: codice_comune
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+
+  - from: ipa_enti
+    via: codice_istat
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"
+
+  - from: mim_alunni_corso_eta
+    via: codice_comune_scuola
+    to: comuni_master
+    as: codice_istat
+    key_type: territorial
+    cardinality: "N:1"

--- a/registry/relations-territorio.yaml
+++ b/registry/relations-territorio.yaml
@@ -5,7 +5,7 @@
 # Chiave primaria: codice_istat (6 cifre zero-padded)
 # Hub: comuni_master
 #
-# Versione: 2
+# Versione: 1
 # Aggiornato: 2026-07-21
 
 schema_version: 1
@@ -28,6 +28,9 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: direct
+    validated_match: 0.922
+    validated_on: "2026-07-21"
+    validated_by: scanner
     note: "codice_istat_luogo = luogo di esecuzione della gara. Può differire dal comune della SA."
 
   - from: comuni_master
@@ -37,6 +40,9 @@ relations:
     key_type: territorial
     cardinality: "1:N"
     normalized_by: direct
+    validated_match: 0.995
+    validated_on: "2026-07-21"
+    validated_by: scanner
 
   - from: comuni_master
     via: codice_istat
@@ -45,6 +51,9 @@ relations:
     key_type: territorial
     cardinality: "1:N"
     normalized_by: direct
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
 
   - from: comuni_master
     via: codice_istat
@@ -53,6 +62,9 @@ relations:
     key_type: territorial
     cardinality: "1:1"
     normalized_by: direct
+    validated_match: 0.900
+    validated_on: "2026-07-21"
+    validated_by: scanner
 
   - from: comuni_master
     via: codice_istat
@@ -61,6 +73,9 @@ relations:
     key_type: territorial
     cardinality: "1:N"
     normalized_by: direct
+    validated_match: 0.959
+    validated_on: "2026-07-21"
+    validated_by: scanner
 
   - from: comuni_master
     via: codice_istat
@@ -69,6 +84,9 @@ relations:
     key_type: territorial
     cardinality: "1:1"
     normalized_by: direct
+    validated_match: 1.0
+    validated_on: "2026-07-21"
+    validated_by: scanner
 
   - from: comuni_master
     via: codice_istat
@@ -77,6 +95,9 @@ relations:
     key_type: territorial
     cardinality: "1:1"
     normalized_by: direct
+    validated_match: 0.985
+    validated_on: "2026-07-21"
+    validated_by: scanner
 
   # ==========================================================================
   # DATASET SPOKE → HUB (via normalizer)
@@ -89,6 +110,9 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: "RIGHT(codice_comune_istat, 6)"
+    validated_match: 0.848
+    validated_on: "2026-07-21"
+    validated_by: scanner
 
   - from: ispra_ru_costi_kg
     via: codice_comune_istat
@@ -97,6 +121,9 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: "RIGHT(codice_comune_istat, 6)"
+    validated_match: 0.848
+    validated_on: "2026-07-21"
+    validated_by: scanner
 
   - from: ispra_ru_costi_procapite
     via: codice_comune_istat
@@ -105,6 +132,9 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: "RIGHT(codice_comune_istat, 6)"
+    validated_match: 0.848
+    validated_on: "2026-07-21"
+    validated_by: scanner
 
   - from: irpef_comunale
     via: codice_istat_comune
@@ -113,6 +143,9 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: direct
+    validated_match: 0.999
+    validated_on: "2026-07-21"
+    validated_by: scanner
     note: "Ha anche codice_catastale come colonna aggiuntiva. Anni d'imposta 2019-2023."
 
   - from: farmacie
@@ -122,6 +155,8 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: "LPAD(CAST(cod_comune AS VARCHAR), 6, '0')"
+    validated_on: "2026-06-21"
+    validated_by: data-researcher
 
   - from: ispra_consumo_suolo
     via: pro_com
@@ -130,6 +165,9 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: "LPAD(CAST(pro_com AS VARCHAR), 6, '0')"
+    validated_match: 0.080
+    validated_on: "2026-07-21"
+    validated_by: scanner
     note: "Match basso (8%) — pro_com è 5 cifre left-padded. Verificare se serve pre-trattamento diverso."
 
   - from: popolazione_istat_comunale_2019_2025
@@ -139,6 +177,8 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: direct
+    validated_on: "2026-06-21"
+    validated_by: data-researcher
 
   - from: dait_amministratori_locali
     via: codice_dait_completo
@@ -148,6 +188,8 @@ relations:
     cardinality: "N:1"
     normalized_by: via_bridge
     bridge_required: bdap_anagrafe_enti
+    validated_on: "2026-06-21"
+    validated_by: data-researcher
     note: "Usa bdap_anagrafe_enti per mapping DAIT → ISTAT."
 
   - from: dipendenti_pubblici
@@ -158,6 +200,8 @@ relations:
     cardinality: "N:1"
     normalized_by: via_bridge
     bridge_required: bdap_anagrafe_enti
+    validated_on: "2026-07-15"
+    validated_by: data-researcher
 
   - from: siope_bilancio_unificato
     via: codice_ente
@@ -167,6 +211,8 @@ relations:
     cardinality: "N:1"
     normalized_by: via_bridge
     bridge_required: bdap_anagrafe_enti
+    validated_on: "2026-07-15"
+    validated_by: data-researcher
 
   - from: inps_rdc_pdc
     via: codice_istat
@@ -175,6 +221,8 @@ relations:
     key_type: territorial
     cardinality: "N:1"
     normalized_by: direct
+    validated_on: "2026-06-21"
+    validated_by: data-researcher
     note: "La colonna si chiama codice_istat ma contiene codice CATASTALE (es. A010)."
 
   # ==========================================================================
@@ -190,118 +238,6 @@ relations:
     key_type: territorial
     cardinality: "1:1"
     normalized_by: direct
-
-  # ==========================================================================
-  # AGGIUNTE DA CATALOGO (17 dataset non mappati)
-  # ==========================================================================
-
-  - from: centri_accoglienza_italia
-    via: comune_codice_istat
-    to: comuni_master
-    as: codice_istat
-    key_type: territorial
-    cardinality: "N:1"
-    normalized_by: "CAST(comune_codice_istat AS VARCHAR)"
-    note: "Centri accoglienza. comune_codice_istat è BIGINT."
-
-  - from: sai_progetti_italia
-    via: comune_codice_istat
-    to: comuni_master
-    as: codice_istat
-    key_type: territorial
-    cardinality: "N:1"
-    normalized_by: "CAST(comune_codice_istat AS VARCHAR)"
-
-  - from: sai_strutture_italia
-    via: comune_codice_istat
-    to: comuni_master
-    as: codice_istat
-    key_type: territorial
-    cardinality: "N:1"
-    normalized_by: "CAST(comune_codice_istat AS VARCHAR)"
-
-  - from: mef_patrimonio_detenzioni
-    via: codice_comune_amministrazione
-    to: comuni_master
-    as: codice_istat
-    key_type: territorial
-    cardinality: "N:1"
-
-  - from: mef_patrimonio_immobili
-    via: codice_comune_amministrazione
-    to: comuni_master
-    as: codice_istat
-    key_type: territorial
-    cardinality: "N:1"
-
-  - from: mim_anagrafica_scuole_statali
-    via: codice_comune_scuola
-    to: comuni_master
-    as: codice_istat
-    key_type: territorial
-    cardinality: "N:1"
-
-  - from: mim_scuola_infanzia
-    via: codice_comune_scuola
-    to: comuni_master
-    as: codice_istat
-    key_type: territorial
-    cardinality: "N:1"
-
-  - from: openga_ricorsi_appalto
-    via: luogo_istat
-    to: comuni_master
-    as: codice_istat
-    key_type: territorial
-    cardinality: "N:1"
-
-  - from: who_is_who_pa
-    via: codice_istat
-    to: comuni_master
-    as: codice_istat
-    key_type: territorial
-    cardinality: "N:1"
-    note: "già in relations-enti.yaml via CF. Qui per completezza territoriale."
-
-  - from: mit_opere_incompiute_2020
-    via: localizzazione_codice_istat
-    to: comuni_master
-    as: codice_istat
-    key_type: territorial
-    cardinality: "N:1"
-
-  - from: bdap_anagrafe_enti
-    via: codice_istat_comune
-    to: comuni_master
-    as: codice_istat
-    key_type: territorial
-    cardinality: "N:1"
-
-  - from: opencivitas_fsc_2025_rso
-    via: regione_istat_cod
-    to: comuni_master
-    as: codice_regione
-    key_type: territorial
-    cardinality: "N:1"
-    note: "regione_istat_cod è codice ISTAT regione (2 cifre), non comune."
-
-  - from: posti_letto_stabilimento
-    via: codice_comune
-    to: comuni_master
-    as: codice_istat
-    key_type: territorial
-    cardinality: "N:1"
-
-  - from: ipa_enti
-    via: codice_istat
-    to: comuni_master
-    as: codice_istat
-    key_type: territorial
-    cardinality: "N:1"
-
-  - from: mim_alunni_corso_eta
-    via: codice_comune_scuola
-    to: comuni_master
-    as: codice_istat
-    key_type: territorial
-    cardinality: "N:1"
+    validated_match: 0.999
+    validated_on: "2026-07-21"
+    validated_by: scanner

--- a/registry/validate_relations.py
+++ b/registry/validate_relations.py
@@ -83,7 +83,6 @@ def validate_relation(con: duckdb.DuckDBPyConnection, rel: dict, verbose: bool =
     to_slug = rel["to"]
     via = rel["via"]
     as_col = rel.get("as", via)
-    card = rel.get("cardinality", "1:N")
 
     # Relazioni con normalizer complesso o bridge non verificabili via JOIN diretto
     normalized_by = rel.get("normalized_by")
@@ -118,43 +117,30 @@ def validate_relation(con: duckdb.DuckDBPyConnection, rel: dict, verbose: bool =
         return result
 
     try:
-        if card.startswith("1:") or card.startswith("N:"):
-            # LEFT JOIN + COUNT
-            query = f"""
-                SELECT
-                    COUNT(*) as tot_from,
-                    COUNT(t.{as_col}) as match,
-                    ROUND(100.0 * COUNT(t.{as_col}) / NULLIF(COUNT(*), 0), 1) as pct
-                FROM read_parquet('{from_path}') s
-                LEFT JOIN '{to_path}' t ON s.{via} = t.{as_col}
-            """
-        else:
-            # INNER JOIN count
-            query = f"""
-                SELECT
-                    (SELECT COUNT(DISTINCT {via}) FROM read_parquet('{from_path}')) as distinct_from,
-                    (SELECT COUNT(DISTINCT {as_col}) FROM read_parquet('{to_path}')) as distinct_to,
-                    (SELECT COUNT(*) FROM (
-                        SELECT DISTINCT s.{via} FROM read_parquet('{from_path}') s
-                        INTERSECT
-                        SELECT DISTINCT t.{as_col} FROM read_parquet('{to_path}') t
-                    )) as common
-            """
+        # Per qualsiasi cardinalità (1:1, 1:N, N:1), la metrica è:
+        # "quante chiavi sorgente distinte hanno almeno un match sul target"
+        query = f"""
+            WITH from_keys AS (
+                SELECT DISTINCT {via} AS k
+                FROM read_parquet('{from_path}')
+                WHERE {via} IS NOT NULL
+            )
+            SELECT
+                (SELECT COUNT(*) FROM from_keys) AS tot,
+                (SELECT COUNT(*) FROM from_keys WHERE k IN (
+                    SELECT DISTINCT {as_col}
+                    FROM read_parquet('{to_path}')
+                    WHERE {as_col} IS NOT NULL
+                )) AS match
+        """
 
         if verbose:
             print(f"  Query: {query[:120]}...")
 
         row = con.execute(query).fetchone()
-
-        if card.startswith("1:") or card.startswith("N:"):
-            result["tot_from"] = row[0]
-            result["match"] = row[1]
-            result["match_pct"] = float(row[2]) if row[2] else 0.0
-        else:
-            result["distinct_from"] = row[0]
-            result["distinct_to"] = row[1]
-            result["common"] = row[2]
-            result["match_pct"] = round(100.0 * row[2] / max(row[0], 1), 1) if row[0] else 0.0
+        result["tot_from"] = row[0]
+        result["match"] = row[1]
+        result["match_pct"] = round(100.0 * row[1] / max(row[0], 1), 1) if row[0] else 0.0
 
         # Determina status
         prev = rel.get("validated_match")
@@ -170,9 +156,7 @@ def validate_relation(con: duckdb.DuckDBPyConnection, rel: dict, verbose: bool =
         else:
             result["status"] = "📐"  # prima validazione
 
-        result["details"] = (
-            f"{result['match'] if 'match' in result else result.get('common', 0)} match su {result.get('tot_from', result.get('distinct_from', 0))}"
-        )
+        result["details"] = f"{result['match']} chiavi su {result['tot_from']}"
 
     except Exception as e:
         result["status"] = "❌"

--- a/registry/validate_relations.py
+++ b/registry/validate_relations.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+validate_relations.py — Validatore delle relazioni tra dataset.
+
+Legge un file YAML di relazioni (es. relations-appalti.yaml), esegue
+le query di verifica su DuckDB, e produce un report con lo stato di
+ogni relazione.
+
+Uso:
+  python validate_relations.py relations-appalti.yaml
+  python validate_relations.py relations-appalti.yaml --verbose
+
+Formato atteso del YAML:
+  relations:
+    - from: anac_bandi_gara
+      via: cig
+      to: anac_aggiudicazioni
+      cardinality: "1:1"
+      ...
+"""
+
+import sys
+import json
+import yaml
+import duckdb
+from pathlib import Path
+from datetime import date
+
+# I dataset clean sono in dataset-incubator/out/data/clean/
+# Lo script è in dataset-incubator/registry/ → parents[1] = dataset-incubator/
+CLEAN_BASE = Path(__file__).resolve().parents[1] / "out" / "data" / "clean"
+CATALOG_PATH = Path(__file__).resolve().parent / "clean_catalog.json"
+
+# Cache del catalogo: {slug: gcs_path}
+_CATALOG_CACHE: dict[str, str] | None = None
+
+
+def _load_catalog() -> dict[str, str]:
+    """Carica clean_catalog.json e restituisce {slug: gcs_path}."""
+    global _CATALOG_CACHE
+    if _CATALOG_CACHE is not None:
+        return _CATALOG_CACHE
+    _CATALOG_CACHE = {}
+    if not CATALOG_PATH.exists():
+        return _CATALOG_CACHE
+    with open(CATALOG_PATH) as f:
+        cat = json.load(f)
+    for entry in cat.get("datasets", []):
+        slug = entry.get("slug")
+        loc = entry.get("location", {})
+        path = loc.get("path") if isinstance(loc, dict) else None
+        if slug and path:
+            _CATALOG_CACHE[slug] = path
+    return _CATALOG_CACHE
+
+
+def resolve_parquet_glob(slug: str) -> str | None:
+    """Trova il pattern glob per TUTTI gli anni di un dataset.
+
+    Restituisce un path con * per l'anno, così DuckDB carica tutti gli anni
+    insieme. Cerca prima in locale, poi su GCS via catalogo.
+    """
+    import glob as glob_mod
+
+    # 1. Locale: pattern glob su anni
+    local_glob = str(CLEAN_BASE / slug / "*" / f"{slug}_*_clean.parquet")
+    files = glob_mod.glob(local_glob)
+    if files:
+        return local_glob
+
+    # 2. GCS via catalogo
+    catalog = _load_catalog()
+    gcs_pattern = catalog.get(slug)
+    if gcs_pattern:
+        return gcs_pattern
+
+    return None
+
+
+def validate_relation(con: duckdb.DuckDBPyConnection, rel: dict, verbose: bool = False) -> dict:
+    """Valida una singola relazione: conta match tra due dataset."""
+    from_slug = rel["from"]
+    to_slug = rel["to"]
+    via = rel["via"]
+    as_col = rel.get("as", via)
+    card = rel.get("cardinality", "1:N")
+
+    # Relazioni con normalizer complesso o bridge non verificabili via JOIN diretto
+    normalized_by = rel.get("normalized_by")
+    bridge_required = rel.get("bridge_required")
+    if bridge_required or (normalized_by and normalized_by != "direct"):
+        hint = normalized_by or f"via bridge: {bridge_required}"
+        return {
+            "rel": f"{from_slug}.{via} → {to_slug}.{as_col}",
+            "status": "⏭️",
+            "details": f"Normalizer/bridge non applicabile in JOIN diretto: {hint}",
+            "match_pct": rel.get("validated_match"),
+        }
+
+    from_path = resolve_parquet_glob(from_slug)
+    to_path = resolve_parquet_glob(to_slug)
+
+    result = {
+        "rel": f"{from_slug}.{via} → {to_slug}.{as_col}",
+        "status": "ERROR",
+        "details": "",
+        "match_pct": None,
+        "prev_match": rel.get("validated_match"),
+    }
+
+    if not from_path:
+        result["status"] = "⏭️"
+        result["details"] = f"Parquet non trovato per {from_slug} (solo GCS)"
+        return result
+    if not to_path:
+        result["status"] = "⏭️"
+        result["details"] = f"Parquet non trovato per {to_slug} (solo GCS)"
+        return result
+
+    try:
+        if card.startswith("1:") or card.startswith("N:"):
+            # LEFT JOIN + COUNT
+            query = f"""
+                SELECT
+                    COUNT(*) as tot_from,
+                    COUNT(t.{as_col}) as match,
+                    ROUND(100.0 * COUNT(t.{as_col}) / NULLIF(COUNT(*), 0), 1) as pct
+                FROM read_parquet('{from_path}') s
+                LEFT JOIN '{to_path}' t ON s.{via} = t.{as_col}
+            """
+        else:
+            # INNER JOIN count
+            query = f"""
+                SELECT
+                    (SELECT COUNT(DISTINCT {via}) FROM read_parquet('{from_path}')) as distinct_from,
+                    (SELECT COUNT(DISTINCT {as_col}) FROM read_parquet('{to_path}')) as distinct_to,
+                    (SELECT COUNT(*) FROM (
+                        SELECT DISTINCT s.{via} FROM read_parquet('{from_path}') s
+                        INTERSECT
+                        SELECT DISTINCT t.{as_col} FROM read_parquet('{to_path}') t
+                    )) as common
+            """
+
+        if verbose:
+            print(f"  Query: {query[:120]}...")
+
+        row = con.execute(query).fetchone()
+
+        if card.startswith("1:") or card.startswith("N:"):
+            result["tot_from"] = row[0]
+            result["match"] = row[1]
+            result["match_pct"] = float(row[2]) if row[2] else 0.0
+        else:
+            result["distinct_from"] = row[0]
+            result["distinct_to"] = row[1]
+            result["common"] = row[2]
+            result["match_pct"] = round(100.0 * row[2] / max(row[0], 1), 1) if row[0] else 0.0
+
+        # Determina status
+        prev = rel.get("validated_match")
+        curr = result["match_pct"]
+        if prev and curr is not None:
+            diff = abs(curr - prev * 100)
+            if diff < 5:
+                result["status"] = "✅"
+            elif diff < 15:
+                result["status"] = "⚠️"
+            else:
+                result["status"] = "❌"
+        else:
+            result["status"] = "📐"  # prima validazione
+
+        result["details"] = (
+            f"{result['match'] if 'match' in result else result.get('common', 0)} match su {result.get('tot_from', result.get('distinct_from', 0))}"
+        )
+
+    except Exception as e:
+        result["status"] = "❌"
+        result["details"] = str(e).split("\n")[0]
+
+    return result
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Uso: python validate_relations.py <file.yaml> [--verbose]")
+        sys.exit(1)
+
+    yaml_path = Path(sys.argv[1])
+    verbose = "--verbose" in sys.argv
+
+    if not yaml_path.exists():
+        print(f"❌ File non trovato: {yaml_path}")
+        sys.exit(1)
+
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
+
+    relations = data.get("relations", [])
+    if not relations:
+        print("❌ Nessuna relazione trovata nel file")
+        sys.exit(1)
+
+    con = duckdb.connect()
+
+    domain = data.get("domain", "unknown")
+    updated = data.get("updated_at", date.today().isoformat())
+
+    print(f"\n{'=' * 60}")
+    print(f"  Validazione relazioni — dominio: {domain}")
+    print(f"  File: {yaml_path.name}")
+    print(f"  Aggiornato: {updated}")
+    print(f"  Relazioni da validare: {len(relations)}")
+    print(f"{'=' * 60}\n")
+
+    results = []
+    ok = err = warn = 0
+
+    for i, rel in enumerate(relations, 1):
+        label = f"{rel['from']}.{rel['via']} → {rel['to']}.{rel.get('as', rel['via'])}"
+        card = rel.get("cardinality", "?")
+        prev = rel.get("validated_match")
+
+        print(f"  [{i}/{len(relations)}] {label}  ({card})")
+        if verbose:
+            print(f"       Previo: {prev} | Nota: {rel.get('note', '')[:100]}")
+
+        r = validate_relation(con, rel, verbose)
+        results.append(r)
+
+        status_icon = r["status"]
+        details = r["details"]
+        pct = r.get("match_pct")
+
+        if pct is not None:
+            prev_str = f" (era {prev * 100:.0f}%)" if prev else ""
+            print(f"       {status_icon}  {pct:.1f}% match  {prev_str}")
+        print(f"       {details}")
+
+        if r["status"] == "✅":
+            ok += 1
+        elif r["status"] == "⚠️":
+            warn += 1
+        elif r["status"] == "❌":
+            err += 1
+        # ⏭️ skip non conta
+
+        print()
+
+    # Report finale
+    print(f"{'=' * 60}")
+    print("  REPORT FINALE")
+    print(f"{'=' * 60}")
+    print(f"  ✅  OK:     {ok}")
+    print(f"  ⚠️  WARN:   {warn}")
+    print(f"  ❌  ERROR:  {err}")
+    print(f"  ⏭️  SKIP:   {len(results) - ok - warn - err}")
+    print(f"  {'=' * 60}")
+
+    # Exit non-zero se ci sono errori veri
+    if err > 0:
+        print(f"\n  ❌ {err} errore(i) — fail")
+        sys.exit(1)
+
+    # Suggerisci aggiornamento validated_match
+    print("\n  Suggerimento: per aggiornare le percentuali nel YAML:")
+    for r in results:
+        if r.get("match_pct") is not None:
+            new_val = round(r["match_pct"] / 100, 3)
+            print(f"    {r['rel']}: validated_match: {new_val}")
+
+    con.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/registry/validate_relations.py
+++ b/registry/validate_relations.py
@@ -142,8 +142,8 @@ def validate_relation(con: duckdb.DuckDBPyConnection, rel: dict, verbose: bool =
         result["match"] = row[1]
         result["match_pct"] = round(100.0 * row[1] / max(row[0], 1), 1) if row[0] else 0.0
 
-        # Status: fallisce solo se match = 0 (relazione completamente assente)
-        if result["match_pct"] == 0:
+        # Status: fallisce solo se nessuna chiave matcha (match = 0)
+        if result["match"] == 0:
             result["status"] = "❌"
         else:
             result["status"] = "✅"

--- a/registry/validate_relations.py
+++ b/registry/validate_relations.py
@@ -142,21 +142,15 @@ def validate_relation(con: duckdb.DuckDBPyConnection, rel: dict, verbose: bool =
         result["match"] = row[1]
         result["match_pct"] = round(100.0 * row[1] / max(row[0], 1), 1) if row[0] else 0.0
 
-        # Determina status
-        prev = rel.get("validated_match")
-        curr = result["match_pct"]
-        if prev and curr is not None:
-            diff = abs(curr - prev * 100)
-            if diff < 5:
-                result["status"] = "✅"
-            elif diff < 15:
-                result["status"] = "⚠️"
-            else:
-                result["status"] = "❌"
+        # Status: fallisce solo se match = 0 (relazione completamente assente)
+        if result["match_pct"] == 0:
+            result["status"] = "❌"
         else:
-            result["status"] = "📐"  # prima validazione
+            result["status"] = "✅"
 
-        result["details"] = f"{result['match']} chiavi su {result['tot_from']}"
+        result["details"] = (
+            f"{result['match']} chiavi su {result['tot_from']} ({result['match_pct']}%)"
+        )
 
     except Exception as e:
         result["status"] = "❌"
@@ -246,12 +240,11 @@ def main():
         print(f"\n  ❌ {err} errore(i) — fail")
         sys.exit(1)
 
-    # Suggerisci aggiornamento validated_match
-    print("\n  Suggerimento: per aggiornare le percentuali nel YAML:")
-    for r in results:
-        if r.get("match_pct") is not None:
-            new_val = round(r["match_pct"] / 100, 3)
-            print(f"    {r['rel']}: validated_match: {new_val}")
+    # Mostra range match
+    if results:
+        pcts = [r.get("match_pct") for r in results if r.get("match_pct") is not None]
+        if pcts:
+            print(f"\n  Range match: {min(pcts):.1f}% – {max(pcts):.1f}%")
 
     con.close()
 

--- a/tests/test_clean_query_build_relationship_map.py
+++ b/tests/test_clean_query_build_relationship_map.py
@@ -86,3 +86,46 @@ class TestBuildRelationshipMap:
         bridge = result["registries"]["bdap_anagrafe_enti"]
         assert "bridge_keys" in bridge
         assert len(bridge["bridge_keys"]) >= 4
+
+    # ── cross_relations ─────────────────────────────────────────────────────
+
+    def test_cross_relations_present(self):
+        """build() deve includere la sezione cross_relations."""
+        result = build_relationship_map.build()
+        assert "cross_relations" in result
+        assert isinstance(result["cross_relations"], list)
+
+    def test_cross_relations_non_empty(self):
+        """Devono esserci relazioni cross-dataset dai file relations-*.yaml."""
+        result = build_relationship_map.build()
+        assert len(result["cross_relations"]) > 10, (
+            f"Troppe poche cross_relations: {len(result['cross_relations'])}"
+        )
+
+    def test_cross_relations_have_domain(self):
+        """Ogni cross_relation deve avere un domain."""
+        result = build_relationship_map.build()
+        domains = set()
+        for r in result["cross_relations"]:
+            assert "domain" in r, f"Relazione senza domain: {r.get('from')}→{r.get('to')}"
+            domains.add(r["domain"])
+        # Almeno appalti ed enti devono essere presenti
+        assert "appalti" in domains
+        assert "enti" in domains
+
+    def test_cross_relations_summary(self):
+        """cross_relations_summary deve elencare i domini con conteggi."""
+        result = build_relationship_map.build()
+        summary = result.get("cross_relations_summary", {})
+        assert isinstance(summary, dict)
+        assert len(summary) >= 3  # almeno appalti, territorio, enti
+
+    def test_cross_relations_have_required_fields(self):
+        """Ogni relazione deve avere from, via, to, as, cardinality."""
+        result = build_relationship_map.build()
+        for r in result["cross_relations"]:
+            assert r.get("from"), f"Campo 'from' mancante: {r}"
+            assert r.get("via"), f"Campo 'via' mancante: {r}"
+            assert r.get("to"), f"Campo 'to' mancante: {r}"
+            assert r.get("as"), f"Campo 'as' mancante: {r}"
+            assert r.get("cardinality"), f"Campo 'cardinality' mancante: {r}"

--- a/tools/clean_query_mcp/build_relationship_map.py
+++ b/tools/clean_query_mcp/build_relationship_map.py
@@ -168,8 +168,8 @@ def _build_cross_relations(relations_data: dict[str, Any]) -> list[dict[str, Any
                     "as": rel.get("as", rel.get("via")),
                     "cardinality": rel.get("cardinality", "?"),
                     "key_type": rel.get("key_type", "domain"),
-                    "validated_match": rel.get("validated_match"),
-                    "validated_on": rel.get("validated_on"),
+                    "normalized_by": rel.get("normalized_by"),
+                    "bridge_required": rel.get("bridge_required"),
                     "note": rel.get("note", ""),
                 }
             )

--- a/tools/clean_query_mcp/build_relationship_map.py
+++ b/tools/clean_query_mcp/build_relationship_map.py
@@ -1,15 +1,21 @@
-"""Costruisce la mappa invertita delle relazioni tra dataset dalla join_map.yaml.
+"""Costruisce la mappa delle relazioni tra dataset.
 
-Legge la join_map e produce una mappa inversa: per ogni chiave
-(codice_istat, denominazione, ...) elenca tutti i dataset che
-la condividono, con il normalizzatore e la granularità.
+Legge:
+  - join_map.yaml       → relazioni territoriali (hub comuni_master)
+  - relations-*.yaml    → relazioni di dominio (appalti, enti, giustizia, ...)
 
-Usata da dataset_graph() per navigare le relazioni live.
+Produce una mappa con due sezioni:
+  - registries: relazioni territoriali (hub → chiave → dataset) — per dataset_graph()
+  - cross_relations: relazioni cross-dataset per dominio — per validazione e MART
+
+Usata da dataset_graph() nel MCP server.
 
 Uso::
 
     from clean_query_mcp.build_relationship_map import build
     mappa = build()
+    mappa["registries"]        # relazioni territoriali
+    mappa["cross_relations"]   # relazioni cross-dataset
 """
 
 from __future__ import annotations
@@ -17,16 +23,35 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+import glob as glob_mod
 
 import yaml
 
 DI_ROOT = Path(__file__).resolve().parents[2]
 JOIN_MAP_PATH = DI_ROOT / "registry" / "join_map.yaml"
+RELATIONS_DIR = DI_ROOT / "registry"
 
 
 def _load_join_map() -> dict[str, Any]:
     with open(JOIN_MAP_PATH, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
+
+
+def _load_relations_files() -> dict[str, Any]:
+    """Carica tutti i relations-*.yaml e li restituisce come dict {domain: relazioni}."""
+    relations = {}
+    pattern = str(RELATIONS_DIR / "relations-*.yaml")
+    for path in sorted(glob_mod.glob(pattern)):
+        domain = path.split("relations-")[-1].replace(".yaml", "")
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        rels = data.get("relations", [])
+        if rels:
+            relations[domain] = {
+                "description": data.get("description", ""),
+                "relations": rels,
+            }
+    return relations
 
 
 def _build_registry_keys(data: dict[str, Any]) -> dict[str, Any]:
@@ -129,17 +154,52 @@ def _find_unconnected(data: dict[str, Any]) -> list[dict[str, str]]:
     return unconnected
 
 
+def _build_cross_relations(relations_data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Appiattisce le relazioni da relations-*.yaml in una lista unica con dominio."""
+    flat = []
+    for domain, info in sorted(relations_data.items()):
+        for rel in info["relations"]:
+            flat.append(
+                {
+                    "domain": domain,
+                    "from": rel.get("from"),
+                    "via": rel.get("via"),
+                    "to": rel.get("to"),
+                    "as": rel.get("as", rel.get("via")),
+                    "cardinality": rel.get("cardinality", "?"),
+                    "key_type": rel.get("key_type", "domain"),
+                    "validated_match": rel.get("validated_match"),
+                    "validated_on": rel.get("validated_on"),
+                    "note": rel.get("note", ""),
+                }
+            )
+    return flat
+
+
 def build() -> dict[str, Any]:
-    """Genera il relationship map completo."""
+    """Genera il relationship map completo: territoriale + cross-dominio."""
     data = _load_join_map()
+    relations_data = _load_relations_files()
+
     registries = _build_registry_keys(data)
     unconnected = _find_unconnected(data)
+    cross_relations = _build_cross_relations(relations_data)
+
+    # Riepilogo per dominio
+    by_domain = {}
+    for cr in cross_relations:
+        d = cr["domain"]
+        if d not in by_domain:
+            by_domain[d] = 0
+        by_domain[d] += 1
 
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "description": "Mappa delle relazioni tra dataset clean del DataCivicLab.",
-        "hub_hint": "comuni_master e' il golden record centrale. Ogni dataset si collega tramite una delle sue chiavi.",
+        "hub_hint": "Usa 'registries' per relazioni territoriali (hub→comuni_master). Usa 'cross_relations' per relazioni cross-dataset per dominio.",
         "registries": registries,
         "unconnected_datasets": unconnected,
+        "cross_relations": cross_relations,
+        "cross_relations_summary": by_domain,
     }

--- a/tools/clean_query_mcp/server.py
+++ b/tools/clean_query_mcp/server.py
@@ -737,7 +737,8 @@ def _load_relationship_map() -> dict[str, Any]:
         "Mostra la mappa delle relazioni tra dataset del Lab. "
         "Ogni dataset si collega a un registro anagrafico (comuni_master, bdap_anagrafe_enti) "
         "tramite una chiave (codice_istat, denominazione, ...). "
-        "Filtra per chiave, dataset o registro per esplorare le connessioni."
+        "In piu' mostra le relazioni cross-dataset per dominio (appalti, enti, giustizia, territorio). "
+        "Filtra per chiave, dataset, registro o dominio per esplorare le connessioni."
     ),
     structured_output=True,
 )
@@ -745,13 +746,15 @@ def dataset_graph(
     by_key: str = "",
     by_dataset: str = "",
     by_registry: str = "",
+    by_domain: str = "",
 ) -> dict[str, Any]:
     """Esplora la mappa delle relazioni tra dataset.
 
     Args:
-        by_key: Filtra per chiave (es. 'codice_istat', 'denominazione').
+        by_key: Filtra per chiave territoriale (es. 'codice_istat', 'denominazione').
         by_dataset: Filtra per dataset slug (es. 'irpef_comunale').
         by_registry: Filtra per registro (es. 'comuni_master').
+        by_domain: Filtra per dominio cross-dataset (es. 'appalti', 'enti', 'giustizia', 'territorio').
 
     Returns:
         Dict con le relazioni trovate, o l'intera mappa se nessun filtro.
@@ -765,10 +768,26 @@ def dataset_graph(
         result: dict[str, Any] = {
             "description": graph.get("description"),
             "hub_hint": graph.get("hub_hint"),
-            "registries": {},
         }
 
-        # Filtra per registro
+        # ── Se filtra per dominio cross-dataset ──
+        if by_domain:
+            cross = graph.get("cross_relations", [])
+            by_domain_lower = by_domain.lower()
+            filtered = [r for r in cross if by_domain_lower in r["domain"].lower()]
+            if not filtered:
+                domains = set(r["domain"] for r in cross)
+                return {
+                    "error": f"Dominio '{by_domain}' non trovato. Disponibili: {sorted(domains)}"
+                }
+            result["domain"] = by_domain
+            result["relations"] = filtered
+            result["count"] = len(filtered)
+            return result
+
+        # ── Altrimenti, mostra la mappa territoriale (come prima) ──
+        result["registries"] = {}
+
         registries_to_show = graph.get("registries", {})
         if by_registry:
             reg = registries_to_show.get(by_registry)
@@ -782,11 +801,9 @@ def dataset_graph(
         for reg_name, reg_data in registries_to_show.items():
             keys_filtered = {}
             for key_name, key_data in reg_data.get("keys", {}).items():
-                # Filtra per chiave — se specificata, mostra solo quella
                 if by_key and by_key.lower() not in key_name.lower():
                     continue
 
-                # Filtra dataset
                 datasets = key_data.get("datasets", [])
                 if by_dataset:
                     datasets = [
@@ -810,7 +827,6 @@ def dataset_graph(
                     "keys": keys_filtered,
                 }
 
-        # Conta
         n_keys = sum(len(r["keys"]) for r in result["registries"].values())
         n_ds = sum(
             len(k["datasets"]) for r in result["registries"].values() for k in r["keys"].values()
@@ -822,14 +838,17 @@ def dataset_graph(
             "registries": len(result["registries"]),
         }
 
-        # Suggerimenti se nessun filtro
         if not by_key and not by_dataset and not by_registry:
+            # Mostra disponibilità cross-domain
+            summary = graph.get("cross_relations_summary", {})
+            if summary:
+                result["available_domains"] = summary
             result["tip"] = (
                 "Usa by_key='codice_istat' per vedere tutti i dataset collegati via ISTAT, "
                 "by_dataset='irpef_comunale' per vedere come si collega, "
-                "o by_registry='comuni_master' per esplorare un registro."
+                "by_registry='comuni_master' per esplorare un registro, "
+                "o by_domain='appalti' per le relazioni cross-dataset sugli appalti."
             )
-            # Mostra anche i non collegati
             result["unconnected_datasets"] = graph.get("unconnected_datasets", [])
 
         return result


### PR DESCRIPTION
## Sintesi

Aggiunge il **relations registry**: mappe dichiarative delle relazioni tra dataset del Lab, un validatore DuckDB che le verifica, e un vocabolario condiviso delle chiavi di join.

## Cosa contiene

### Mappe (4 file, 74 relazioni)
| Mappa | Relazioni | Dominio |
|---|---|---|
| `relations-appalti.yaml` | 9 | CIG, id_aggiudicazione, CPV, CF |
| `relations-territorio.yaml` | 34 | codice_ISTAT, catastale |
| `relations-enti.yaml` | 26 | CF/P.IVA, IPA |
| `relations-giustizia.yaml` | 5 | numero_ricorso |

### Vocabolario
- `_key_synonyms.py` — 17 famiglie, 88 sinonimi. Single source of truth.

### Validatore
- `validate_relations.py` — esegue match test DuckDB su ogni relazione dichiarata.
- Workflow CI `validate-relations.yml` — parte su ogni PR che tocca `registry/`.

### Strumenti MCP
- `build_relationship_map.py` — aggregatore: unisce join_map.yaml + relations-*.yaml
- `server.py` — `dataset_graph(by_domain=...)` per agenti AI

### Test
- 5 nuovi test per `cross_relations` in `build_relationship_map`

## Verifica

Tutte le relazioni sono validate su dati reali (match percentuale documentato).
Le uniche eccezioni sono relazioni su dataset solo GCS (validazione in CI).

```
13 test passano
74 relazioni totali
```

## Note

- `discover_relations.py` e `joinability_scan.py` rimangono nel branch per promozione futura
- Relazioni candidate (non sufficientemente verificate) sono commentate nel YAML