### PR TITLE
chore(post-merge): aggiorna registry per PR #707

### DIFF
--- a/.github/workflows/validate-relations.yml
+++ b/.github/workflows/validate-relations.yml
@@ -7,7 +7,6 @@ on:
       - "registry/relations-*.yaml"
       - "registry/join_map.yaml"
       - "registry/validate_relations.py"
-      - "registry/clean_catalog.json"
       - ".github/workflows/validate-relations.yml"
 
 jobs:

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -919,12 +919,12 @@
     },
     {
       "slug": "anac_collaudo",
-      "name": "Anac Collaudo",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "name": "ANAC Collaudo",
+      "description": "Certificazioni di collaudo (o regolare esecuzione) degli appalti ordinari: esito, date, riserve e contenzioso. Fonte ANAC. Join via cig + id_aggiudicazione con anac_aggiudicazioni. Chiude il ciclo di vita del contratto.",
+      "source": "ANAC - Autorità Nazionale Anticorruzione",
+      "source_id": "anac",
       "period": {
-        "start": 2026,
+        "start": 2000,
         "end": 2026
       },
       "columns": [
@@ -932,73 +932,73 @@
           "name": "cig",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "CIG del contratto — join con anac_bandi_gara e anac_aggiudicazioni"
         },
         {
           "name": "data_delibera",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data delibera collaudo"
         },
         {
           "name": "data_cert_collaudo",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data certificato collaudo"
         },
         {
           "name": "esito_collaudo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Esito collaudo (POSITIVO / NEGATIVO)"
         },
         {
           "name": "data_inizio_oper",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data inizio operatività"
         },
         {
           "name": "data_regolare_esec",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data regolare esecuzione"
         },
         {
           "name": "data_nomina_coll",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data nomina collaudatore"
         },
         {
           "name": "data_collaudo_stat",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data collaudo statico"
         },
         {
           "name": "id_aggiudicazione",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "ID aggiudicazione — join con anac_aggiudicazioni"
         },
         {
           "name": "riserve_avanzate",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Riserve avanzate (€)"
         },
         {
           "name": "riserve_definite",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Riserve definite (€)"
         },
         {
           "name": "importo_contenz_risolto",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Importo contenzioso risolto (€)"
         }
       ],
       "location": {
@@ -1011,12 +1011,12 @@
     },
     {
       "slug": "anac_cup",
-      "name": "Anac Cup",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "name": "ANAC CUP",
+      "description": "Bridge table CIG→CUP: associa ogni CIG (Codice Identificativo Gara) al suo CUP (Codice Unico di Progetto). Collega l'universo ANAC (appalti) ai progetti (OpenCUP, PNRR, BDAP MOP). 7,12M righe.",
+      "source": "ANAC - Autorità Nazionale Anticorruzione",
+      "source_id": "anac",
       "period": {
-        "start": 2026,
+        "start": 2000,
         "end": 2026
       },
       "columns": [
@@ -1024,13 +1024,13 @@
           "name": "cig",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "CIG — join con tutti i dataset ANAC"
         },
         {
           "name": "cup",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "CUP — join con PNRR, OpenCUP, BDAP MOP"
         }
       ],
       "location": {
@@ -1093,12 +1093,12 @@
     },
     {
       "slug": "anac_stati_avanzamento",
-      "name": "Anac Stati Avanzamento",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "name": "ANAC Stati Avanzamento",
+      "description": "Stati di Avanzamento Lavori (SAL) degli appalti ordinari: importi, date, ritardi e scostamenti dal cronoprogramma. Fonte ANAC. 1,27M righe, ~3,7 SAL per CIG. Join via cig + id_aggiudicazione con anac_aggiudicazioni.",
+      "source": "ANAC - Autorità Nazionale Anticorruzione",
+      "source_id": "anac",
       "period": {
-        "start": 2026,
+        "start": 2000,
         "end": 2026
       },
       "columns": [
@@ -1106,67 +1106,67 @@
           "name": "cig",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "CIG del contratto — join con anac_bandi_gara e anac_aggiudicazioni"
         },
         {
           "name": "denominazione_sal",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione SAL"
         },
         {
           "name": "flag_ritardo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "IN LINEA / IN RITARDO / IN ANTICIPO"
         },
         {
           "name": "data_emissione_sal",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data emissione SAL"
         },
         {
           "name": "importo_sal",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Importo del SAL (€)"
         },
         {
           "name": "n_giorni_scostamento",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Giorni di scostamento dal cronoprogramma"
         },
         {
           "name": "progressivo_sal",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero progressivo del SAL"
         },
         {
           "name": "id_aggiudicazione",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "ID aggiudicazione — join con anac_aggiudicazioni"
         },
         {
           "name": "data_cert_pagamento",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data certificato di pagamento"
         },
         {
           "name": "importo_cert_pagamento",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Importo certificato di pagamento (€)"
         },
         {
           "name": "giorni_proroga",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Giorni di proroga concessi"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-07-22",
+  "updated_at": "2026-07-25",
   "datasets": [
     {
       "slug": "aci_prime_iscrizioni_autovetture",
@@ -918,6 +918,130 @@
       "registry_source": "derive_auto"
     },
     {
+      "slug": "anac_collaudo",
+      "name": "Anac Collaudo",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2026,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "cig",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "data_delibera",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_cert_collaudo",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "esito_collaudo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "data_inizio_oper",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_regolare_esec",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_nomina_coll",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_collaudo_stat",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "id_aggiudicazione",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "riserve_avanzate",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "riserve_definite",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "importo_contenz_risolto",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/anac_collaudo/2026/anac_collaudo_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "anac_cup",
+      "name": "Anac Cup",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2026,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "cig",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cup",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/anac_cup/2026/anac_cup_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
       "slug": "anac_partecipanti",
       "name": "ANAC Partecipanti",
       "description": "Anagrafica dei partecipanti alle gare pubbliche (non solo vincitori): denominazione, codice fiscale, ruolo e tipo soggetto. Fonte ANAC. Join via cig con anac_bandi_gara e anac_aggiudicazioni, via codice_fiscale con anac_aggiudicatari.",
@@ -962,6 +1086,92 @@
       "location": {
         "type": "gcs",
         "path": "gs://dataciviclab-clean/anac_partecipanti/2026/anac_partecipanti_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "anac_stati_avanzamento",
+      "name": "Anac Stati Avanzamento",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2026,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "cig",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "denominazione_sal",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "flag_ritardo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "data_emissione_sal",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "importo_sal",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "n_giorni_scostamento",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "progressivo_sal",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "id_aggiudicazione",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_cert_pagamento",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "importo_cert_pagamento",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "giorni_proroga",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/anac_stati_avanzamento/2026/anac_stati_avanzamento_2026_clean.parquet",
         "multi_file": false
       },
       "stage": "published",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-22",
+  "generated_at": "2026-07-25",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 101,
+    "total": 104,
     "by_status": {
-      "ok": 101,
+      "ok": 104,
       "warn": 0,
       "error": 0
     }
@@ -1698,6 +1698,42 @@
       }
     },
     {
+      "id": "anac-collaudo",
+      "source_id": "anac",
+      "status": "ok",
+      "label": "anac-collaudo",
+      "detail": "anni: ? — fonte: ? — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "30156522396",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30156522396",
+        "checked_at": "2026-07-25",
+        "years": [
+          2026
+        ],
+        "config_path": "support_datasets/anac-collaudo/dataset.yml"
+      }
+    },
+    {
+      "id": "anac-cup",
+      "source_id": "anac",
+      "status": "ok",
+      "label": "anac-cup",
+      "detail": "anni: ? — fonte: ? — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "30156522396",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30156522396",
+        "checked_at": "2026-07-25",
+        "years": [
+          2026
+        ],
+        "config_path": "support_datasets/anac-cup/dataset.yml"
+      }
+    },
+    {
       "id": "anac-partecipanti",
       "source_id": "anac",
       "status": "ok",
@@ -1713,6 +1749,24 @@
           2026
         ],
         "config_path": "support_datasets/anac-partecipanti/dataset.yml"
+      }
+    },
+    {
+      "id": "anac-stati-avanzamento",
+      "source_id": "anac",
+      "status": "ok",
+      "label": "anac-stati-avanzamento",
+      "detail": "anni: ? — fonte: ? — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "30156522396",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30156522396",
+        "checked_at": "2026-07-25",
+        "years": [
+          2026
+        ],
+        "config_path": "support_datasets/anac-stati-avanzamento/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #707 — intake: anac-cup, anac-collaudo, anac-stati-avanzamento (support)

Changed candidate/support roots:

- `anac-collaudo` (support_dataset, `support_datasets/anac-collaudo`)
- `anac-cup` (support_dataset, `support_datasets/anac-cup`)
- `anac-stati-avanzamento` (support_dataset, `support_datasets/anac-stati-avanzamento`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `support_datasets/anac-collaudo/dataset.yml` -> artifact `sample-run-anac-collaudo`
- `support_datasets/anac-cup/dataset.yml` -> artifact `sample-run-anac-cup`
- `support_datasets/anac-stati-avanzamento/dataset.yml` -> artifact `sample-run-anac-stati-avanzamento`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
