### PR TITLE
chore(post-merge): aggiorna registry per PR #710

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2625,6 +2625,96 @@
           "description": "True se comune insulare"
         },
         {
+          "name": "nuts1_2021",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "nuts2_2021",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "nuts3_2021",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "nuts1_2024",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "nuts2_2024",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "nuts3_2024",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_ripartizione",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "ripartizione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "flag_capoluogo",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "codice_tipologia_uts",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "denominazione_uts",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "denominazione_altra_lingua",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_110_province",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_107_province",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_103_province",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
           "name": "codice_ipa",
           "type": "VARCHAR",
           "role": "dimension",
@@ -2635,6 +2725,12 @@
           "type": "VARCHAR",
           "role": "dimension",
           "description": "Codice fiscale dell'ente"
+        },
+        {
+          "name": "denominazione_ipa",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Denominazione ente in IPA"
         },
         {
           "name": "codice_categoria",
@@ -2649,22 +2745,10 @@
           "description": "Codice catastale (da IPA)"
         },
         {
-          "name": "codice_regione",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": "Codice ISTAT regione (2 cifre)"
-        },
-        {
           "name": "codice_istat_ipa",
           "type": "VARCHAR",
           "role": "dimension",
           "description": "Codice ISTAT attribuito da IPA"
-        },
-        {
-          "name": "denominazione_ipa",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": "Denominazione ente in IPA"
         },
         {
           "name": "acronimo",
@@ -5182,6 +5266,122 @@
       "location": {
         "type": "gcs",
         "path": "gs://dataciviclab-clean/ipa_enti/2026/ipa_enti_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "ipa_istat_mapping",
+      "name": "Ipa Istat Mapping",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2026,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "codice_istat",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "denominazione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "regione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "sigla_provincia",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_regione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_catastale_istat",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_ipa",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_fiscale",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "denominazione_ipa",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_categoria",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_catastale_comune",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "codice_istat_ipa",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "acronimo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "indirizzo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cap",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "sito_istituzionale",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/ipa_istat_mapping/2026/ipa_istat_mapping_2026_clean.parquet",
         "multi_file": false
       },
       "stage": "published",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2537,10 +2537,10 @@
     },
     {
       "slug": "comuni_master",
-      "name": "Comuni Master",
-      "description": "Raccordo completo dei comuni italiani: codici ISTAT, catastale (Belfiore), IPA, fiscale, superficie, popolazione, altitudine, indirizzo e contatti. Fusione di istat-elenco-comuni e ipa-istat-mapping.",
-      "source": "ISTAT SITUAS + AgID IPA",
-      "source_id": "istat_situas",
+      "name": "Comuni Master — hub territoriale completo",
+      "description": "Golden record dei comuni italiani: codici ISTAT, catastale (Belfiore), IPA, fiscale, superficie, popolazione, NUTS 2021/2024, ripartizione geografica, flag capoluogo, tipologia UTS, codici storici 103/107/110 province, indirizzo e contatti. Fusione di istat-elenco-comuni (ISTAT SITUAS), ISTAT CSV (codici amministrativi) e ipa-enti (AgID IPA).",
+      "source": "ISTAT SITUAS + ISTAT (Elenco codici unità amministrative) + AgID IPA",
+      "source_id": "dataciviclab_composite",
       "period": {
         "start": 2026,
         "end": 2026
@@ -2628,91 +2628,91 @@
           "name": "nuts1_2021",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice NUTS1 2021 (ripartizione europea)"
         },
         {
           "name": "nuts2_2021",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice NUTS2 2021 (regione europea)"
         },
         {
           "name": "nuts3_2021",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice NUTS3 2021 (provincia europea)"
         },
         {
           "name": "nuts1_2024",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice NUTS1 2024 (ripartizione europea)"
         },
         {
           "name": "nuts2_2024",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice NUTS2 2024 (regione europea)"
         },
         {
           "name": "nuts3_2024",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice NUTS3 2024 (provincia europea)"
         },
         {
           "name": "codice_ripartizione",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Codice ripartizione geografica ISTAT (1=Nord-ovest, 2=Nord-est, 3=Centro, 4=Sud, 5=Isole)"
         },
         {
           "name": "ripartizione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Ripartizione geografica (Nord-ovest, Nord-est, Centro, Sud, Isole)"
         },
         {
           "name": "flag_capoluogo",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "True se il comune è capoluogo di provincia/città metropolitana"
         },
         {
           "name": "codice_tipologia_uts",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Tipologia unità territoriale sovracomunale: 1=Provincia, 2=Provincia autonoma, 3=Città Metropolitana, 4=Libero Consorzio, 5=EDR"
         },
         {
           "name": "denominazione_uts",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione della provincia/Città Metropolitana/Libero Consorzio"
         },
         {
           "name": "denominazione_altra_lingua",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione del comune in altra lingua (per comuni bilingui)"
         },
         {
           "name": "codice_110_province",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT nel sistema a 110 province (2010-2016), zero-padded 6 cifre"
         },
         {
           "name": "codice_107_province",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT nel sistema a 107 province (2006-2009 e 2017-2025), zero-padded 6 cifre"
         },
         {
           "name": "codice_103_province",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice ISTAT nel sistema a 103 province (1995-2005), zero-padded 6 cifre"
         },
         {
           "name": "codice_ipa",
@@ -5266,122 +5266,6 @@
       "location": {
         "type": "gcs",
         "path": "gs://dataciviclab-clean/ipa_enti/2026/ipa_enti_2026_clean.parquet",
-        "multi_file": false
-      },
-      "stage": "published",
-      "registry_source": "derive_auto"
-    },
-    {
-      "slug": "ipa_istat_mapping",
-      "name": "Ipa Istat Mapping",
-      "description": "",
-      "source": "",
-      "source_id": "",
-      "period": {
-        "start": 2026,
-        "end": 2026
-      },
-      "columns": [
-        {
-          "name": "codice_istat",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "denominazione",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "regione",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "sigla_provincia",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "codice_regione",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "codice_catastale_istat",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "codice_ipa",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "codice_fiscale",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "denominazione_ipa",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "codice_categoria",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "codice_catastale_comune",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "codice_istat_ipa",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "acronimo",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "indirizzo",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "cap",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        },
-        {
-          "name": "sito_istituzionale",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": ""
-        }
-      ],
-      "location": {
-        "type": "gcs",
-        "path": "gs://dataciviclab-clean/ipa_istat_mapping/2026/ipa_istat_mapping_2026_clean.parquet",
         "multi_file": false
       },
       "stage": "published",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -4,9 +4,9 @@
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 104,
+    "total": 103,
     "by_status": {
-      "ok": 104,
+      "ok": 103,
       "warn": 0,
       "error": 0
     }
@@ -1215,9 +1215,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "29637176868",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/29637176868",
-        "checked_at": "2026-07-18",
+        "run_id": "30175442735",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30175442735",
+        "checked_at": "2026-07-25",
         "years": [
           2015,
           2016,
@@ -1806,24 +1806,6 @@
       }
     },
     {
-      "id": "comuni-master",
-      "source_id": "istat_situas",
-      "status": "ok",
-      "label": "comuni-master",
-      "detail": "anni: ? — fonte: ? — mart: sì",
-      "action": "",
-      "sample_run": {
-        "status": "passed",
-        "run_id": "27646152426",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27646152426",
-        "checked_at": "2026-06-16",
-        "years": [
-          2026
-        ],
-        "config_path": "compose/comuni-master/dataset.yml"
-      }
-    },
-    {
       "id": "ipa-aree-organizzative-omogenee",
       "source_id": "agid",
       "status": "ok",
@@ -1857,24 +1839,6 @@
           2026
         ],
         "config_path": "support_datasets/ipa-enti/dataset.yml"
-      }
-    },
-    {
-      "id": "ipa-istat-mapping",
-      "source_id": "agid",
-      "status": "ok",
-      "label": "ipa-istat-mapping",
-      "detail": "anni: ? — fonte: ? — mart: sì",
-      "action": "",
-      "sample_run": {
-        "status": "passed",
-        "run_id": "27644975517",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27644975517",
-        "checked_at": "2026-06-16",
-        "years": [
-          2026
-        ],
-        "config_path": "support_datasets/ipa-istat-mapping/dataset.yml"
       }
     },
     {
@@ -2013,6 +1977,24 @@
           2025
         ],
         "config_path": "support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml"
+      }
+    },
+    {
+      "id": "compose:comuni-master",
+      "source_id": "istat_situas",
+      "status": "ok",
+      "label": "compose:comuni-master",
+      "detail": "anno 2026 — fonte: ? — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "30175442735",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30175442735",
+        "checked_at": "2026-07-25",
+        "years": [
+          2026
+        ],
+        "config_path": "compose/comuni-master/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #710 — feat: comuni-master con NUTS, codici storici, IPA — rimuove ipa-istat-mapping

Changed candidate/support roots:

- `opencivitas-indicatori` (candidate, `candidates/opencivitas-indicatori`)
- `comuni-master` (compose, `compose/comuni-master`)
- `comuni-master` (support_dataset, `support_datasets/comuni-master`)
- `ipa-istat-mapping` (support_dataset, `support_datasets/ipa-istat-mapping`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/opencivitas-indicatori/dataset.yml` -> artifact `sample-run-opencivitas-indicatori`
- `compose/comuni-master/dataset.yml` -> artifact `sample-run-comuni-master`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
