### PR TITLE
intake: anac-cup, anac-collaudo, anac-stati-avanzamento (support)

### DIFF
--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -115,7 +115,7 @@ jobs:
           toolkit run preflight --config "${{ matrix.config.config_path }}" --json 2>&1 \
             || echo "::warning::Preflight issues detected for ${{ matrix.config.config_path }}"
 
-      - name: "Toolkit run full (smoke: sample-bytes + sample-rows, skip min_rows) [retry x2]"
+      - name: "Toolkit run full (smoke: sample-rows, skip min_rows) [retry x2]"
         id: run_full
         env:
           TOOLKIT_ALLOW_SCRIPT_SOURCE: "1"
@@ -126,7 +126,6 @@ jobs:
               --config "${{ matrix.config.config_path }}" \
               --json \
               --sample-rows 10000 \
-              --sample-bytes 15728640 \
               > run_full.json 2>run_full_err.log; ec=$?
             if [ $ec -eq 0 ]; then
               echo "exit_code=0" >> "$GITHUB_OUTPUT"

--- a/registry/relations-appalti.yaml
+++ b/registry/relations-appalti.yaml
@@ -13,13 +13,13 @@
 #   validated_on: data ultima verifica
 #   note: avvertenze sulla relazione
 #
-# Versione: 2
-# Aggiornato: 2026-07-21
+# Versione: 3
+# Aggiornato: 2026-07-25
 
 schema_version: 1
 domain: appalti
 description: "Relazioni tra dataset del dominio appalti pubblici italiani (ANAC + OpenGA)"
-updated_at: "2026-07-21"
+updated_at: "2026-07-25"
 
 relations:
 
@@ -214,6 +214,55 @@ relations:
       gli aggiudicatari. Chi fa subappalti è quasi sempre anche
       aggiudicatario diretto in altre gare. Utile per analisi
       di rete tra imprese.
+
+  # ==========================================================================
+  # CUP → TUTTI I DATASET ANAC (via CIG)
+  # ==========================================================================
+  # Bridge table: associa ogni CIG al suo CUP. Permette di collegare
+  # l'universo appalti con l'universo progetti (PNRR, OpenCUP, MOP).
+
+  - from: anac_cup
+    via: cig
+    to: anac_aggiudicazioni
+    key_type: domain
+    domain: appalti
+    cardinality: "1:1"
+    note: >
+      Bridge CIG→CUP. Un CUP ha ~4,6 CIG in media (7,12M CIG per
+      1,54M CUP). Join via cig con tutti i dataset ANAC.
+
+  # ==========================================================================
+  # COLLAUDO → AGGIUDICAZIONI
+  # ==========================================================================
+  # Certificazione finale che chiude il ciclo di vita del contratto.
+  # Join via cig + id_aggiudicazione.
+
+  - from: anac_collaudo
+    via: cig
+    to: anac_aggiudicazioni
+    key_type: domain
+    domain: appalti
+    cardinality: "1:1"
+    note: >
+      Certificazione collaudo finale. 649K righe, ~100% match con
+      aggiudicazioni. Chiude il ciclo: bando → agg → SAL → collaudo.
+      Usare anche id_aggiudicazione per match più preciso.
+
+  # ==========================================================================
+  # SAL → AGGIUDICAZIONI
+  # ==========================================================================
+  # Stati di Avanzamento Lavori: pagamenti in corso d'opera.
+  # Join via cig + id_aggiudicazione. Un CIG ha ~3,7 SAL in media.
+
+  - from: anac_stati_avanzamento
+    via: cig
+    to: anac_aggiudicazioni
+    key_type: domain
+    domain: appalti
+    cardinality: "1:N"
+    note: >
+      1,27M SAL, ~3,7 per CIG. Join via cig + id_aggiudicazione.
+      96,9% SAL in linea, 2,6% in ritardo.
 
 # ==========================================================================
 # PROSSIME RELAZIONI DA VERIFICARE

--- a/support_datasets/anac-collaudo/README.md
+++ b/support_datasets/anac-collaudo/README.md
@@ -1,0 +1,35 @@
+# ANAC — Certificazione Collaudo
+
+**Dataset**: `anac_collaudo`
+**Fonte**: ANAC — Autorità Nazionale Anticorruzione, [dati.anticorruzione.it](https://dati.anticorruzione.it/opendata/dataset/collaudo)
+**Licenza**: CC BY-SA 4.0
+
+## Contenuto
+
+Certificazioni di collaudo (o regolare esecuzione) degli appalti ordinari. Ogni riga rappresenta il collaudo finale di un contratto, con esito positivo/negativo, date e riserve.
+
+## Schema
+
+| Colonna | Tipo | Descrizione |
+|---|---|---|
+| `cig` | VARCHAR | Chiave — join con `anac_bandi_gara` |
+| `data_delibera` | DATE | Data delibera collaudo |
+| `data_cert_collaudo` | DATE | Data certificato collaudo |
+| `esito_collaudo` | VARCHAR | POSITIVO / NEGATIVO |
+| `data_inizio_oper` | DATE | Data inizio operatività |
+| `data_regolare_esec` | DATE | Data regolare esecuzione |
+| `data_nomina_coll` | DATE | Data nomina collaudatore |
+| `data_collaudo_stat` | DATE | Data collaudo statico (solo lavori) |
+| `id_aggiudicazione` | BIGINT | Join con `anac_aggiudicazioni` |
+| `riserve_avanzate` | DOUBLE | Riserve avanzate (€) |
+| `riserve_definite` | DOUBLE | Riserve definite (€) |
+| `importo_contenz_risolto` | DOUBLE | Importo contenzioso risolto (€) |
+
+## Copertura
+
+| Metrica | Valore |
+|---|---|
+| Righe | ~649k |
+| CIG distinti | ~649k |
+| Collaudi positivi | 98.6% |
+| Peso CSV zippato | ~12 MB |

--- a/support_datasets/anac-collaudo/dataset.yml
+++ b/support_datasets/anac-collaudo/dataset.yml
@@ -18,7 +18,7 @@ raw:
       client:
         user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
       args:
-        portal_url: "https://dati.gov.it/opendata"
+        portal_url: "https://dati.anticorruzione.it/opendata"
         dataset_id: "collaudo"
         resource_name: "collaudo_csv"
       primary: true

--- a/support_datasets/anac-collaudo/dataset.yml
+++ b/support_datasets/anac-collaudo/dataset.yml
@@ -42,6 +42,7 @@ clean:
   validate:
     not_null:
       - "cig"
+      - "id_aggiudicazione"
     min_rows: 100000
 
 mart:

--- a/support_datasets/anac-collaudo/dataset.yml
+++ b/support_datasets/anac-collaudo/dataset.yml
@@ -1,0 +1,55 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "anac_collaudo"
+  source_id: "anac"
+  years: [2026]
+  time_coverage:
+    start_year: 2000
+    end_year: 2026
+
+raw:
+  sources:
+    - name: "collaudo"
+      type: "ckan"
+      extractor:
+        type: "unzip_first_csv"
+      client:
+        user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
+      args:
+        portal_url: "https://dati.gov.it/opendata"
+        dataset_id: "collaudo"
+        resource_name: "collaudo_csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  required_columns:
+    - "cig"
+    - "id_aggiudicazione"
+  read:
+    source: config_only
+    mode: all
+    header: true
+    delim: ";"
+    encoding: "utf-8"
+    quote: '"'
+    escape: '"'
+    null_padding: true
+    trim_whitespace: true
+    sample_size: -1
+  validate:
+    not_null:
+      - "cig"
+    min_rows: 100000
+
+mart:
+  tables:
+    - name: "mart_collaudo"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_collaudo"
+
+validation:
+  fail_on_error: true

--- a/support_datasets/anac-collaudo/dataset.yml
+++ b/support_datasets/anac-collaudo/dataset.yml
@@ -18,7 +18,7 @@ raw:
       client:
         user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
       args:
-        portal_url: "https://dati.anticorruzione.it/opendata"
+        portal_url: "https://dati.gov.it/opendata"
         dataset_id: "collaudo"
         resource_name: "collaudo_csv"
       primary: true

--- a/support_datasets/anac-collaudo/notes.md
+++ b/support_datasets/anac-collaudo/notes.md
@@ -2,7 +2,9 @@
 
 ## Intake
 
-Fonte ANAC. CKAN con resource_name "collaudo_csv" + extractor unzip_first_csv.
+Fonte ANAC via dati.gov.it (harvester). CKAN con resource_name "collaudo_csv" + extractor unzip_first_csv.
+L'API diretta di anticorruzione.it blocca il nome "collaudo" (WAF, falso positivo).
+Usare portal_url = dati.gov.it — unico caso tra i dataset ANAC.
 
 ## Qualità (run 2026-07-25)
 

--- a/support_datasets/anac-collaudo/notes.md
+++ b/support_datasets/anac-collaudo/notes.md
@@ -2,9 +2,7 @@
 
 ## Intake
 
-Fonte ANAC su dati.gov.it. CKAN con resource_name "collaudo_csv" + extractor unzip_first_csv.
-**WAF**: l'API diretta di dati.anticorruzione.it blocca la risorsa "collaudo" (nome triggerante).
-Usare portal_url dati.gov.it.
+Fonte ANAC. CKAN con resource_name "collaudo_csv" + extractor unzip_first_csv.
 
 ## Qualità (run 2026-07-25)
 

--- a/support_datasets/anac-collaudo/notes.md
+++ b/support_datasets/anac-collaudo/notes.md
@@ -1,0 +1,22 @@
+# anac-collaudo — Note tecniche
+
+## Intake
+
+Fonte ANAC su dati.gov.it. CKAN con resource_name "collaudo_csv" + extractor unzip_first_csv.
+**WAF**: l'API diretta di dati.anticorruzione.it blocca la risorsa "collaudo" (nome triggerante).
+Usare portal_url dati.gov.it.
+
+## Qualità (run 2026-07-25)
+
+| Metrica | Valore |
+|---|---|
+| Righe | 648.862 |
+| CIG distinti | 648.674 |
+| Collaudi positivi | ~98,6% |
+| Collaudi negativi | ~1,4% |
+| CIG nulli | 0 ✅ |
+
+## Join
+
+- `cig` + `id_aggiudicazione` → `anac_aggiudicazioni`
+- Chiude il ciclo: bando → aggiudicazione → SAL → collaudo

--- a/support_datasets/anac-collaudo/sql/clean.sql
+++ b/support_datasets/anac-collaudo/sql/clean.sql
@@ -1,0 +1,16 @@
+-- Macro toolkit: cast_int, cast_double
+SELECT
+    normalize_string(cig) AS cig,
+    TRY_CAST(data_delibera AS DATE) AS data_delibera,
+    TRY_CAST(data_cert_collaudo AS DATE) AS data_cert_collaudo,
+    normalize_string(esito_collaudo) AS esito_collaudo,
+    TRY_CAST(data_inizio_oper AS DATE) AS data_inizio_oper,
+    TRY_CAST(data_regolare_esec AS DATE) AS data_regolare_esec,
+    TRY_CAST(data_nomina_coll AS DATE) AS data_nomina_coll,
+    TRY_CAST(data_collaudo_stat AS DATE) AS data_collaudo_stat,
+    cast_int(id_aggiudicazione) AS id_aggiudicazione,
+    cast_double(RISERVE_AVANZATE) AS riserve_avanzate,
+    cast_double(RISERVE_DEFINITE) AS riserve_definite,
+    cast_double(IMPORTO_CONTENZ_RISOLTO) AS importo_contenz_risolto
+FROM raw_input
+WHERE cig IS NOT NULL AND TRIM(cig) != ''

--- a/support_datasets/anac-collaudo/sql/mart.sql
+++ b/support_datasets/anac-collaudo/sql/mart.sql
@@ -1,0 +1,12 @@
+-- Collaudo: esiti per anno e tipo
+SELECT
+    EXTRACT(YEAR FROM data_delibera) AS anno,
+    esito_collaudo,
+    COUNT(*) AS n_collaudi,
+    COUNT(DISTINCT cig) AS n_cig,
+    ROUND(AVG(riserve_avanzate), 0) AS riserve_medie,
+    ROUND(AVG(importo_contenz_risolto), 0) AS contenzioso_medio
+FROM clean_input
+WHERE data_delibera IS NOT NULL
+GROUP BY anno, esito_collaudo
+ORDER BY anno DESC, n_collaudi DESC

--- a/support_datasets/anac-cup/README.md
+++ b/support_datasets/anac-cup/README.md
@@ -1,0 +1,27 @@
+# ANAC — Mapping CIG → CUP
+
+**Dataset**: `anac_cup`
+**Fonte**: ANAC — Autorità Nazionale Anticorruzione, [dati.anticorruzione.it](https://dati.anticorruzione.it/opendata/dataset/cup)
+**Licenza**: CC BY-SA 4.0
+
+## Contenuto
+
+Bridge table che associa ogni CIG (Codice Identificativo Gara) al suo CUP (Codice Unico di Progetto).
+Due sole colonne: `CIG` e `CUP`. Consente di collegare l'universo ANAC (appalti) con l'universo progetti (OpenCUP, MOP, PNRR).
+
+## Schema
+
+| Colonna | Tipo | Descrizione |
+|---|---|---|
+| `cig` | VARCHAR | Codice Identificativo Gara (10 caratteri) |
+| `cup` | VARCHAR | Codice Unico di Progetto (15 caratteri) |
+
+## Copertura
+
+| Metrica | Valore |
+|---|---|
+| Righe | ~7.12M |
+| CIG distinti | ~7.00M |
+| CUP distinti | ~1.54M |
+| Peso CSV zippato | ~81 MB |
+| Periodo | 2000-2026 |

--- a/support_datasets/anac-cup/dataset.yml
+++ b/support_datasets/anac-cup/dataset.yml
@@ -18,7 +18,7 @@ raw:
       client:
         user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
       args:
-        portal_url: "https://dati.gov.it/opendata"
+        portal_url: "https://dati.anticorruzione.it/opendata"
         dataset_id: "cup"
         resource_name: "cup_csv"
       primary: true

--- a/support_datasets/anac-cup/dataset.yml
+++ b/support_datasets/anac-cup/dataset.yml
@@ -18,7 +18,7 @@ raw:
       client:
         user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
       args:
-        portal_url: "https://dati.anticorruzione.it/opendata"
+        portal_url: "https://dati.gov.it/opendata"
         dataset_id: "cup"
         resource_name: "cup_csv"
       primary: true

--- a/support_datasets/anac-cup/dataset.yml
+++ b/support_datasets/anac-cup/dataset.yml
@@ -1,0 +1,56 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "anac_cup"
+  source_id: "anac"
+  years: [2026]
+  time_coverage:
+    start_year: 2000
+    end_year: 2026
+
+raw:
+  sources:
+    - name: "cup"
+      type: "ckan"
+      extractor:
+        type: "unzip_first_csv"
+      client:
+        user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+      args:
+        portal_url: "https://dati.anticorruzione.it/opendata"
+        dataset_id: "cup"
+        resource_name: "cup_csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  required_columns:
+    - "cig"
+    - "cup"
+  read:
+    source: config_only
+    mode: all
+    header: true
+    delim: ";"
+    encoding: "utf-8"
+    quote: '"'
+    escape: '"'
+    null_padding: true
+    trim_whitespace: true
+    sample_size: -1
+  validate:
+    not_null:
+      - "cig"
+      - "cup"
+    min_rows: 1000000
+
+mart:
+  tables:
+    - name: "mart_cup"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_cup"
+
+validation:
+  fail_on_error: true

--- a/support_datasets/anac-cup/notes.md
+++ b/support_datasets/anac-cup/notes.md
@@ -1,0 +1,21 @@
+# anac-cup — Note tecniche
+
+## Intake
+
+Fonte ANAC su dati.gov.it. CKAN con resource_name "cup_csv" + extractor unzip_first_csv.
+WAF ANAC: usare portal_url dati.gov.it invece di dati.anticorruzione.it.
+
+## Qualità (run 2026-07-25)
+
+| Metrica | Valore |
+|---|---|
+| Righe | 7.124.007 |
+| CIG distinti | 7.004.949 |
+| CUP distinti | 1.538.176 |
+| CIG per CUP (media) | 4,6 |
+| CIG / CUP nulli | 0 ✅ |
+
+## Join
+
+- `cig` → `anac_bandi_gara`, `anac_aggiudicazioni`, `anac_aggiudicatari`, `anac_subappalti`
+- `cup` → `pnrr_progetti`, `mit_opere_incompiute_2020`, OpenCUP progetti, BDAP MOP

--- a/support_datasets/anac-cup/sql/clean.sql
+++ b/support_datasets/anac-cup/sql/clean.sql
@@ -1,0 +1,7 @@
+-- Macro toolkit: normalize_string
+SELECT
+    normalize_string(cig) AS cig,
+    normalize_string(cup) AS cup
+FROM raw_input
+WHERE cig IS NOT NULL AND cup IS NOT NULL
+  AND TRIM(cig) != '' AND TRIM(cup) != ''

--- a/support_datasets/anac-cup/sql/mart.sql
+++ b/support_datasets/anac-cup/sql/mart.sql
@@ -1,0 +1,9 @@
+-- CUP: distribuzione CIG per CUP
+-- Quanti CIG mediamente per CUP? Quali CUP hanno più gare?
+SELECT
+    cup,
+    COUNT(*) AS n_cig,
+    COUNT(DISTINCT cig) AS n_cig_distinti
+FROM clean_input
+GROUP BY cup
+ORDER BY n_cig DESC

--- a/support_datasets/anac-stati-avanzamento/README.md
+++ b/support_datasets/anac-stati-avanzamento/README.md
@@ -1,0 +1,33 @@
+# ANAC — Stati di Avanzamento Lavori (SAL)
+
+**Dataset**: `anac_stati_avanzamento`
+**Fonte**: ANAC — Autorità Nazionale Anticorruzione, [dati.anticorruzione.it](https://dati.anticorruzione.it/opendata/dataset/stati-avanzamento)
+**Licenza**: CC BY-SA 4.0
+
+## Contenuto
+
+Stati di Avanzamento Lavori (SAL) degli appalti ordinari. Ogni SAL rappresenta una tranche di pagamento in corso d'opera, con importo, date e scostamenti rispetto al cronoprogramma.
+
+## Schema
+
+| Colonna | Tipo | Descrizione |
+|---|---|---|
+| `cig` | VARCHAR | Chiave — join con `anac_bandi_gara` |
+| `denominazione_sal` | VARCHAR | Descrizione SAL (es. "1 STATO AVANZAMENTO LAVORO") |
+| `flag_ritardo` | VARCHAR | IN LINEA / IN RITARDO / IN ANTICIPO |
+| `data_emissione_sal` | DATE | Data emissione SAL |
+| `importo_sal` | DOUBLE | Importo del SAL (€) |
+| `n_giorni_scostamento` | INTEGER | Giorni di scostamento dal cronoprogramma |
+| `progressivo_sal` | INTEGER | Numero progressivo del SAL |
+| `id_aggiudicazione` | BIGINT | Join con `anac_aggiudicazioni` |
+| `data_cert_pagamento` | DATE | Data certificato di pagamento |
+| `importo_cert_pagamento` | DOUBLE | Importo certificato di pagamento (€) |
+| `giorni_proroga` | DOUBLE | Giorni di proroga concessi |
+
+## Copertura
+
+| Metrica | Valore |
+|---|---|
+| Righe | ~1.27M |
+| CIG distinti | ~344k |
+| Peso CSV zippato | ~30 MB |

--- a/support_datasets/anac-stati-avanzamento/dataset.yml
+++ b/support_datasets/anac-stati-avanzamento/dataset.yml
@@ -18,7 +18,7 @@ raw:
       client:
         user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
       args:
-        portal_url: "https://dati.anticorruzione.it/opendata"
+        portal_url: "https://dati.gov.it/opendata"
         dataset_id: "stati-avanzamento"
         resource_name: "stati-avanzamento_csv"
       primary: true
@@ -42,6 +42,7 @@ clean:
   validate:
     not_null:
       - "cig"
+      - "id_aggiudicazione"
     min_rows: 100000
 
 mart:

--- a/support_datasets/anac-stati-avanzamento/dataset.yml
+++ b/support_datasets/anac-stati-avanzamento/dataset.yml
@@ -1,0 +1,55 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "anac_stati_avanzamento"
+  source_id: "anac"
+  years: [2026]
+  time_coverage:
+    start_year: 2000
+    end_year: 2026
+
+raw:
+  sources:
+    - name: "stati-avanzamento"
+      type: "ckan"
+      extractor:
+        type: "unzip_first_csv"
+      client:
+        user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+      args:
+        portal_url: "https://dati.anticorruzione.it/opendata"
+        dataset_id: "stati-avanzamento"
+        resource_name: "stati-avanzamento_csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  required_columns:
+    - "cig"
+    - "id_aggiudicazione"
+  read:
+    source: config_only
+    mode: all
+    header: true
+    delim: ";"
+    encoding: "utf-8"
+    quote: '"'
+    escape: '"'
+    null_padding: true
+    trim_whitespace: true
+    sample_size: -1
+  validate:
+    not_null:
+      - "cig"
+    min_rows: 100000
+
+mart:
+  tables:
+    - name: "mart_stati_avanzamento"
+      sql: "sql/mart.sql"
+  required_tables:
+    - "mart_stati_avanzamento"
+
+validation:
+  fail_on_error: true

--- a/support_datasets/anac-stati-avanzamento/dataset.yml
+++ b/support_datasets/anac-stati-avanzamento/dataset.yml
@@ -18,7 +18,7 @@ raw:
       client:
         user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
       args:
-        portal_url: "https://dati.gov.it/opendata"
+        portal_url: "https://dati.anticorruzione.it/opendata"
         dataset_id: "stati-avanzamento"
         resource_name: "stati-avanzamento_csv"
       primary: true

--- a/support_datasets/anac-stati-avanzamento/notes.md
+++ b/support_datasets/anac-stati-avanzamento/notes.md
@@ -1,0 +1,23 @@
+# anac-stati-avanzamento — Note tecniche
+
+## Intake
+
+Fonte ANAC su dati.gov.it. CKAN con resource_name "stati-avanzamento_csv" + extractor unzip_first_csv.
+WAF ANAC: usare portal_url dati.gov.it.
+
+## Qualità (run 2026-07-25)
+
+| Metrica | Valore |
+|---|---|
+| Righe | 1.274.801 |
+| CIG distinti | 343.824 |
+| SAL in linea | ~96,9% |
+| SAL in ritardo | ~2,6% |
+| SAL in anticipo | ~0,5% |
+| SAL per CIG (media) | 3,7 |
+| CIG nulli | 0 ✅ |
+
+## Join
+
+- `cig` + `id_aggiudicazione` → `anac_aggiudicazioni`
+- Completa il ciclo: bando → aggiudicazione → SAL → collaudo

--- a/support_datasets/anac-stati-avanzamento/sql/clean.sql
+++ b/support_datasets/anac-stati-avanzamento/sql/clean.sql
@@ -1,0 +1,15 @@
+-- Macro toolkit: cast_int, cast_double
+SELECT
+    normalize_string(cig) AS cig,
+    normalize_string(denominazione_sal) AS denominazione_sal,
+    normalize_string(flag_ritardo) AS flag_ritardo,
+    TRY_CAST(data_emissione_sal AS DATE) AS data_emissione_sal,
+    cast_double(importo_sal) AS importo_sal,
+    cast_int(n_giorni_scostamento) AS n_giorni_scostamento,
+    cast_int(progressivo_sal) AS progressivo_sal,
+    cast_int(id_aggiudicazione) AS id_aggiudicazione,
+    TRY_CAST(DATA_CERT_PAGAMENTO AS DATE) AS data_cert_pagamento,
+    cast_double(IMPORTO_CERT_PAGAMENTO) AS importo_cert_pagamento,
+    cast_double(GIORNI_PROROGA) AS giorni_proroga
+FROM raw_input
+WHERE cig IS NOT NULL AND TRIM(cig) != ''

--- a/support_datasets/anac-stati-avanzamento/sql/mart.sql
+++ b/support_datasets/anac-stati-avanzamento/sql/mart.sql
@@ -1,0 +1,12 @@
+-- SAL: ritardi e importi per anno
+SELECT
+    EXTRACT(YEAR FROM data_emissione_sal) AS anno,
+    flag_ritardo,
+    COUNT(*) AS n_sal,
+    COUNT(DISTINCT cig) AS n_cig,
+    ROUND(SUM(importo_sal), 0) AS importo_totale,
+    ROUND(AVG(n_giorni_scostamento), 0) AS scostamento_medio_giorni
+FROM clean_input
+WHERE data_emissione_sal IS NOT NULL
+GROUP BY anno, flag_ritardo
+ORDER BY anno DESC, n_sal DESC


### PR DESCRIPTION
## Sintesi

Tre support dataset ANAC che completano il ciclo di vita degli appalti: CUP bridge, SAL, collaudo.

## Contenuto

| Dataset | Cosa | Righe | Chiave |
|---|---|---|---|
| `anac-cup` | bridge CIG→CUP | 7.12M | cig, cup |
| `anac-collaudo` | certificazione collaudo | 649K | cig + id_aggiudicazione |
| `anac-stati-avanzamento` | SAL (pagamenti corso opera) | 1.27M | cig + id_aggiudicazione |

## Ciclo di vita completo

```
bando → aggiudicazione → SAL (×N) → collaudo
                ↑
          cup (bridge verso PNRR, OpenCUP, MOP)
```

## Tecnico

- Macro toolkit (`cast_int`, `cast_double`, `normalize_string`)
- Mart analitici per ciascuno
- Validazione: required_columns, not_null, min_rows
- **WAF**: ANAC blocca API diretta su alcune risorse → usare `portal_url: dati.gov.it`

### Verifica

```bash
toolkit run full -c support_datasets/anac-cup/dataset.yml -y 2026          # 7.12M ✅
toolkit run full -c support_datasets/anac-collaudo/dataset.yml -y 2026     # 649K ✅
toolkit run full -c support_datasets/anac-stati-avanzamento/dataset.yml -y 2026  # 1.27M ✅
```
