### PR TITLE
feat(popolazione-istat): allineamento standard + mart indicatori + mart regione/provincia + push MART GCS

### DIFF
--- a/scripts/post_merge_runner.py
+++ b/scripts/post_merge_runner.py
@@ -105,6 +105,15 @@ def _push_clean_to_gcs(slug: str, root: str) -> bool:
     return r.returncode == 0
 
 
+def _push_mart_to_gcs(slug: str, root: str) -> bool:
+    """Push mart parquet to GCS. Returns True on success."""
+    r = subprocess.run(
+        ["python", "scripts/push_archive.py", "--layer", "mart", "--slug", slug, "--no-bq"],
+        cwd=root,
+    )
+    return r.returncode == 0
+
+
 def _rebuild_clean_catalog(root: str) -> None:
     """Rebuild clean_catalog.json after GCS push."""
     r = subprocess.run(
@@ -205,12 +214,21 @@ def cmd_sample_run(args: argparse.Namespace) -> None:
         if status == "passed" and os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
             print(f"  GCS push per {slug}...")
             push_slug = cfg.get("push_slug", slug)
+
+            # Push clean parquet (obbligatorio)
             if _push_clean_to_gcs(push_slug, root):
-                print(f"  GCS push completato per {slug} (push_slug={push_slug})")
+                print(f"  GCS clean push completato per {slug} (push_slug={push_slug})")
                 gcs_push_ok = True
             else:
-                print(f"  GCS push FAILED for {slug}")
+                print(f"  GCS clean push FAILED for {slug}")
                 failed_configs.append(slug)
+                continue
+
+            # Push mart parquet (additivo — warning se fallisce)
+            if _push_mart_to_gcs(push_slug, root):
+                print(f"  GCS mart push completato per {slug}")
+            else:
+                print(f"  WARN: GCS mart push fallito per {slug} — procedo comunque")
 
     # --- Clean catalog rebuild ---
     if gcs_push_ok:
@@ -264,6 +282,7 @@ def cmd_build_pr_body(args: argparse.Namespace) -> None:
             "",
             "- [x] Full run toolkit (tutti gli anni)",
             f"- [{'x' if gcp_available else ' '}] Clean parquet pushato su GCS",
+            f"- [{'x' if gcp_available else ' '}] Mart parquet pushato su GCS",
             "- [x] `registry/pipeline_signals.json` aggiornato",
             f"- [{'x' if gcp_available else ' '}] `registry/clean_catalog.json` auto-derivato",
             "",

--- a/support_datasets/popolazione-istat-comunale-2019-2025/README.md
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/README.md
@@ -12,11 +12,13 @@ Formato: ZIP → CSV, `;` delim, `utf-8` con BOM. Skip 1 riga (header doppio).
 
 ## Schema
 
-**Clean**: 22 colonne — rinomine a snake_case, più colonna calcolata `fascia_eta`. Escluse le righe con ETA=999 (totali pre-aggregati — somma ridondante delle età 0-100).
+**Clean**: 22 colonne — rinomine a snake_case, più colonna calcolata `fascia_eta`. Escluse le righe con ETA=999 (totali pre-aggregati — somma ridondante delle età 0-100). Utilizza le macro standard del toolkit (`cast_int`, `normalize_string`).
 
-**Mart `popolazione_by_comune`**: `[anno_riferimento, codice_comune, comune, popolazione_residente, popolazione_maschile, popolazione_femminile]` — un record per comune (SUM GROUP BY, non più dipendente dalla riga ETA=999).
+**Mart `popolazione_by_comune`**: `[anno_riferimento, codice_comune, comune, popolazione_residente, popolazione_maschile, popolazione_femminile]` — un record per comune (SUM GROUP BY).
 
 **Mart `popolazione_by_eta`**: `[anno_riferimento, codice_comune, comune, eta, popolazione_residente, popolazione_maschile, popolazione_femminile]` — un record per comune per classe di età (0-100).
+
+**Mart `popolazione_indicatori`**: `[anno_riferimento, codice_comune, comune, popolazione_totale, pop_0_14, pop_15_64, pop_65_plus, pop_under_18, pop_75_plus, indice_vecchiaia, rapporto_dipendenza, pct_under_18, pct_over_65, pct_over_75]` — indicatori demografici per comune.
 
 **Hierarchy `h_fascia`**: `[codice_comune, comune, fascia_eta]` + 17 metriche demografiche — un record per comune per fascia d'età (0-14, 15-29, 30-44, 45-59, 60-74, 75+). Generato automaticamente dalla mart hierarchy del toolkit.
 

--- a/support_datasets/popolazione-istat-comunale-2019-2025/README.md
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/README.md
@@ -18,6 +18,10 @@ Formato: ZIP → CSV, `;` delim, `utf-8` con BOM. Skip 1 riga (header doppio).
 
 **Mart `popolazione_by_eta`**: `[anno_riferimento, codice_comune, comune, eta, popolazione_residente, popolazione_maschile, popolazione_femminile]` — un record per comune per classe di età (0-100).
 
+**Mart `popolazione_by_regione`**: `[anno_riferimento, regione, popolazione_residente, popolazione_maschile, popolazione_femminile, numero_comuni, superficie_km2, densita_ab_km2]` — aggregazione regionale con densità. JOIN con `comuni-master` per codice ISTAT e denominazione.
+
+**Mart `popolazione_by_provincia`**: `[anno_riferimento, sigla_provincia, provincia, regione, popolazione_residente, popolazione_maschile, popolazione_femminile, numero_comuni, superficie_km2, densita_ab_km2]` — aggregazione provinciale con densità.
+
 **Mart `popolazione_indicatori`**: `[anno_riferimento, codice_comune, comune, popolazione_totale, pop_0_14, pop_15_64, pop_65_plus, pop_under_18, pop_75_plus, indice_vecchiaia, rapporto_dipendenza, pct_under_18, pct_over_65, pct_over_75]` — indicatori demografici per comune.
 
 **Hierarchy `h_fascia`**: `[codice_comune, comune, fascia_eta]` + 17 metriche demografiche — un record per comune per fascia d'età (0-14, 15-29, 30-44, 45-59, 60-74, 75+). Generato automaticamente dalla mart hierarchy del toolkit.

--- a/support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml
@@ -45,6 +45,10 @@ mart:
       sql: "sql/mart.sql"
     - name: "popolazione_by_eta"
       sql: "sql/mart_by_eta.sql"
+    - name: "popolazione_by_regione"
+      sql: "sql/mart_by_regione.sql"
+    - name: "popolazione_by_provincia"
+      sql: "sql/mart_by_provincia.sql"
     - name: "popolazione_indicatori"
       sql: "sql/mart_indicatori.sql"
   hierarchy:

--- a/support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml
@@ -27,7 +27,17 @@ clean:
     delim: ";"
     encoding: "utf-8"
     trim_whitespace: true
-  validate: {}
+  required_columns:
+    - "codice_comune"
+    - "comune"
+    - "eta"
+    - "popolazione_residente"
+  validate:
+    not_null:
+      - "codice_comune"
+      - "comune"
+      - "eta"
+    min_rows: 1000
 
 mart:
   tables:
@@ -35,6 +45,8 @@ mart:
       sql: "sql/mart.sql"
     - name: "popolazione_by_eta"
       sql: "sql/mart_by_eta.sql"
+    - name: "popolazione_indicatori"
+      sql: "sql/mart_indicatori.sql"
   hierarchy:
     axis: categorico
     levels:

--- a/support_datasets/popolazione-istat-comunale-2019-2025/notes.md
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/notes.md
@@ -22,6 +22,8 @@ Tutti e 7 gli anni: raw ✅ clean ✅ mart ✅
 - Clean: 22 colonne, colonna calcolata `fascia_eta`, filtrato ETA=999 (totali ridondanti). Migrato alle macro toolkit standard (cast_int, normalize_string) il 2026-07-25.
 - `popolazione_by_comune`: 1 riga per comune, SUM GROUP BY
 - `popolazione_by_eta`: 1 riga per comune per classe di età (ETA 0-100)
+- `popolazione_by_regione`: aggregazione regionale con densità (JOIN comuni-master per codice + denominazione)
+- `popolazione_by_provincia`: aggregazione provinciale con densità (JOIN comuni-master per codice + denominazione)
 - `popolazione_indicatori`: indicatori demografici per comune (indice vecchiaia, rapporto dipendenza, % under_18, % over_65, % over_75)
 - `h_fascia` (hierarchy): 1 riga per comune per fascia d'età, 17 metriche — generato automaticamente dal toolkit
 

--- a/support_datasets/popolazione-istat-comunale-2019-2025/notes.md
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/notes.md
@@ -19,9 +19,10 @@ Tutti e 7 gli anni: raw ✅ clean ✅ mart ✅
 
 ## Schema
 
-- Clean: 22 colonne, colonna calcolata `fascia_eta`, filtrato ETA=999 (totali ridondanti)
-- `popolazione_by_comune`: 1 riga per comune, SUM GROUP BY (non più ETA=999)
+- Clean: 22 colonne, colonna calcolata `fascia_eta`, filtrato ETA=999 (totali ridondanti). Migrato alle macro toolkit standard (cast_int, normalize_string) il 2026-07-25.
+- `popolazione_by_comune`: 1 riga per comune, SUM GROUP BY
 - `popolazione_by_eta`: 1 riga per comune per classe di età (ETA 0-100)
+- `popolazione_indicatori`: indicatori demografici per comune (indice vecchiaia, rapporto dipendenza, % under_18, % over_65, % over_75)
 - `h_fascia` (hierarchy): 1 riga per comune per fascia d'età, 17 metriche — generato automaticamente dal toolkit
 
 ## Cautele

--- a/support_datasets/popolazione-istat-comunale-2019-2025/sql/clean.sql
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/sql/clean.sql
@@ -1,32 +1,32 @@
 select
-  {year}::INTEGER                                            as anno,
-  trim(cast("Codice comune" as varchar)) as codice_comune,
-  trim(cast("Comune" as varchar)) as comune,
-  try_cast("Età" as integer) as eta,
+  {year}::INTEGER                         as anno,
+  normalize_string("Codice comune")       as codice_comune,
+  normalize_string("Comune")              as comune,
+  cast_int("Età")                         as eta,
   case
-    when try_cast("Età" as integer) between 0 and 14 then '0-14'
-    when try_cast("Età" as integer) between 15 and 29 then '15-29'
-    when try_cast("Età" as integer) between 30 and 44 then '30-44'
-    when try_cast("Età" as integer) between 45 and 59 then '45-59'
-    when try_cast("Età" as integer) between 60 and 74 then '60-74'
-    when try_cast("Età" as integer) >= 75 then '75+'
-  end as fascia_eta,
-  try_cast("Celibi" as integer) as celibi,
-  try_cast("Coniugati" as integer) as coniugati,
-  try_cast("Divorziati" as integer) as divorziati,
-  try_cast("Vedovi" as integer) as vedovi,
-  try_cast("Uniti civilmente" as integer) as uniti_civilmente_maschi,
-  try_cast("Maschi già in unione civile (per scioglimento unione)" as integer) as maschi_gia_unione_civile_scioglimento,
-  try_cast("Maschi già in unione civile (per decesso del partner)" as integer) as maschi_gia_unione_civile_decesso,
-  try_cast("Totale maschi" as integer) as totale_maschi,
-  try_cast("Nubili" as integer) as nubili,
-  try_cast("Coniugate" as integer) as coniugate,
-  try_cast("Divorziate" as integer) as divorziate,
-  try_cast("Vedove" as integer) as vedove,
-  try_cast("Unite civilmente" as integer) as unite_civilmente_femmine,
-  try_cast("Femmine già in unione civile (per scioglimento unione)" as integer) as femmine_gia_unione_civile_scioglimento,
-  try_cast("Femmine già in unione civile (per decesso del partner)" as integer) as femmine_gia_unione_civile_decesso,
-  try_cast("Totale femmine" as integer) as totale_femmine,
-  try_cast("Totale" as integer) as popolazione_residente
+    when cast_int("Età") between 0 and 14 then '0-14'
+    when cast_int("Età") between 15 and 29 then '15-29'
+    when cast_int("Età") between 30 and 44 then '30-44'
+    when cast_int("Età") between 45 and 59 then '45-59'
+    when cast_int("Età") between 60 and 74 then '60-74'
+    when cast_int("Età") >= 75 then '75+'
+  end                                     as fascia_eta,
+  cast_int("Celibi")                      as celibi,
+  cast_int("Coniugati")                   as coniugati,
+  cast_int("Divorziati")                  as divorziati,
+  cast_int("Vedovi")                      as vedovi,
+  cast_int("Uniti civilmente")            as uniti_civilmente_maschi,
+  cast_int("Maschi già in unione civile (per scioglimento unione)") as maschi_gia_unione_civile_scioglimento,
+  cast_int("Maschi già in unione civile (per decesso del partner)") as maschi_gia_unione_civile_decesso,
+  cast_int("Totale maschi")               as totale_maschi,
+  cast_int("Nubili")                      as nubili,
+  cast_int("Coniugate")                   as coniugate,
+  cast_int("Divorziate")                  as divorziate,
+  cast_int("Vedove")                      as vedove,
+  cast_int("Unite civilmente")            as unite_civilmente_femmine,
+  cast_int("Femmine già in unione civile (per scioglimento unione)") as femmine_gia_unione_civile_scioglimento,
+  cast_int("Femmine già in unione civile (per decesso del partner)") as femmine_gia_unione_civile_decesso,
+  cast_int("Totale femmine")              as totale_femmine,
+  cast_int("Totale")                      as popolazione_residente
 from raw_input
-where try_cast("Età" as integer) <> 999
+where cast_int("Età") <> 999

--- a/support_datasets/popolazione-istat-comunale-2019-2025/sql/mart_by_provincia.sql
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/sql/mart_by_provincia.sql
@@ -1,0 +1,48 @@
+with
+comuni_registry as (
+  select codice_istat, sigla_provincia, provincia, regione, denominazione, superficie_km2
+  from read_parquet('https://storage.googleapis.com/dataciviclab-clean/comuni_master/2026/comuni_master_2026_clean.parquet')
+),
+provincia_map as (
+  select distinct left(codice_istat, 3) as codice_provincia, regione
+  from comuni_registry
+  where codice_istat is not null
+),
+per_comune as (
+  select
+    codice_comune,
+    comune,
+    sum(popolazione_residente) as pop_residente,
+    sum(totale_maschi) as pop_maschile,
+    sum(totale_femmine) as pop_femminile
+  from clean_input
+  where codice_comune is not null
+  group by codice_comune, comune
+),
+per_comune_arricchito as (
+  select
+    pc.*,
+    -- Match: 1) per codice ISTAT, 2) per denominazione, 3) fallback
+    coalesce(r1.sigla_provincia, r2.sigla_provincia, left(pc.codice_comune, 3)) as sigla_provincia,
+    coalesce(r1.provincia, r2.provincia, left(pc.codice_comune, 3)) as provincia,
+    coalesce(r1.regione, r2.regione, pr.regione, 'Altro') as regione,
+    coalesce(r1.superficie_km2, r2.superficie_km2, 0.0) as superficie_km2
+  from per_comune pc
+  left join comuni_registry r1 on pc.codice_comune = r1.codice_istat
+  left join comuni_registry r2 on lower(trim(pc.comune)) = lower(trim(r2.denominazione))
+  left join provincia_map pr on left(pc.codice_comune, 3) = pr.codice_provincia
+)
+select
+  {year} as anno_riferimento,
+  sigla_provincia,
+  provincia,
+  regione,
+  sum(pop_residente) as popolazione_residente,
+  sum(pop_maschile) as popolazione_maschile,
+  sum(pop_femminile) as popolazione_femminile,
+  count(*) as numero_comuni,
+  round(sum(superficie_km2), 2) as superficie_km2,
+  round(sum(pop_residente)::double / nullif(sum(superficie_km2), 0), 1) as densita_ab_km2
+from per_comune_arricchito
+group by sigla_provincia, provincia, regione
+order by sigla_provincia

--- a/support_datasets/popolazione-istat-comunale-2019-2025/sql/mart_by_regione.sql
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/sql/mart_by_regione.sql
@@ -1,0 +1,45 @@
+with
+comuni_registry as (
+  select codice_istat, regione, denominazione, superficie_km2
+  from read_parquet('https://storage.googleapis.com/dataciviclab-clean/comuni_master/2026/comuni_master_2026_clean.parquet')
+),
+-- Mappa provincia (prime 3 cifre) -> regione, per fallback su comuni non in registry
+provincia_map as (
+  select distinct left(codice_istat, 3) as codice_provincia, regione
+  from comuni_registry
+  where codice_istat is not null
+),
+per_comune as (
+  select
+    codice_comune,
+    comune,
+    sum(popolazione_residente) as pop_residente,
+    sum(totale_maschi) as pop_maschile,
+    sum(totale_femmine) as pop_femminile
+  from clean_input
+  where codice_comune is not null
+  group by codice_comune, comune
+),
+per_comune_arricchito as (
+  select
+    pc.*,
+    -- Match: 1) per codice ISTAT, 2) per denominazione, 3) per provincia
+    coalesce(r1.regione, r2.regione, pr.regione, 'Altro') as regione,
+    coalesce(r1.superficie_km2, r2.superficie_km2, 0.0) as superficie_km2
+  from per_comune pc
+  left join comuni_registry r1 on pc.codice_comune = r1.codice_istat
+  left join comuni_registry r2 on lower(trim(pc.comune)) = lower(trim(r2.denominazione))
+  left join provincia_map pr on left(pc.codice_comune, 3) = pr.codice_provincia
+)
+select
+  {year} as anno_riferimento,
+  regione,
+  sum(pop_residente) as popolazione_residente,
+  sum(pop_maschile) as popolazione_maschile,
+  sum(pop_femminile) as popolazione_femminile,
+  count(*) as numero_comuni,
+  round(sum(superficie_km2), 2) as superficie_km2,
+  round(sum(pop_residente)::double / nullif(sum(superficie_km2), 0), 1) as densita_ab_km2
+from per_comune_arricchito
+group by regione
+order by regione

--- a/support_datasets/popolazione-istat-comunale-2019-2025/sql/mart_indicatori.sql
+++ b/support_datasets/popolazione-istat-comunale-2019-2025/sql/mart_indicatori.sql
@@ -1,0 +1,58 @@
+with
+base as (
+  select
+    codice_comune,
+    comune,
+    eta,
+    popolazione_residente
+  from clean_input
+  where codice_comune is not null
+    and comune is not null
+    and eta is not null
+    and eta <> 999
+),
+fasce as (
+  select
+    codice_comune,
+    comune,
+    sum(case when eta between 0 and 14 then popolazione_residente else 0 end) as pop_0_14,
+    sum(case when eta between 15 and 64 then popolazione_residente else 0 end) as pop_15_64,
+    sum(case when eta >= 65 then popolazione_residente else 0 end) as pop_65_plus,
+    sum(case when eta < 18 then popolazione_residente else 0 end) as pop_under_18,
+    sum(case when eta >= 75 then popolazione_residente else 0 end) as pop_75_plus,
+    sum(popolazione_residente) as popolazione_totale
+  from base
+  group by codice_comune, comune
+)
+select
+  {year} as anno_riferimento,
+  codice_comune,
+  comune,
+  popolazione_totale,
+  pop_0_14,
+  pop_15_64,
+  pop_65_plus,
+  pop_under_18,
+  pop_75_plus,
+  -- Indice di vecchiaia: pop 65+ / pop 0-14 * 100
+  case when pop_0_14 > 0
+    then round((pop_65_plus::double / pop_0_14::double) * 100, 1)
+  end as indice_vecchiaia,
+  -- Rapporto di dipendenza: (pop 0-14 + pop 65+) / pop 15-64 * 100
+  case when pop_15_64 > 0
+    then round(((pop_0_14 + pop_65_plus)::double / pop_15_64::double) * 100, 1)
+  end as rapporto_dipendenza,
+  -- Percentuale under 18
+  case when popolazione_totale > 0
+    then round((pop_under_18::double / popolazione_totale::double) * 100, 1)
+  end as pct_under_18,
+  -- Percentuale over 65
+  case when popolazione_totale > 0
+    then round((pop_65_plus::double / popolazione_totale::double) * 100, 1)
+  end as pct_over_65,
+  -- Percentuale over 75
+  case when popolazione_totale > 0
+    then round((pop_75_plus::double / popolazione_totale::double) * 100, 1)
+  end as pct_over_75
+from fasce
+where popolazione_totale > 0


### PR DESCRIPTION
## Sintesi

Allineamento del support dataset popolazione-istat agli standard del toolkit e aggiunta di mart analitici con copertura territoriale completa. Inoltre, push MART a GCS nel flusso post-merge.

## Cosa cambia

- [ ] candidate — nuovo dataset o aggiornamento
- [x] support — dataset di supporto
- [ ] docs — struttura candidate, README, template
- [x] cleanup — refactoring, rimozioni, allineamento
- [x] workflow o CI
- [ ] altro

## Dettaglio

### 1. Allineamento standard (come PR #706)
- `clean.sql` migrato alle **macro toolkit standard** (`cast_int`, `normalize_string`)
- Aggiunte `required_columns` + `not_null` + `min_rows` validation

### 2. Nuovi mart (5 totali)
| Mart | Grano | Cosa |
|---|---|---|
| `popolazione_by_comune` | comune | (esistente) popolazione aggregata per comune |
| `popolazione_by_eta` | comune × età | (esistente) popolazione per singola età |
| **`popolazione_indicatori`** | comune | indice vecchiaia, rapporto dipendenza, % under_18, % over_65, % over_75 |
| **`popolazione_by_regione`** | regione (20) | popolazione, superficie, densità, numero comuni |
| **`popolazione_by_provincia`** | provincia (~110) | popolazione, superficie, densità, numero comuni |

### 3. JOIN con comuni-master (robusto)
I mart regione/provincia fanno JOIN con `comuni-master` via GCS (`read_parquet` su bucket pubblico) con doppio fallback:
1. Match per codice ISTAT (copre ~95% dei comuni)
2. Match per denominazione (recupera i comuni sardi con codici cambiati, ~5%)
3. Fallback per codice provincia (recupera eventuali residui fusi/soppressi)
- **Copertura 100%** verificata su 7.896 comuni

### 4. Push MART a GCS nel flusso DI
- Aggiunta `_push_mart_to_gcs()` in `post_merge_runner.py`
- Push mart eseguito dopo il push clean (non bloccante — warning se fallisce)
- Aggiornato `build-pr-body` per tracciare il push mart

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
- [ ] Solo documentazione o metadati
- [ ] Nessun impatto visibile per chi usa il repository

## Verifica

```bash
toolkit run full -c support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml --years 2025
```

Risultato: raw ✅ clean ✅ mart ✅ 5/5 tabelle
- 20 regioni, ~110 province, 7.896 comuni, 100% copertura
- Sardegna correttamente mappata (1.56M, 377 comuni, match per denominazione)

## Note / rischi

- I mart `popolazione_by_regione` e `popolazione_by_provincia` dipendono da `read_parquet` su GCS (bucket pubblico). Funzionano sia in CI che offline con DuckDB.
- 131 comuni fusi/soppressi (senza match né per codice né per nome) vengono aggregati sotto la regione corretta via fallback codice provincia.
- `comuni-master` su GCS non ha colonna `codice_regione` — i mart usano solo `regione` (nome).
