### PR TITLE
chore(post-merge): aggiorna registry per PR #709

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -557,224 +557,224 @@
     },
     {
       "slug": "anac_appalti_master",
-      "name": "Anac Appalti Master",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "name": "ANAC Appalti Master",
+      "description": "Compose di 8 dataset ANAC: bando → aggiudicazione → vincitore → collaudo, con partecipazione, subappalti, SAL e CUP. 6,08M CIG (2016-2025), grana 1 riga per CIG.",
+      "source": "DataCivicLab (composite: ANAC, 8 dataset)",
+      "source_id": "dataciviclab_composite",
       "period": {
-        "start": 2026,
-        "end": 2026
+        "start": 2016,
+        "end": 2025
       },
       "columns": [
         {
           "name": "cig",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "CIG — chiave primaria"
         },
         {
           "name": "anno",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di pubblicazione del bando"
         },
         {
           "name": "oggetto_gara",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Oggetto della gara"
         },
         {
           "name": "importo_complessivo_gara",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Importo complessivo del bando (include accordi quadro!)"
         },
         {
           "name": "oggetto_principale",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Settore: LAVORI / SERVIZI / FORNITURE"
         },
         {
           "name": "stato",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Stato del bando (ATTIVO, ANNULLATO, ecc.)"
         },
         {
           "name": "esito_bando",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Esito del bando"
         },
         {
           "name": "flag_pnrr",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Bando legato al PNRR/PNC"
         },
         {
           "name": "cod_cpv",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice CPV"
         },
         {
           "name": "descr_cpv",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione CPV"
         },
         {
           "name": "amministrazione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione stazione appaltante"
         },
         {
           "name": "provincia",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Provincia del luogo di esecuzione"
         },
         {
           "name": "sezione_regionale",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Sezione regionale ANAC"
         },
         {
           "name": "importo_agg",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Importo di aggiudicazione (€)"
         },
         {
           "name": "data_agg",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data di aggiudicazione"
         },
         {
           "name": "ribasso",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Ribasso percentuale di aggiudicazione"
         },
         {
           "name": "offerte_ammesse",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero di offerte ammesse"
         },
         {
           "name": "flag_subappalto",
           "type": "BOOLEAN",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Subappalto autorizzato"
         },
         {
           "name": "criterio_agg",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Criterio di aggiudicazione"
         },
         {
           "name": "operatore",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Denominazione operatore economico vincitore"
         },
         {
           "name": "cf",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "CF/P.IVA operatore vincitore"
         },
         {
           "name": "tipo_soggetto",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipo soggetto vincitore"
         },
         {
           "name": "n_operatori",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero operatori per CIG (ATI/RTI)"
         },
         {
           "name": "n_partecipanti",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero partecipanti alla gara"
         },
         {
           "name": "n_imprese_partecipanti",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero imprese distinte partecipanti"
         },
         {
           "name": "n_subappalti",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero subappalti autorizzati"
         },
         {
           "name": "n_subappaltatori",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero subappaltatori distinti"
         },
         {
           "name": "esito_collaudo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Esito collaudo (POSITIVO / NEGATIVO)"
         },
         {
           "name": "data_collaudo",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data collaudo"
         },
         {
           "name": "riserve_avanzate",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Riserve avanzate (€)"
         },
         {
           "name": "contenzioso",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Importo contenzioso risolto (€)"
         },
         {
           "name": "n_sal",
           "type": "INTEGER",
           "role": "metric",
-          "description": ""
+          "description": "Numero SAL registrati"
         },
         {
           "name": "importo_totale_sal",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Importo totale SAL (€)"
         },
         {
           "name": "scostamento_medio",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Scostamento medio giorni dal cronoprogramma"
         },
         {
           "name": "cup",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "CUP — bridge verso PNRR/OpenCUP"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-07-25",
+  "updated_at": "2026-07-27",
   "datasets": [
     {
       "slug": "aci_prime_iscrizioni_autovetture",
@@ -550,6 +550,236 @@
       "location": {
         "type": "gcs",
         "path": "gs://dataciviclab-clean/anac_aggiudicazioni/2026/anac_aggiudicazioni_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "anac_appalti_master",
+      "name": "Anac Appalti Master",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2026,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "cig",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "anno",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "oggetto_gara",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "importo_complessivo_gara",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "oggetto_principale",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "stato",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "esito_bando",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "flag_pnrr",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "cod_cpv",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "descr_cpv",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "amministrazione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "provincia",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "sezione_regionale",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "importo_agg",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_agg",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "ribasso",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "offerte_ammesse",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "flag_subappalto",
+          "type": "BOOLEAN",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "criterio_agg",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "operatore",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cf",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "tipo_soggetto",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "n_operatori",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "n_partecipanti",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "n_imprese_partecipanti",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "n_subappalti",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "n_subappaltatori",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "esito_collaudo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "data_collaudo",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "riserve_avanzate",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "contenzioso",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "n_sal",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "importo_totale_sal",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "scostamento_medio",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "cup",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/anac_appalti_master/2026/anac_appalti_master_2026_clean.parquet",
         "multi_file": false
       },
       "stage": "published",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-26",
+  "generated_at": "2026-07-27",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 103,
+    "total": 104,
     "by_status": {
-      "ok": 103,
+      "ok": 104,
       "warn": 0,
       "error": 0
     }
@@ -1977,6 +1977,24 @@
           2025
         ],
         "config_path": "support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml"
+      }
+    },
+    {
+      "id": "compose:anac-appalti-master",
+      "source_id": "dataciviclab_composite",
+      "status": "ok",
+      "label": "compose:anac-appalti-master",
+      "detail": "anno 2026 — fonte: ? — mart: sì",
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "30248169062",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30248169062",
+        "checked_at": "2026-07-27",
+        "years": [
+          2026
+        ],
+        "config_path": "compose/anac-appalti-master/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #709 — compose: anac-appalti-master — 8 dataset ANAC unificati (6.08M CIG, grana 1:1)

Changed candidate/support roots:

- `anac-appalti-master` (compose, `compose/anac-appalti-master`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `compose/anac-appalti-master/dataset.yml` -> artifact `sample-run-anac-appalti-master`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
