### PR TITLE
compose: anac-appalti-master — 8 dataset ANAC unificati (6.08M CIG, grana 1:1)

### DIFF
--- a/compose/anac-appalti-master/README.md
+++ b/compose/anac-appalti-master/README.md
@@ -7,17 +7,17 @@
 
 Vista completa del ciclo di vita degli appalti pubblici italiani: da bando a collaudo, passando per aggiudicazione, vincitore, partecipazione, subappalti, SAL e CUP.
 
-**Grana**: 1 riga per CIG (6.1M righe, 10 anni 2016-2025).
+**Grana**: 1 riga per CIG (6.08M righe = 6.08M CIG, 10 anni 2016-2025).
 
 ## Copertura
 
 | Metrica | Valore |
 |---|---|
-| Righe | 6.125.177 |
+| Righe | 6.080.637 |
 | CIG distinti | 6.080.637 |
-| Con vincitore | 3.986.096 (65%) |
-| Con collaudo | 450.581 |
-| Con CUP | 1.397.284 |
+| Con vincitore | 3.947.250 (65%) |
+| Con collaudo | ~450K |
+| Con CUP | ~1.4M |
 
 ## Schema (35 colonne)
 

--- a/compose/anac-appalti-master/README.md
+++ b/compose/anac-appalti-master/README.md
@@ -7,38 +7,48 @@
 
 Vista completa del ciclo di vita degli appalti pubblici italiani: da bando a collaudo, passando per aggiudicazione, vincitore, partecipazione, subappalti, SAL e CUP.
 
-10.4M righe su 10 anni (2016-2025), 8 dataset ANAC unificati.
+**Grana**: 1 riga per CIG (6.1M righe, 10 anni 2016-2025).
 
-## Schema (34 colonne)
+## Copertura
+
+| Metrica | Valore |
+|---|---|
+| Righe | 6.125.177 |
+| CIG distinti | 6.080.637 |
+| Con vincitore | 3.986.096 (65%) |
+| Con collaudo | 450.581 |
+| Con CUP | 1.397.284 |
+
+## Schema (35 colonne)
 
 | Gruppo | Colonne |
 |---|---|
-| Bando | `cig`, `anno`, `oggetto_gara`, `importo_complessivo_gara`, `oggetto_principale`, `flag_pnrr`, `cod_cpv` |
+| Bando | `cig`, `anno`, `oggetto_gara`, `importo_complessivo_gara`, `flag_pnrr`, `cod_cpv` |
 | SA | `amministrazione`, `provincia`, `sezione_regionale` |
-| Aggiudicazione | `importo_agg`, `data_agg`, `ribasso`, `offerte_ammesse`, `flag_subappalto`, `criterio_agg` |
-| Vincitore | `operatore`, `cf`, `tipo_soggetto` |
+| Aggiudicazione | `importo_agg`, `data_agg`, `ribasso`, `offerte_ammesse`, `flag_subappalto` |
+| Vincitore | `operatore`, `cf`, `tipo_soggetto`, `n_operatori` |
 | Partecipazione | `n_partecipanti`, `n_imprese_partecipanti` |
 | Subappalto | `n_subappalti`, `n_subappaltatori` |
-| Collaudo | `esito_collaudo`, `data_collaudo`, `riserve_avanzate`, `contenzioso` |
+| Collaudo | `esito_collaudo`, `data_collaudo`, `riserve_avanzate` |
 | SAL | `n_sal`, `importo_totale_sal`, `scostamento_medio` |
 | CUP | `cup` |
 
 ## Mart analitici
 
-| Mart | Cosa | Righe |
-|---|---|---|
-| `mart_trend_annuale` | Bandi/importi/PNRR/collaudi per anno e settore | 32 |
-| `mart_top_sa` | Top 100 SA per importo bandito | 100 |
+| Mart | Cosa |
+|---|---|
+| `mart_trend_annuale` | Bandi/importi/PNRR/collaudi per anno e settore |
+| `mart_top_sa` | Top 100 SA per importo bandito |
 
 ## Join model
 
 ```
-bandi (2016-2025)
- ├──cig──→ aggiudicazioni
- │           └──id_aggiudicazione──→ aggiudicatari
+bandi (2016-2025) — 1 riga per CIG
+ ├──cig──→ aggiudicazioni  (1:1)
+ │           └──id_aggiudicazione──→ aggiudicatari (agg a 1 per CIG)
  ├──cig──→ partecipanti (agg)
  ├──cig──→ subappalti (agg)
- ├──cig──→ collaudo
+ ├──cig──→ collaudo (agg a 1 per CIG)
  ├──cig──→ SAL (agg)
- └──cig──→ CUP (bridge)
+ └──cig──→ CUP (agg a 1 per CIG)
 ```

--- a/compose/anac-appalti-master/README.md
+++ b/compose/anac-appalti-master/README.md
@@ -1,0 +1,44 @@
+# ANAC Appalti Master (compose)
+
+**Dataset**: `anac_appalti_master`
+**Tipo**: compose — unisce 8 dataset ANAC in un'unica vista
+
+## Cos'è
+
+Vista completa del ciclo di vita degli appalti pubblici italiani: da bando a collaudo, passando per aggiudicazione, vincitore, partecipazione, subappalti, SAL e CUP.
+
+10.4M righe su 10 anni (2016-2025), 8 dataset ANAC unificati.
+
+## Schema (34 colonne)
+
+| Gruppo | Colonne |
+|---|---|
+| Bando | `cig`, `anno`, `oggetto_gara`, `importo_complessivo_gara`, `oggetto_principale`, `flag_pnrr`, `cod_cpv` |
+| SA | `amministrazione`, `provincia`, `sezione_regionale` |
+| Aggiudicazione | `importo_agg`, `data_agg`, `ribasso`, `offerte_ammesse`, `flag_subappalto`, `criterio_agg` |
+| Vincitore | `operatore`, `cf`, `tipo_soggetto` |
+| Partecipazione | `n_partecipanti`, `n_imprese_partecipanti` |
+| Subappalto | `n_subappalti`, `n_subappaltatori` |
+| Collaudo | `esito_collaudo`, `data_collaudo`, `riserve_avanzate`, `contenzioso` |
+| SAL | `n_sal`, `importo_totale_sal`, `scostamento_medio` |
+| CUP | `cup` |
+
+## Mart analitici
+
+| Mart | Cosa | Righe |
+|---|---|---|
+| `mart_trend_annuale` | Bandi/importi/PNRR/collaudi per anno e settore | 32 |
+| `mart_top_sa` | Top 100 SA per importo bandito | 100 |
+
+## Join model
+
+```
+bandi (2016-2025)
+ ├──cig──→ aggiudicazioni
+ │           └──id_aggiudicazione──→ aggiudicatari
+ ├──cig──→ partecipanti (agg)
+ ├──cig──→ subappalti (agg)
+ ├──cig──→ collaudo
+ ├──cig──→ SAL (agg)
+ └──cig──→ CUP (bridge)
+```

--- a/compose/anac-appalti-master/dataset.yml
+++ b/compose/anac-appalti-master/dataset.yml
@@ -1,0 +1,44 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "anac_appalti_master"
+  source_id: "dataciviclab_composite"
+  years: [2026]
+
+raw:
+  output_policy: overwrite
+  sources:
+    - type: script
+      args:
+        command: "python preprocess.py {year} output.parquet"
+        output: "output.parquet"
+        filename: "output.parquet"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    mode: latest
+    source: auto
+  validate:
+    min_rows: 100000
+    promotion:
+      max_row_drop_pct: 100
+      warn_removed_columns: false
+
+mart:
+  tables:
+    - name: "mart_trend_annuale"
+      sql: "sql/mart_trend_annuale.sql"
+    - name: "mart_top_sa"
+      sql: "sql/mart_top_sa.sql"
+  validate:
+    table_rules:
+      mart_trend_annuale:
+        min_rows: 10
+      mart_top_sa:
+        min_rows: 10
+
+validation:
+  fail_on_error: true

--- a/compose/anac-appalti-master/notes.md
+++ b/compose/anac-appalti-master/notes.md
@@ -1,0 +1,42 @@
+# Note tecniche — anac-appalti-master
+
+## Struttura
+
+Preprocess.py con DuckDB:
+1. Materializza tutte le tabelle dimensionali (agg, aggte, coll, cup, part_agg, sub_agg, sal_agg)
+2. Processa ogni anno di bandi con INSERT INTO (evita OOM)
+3. Copia il risultato in raw + clean
+
+## Join model validato
+
+| Passaggio | Chiave | Tipo |
+|---|---|---|
+| bandi → aggiudicazioni | `cig` | LEFT JOIN (65% match) |
+| aggiudicazioni → aggiudicatari | `id_aggiudicazione` | LEFT JOIN (99.7% match) |
+| bandi → partecipanti | `cig` | LEFT JOIN (agg) |
+| bandi → subappalti | `cig` | LEFT JOIN (agg) |
+| bandi → collaudo | `cig` | LEFT JOIN |
+| bandi → SAL | `cig` | LEFT JOIN (agg) |
+| bandi → CUP | `cig` | LEFT JOIN |
+
+## Dataset sorgente
+
+| Dataset | Anni | Ruolo |
+|---|---|---|
+| `anac_bandi_gara` | 2016-2025 | Base: bando |
+| `anac_aggiudicazioni` | 2000-2026 | Aggiudicazione |
+| `anac_aggiudicatari` | 2000-2026 | Vincitore |
+| `anac_partecipanti` | 2023-2026 | Concorrenza (agg) |
+| `anac_subappalti` | 2020-2026 | Subappalto (agg) |
+| `anac_collaudo` | 2000-2026 | Collaudo |
+| `anac_stati_avanzamento` | 2000-2026 | SAL (agg) |
+| `anac_cup` | 2000-2026 | Bridge CUP |
+
+## Performance
+
+| Macchina | RAM | Tempo |
+|---|---|---|
+| Locale (7.5GB, swap pieno) | 4GB config | ~10 min (raw+clean) |
+| CI (GitHub Actions 7GB) | — | ~5 min stimato |
+
+Il collo di bottiglia è DuckDB che carica i parquet da GCS via HTTP. I join sono veloci.

--- a/compose/anac-appalti-master/notes.md
+++ b/compose/anac-appalti-master/notes.md
@@ -3,9 +3,10 @@
 ## Struttura
 
 Preprocess.py con DuckDB:
-1. Materializza tutte le tabelle dimensionali (agg, aggte, coll, cup, part_agg, sub_agg, sal_agg)
-2. Processa ogni anno di bandi con INSERT INTO (evita OOM)
-3. Copia il risultato in raw + clean
+1. Materializza tutte le tabelle dimensionali aggregate a livello CIG
+2. Bandi deduplicati via QUALIFY ROW_NUMBER() (picking max importo_lotto per CIG)
+3. Aggiudicazioni, collaudo aggregati via any_value() a 1 riga per CIG
+4. Processa ogni anno di bandi con INSERT INTO (evita OOM)
 
 ## Join model validato
 
@@ -32,11 +33,18 @@ Preprocess.py con DuckDB:
 | `anac_stati_avanzamento` | 2000-2026 | SAL (agg) |
 | `anac_cup` | 2000-2026 | Bridge CUP |
 
+## Qualità (run 2026-07-25)
+
+| Metrica | Valore |
+|---|---|
+| Righe clean | 6.080.637 |
+| CIG distinti | 6.080.637 |
+| Con vincitore | 3.947.250 (65%) |
+| Collaudi | da popolare |
+
 ## Performance
 
 | Macchina | RAM | Tempo |
 |---|---|---|
-| Locale (7.5GB, swap pieno) | 4GB config | ~10 min (raw+clean) |
+| Locale (7.5GB, swap pieno) | 4GB config | ~8 min (raw+clean+mart) |
 | CI (GitHub Actions 7GB) | — | ~5 min stimato |
-
-Il collo di bottiglia è DuckDB che carica i parquet da GCS via HTTP. I join sono veloci.

--- a/compose/anac-appalti-master/preprocess.py
+++ b/compose/anac-appalti-master/preprocess.py
@@ -24,18 +24,40 @@ def main():
 
     print("Caricamento tabelle dimensionali...", flush=True)
 
-    # Tabelle 1:1 con CIG (no aggregazione necessaria)
-    for tbl, url, label in [
-        (
-            "agg",
-            f"{GCS}/anac_aggiudicazioni/2026/anac_aggiudicazioni_2026_clean.parquet",
-            "aggiudicazioni",
-        ),
-        ("coll", f"{GCS}/anac_collaudo/2026/anac_collaudo_2026_clean.parquet", "collaudo"),
-    ]:
-        con.execute(f"CREATE TEMP TABLE {tbl} AS SELECT * FROM read_parquet('{url}')")
-        r = con.execute(f"SELECT count(*) FROM {tbl}").fetchone()
-        print(f"  {label}: {r[0]:,}", flush=True)
+    # Aggiudicazioni: aggrega a 1 riga per CIG (ci sono ~13K CIG con più righe)
+    con.execute(f"""
+        CREATE TEMP TABLE agg AS
+        SELECT cig,
+            any_value(importo_aggiudicazione) AS importo_aggiudicazione,
+            any_value(data_aggiudicazione_definitiva) AS data_aggiudicazione_definitiva,
+            any_value(ribasso_aggiudicazione) AS ribasso_aggiudicazione,
+            any_value(numero_offerte_ammesse) AS numero_offerte_ammesse,
+            any_value(flag_subappalto) AS flag_subappalto,
+            any_value(criterio_aggiudicazione) AS criterio_aggiudicazione,
+            any_value(asta_elettronica) AS asta_elettronica,
+            any_value(id_aggiudicazione) AS id_aggiudicazione,
+            count(*) AS n_righe_agg
+        FROM read_parquet('{GCS}/anac_aggiudicazioni/2026/anac_aggiudicazioni_2026_clean.parquet')
+        WHERE cig IS NOT NULL
+        GROUP BY cig
+    """)
+    r = con.execute("SELECT count(*) FROM agg").fetchone()
+    print(f"  aggiudicazioni (agg): {r[0]:,} gruppi", flush=True)
+
+    # Collaudo: aggrega a 1 riga per CIG (188 CIG con più righe)
+    con.execute(f"""
+        CREATE TEMP TABLE coll AS
+        SELECT cig,
+            any_value(esito_collaudo) AS esito_collaudo,
+            any_value(data_delibera) AS data_delibera,
+            any_value(riserve_avanzate) AS riserve_avanzate,
+            any_value(importo_contenz_risolto) AS importo_contenz_risolto
+        FROM read_parquet('{GCS}/anac_collaudo/2026/anac_collaudo_2026_clean.parquet')
+        WHERE cig IS NOT NULL
+        GROUP BY cig
+    """)
+    r = con.execute("SELECT count(*) FROM coll").fetchone()
+    print(f"  collaudo (agg): {r[0]:,} gruppi", flush=True)
 
     # Aggiudicatari: aggrega a 1 riga per CIG (un CIG può avere più operatori ATI/RTI)
     con.execute(f"""
@@ -130,7 +152,10 @@ def main():
                 col.riserve_avanzate, col.importo_contenz_risolto,
                 coalesce(sa.n_sal, 0), coalesce(sa.tot_sal, 0), sa.scost,
                 cu.cup
-            FROM read_parquet('{GCS}/anac_bandi_gara/{anno}/anac_bandi_gara_{anno}_clean.parquet') b
+            FROM (
+                SELECT * FROM read_parquet('{GCS}/anac_bandi_gara/{anno}/anac_bandi_gara_{anno}_clean.parquet')
+                QUALIFY ROW_NUMBER() OVER (PARTITION BY cig ORDER BY importo_lotto DESC) = 1
+            ) b
             LEFT JOIN agg a ON b.cig = a.cig
             LEFT JOIN aggte_agg t ON b.cig = t.cig
             LEFT JOIN part_agg p ON b.cig = p.cig

--- a/compose/anac-appalti-master/preprocess.py
+++ b/compose/anac-appalti-master/preprocess.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Preprocess: anac_appalti_master — 8 dataset, anno per anno.
+
+Usage: TOOLKIT_ALLOW_SCRIPT_SOURCE=1 toolkit run raw ...
+   or: python preprocess.py <year> <output.parquet>
+"""
+
+import sys
+import shutil
+import duckdb
+from pathlib import Path
+
+GCS = "https://storage.googleapis.com/dataciviclab-clean"
+BANDI_ANNI = list(range(2016, 2026))
+
+
+def main():
+    output_path = Path(sys.argv[2]).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    con = duckdb.connect()
+    con.execute("SET memory_limit = '4GB'")
+    con.execute("SET temp_directory = '/tmp/duckdb_tmp'")
+    con.execute("SET threads = 2")
+    con.execute("SET preserve_insertion_order = false")
+
+    # Materializza tabelle dimensionali (una volta)
+    print("Caricamento tabelle dimensionali...", flush=True)
+
+    agg = {}
+    for tbl, url, label in [
+        (
+            "agg",
+            f"{GCS}/anac_aggiudicazioni/2026/anac_aggiudicazioni_2026_clean.parquet",
+            "aggiudicazioni",
+        ),
+        (
+            "aggte",
+            f"{GCS}/anac_aggiudicatari/2026/anac_aggiudicatari_2026_clean.parquet",
+            "aggiudicatari",
+        ),
+        ("coll", f"{GCS}/anac_collaudo/2026/anac_collaudo_2026_clean.parquet", "collaudo"),
+        ("cup", f"{GCS}/anac_cup/2026/anac_cup_2026_clean.parquet", "cup"),
+    ]:
+        con.execute(f"CREATE TEMP TABLE {tbl} AS SELECT * FROM read_parquet('{url}')")
+        r = con.execute(f"SELECT count(*) FROM {tbl}").fetchone()
+        print(f"  {label}: {r[0]:,}", flush=True)
+        agg[tbl] = r[0]
+
+    for tbl, url, sql, label in [
+        (
+            "part_agg",
+            f"{GCS}/anac_partecipanti/2026/anac_partecipanti_2026_clean.parquet",
+            "SELECT cig, count(*) AS n, count(DISTINCT codice_fiscale) AS n_imprese FROM read_parquet('{}') WHERE cig IS NOT NULL GROUP BY cig",
+            "partecipanti (agg)",
+        ),
+        (
+            "sub_agg",
+            f"{GCS}/anac_subappalti/2026/anac_subappalti_2026_clean.parquet",
+            "SELECT cig, count(*) AS n, count(DISTINCT codice_fiscale) AS n_sub FROM read_parquet('{}') WHERE cig IS NOT NULL GROUP BY cig",
+            "subappalti (agg)",
+        ),
+        (
+            "sal_agg",
+            f"{GCS}/anac_stati_avanzamento/2026/anac_stati_avanzamento_2026_clean.parquet",
+            "SELECT cig, count(*) AS n_sal, sum(importo_sal) AS tot_sal, avg(n_giorni_scostamento) AS scost FROM read_parquet('{}') WHERE cig IS NOT NULL GROUP BY cig",
+            "SAL (agg)",
+        ),
+    ]:
+        con.execute(f"CREATE TEMP TABLE {tbl} AS {sql.format(url)}")
+        r = con.execute(f"SELECT count(*) FROM {tbl}").fetchone()
+        print(f"  {label}: {r[0]:,} gruppi", flush=True)
+
+    # Crea tabella finale
+    con.execute("""
+        CREATE TEMP TABLE final (
+            cig VARCHAR, anno INT, oggetto_gara VARCHAR,
+            importo_complessivo_gara DOUBLE, oggetto_principale VARCHAR,
+            stato VARCHAR, esito_bando VARCHAR, flag_pnrr BOOLEAN,
+            cod_cpv VARCHAR, descr_cpv VARCHAR,
+            amministrazione VARCHAR, provincia VARCHAR, sezione_regionale VARCHAR,
+            importo_agg DOUBLE, data_agg DATE, ribasso DOUBLE,
+            offerte_ammesse INT, flag_subappalto BOOLEAN, criterio_agg VARCHAR,
+            operatore VARCHAR, cf VARCHAR, tipo_soggetto VARCHAR,
+            n_partecipanti INT, n_imprese_partecipanti INT,
+            n_subappalti INT, n_subappaltatori INT,
+            esito_collaudo VARCHAR, data_collaudo DATE,
+            riserve_avanzate DOUBLE, contenzioso DOUBLE,
+            n_sal INT, importo_totale_sal DOUBLE, scostamento_medio DOUBLE,
+            cup VARCHAR
+        )
+    """)
+
+    # Processa un anno per volta
+    print(f"Processo {len(BANDI_ANNI)} anni di bandi...", flush=True)
+    for anno in BANDI_ANNI:
+        print(f"  {anno}...", end=" ", flush=True)
+        con.execute(f"""
+            INSERT INTO final
+            SELECT b.cig, {anno}, b.oggetto_gara, b.importo_complessivo_gara,
+                b.oggetto_principale_contratto, b.stato, b.esito, b.flag_pnrr,
+                b.cod_cpv, b.descrizione_cpv,
+                b.denominazione_amministrazione_appaltante, b.provincia,
+                b.sezione_regionale,
+                a.importo_aggiudicazione, a.data_aggiudicazione_definitiva,
+                a.ribasso_aggiudicazione, a.numero_offerte_ammesse,
+                a.flag_subappalto, a.criterio_aggiudicazione,
+                t.denominazione, t.codice_fiscale, t.tipo_soggetto,
+                coalesce(p.n, 0), coalesce(p.n_imprese, 0),
+                coalesce(s.n, 0), coalesce(s.n_sub, 0),
+                col.esito_collaudo, col.data_delibera,
+                col.riserve_avanzate, col.importo_contenz_risolto,
+                coalesce(sa.n_sal, 0), coalesce(sa.tot_sal, 0), sa.scost,
+                cu.cup
+            FROM read_parquet('{GCS}/anac_bandi_gara/{anno}/anac_bandi_gara_{anno}_clean.parquet') b
+            LEFT JOIN agg a ON b.cig = a.cig
+            LEFT JOIN aggte t ON a.id_aggiudicazione = t.id_aggiudicazione
+            LEFT JOIN part_agg p ON b.cig = p.cig
+            LEFT JOIN sub_agg s ON b.cig = s.cig
+            LEFT JOIN coll col ON b.cig = col.cig
+            LEFT JOIN sal_agg sa ON b.cig = sa.cig
+            LEFT JOIN cup cu ON b.cig = cu.cig
+        """)
+        r = con.execute("SELECT count(*) FROM final").fetchone()
+        print(f"{r[0]:,}", flush=True)
+
+    r = con.execute("SELECT count(*) FROM final").fetchone()
+    print(f"\nScrittura {r[0]:,} righe → {output_path}", flush=True)
+    con.execute(f"COPY final TO '{output_path}' (FORMAT PARQUET)")
+
+    # Copia in clean (per validazione toolkit)
+    clean_dir = output_path.parent.parent.parent / "clean" / output_path.parent.name
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    clean_file = clean_dir / f"anac_appalti_master_{output_path.parent.name}_clean.parquet"
+    shutil.copy2(output_path, clean_file)
+    print(f"  Copiato in {clean_file}", flush=True)
+    print("✅ Fatto!", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/compose/anac-appalti-master/preprocess.py
+++ b/compose/anac-appalti-master/preprocess.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 """Preprocess: anac_appalti_master — 8 dataset, anno per anno.
 
-Usage: TOOLKIT_ALLOW_SCRIPT_SOURCE=1 toolkit run raw ...
-   or: python preprocess.py <year> <output.parquet>
+Grana: 1 riga per CIG. Aggiudicatari, collaudo e cup aggregati a livello CIG.
 """
 
 import sys
-import shutil
 import duckdb
 from pathlib import Path
 
@@ -24,29 +22,48 @@ def main():
     con.execute("SET threads = 2")
     con.execute("SET preserve_insertion_order = false")
 
-    # Materializza tabelle dimensionali (una volta)
     print("Caricamento tabelle dimensionali...", flush=True)
 
-    agg = {}
+    # Tabelle 1:1 con CIG (no aggregazione necessaria)
     for tbl, url, label in [
         (
             "agg",
             f"{GCS}/anac_aggiudicazioni/2026/anac_aggiudicazioni_2026_clean.parquet",
             "aggiudicazioni",
         ),
-        (
-            "aggte",
-            f"{GCS}/anac_aggiudicatari/2026/anac_aggiudicatari_2026_clean.parquet",
-            "aggiudicatari",
-        ),
         ("coll", f"{GCS}/anac_collaudo/2026/anac_collaudo_2026_clean.parquet", "collaudo"),
-        ("cup", f"{GCS}/anac_cup/2026/anac_cup_2026_clean.parquet", "cup"),
     ]:
         con.execute(f"CREATE TEMP TABLE {tbl} AS SELECT * FROM read_parquet('{url}')")
         r = con.execute(f"SELECT count(*) FROM {tbl}").fetchone()
         print(f"  {label}: {r[0]:,}", flush=True)
-        agg[tbl] = r[0]
 
+    # Aggiudicatari: aggrega a 1 riga per CIG (un CIG può avere più operatori ATI/RTI)
+    con.execute(f"""
+        CREATE TEMP TABLE aggte_agg AS
+        SELECT cig,
+            any_value(denominazione) AS operatore,
+            any_value(codice_fiscale) AS cf,
+            any_value(tipo_soggetto) AS tipo_soggetto,
+            count(*) AS n_operatori
+        FROM read_parquet('{GCS}/anac_aggiudicatari/2026/anac_aggiudicatari_2026_clean.parquet')
+        WHERE cig IS NOT NULL
+        GROUP BY cig
+    """)
+    r = con.execute("SELECT count(*) FROM aggte_agg").fetchone()
+    print(f"  aggiudicatari (agg): {r[0]:,} gruppi", flush=True)
+
+    # CUP: aggrega a 1 riga per CIG
+    con.execute(f"""
+        CREATE TEMP TABLE cup_agg AS
+        SELECT cig, any_value(cup) AS cup
+        FROM read_parquet('{GCS}/anac_cup/2026/anac_cup_2026_clean.parquet')
+        WHERE cig IS NOT NULL
+        GROUP BY cig
+    """)
+    r = con.execute("SELECT count(*) FROM cup_agg").fetchone()
+    print(f"  cup (agg): {r[0]:,} gruppi", flush=True)
+
+    # Tabelle aggregate (già pronte)
     for tbl, url, sql, label in [
         (
             "part_agg",
@@ -71,7 +88,7 @@ def main():
         r = con.execute(f"SELECT count(*) FROM {tbl}").fetchone()
         print(f"  {label}: {r[0]:,} gruppi", flush=True)
 
-    # Crea tabella finale
+    # Crea tabella finale (1 riga per CIG)
     con.execute("""
         CREATE TEMP TABLE final (
             cig VARCHAR, anno INT, oggetto_gara VARCHAR,
@@ -82,6 +99,7 @@ def main():
             importo_agg DOUBLE, data_agg DATE, ribasso DOUBLE,
             offerte_ammesse INT, flag_subappalto BOOLEAN, criterio_agg VARCHAR,
             operatore VARCHAR, cf VARCHAR, tipo_soggetto VARCHAR,
+            n_operatori INT,
             n_partecipanti INT, n_imprese_partecipanti INT,
             n_subappalti INT, n_subappaltatori INT,
             esito_collaudo VARCHAR, data_collaudo DATE,
@@ -91,7 +109,6 @@ def main():
         )
     """)
 
-    # Processa un anno per volta
     print(f"Processo {len(BANDI_ANNI)} anni di bandi...", flush=True)
     for anno in BANDI_ANNI:
         print(f"  {anno}...", end=" ", flush=True)
@@ -105,7 +122,8 @@ def main():
                 a.importo_aggiudicazione, a.data_aggiudicazione_definitiva,
                 a.ribasso_aggiudicazione, a.numero_offerte_ammesse,
                 a.flag_subappalto, a.criterio_aggiudicazione,
-                t.denominazione, t.codice_fiscale, t.tipo_soggetto,
+                t.operatore, t.cf, t.tipo_soggetto,
+                coalesce(t.n_operatori, 0) AS n_operatori,
                 coalesce(p.n, 0), coalesce(p.n_imprese, 0),
                 coalesce(s.n, 0), coalesce(s.n_sub, 0),
                 col.esito_collaudo, col.data_delibera,
@@ -114,12 +132,12 @@ def main():
                 cu.cup
             FROM read_parquet('{GCS}/anac_bandi_gara/{anno}/anac_bandi_gara_{anno}_clean.parquet') b
             LEFT JOIN agg a ON b.cig = a.cig
-            LEFT JOIN aggte t ON a.id_aggiudicazione = t.id_aggiudicazione
+            LEFT JOIN aggte_agg t ON b.cig = t.cig
             LEFT JOIN part_agg p ON b.cig = p.cig
             LEFT JOIN sub_agg s ON b.cig = s.cig
             LEFT JOIN coll col ON b.cig = col.cig
             LEFT JOIN sal_agg sa ON b.cig = sa.cig
-            LEFT JOIN cup cu ON b.cig = cu.cig
+            LEFT JOIN cup_agg cu ON b.cig = cu.cig
         """)
         r = con.execute("SELECT count(*) FROM final").fetchone()
         print(f"{r[0]:,}", flush=True)
@@ -127,13 +145,6 @@ def main():
     r = con.execute("SELECT count(*) FROM final").fetchone()
     print(f"\nScrittura {r[0]:,} righe → {output_path}", flush=True)
     con.execute(f"COPY final TO '{output_path}' (FORMAT PARQUET)")
-
-    # Copia in clean (per validazione toolkit)
-    clean_dir = output_path.parent.parent.parent / "clean" / output_path.parent.name
-    clean_dir.mkdir(parents=True, exist_ok=True)
-    clean_file = clean_dir / f"anac_appalti_master_{output_path.parent.name}_clean.parquet"
-    shutil.copy2(output_path, clean_file)
-    print(f"  Copiato in {clean_file}", flush=True)
     print("✅ Fatto!", flush=True)
 
 

--- a/compose/anac-appalti-master/sql/clean.sql
+++ b/compose/anac-appalti-master/sql/clean.sql
@@ -1,0 +1,1 @@
+SELECT * FROM raw_input

--- a/compose/anac-appalti-master/sql/mart_top_sa.sql
+++ b/compose/anac-appalti-master/sql/mart_top_sa.sql
@@ -1,0 +1,13 @@
+-- Top stazioni appaltanti per volume
+SELECT
+    amministrazione,
+    count(*) AS n_bandi,
+    round(sum(importo_complessivo_gara), 0) AS importo_totale_bandi,
+    round(sum(importo_agg), 0) AS importo_totale_aggiudicato,
+    count(DISTINCT operatore) AS n_operatori_distinti,
+    round(avg(n_partecipanti), 1) AS media_partecipanti
+FROM clean_input
+WHERE amministrazione IS NOT NULL
+GROUP BY amministrazione
+ORDER BY importo_totale_bandi DESC
+LIMIT 100

--- a/compose/anac-appalti-master/sql/mart_trend_annuale.sql
+++ b/compose/anac-appalti-master/sql/mart_trend_annuale.sql
@@ -1,9 +1,10 @@
 -- Trend annuale: bandi, importi, vincitori per anno e settore
+-- Grana: 1 riga per CIG. COUNT(*) = n_CIG, non n_operatori.
 SELECT
     anno,
     oggetto_principale AS settore,
-    count(*) AS n_bandi,
-    count(DISTINCT cig) AS n_cig,
+    count(*) AS n_cig,
+    count(DISTINCT cig) AS n_cig_distinti,
     count(DISTINCT amministrazione) AS n_sa,
     count(DISTINCT operatore) AS n_operatori,
     round(avg(importo_agg), 0) AS importo_medio,
@@ -14,4 +15,4 @@ SELECT
 FROM clean_input
 WHERE anno IS NOT NULL
 GROUP BY anno, oggetto_principale
-ORDER BY anno DESC, n_bandi DESC
+ORDER BY anno DESC, n_cig DESC

--- a/compose/anac-appalti-master/sql/mart_trend_annuale.sql
+++ b/compose/anac-appalti-master/sql/mart_trend_annuale.sql
@@ -1,0 +1,17 @@
+-- Trend annuale: bandi, importi, vincitori per anno e settore
+SELECT
+    anno,
+    oggetto_principale AS settore,
+    count(*) AS n_bandi,
+    count(DISTINCT cig) AS n_cig,
+    count(DISTINCT amministrazione) AS n_sa,
+    count(DISTINCT operatore) AS n_operatori,
+    round(avg(importo_agg), 0) AS importo_medio,
+    round(sum(importo_agg), 0) AS importo_totale,
+    sum(CASE WHEN flag_pnrr THEN 1 ELSE 0 END) AS n_pnrr,
+    count(*) FILTER (WHERE esito_collaudo IS NOT NULL) AS n_collaudati,
+    count(*) FILTER (WHERE esito_collaudo = 'POSITIVO') AS n_collaudi_positivi
+FROM clean_input
+WHERE anno IS NOT NULL
+GROUP BY anno, oggetto_principale
+ORDER BY anno DESC, n_bandi DESC


### PR DESCRIPTION
## Sintesi

Compose che unifica 8 dataset ANAC in un'unica vista: bando → aggiudicazione → vincitore → collaudo, con partecipazione, subappalti, SAL e CUP.

**Grana**: 1 riga per CIG (6.08M righe = 6.08M CIG). Tutte le tabelle sono aggregate/deduplicate a livello CIG.

## Copertura

| Metrica | Valore |
|---|---|
| Righe | 6.080.637 |
| CIG distinti | 6.080.637 |
| Anni | 2016-2025 |
| Dataset uniti | 8 |
| Colonne | 35 |
| Con vincitore | ~3.95M (65%) |

## Join model

```
bandi (2016-2025) — dedup a 1 riga per CIG
 ├──cig──→ aggiudicazioni (agg a 1 per CIG)
 │           └──id_aggiudicazione──→ aggiudicatari (agg a 1 per CIG)
 ├──cig──→ partecipanti (agg), subappalti (agg)
 ├──cig──→ collaudo (agg a 1 per CIG)
 ├──cig──→ SAL (agg)
 └──cig──→ CUP (agg a 1 per CIG)
```

## Mart analitici

- `mart_trend_annuale` — bandi/importi/PNRR/collaudi per anno e settore
- `mart_top_sa` — top 100 SA per importo bandito

## Verifica

```bash
TOOLKIT_ALLOW_SCRIPT_SOURCE=1 toolkit run full -c compose/anac-appalti-master/dataset.yml -y 2026
```

**Esito:** raw ✅ clean ✅ 6.080.637 righe = 6.080.637 CIG · mart ✅ 2/2

Closes #673
