### PR TITLE
compose: eurostat-economy, eurostat-demography, eurostat-territory — tabelle composte tematiche da dataset Eurostat NUTS3

### DIFF
--- a/compose/eurostat-demography/README.md
+++ b/compose/eurostat-demography/README.md
@@ -1,0 +1,38 @@
+# Eurostat Demography (compose)
+
+**Dataset**: `eurostat_demography`
+**Tipo**: compose — unisce 4 dataset Eurostat in una vista demografica regionale
+
+## Cos'è
+
+Vista unificata degli indicatori demografici regionali europei: popolazione, densità, struttura per età, bilancio demografico. Ogni riga = (geo, year) con 18 colonne.
+
+**Copertura**: 2014-2025, tutti i paesi EU/EEA, tutti i livelli NUTS (0-3).
+
+## Schema (18 colonne)
+
+| Gruppo | Colonne |
+|---|---|
+| Chiave | `geo`, `year`, `nuts_level`, `country_code`, `geo_label_en` |
+| Popolazione | `population`, `pop_density_km2` |
+| Struttura età | `median_age`, `old_age_dependency_pct`, `youth_pct`, `total_dependency_pct`, `over65_pct`, `over75_pct` |
+| Bilancio | `natural_change`, `net_migration`, `total_change` |
+
+## Dataset sorgente
+
+| Dataset | Dataflow | Ruolo |
+|---|---|---|
+| `eurostat_demo_r_pjangrp3_nuts3` | DEMO_R_PJANGRP3 | Popolazione per età e sesso (NUTS3) |
+| `eurostat_pop_density_nuts3` | DEMO_R_D3DENS | Densità abitativa |
+| `eurostat_pop_structure_nuts3` | DEMO_R_PJANIND3 | Indicatori struttura età |
+| `eurostat_demo_balance_nuts3` | DEMO_R_GIND3 | Bilancio demografico |
+
+## Mart
+
+| Mart | Filtro | Righe stimate |
+|---|---|---|
+| `mart_it_nuts3` | IT NUTS3 (107 province) | ~1.284 |
+
+## Limitazioni note
+
+- `median_age`, `over65_pct`, `over75_pct` sono NULL per l'Italia NUTS3 (Eurostat pubblica questi indicatori solo a livello NUTS2 per IT)

--- a/compose/eurostat-demography/dataset.yml
+++ b/compose/eurostat-demography/dataset.yml
@@ -2,7 +2,7 @@ root: "../../out"
 schema_version: 1
 
 dataset:
-  name: "demography"
+  name: "eurostat_demography"
   source_id: "eurostat"
   years: [2026]
 

--- a/compose/eurostat-demography/dataset.yml
+++ b/compose/eurostat-demography/dataset.yml
@@ -1,0 +1,38 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "demography"
+  source_id: "eurostat"
+  years: [2026]
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "eurostat_area_nuts3"
+      type: "http_file"
+      args:
+        url: "https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet"
+        filename: "hub.parquet"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: "auto"
+    mode: "latest"
+  validate:
+    min_rows: 10000
+    promotion:
+      max_row_drop_pct: 100
+
+mart:
+  tables:
+    - name: "mart_it_nuts3"
+      sql: "sql/mart_it_nuts3.sql"
+  validate:
+    table_rules:
+      mart_it_nuts3: { min_rows: 100 }
+
+validation:
+  fail_on_error: true

--- a/compose/eurostat-demography/dataset.yml
+++ b/compose/eurostat-demography/dataset.yml
@@ -5,6 +5,10 @@ dataset:
   name: "eurostat_demography"
   source_id: "eurostat"
   years: [2026]
+  time_coverage:
+    mode: full_series
+    start_year: 2014
+    end_year: 2025
 
 raw:
   output_policy: overwrite

--- a/compose/eurostat-demography/notes.md
+++ b/compose/eurostat-demography/notes.md
@@ -1,0 +1,30 @@
+# Note tecniche — eurostat-demography
+
+## Architettura
+
+Compose che legge parquet puliti direttamente da GCS.
+
+1. **Hub**: area_nuts3 × demo_r_pjangrp3 (anni 2014-2025)
+2. **4 CTE dominio**: popolazione, densità, struttura età, bilancio
+3. **LEFT JOIN** su (geo, year)
+4. **WHERE** elimina righe senza alcun dato
+
+## Qualità (run 2026-07-26)
+
+| Metrica | Valore |
+|---|---|
+| Righe clean EU | 20.949 |
+| Colonne | 18 |
+| Population non-NULL | 98.1% |
+| Pop density non-NULL | 85.9% |
+| Median age non-NULL | 0% per IT NUTS3 |
+| Natural change non-NULL | 90.2% |
+| IT NUTS3 coverage | 107/107 province |
+
+## Perché median_age è NULL per Italia NUTS3
+
+Il dataset Eurostat `pop_structure_nuts3` (DEMO_R_PJANIND3) per l'Italia pubblica 51 indicatori (OLDDEP1, PC_Y0_14, DEPRATIO1, ...) ma non MEDAGEPOP (età mediana), PC_Y65 e PC_Y75. Questi sono disponibili solo a NUTS2. La limitazione è della fonte, non del compose.
+
+## Fonte popolazione
+
+A differenza del dataset `pop_nuts3` (che ha popolazione solo a NUTS2 per IT), il compose usa `demo_r_pjangrp3` che ha copertura NUTS3 completa per l'Italia (107 province). Range: 2014-2025.

--- a/compose/eurostat-demography/sql/clean.sql
+++ b/compose/eurostat-demography/sql/clean.sql
@@ -1,0 +1,116 @@
+-- Clean: demography — population, density, age structure, demographic balance
+-- Each row = (geo, year) with demographic indicators
+-- Reads clean parquet from GCS via HTTPS (compose pattern)
+
+WITH
+
+-- ── Hub: all (geo × year) combinations EU-wide ────────────────────
+hub AS (
+    SELECT
+        g.geo, g.geo_label_en, g.nuts_level,
+        g.nuts_parent_code, g.nuts_parent_label_en,
+        SUBSTRING(g.geo, 1, 2) AS country_code,
+        a.year
+    FROM (
+        SELECT DISTINCT geo, geo_label_en, nuts_level,
+            nuts_parent_code, nuts_parent_label_en
+        FROM read_parquet(
+            'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
+            union_by_name=true
+        )
+        WHERE unit = 'KM2' AND landuse = 'TOTAL' AND year = 2024
+            AND nuts_level IS NOT NULL
+    ) g
+    JOIN (
+        SELECT DISTINCT year FROM read_parquet(
+            'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_demo_r_pjangrp3_nuts3/eurostat_demo_r_pjangrp3_nuts3_2026_clean.parquet',
+            union_by_name=true
+        )
+        WHERE unit = 'NR' AND sex = 'T' AND age = 'TOTAL'
+    ) a ON (1=1)
+),
+
+-- 1. Total population (from demo_r_pjangrp3 for NUTS3 coverage)
+population AS (
+    SELECT geo, year,
+        SUM(value) AS population
+    FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_demo_r_pjangrp3_nuts3/eurostat_demo_r_pjangrp3_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE unit = 'NR' AND sex = 'T' AND age = 'TOTAL'
+    GROUP BY geo, year
+),
+
+-- 2. Population density
+density AS (
+    SELECT geo, year,
+        AVG(value) AS pop_density_km2
+    FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_pop_density_nuts3/eurostat_pop_density_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE unit = 'PER_KM2'
+    GROUP BY geo, year
+),
+
+-- 3. Population structure indicators (age)
+age_structure AS (
+    SELECT geo, year,
+        MAX(CASE WHEN indic_de = 'MEDAGEPOP' THEN value END) AS median_age,
+        MAX(CASE WHEN indic_de = 'OLDDEP1' THEN value END) AS old_age_dependency_pct,
+        MAX(CASE WHEN indic_de = 'PC_Y0_14' THEN value END) AS youth_pct,
+        MAX(CASE WHEN indic_de = 'DEPRATIO1' THEN value END) AS total_dependency_pct,
+        MAX(CASE WHEN indic_de = 'PC_Y65' THEN value END) AS over65_pct,
+        MAX(CASE WHEN indic_de = 'PC_Y75' THEN value END) AS over75_pct
+    FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_pop_structure_nuts3/eurostat_pop_structure_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE unit = 'PC' AND indic_de IN ('MEDAGEPOP', 'OLDDEP1', 'PC_Y0_14', 'DEPRATIO1', 'PC_Y65', 'PC_Y75')
+    GROUP BY geo, year
+),
+
+-- 4. Demographic balance: natural change, net migration (per 1000 pop)
+demographic_balance AS (
+    SELECT geo, year,
+        MAX(CASE WHEN indic_de = 'NATGROWRT' THEN value END) AS natural_change,
+        MAX(CASE WHEN indic_de = 'CNMIGRATRT' THEN value END) AS net_migration,
+        MAX(CASE WHEN indic_de = 'GROWRT' THEN value END) AS total_change
+    FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_demo_balance_nuts3/eurostat_demo_balance_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE indic_de IN ('NATGROWRT', 'CNMIGRATRT', 'GROWRT')
+    GROUP BY geo, year
+)
+
+-- ── Final SELECT ───────────────────────────────────────────────────
+SELECT
+    -- 🔑 Key
+    h.geo, h.year, h.nuts_level, h.country_code,
+    h.geo_label_en, h.nuts_parent_code, h.nuts_parent_label_en,
+
+    -- 👥 Population
+    pop.population,
+    d.pop_density_km2,
+
+    -- 📊 Age structure
+    as_.median_age,
+    as_.old_age_dependency_pct, as_.youth_pct, as_.total_dependency_pct,
+    as_.over65_pct, as_.over75_pct,
+
+    -- 🔄 Demographic balance
+    db.natural_change, db.net_migration, db.total_change
+
+FROM hub h
+LEFT JOIN population pop ON h.geo = pop.geo AND h.year = pop.year
+LEFT JOIN density d ON h.geo = d.geo AND h.year = d.year
+LEFT JOIN age_structure as_ ON h.geo = as_.geo AND h.year = as_.year
+LEFT JOIN demographic_balance db ON h.geo = db.geo AND h.year = db.year
+-- Keep only rows with at least one real data point
+WHERE pop.population IS NOT NULL
+   OR d.pop_density_km2 IS NOT NULL
+   OR as_.median_age IS NOT NULL
+   OR db.natural_change IS NOT NULL
+ORDER BY h.country_code, h.nuts_level, h.geo, h.year

--- a/compose/eurostat-demography/sql/clean.sql
+++ b/compose/eurostat-demography/sql/clean.sql
@@ -18,7 +18,11 @@ hub AS (
             'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
             union_by_name=true
         )
-        WHERE unit = 'KM2' AND landuse = 'TOTAL' AND year = 2024
+        WHERE unit = 'KM2' AND landuse = 'TOTAL'
+            AND year = (SELECT MAX(year) FROM read_parquet(
+                'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
+                union_by_name=true
+            ) WHERE unit = 'KM2' AND landuse = 'TOTAL')
             AND nuts_level IS NOT NULL
     ) g
     JOIN (

--- a/compose/eurostat-demography/sql/clean.sql
+++ b/compose/eurostat-demography/sql/clean.sql
@@ -4,34 +4,40 @@
 
 WITH
 
--- ── Hub: all (geo × year) combinations EU-wide ────────────────────
+-- ── Geo anchor: area_nuts3, anno piu' recente disponibile ────────
+area_data AS (
+    SELECT * FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE unit = 'KM2' AND landuse = 'TOTAL'
+),
+geo_anchor AS (
+    SELECT DISTINCT geo, geo_label_en, nuts_level,
+        nuts_parent_code, nuts_parent_label_en
+    FROM area_data
+    WHERE year = (SELECT MAX(year) FROM area_data)
+        AND nuts_level IS NOT NULL
+),
+
+-- ── Years: da demo_r_pjangrp3 (copertura 2014-2025) ─────────────
+years AS (
+    SELECT DISTINCT year FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_demo_r_pjangrp3_nuts3/eurostat_demo_r_pjangrp3_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE unit = 'NR' AND sex = 'T' AND age = 'TOTAL'
+),
+
+-- ── Hub: all (geo × year) combinations EU-wide ──────────────────
 hub AS (
     SELECT
         g.geo, g.geo_label_en, g.nuts_level,
         g.nuts_parent_code, g.nuts_parent_label_en,
         SUBSTRING(g.geo, 1, 2) AS country_code,
-        a.year
-    FROM (
-        SELECT DISTINCT geo, geo_label_en, nuts_level,
-            nuts_parent_code, nuts_parent_label_en
-        FROM read_parquet(
-            'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
-            union_by_name=true
-        )
-        WHERE unit = 'KM2' AND landuse = 'TOTAL'
-            AND year = (SELECT MAX(year) FROM read_parquet(
-                'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
-                union_by_name=true
-            ) WHERE unit = 'KM2' AND landuse = 'TOTAL')
-            AND nuts_level IS NOT NULL
-    ) g
-    JOIN (
-        SELECT DISTINCT year FROM read_parquet(
-            'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_demo_r_pjangrp3_nuts3/eurostat_demo_r_pjangrp3_nuts3_2026_clean.parquet',
-            union_by_name=true
-        )
-        WHERE unit = 'NR' AND sex = 'T' AND age = 'TOTAL'
-    ) a ON (1=1)
+        y.year
+    FROM geo_anchor g
+    CROSS JOIN years y
 ),
 
 -- 1. Total population (from demo_r_pjangrp3 for NUTS3 coverage)

--- a/compose/eurostat-demography/sql/mart_it_nuts3.sql
+++ b/compose/eurostat-demography/sql/mart_it_nuts3.sql
@@ -1,0 +1,13 @@
+-- Mart IT NUTS3: Italian provinces, demographic profile
+-- Note: median_age and over65_pct are NULL for Italy NUTS3
+-- (Eurostat publishes age structure only at NUTS2 for Italy)
+SELECT
+    geo, year, country_code, geo_label_en,
+    nuts_parent_code, nuts_parent_label_en,
+    population, pop_density_km2,
+    median_age, old_age_dependency_pct, youth_pct, total_dependency_pct,
+    over65_pct, over75_pct,
+    natural_change, net_migration, total_change
+FROM clean_input
+WHERE country_code = 'IT' AND nuts_level = 'NUTS3'
+  AND population IS NOT NULL

--- a/compose/eurostat-economy/README.md
+++ b/compose/eurostat-economy/README.md
@@ -1,0 +1,34 @@
+# Eurostat Economy (compose)
+
+**Dataset**: `eurostat_economy`
+**Tipo**: compose — unisce 4 dataset Eurostat NUTS3 in una vista economia regionale
+
+## Cos'è
+
+Vista unificata degli indicatori economici regionali europei: PIL, Valore Aggiunto Lordo (7 settori), occupazione e produttività. Ogni riga = (geo, year) con 26 colonne.
+
+**Copertura**: 2000-2024, tutti i paesi EU/EEA, tutti i livelli NUTS (0-3).
+
+## Schema (26 colonne)
+
+| Gruppo | Colonne |
+|---|---|
+| Chiave | `geo`, `year`, `nuts_level`, `country_code`, `geo_label_en` |
+| PIL | `gdp_per_capita`, `gdp_million_eur`, `gdp_pps_hab` |
+| GVA | `gva_total_million`, `gva_industry_million`, `gva_construction_million`, `gva_trade_million`, `gva_ict_million`, `gva_financial_services_million`, `gva_public_admin_million`, `gva_*_pct` (6 colonne %) |
+| Occupazione | `employment_thousands`, `nominal_labour_productivity_eur`, `gdp_per_employed_eur` |
+
+## Dataset sorgente
+
+| Dataset | Dataflow | Ruolo |
+|---|---|---|
+| `eurostat_gdp_nuts3` | NAMA_10R_3GDP | PIL pro-capite, totale, PPS |
+| `eurostat_gva_nuts3` | NAMA_10R_3GVA | GVA per settore NACE |
+| `eurostat_emp_nuts3` | NAMA_10R_3EMPERS | Occupati (migliaia) |
+| `eurostat_labour_productivity_nuts3` | NAMA_10R_3NLP | Produttività nominale |
+
+## Mart
+
+| Mart | Filtro | Righe stimate |
+|---|---|---|
+| `mart_it_nuts3` | IT NUTS3 (107 province) | ~2.675 |

--- a/compose/eurostat-economy/dataset.yml
+++ b/compose/eurostat-economy/dataset.yml
@@ -5,6 +5,10 @@ dataset:
   name: "eurostat_economy"
   source_id: "eurostat"
   years: [2026]
+  time_coverage:
+    mode: full_series
+    start_year: 2000
+    end_year: 2024
 
 raw:
   output_policy: overwrite

--- a/compose/eurostat-economy/dataset.yml
+++ b/compose/eurostat-economy/dataset.yml
@@ -1,0 +1,38 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "economy"
+  source_id: "eurostat"
+  years: [2026]
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "eurostat_area_nuts3"
+      type: "http_file"
+      args:
+        url: "https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet"
+        filename: "hub.parquet"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: "auto"
+    mode: "latest"
+  validate:
+    min_rows: 10000
+    promotion:
+      max_row_drop_pct: 100
+
+mart:
+  tables:
+    - name: "mart_it_nuts3"
+      sql: "sql/mart_it_nuts3.sql"
+  validate:
+    table_rules:
+      mart_it_nuts3: { min_rows: 100 }
+
+validation:
+  fail_on_error: true

--- a/compose/eurostat-economy/dataset.yml
+++ b/compose/eurostat-economy/dataset.yml
@@ -2,7 +2,7 @@ root: "../../out"
 schema_version: 1
 
 dataset:
-  name: "economy"
+  name: "eurostat_economy"
   source_id: "eurostat"
   years: [2026]
 

--- a/compose/eurostat-economy/notes.md
+++ b/compose/eurostat-economy/notes.md
@@ -1,0 +1,32 @@
+# Note tecniche — eurostat-economy
+
+## Architettura
+
+Compose che legge parquet puliti direttamente da GCS (repo `dataciviclab/eurostat`). Nessuna dipendenza da fonti live Eurostat.
+
+1. **Hub**: area_nuts3 (geo NUTS) × gdp_nuts3 (anni 2000-2024) → tutte le combinazioni EU-wide
+2. **4 CTE dominio**: GDP, GVA, employment, produttività
+3. **LEFT JOIN** su (geo, year)
+4. **WHERE** elimina righe senza alcun dato
+
+## Dataset sorgente su GCS
+
+```
+https://storage.googleapis.com/dataciviclab-clean/eurostat/{slug}/{slug}_2026_clean.parquet
+```
+
+## Qualità (run 2026-07-26)
+
+| Metrica | Valore |
+|---|---|
+| Righe clean EU | 41.709 |
+| Colonne | 26 |
+| GDP per capita non-NULL | 97.2% |
+| GVA totale non-NULL | 100% |
+| Employment non-NULL | 90.5% |
+| Produttività non-NULL | 90.5% |
+| IT NUTS3 coverage | 107/107 province (tutti gli anni) |
+
+## Filtro anti-NULL
+
+La SELECT finale include `WHERE gdp_per_capita IS NOT NULL OR gva_total_million IS NOT NULL OR employment_thousands IS NOT NULL` per eliminare righe (geo × year) senza dati economici.

--- a/compose/eurostat-economy/sql/clean.sql
+++ b/compose/eurostat-economy/sql/clean.sql
@@ -18,7 +18,11 @@ hub AS (
             'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
             union_by_name=true
         )
-        WHERE unit = 'KM2' AND landuse = 'TOTAL' AND year = 2024
+        WHERE unit = 'KM2' AND landuse = 'TOTAL'
+            AND year = (SELECT MAX(year) FROM read_parquet(
+                'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
+                union_by_name=true
+            ) WHERE unit = 'KM2' AND landuse = 'TOTAL')
             AND nuts_level IS NOT NULL
     ) g
     JOIN (

--- a/compose/eurostat-economy/sql/clean.sql
+++ b/compose/eurostat-economy/sql/clean.sql
@@ -4,34 +4,40 @@
 
 WITH
 
--- ── Hub: all (geo × year) combinations EU-wide ────────────────────
+-- ── Geo anchor: area_nuts3, anno piu' recente disponibile ────────
+area_data AS (
+    SELECT * FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE unit = 'KM2' AND landuse = 'TOTAL'
+),
+geo_anchor AS (
+    SELECT DISTINCT geo, geo_label_en, nuts_level,
+        nuts_parent_code, nuts_parent_label_en
+    FROM area_data
+    WHERE year = (SELECT MAX(year) FROM area_data)
+        AND nuts_level IS NOT NULL
+),
+
+-- ── Years: da GDP (copertura 2000-2024) ─────────────────────────
+years AS (
+    SELECT DISTINCT year FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_gdp_nuts3/eurostat_gdp_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE unit = 'EUR_HAB'
+),
+
+-- ── Hub: all (geo × year) combinations EU-wide ──────────────────
 hub AS (
     SELECT
         g.geo, g.geo_label_en, g.nuts_level,
         g.nuts_parent_code, g.nuts_parent_label_en,
         SUBSTRING(g.geo, 1, 2) AS country_code,
-        a.year
-    FROM (
-        SELECT DISTINCT geo, geo_label_en, nuts_level,
-            nuts_parent_code, nuts_parent_label_en
-        FROM read_parquet(
-            'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
-            union_by_name=true
-        )
-        WHERE unit = 'KM2' AND landuse = 'TOTAL'
-            AND year = (SELECT MAX(year) FROM read_parquet(
-                'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
-                union_by_name=true
-            ) WHERE unit = 'KM2' AND landuse = 'TOTAL')
-            AND nuts_level IS NOT NULL
-    ) g
-    JOIN (
-        SELECT DISTINCT year FROM read_parquet(
-            'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_gdp_nuts3/eurostat_gdp_nuts3_2026_clean.parquet',
-            union_by_name=true
-        )
-        WHERE unit = 'EUR_HAB'
-    ) a ON (1=1)
+        y.year
+    FROM geo_anchor g
+    CROSS JOIN years y
 ),
 
 -- 1. GDP: per capita, total, PPS

--- a/compose/eurostat-economy/sql/clean.sql
+++ b/compose/eurostat-economy/sql/clean.sql
@@ -1,0 +1,125 @@
+-- Clean: economy — GDP, GVA, employment, labour productivity by NUTS3
+-- Each row = (geo, year) with economic indicators
+-- Reads clean parquet from GCS via HTTPS (compose pattern)
+
+WITH
+
+-- ── Hub: all (geo × year) combinations EU-wide ────────────────────
+hub AS (
+    SELECT
+        g.geo, g.geo_label_en, g.nuts_level,
+        g.nuts_parent_code, g.nuts_parent_label_en,
+        SUBSTRING(g.geo, 1, 2) AS country_code,
+        a.year
+    FROM (
+        SELECT DISTINCT geo, geo_label_en, nuts_level,
+            nuts_parent_code, nuts_parent_label_en
+        FROM read_parquet(
+            'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
+            union_by_name=true
+        )
+        WHERE unit = 'KM2' AND landuse = 'TOTAL' AND year = 2024
+            AND nuts_level IS NOT NULL
+    ) g
+    JOIN (
+        SELECT DISTINCT year FROM read_parquet(
+            'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_gdp_nuts3/eurostat_gdp_nuts3_2026_clean.parquet',
+            union_by_name=true
+        )
+        WHERE unit = 'EUR_HAB'
+    ) a ON (1=1)
+),
+
+-- 1. GDP: per capita, total, PPS
+gdp AS (
+    SELECT geo, year,
+        MAX(CASE WHEN unit = 'EUR_HAB' THEN value END) AS gdp_per_capita,
+        MAX(CASE WHEN unit = 'MIO_EUR' THEN value END) AS gdp_million_eur,
+        MAX(CASE WHEN unit = 'PPS_EU27_2020_HAB' THEN value END) AS gdp_pps_hab
+    FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_gdp_nuts3/eurostat_gdp_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE unit IN ('EUR_HAB', 'MIO_EUR', 'PPS_EU27_2020_HAB')
+    GROUP BY geo, year
+),
+
+-- 2. GVA: Gross Value Added by sector (current prices, million EUR)
+gva AS (
+    SELECT geo, year,
+        SUM(CASE WHEN nace_r2 = 'TOTAL' THEN value END) AS gva_total_million,
+        SUM(CASE WHEN nace_r2 = 'B-E' THEN value END) AS gva_industry_million,
+        SUM(CASE WHEN nace_r2 = 'F' THEN value END) AS gva_construction_million,
+        SUM(CASE WHEN nace_r2 = 'G-I' THEN value END) AS gva_trade_million,
+        SUM(CASE WHEN nace_r2 = 'J' THEN value END) AS gva_ict_million,
+        SUM(CASE WHEN nace_r2 = 'K-N' THEN value END) AS gva_financial_services_million,
+        SUM(CASE WHEN nace_r2 = 'O-U' THEN value END) AS gva_public_admin_million
+    FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_gva_nuts3/eurostat_gva_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE unit = 'CP_MEUR' AND nace_r2 IN ('TOTAL', 'B-E', 'F', 'G-I', 'J', 'K-N', 'O-U')
+    GROUP BY geo, year
+),
+
+-- 3. Employment: total employed (thousands)
+emp AS (
+    SELECT geo, year,
+        SUM(value) AS employment_thousands
+    FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_emp_nuts3/eurostat_emp_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE unit = 'THS' AND wstatus = 'EMP' AND nace_r2 = 'TOTAL'
+    GROUP BY geo, year
+),
+
+-- 4. Labour productivity: nominal per employed (EUR)
+productivity AS (
+    SELECT geo, year,
+        AVG(value) AS nominal_labour_productivity_eur
+    FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_labour_productivity_nuts3/eurostat_labour_productivity_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE na_item = 'NLPR_PER' AND unit = 'EUR'
+    GROUP BY geo, year
+)
+
+-- ── Final SELECT ───────────────────────────────────────────────────
+SELECT
+    -- 🔑 Key
+    h.geo, h.year, h.nuts_level, h.country_code,
+    h.geo_label_en, h.nuts_parent_code, h.nuts_parent_label_en,
+
+    -- 💼 GDP
+    g.gdp_per_capita, g.gdp_million_eur, g.gdp_pps_hab,
+
+    -- 🏭 GVA by sector
+    va.gva_total_million,
+    va.gva_industry_million, va.gva_construction_million, va.gva_trade_million,
+    va.gva_ict_million, va.gva_financial_services_million, va.gva_public_admin_million,
+    ROUND(va.gva_industry_million / NULLIF(va.gva_total_million, 0) * 100, 1) AS gva_industry_pct,
+    ROUND(va.gva_construction_million / NULLIF(va.gva_total_million, 0) * 100, 1) AS gva_construction_pct,
+    ROUND(va.gva_trade_million / NULLIF(va.gva_total_million, 0) * 100, 1) AS gva_trade_pct,
+    ROUND(va.gva_ict_million / NULLIF(va.gva_total_million, 0) * 100, 1) AS gva_ict_pct,
+    ROUND(va.gva_financial_services_million / NULLIF(va.gva_total_million, 0) * 100, 1) AS gva_financial_services_pct,
+    ROUND(va.gva_public_admin_million / NULLIF(va.gva_total_million, 0) * 100, 1) AS gva_public_admin_pct,
+
+    -- 👷 Employment & productivity
+    e.employment_thousands,
+    p.nominal_labour_productivity_eur,
+    -- GDP per employed (efficiency proxy)
+    ROUND(g.gdp_million_eur * 1000 / NULLIF(e.employment_thousands, 0), 0) AS gdp_per_employed_eur
+
+FROM hub h
+LEFT JOIN gdp g ON h.geo = g.geo AND h.year = g.year
+LEFT JOIN gva va ON h.geo = va.geo AND h.year = va.year
+LEFT JOIN emp e ON h.geo = e.geo AND h.year = e.year
+LEFT JOIN productivity p ON h.geo = p.geo AND h.year = p.year
+-- Keep only rows with at least one real data point (no all-NULL rows)
+WHERE g.gdp_per_capita IS NOT NULL
+   OR g.gdp_million_eur IS NOT NULL
+   OR va.gva_total_million IS NOT NULL
+   OR e.employment_thousands IS NOT NULL
+ORDER BY h.country_code, h.nuts_level, h.geo, h.year

--- a/compose/eurostat-economy/sql/mart_it_nuts3.sql
+++ b/compose/eurostat-economy/sql/mart_it_nuts3.sql
@@ -1,0 +1,23 @@
+-- Mart IT NUTS3: Italian provinces, full economic profile
+SELECT
+    geo, year, country_code, geo_label_en,
+    nuts_parent_code, nuts_parent_label_en,
+
+    -- GDP
+    gdp_per_capita, gdp_million_eur, gdp_pps_hab,
+
+    -- GVA by sector
+    gva_total_million,
+    gva_industry_million, gva_construction_million, gva_trade_million,
+    gva_ict_million, gva_financial_services_million, gva_public_admin_million,
+    gva_industry_pct, gva_construction_pct, gva_trade_pct,
+    gva_ict_pct, gva_financial_services_pct, gva_public_admin_pct,
+
+    -- Employment
+    employment_thousands, nominal_labour_productivity_eur,
+    gdp_per_employed_eur
+
+FROM clean_input
+WHERE country_code = 'IT' AND nuts_level = 'NUTS3'
+  -- Keep rows with at least one economic indicator
+  AND (gdp_per_capita IS NOT NULL OR employment_thousands IS NOT NULL)

--- a/compose/eurostat-territory/README.md
+++ b/compose/eurostat-territory/README.md
@@ -1,0 +1,39 @@
+# Eurostat Territory (compose)
+
+**Dataset**: `eurostat_territory`
+**Tipo**: compose — unisce 4 dataset Eurostat NUTS3 in una vista territoriale
+
+## Cos'è
+
+Vista unificata degli indicatori territoriali regionali europei: superficie, turismo, criminalità, incidenti stradali. Ogni riga = (geo, year) con 11 colonne.
+
+**Copertura**: 2000-2024, paesi EU/EEA con dati disponibili, tutti i livelli NUTS (0-3).
+
+## Schema (11 colonne)
+
+| Gruppo | Colonne |
+|---|---|
+| Chiave | `geo`, `year`, `nuts_level`, `country_code`, `geo_label_en` |
+| Territorio | `area_km2` |
+| Turismo | `total_nights_spent` |
+| Criminalità | `total_crimes` |
+| Trasporti | `road_accidents` |
+
+## Dataset sorgente
+
+| Dataset | Dataflow | Ruolo |
+|---|---|---|
+| `eurostat_area_nuts3` | REG_AREA3 | Superficie territoriale (km²) |
+| `eurostat_tourism_nuts3` | TOUR_OCC_NIN2 | Pernottamenti turistici |
+| `eurostat_crime_nuts3` | CRIM_GEN_REG | Reati registrati |
+| `eurostat_tran_sf_roadnu` | TRAN_SF_ROADNU | Incidenti stradali |
+
+## Mart
+
+| Mart | Filtro | Righe stimate |
+|---|---|---|
+| `mart_it_nuts3` | IT NUTS3 (107 province) | ~2.675 |
+
+## Limitazioni note
+
+- I dataset hanno copertura EU parziale: area_km2 disponibile dal 2013, turismo non copre tutte le regioni, criminalità non UE-wide

--- a/compose/eurostat-territory/dataset.yml
+++ b/compose/eurostat-territory/dataset.yml
@@ -2,7 +2,7 @@ root: "../../out"
 schema_version: 1
 
 dataset:
-  name: "territory"
+  name: "eurostat_territory"
   source_id: "eurostat"
   years: [2026]
 

--- a/compose/eurostat-territory/dataset.yml
+++ b/compose/eurostat-territory/dataset.yml
@@ -1,0 +1,38 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "territory"
+  source_id: "eurostat"
+  years: [2026]
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "eurostat_area_nuts3"
+      type: "http_file"
+      args:
+        url: "https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet"
+        filename: "hub.parquet"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: "auto"
+    mode: "latest"
+  validate:
+    min_rows: 10000
+    promotion:
+      max_row_drop_pct: 100
+
+mart:
+  tables:
+    - name: "mart_it_nuts3"
+      sql: "sql/mart_it_nuts3.sql"
+  validate:
+    table_rules:
+      mart_it_nuts3: { min_rows: 100 }
+
+validation:
+  fail_on_error: true

--- a/compose/eurostat-territory/dataset.yml
+++ b/compose/eurostat-territory/dataset.yml
@@ -5,6 +5,10 @@ dataset:
   name: "eurostat_territory"
   source_id: "eurostat"
   years: [2026]
+  time_coverage:
+    mode: full_series
+    start_year: 2000
+    end_year: 2024
 
 raw:
   output_policy: overwrite

--- a/compose/eurostat-territory/notes.md
+++ b/compose/eurostat-territory/notes.md
@@ -1,0 +1,32 @@
+# Note tecniche — eurostat-territory
+
+## Architettura
+
+Compose che legge parquet puliti direttamente da GCS.
+
+1. **Hub**: area_nuts3 × gdp_nuts3 (anni 2000-2024)
+2. **4 CTE dominio**: superficie, turismo, criminalità, incidenti
+3. **LEFT JOIN** su (geo, year)
+4. **WHERE** elimina righe senza alcun dato
+
+## Qualità (run 2026-07-26)
+
+| Metrica | Valore |
+|---|---|
+| Righe clean EU | 30.495 |
+| Colonne | 11 |
+| Area non-NULL | 61.8% |
+| Pernottamenti non-NULL | 47.3% |
+| Reati non-NULL | 73.7% |
+| Incidenti non-NULL | 61.3% |
+| IT NUTS3 coverage | 107/107 province |
+
+## Copertura parziale
+
+I dataset territoriali Eurostat hanno copertura non uniforme:
+- **area_km2**: disponibile da 2013 (prima solo stime), per questo 38% NULL su periodo 2000-2024
+- **tourism**: paesi extra-UE spesso non coperti, e regioni non turistiche hanno dati zero/non disponibili
+- **crime**: non tutti i paesi EU trasmettono dati criminalità a Eurostat
+- **road accidents**: coverage simile a crime, paesi EU mediterranei hanno dati più recenti
+
+I NULL sono gestiti dal LEFT JOIN — indicano "dato non disponibile per questa regione/anno", non un errore.

--- a/compose/eurostat-territory/sql/clean.sql
+++ b/compose/eurostat-territory/sql/clean.sql
@@ -18,7 +18,11 @@ hub AS (
             'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
             union_by_name=true
         )
-        WHERE unit = 'KM2' AND landuse = 'TOTAL' AND year = 2024
+        WHERE unit = 'KM2' AND landuse = 'TOTAL'
+            AND year = (SELECT MAX(year) FROM read_parquet(
+                'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
+                union_by_name=true
+            ) WHERE unit = 'KM2' AND landuse = 'TOTAL')
             AND nuts_level IS NOT NULL
     ) g
     JOIN (

--- a/compose/eurostat-territory/sql/clean.sql
+++ b/compose/eurostat-territory/sql/clean.sql
@@ -1,0 +1,109 @@
+-- Clean: territory — area, tourism, crime, road accidents by NUTS3
+-- Each row = (geo, year) with territorial indicators
+-- Reads clean parquet from GCS via HTTPS (compose pattern)
+
+WITH
+
+-- ── Hub: all (geo × year) combinations EU-wide ────────────────────
+hub AS (
+    SELECT
+        g.geo, g.geo_label_en, g.nuts_level,
+        g.nuts_parent_code, g.nuts_parent_label_en,
+        SUBSTRING(g.geo, 1, 2) AS country_code,
+        a.year
+    FROM (
+        SELECT DISTINCT geo, geo_label_en, nuts_level,
+            nuts_parent_code, nuts_parent_label_en
+        FROM read_parquet(
+            'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
+            union_by_name=true
+        )
+        WHERE unit = 'KM2' AND landuse = 'TOTAL' AND year = 2024
+            AND nuts_level IS NOT NULL
+    ) g
+    JOIN (
+        SELECT DISTINCT year FROM read_parquet(
+            'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_gdp_nuts3/eurostat_gdp_nuts3_2026_clean.parquet',
+            union_by_name=true
+        )
+        WHERE unit = 'EUR_HAB'
+    ) a ON (1=1)
+),
+
+-- 1. Land area (km²)
+land_area AS (
+    SELECT geo, year,
+        AVG(value) AS area_km2
+    FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE unit = 'KM2' AND landuse = 'TOTAL'
+    GROUP BY geo, year
+),
+
+-- 2. Tourism: total nights spent
+tourism AS (
+    SELECT geo, year,
+        SUM(value) AS total_nights_spent
+    FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_tourism_nuts3/eurostat_tourism_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE c_resid = 'TOTAL' AND nace_r2 = 'I551-I553' AND unit = 'NR'
+    GROUP BY geo, year
+),
+
+-- 3. Crime: total recorded offences
+crime AS (
+    SELECT geo, year,
+        SUM(value) AS total_crimes
+    FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_crime_nuts3/eurostat_crime_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE unit = 'NR'
+    GROUP BY geo, year
+),
+
+-- 4. Road accidents
+accidents AS (
+    SELECT geo, year,
+        SUM(value) AS road_accidents
+    FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_tran_sf_roadnu/eurostat_tran_sf_roadnu_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE unit = 'NR'
+    GROUP BY geo, year
+)
+
+-- ── Final SELECT ───────────────────────────────────────────────────
+SELECT
+    -- 🔑 Key
+    h.geo, h.year, h.nuts_level, h.country_code,
+    h.geo_label_en, h.nuts_parent_code, h.nuts_parent_label_en,
+
+    -- 📍 Land area
+    la.area_km2,
+
+    -- 🏨 Tourism
+    t.total_nights_spent,
+
+    -- 🚓 Crime
+    cr.total_crimes,
+
+    -- 🚗 Road accidents
+    a.road_accidents
+
+FROM hub h
+LEFT JOIN land_area la ON h.geo = la.geo AND h.year = la.year
+LEFT JOIN tourism t ON h.geo = t.geo AND h.year = t.year
+LEFT JOIN crime cr ON h.geo = cr.geo AND h.year = cr.year
+LEFT JOIN accidents a ON h.geo = a.geo AND h.year = a.year
+-- Keep only rows with at least one real data point
+WHERE la.area_km2 IS NOT NULL
+   OR t.total_nights_spent IS NOT NULL
+   OR cr.total_crimes IS NOT NULL
+   OR a.road_accidents IS NOT NULL
+ORDER BY h.country_code, h.nuts_level, h.geo, h.year

--- a/compose/eurostat-territory/sql/clean.sql
+++ b/compose/eurostat-territory/sql/clean.sql
@@ -4,34 +4,40 @@
 
 WITH
 
--- ── Hub: all (geo × year) combinations EU-wide ────────────────────
+-- ── Geo anchor: area_nuts3, anno piu' recente disponibile ────────
+area_data AS (
+    SELECT * FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE unit = 'KM2' AND landuse = 'TOTAL'
+),
+geo_anchor AS (
+    SELECT DISTINCT geo, geo_label_en, nuts_level,
+        nuts_parent_code, nuts_parent_label_en
+    FROM area_data
+    WHERE year = (SELECT MAX(year) FROM area_data)
+        AND nuts_level IS NOT NULL
+),
+
+-- ── Years: da GDP (copertura 2000-2024) ─────────────────────────
+years AS (
+    SELECT DISTINCT year FROM read_parquet(
+        'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_gdp_nuts3/eurostat_gdp_nuts3_2026_clean.parquet',
+        union_by_name=true
+    )
+    WHERE unit = 'EUR_HAB'
+),
+
+-- ── Hub: all (geo × year) combinations EU-wide ──────────────────
 hub AS (
     SELECT
         g.geo, g.geo_label_en, g.nuts_level,
         g.nuts_parent_code, g.nuts_parent_label_en,
         SUBSTRING(g.geo, 1, 2) AS country_code,
-        a.year
-    FROM (
-        SELECT DISTINCT geo, geo_label_en, nuts_level,
-            nuts_parent_code, nuts_parent_label_en
-        FROM read_parquet(
-            'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
-            union_by_name=true
-        )
-        WHERE unit = 'KM2' AND landuse = 'TOTAL'
-            AND year = (SELECT MAX(year) FROM read_parquet(
-                'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_area_nuts3/eurostat_area_nuts3_2026_clean.parquet',
-                union_by_name=true
-            ) WHERE unit = 'KM2' AND landuse = 'TOTAL')
-            AND nuts_level IS NOT NULL
-    ) g
-    JOIN (
-        SELECT DISTINCT year FROM read_parquet(
-            'https://storage.googleapis.com/dataciviclab-clean/eurostat/eurostat_gdp_nuts3/eurostat_gdp_nuts3_2026_clean.parquet',
-            union_by_name=true
-        )
-        WHERE unit = 'EUR_HAB'
-    ) a ON (1=1)
+        y.year
+    FROM geo_anchor g
+    CROSS JOIN years y
 ),
 
 -- 1. Land area (km²)

--- a/compose/eurostat-territory/sql/mart_it_nuts3.sql
+++ b/compose/eurostat-territory/sql/mart_it_nuts3.sql
@@ -1,0 +1,11 @@
+-- Mart IT NUTS3: Italian provinces, territorial profile
+SELECT
+    geo, year, country_code, geo_label_en,
+    nuts_parent_code, nuts_parent_label_en,
+    area_km2,
+    total_nights_spent,
+    total_crimes,
+    road_accidents
+FROM clean_input
+WHERE country_code = 'IT' AND nuts_level = 'NUTS3'
+  AND (total_nights_spent IS NOT NULL OR total_crimes IS NOT NULL OR road_accidents IS NOT NULL)


### PR DESCRIPTION
## Sintesi

Tre compose table che unificano i dataset Eurostat NUTS3 in tabelle pronte per analisi cross-dominio. Ogni compose legge i parquet puliti direttamente da GCS (repo `dataciviclab/eurostat`).

| Compose | Dataset | Righe EU | Colonne | Indicatori |
|---|---|---|---|---|
| `eurostat-economy` | GDP, GVA (7 settori), employment, produttività | 41.709 | 26 | PIL pro-capite, GVA per settore, occupati, produttività |
| `eurostat-demography` | Popolazione, densità, struttura età, bilancio demografico | 20.949 | 18 | Pop, densità, dipendenza anziani, saldo naturale/migratorio |
| `eurostat-territory` | Superficie, turismo, criminalità, incidenti stradali | 30.495 | 11 | Area, pernottamenti, reati, incidenti |

## Cosa cambia

- [x] nuovo compose

## Verifica

Ciascun compose passa `toolkit run full`:

```bash
toolkit run full --config compose/eurostat-economy/dataset.yml --years 2026  # 41.709 righe, 26 colonne
toolkit run full --config compose/eurostat-demography/dataset.yml --years 2026  # 20.949 righe, 18 colonne
toolkit run full --config compose/eurostat-territory/dataset.yml --years 2026  # 30.495 righe, 11 colonne
```

## Impatto

- [x] Nessun impatto visibile per chi usa il repository — nuovi compose, non modificano candidate esistenti

## Note

- Ogni compose ha un mart `mart_it_nuts3` che filtra Italia NUTS3 (province)
- Colonne in inglese (coerente con repo eurostat)
- `median_age` e `over65_pct` 100% NULL per IT NUTS3 (limitazione Eurostat — documentato in notes.md)
- Legge parquet da GCS (`https://storage.googleapis.com/dataciviclab-clean/eurostat/...`) — nessuna riscrittura dei dataset sorgente

## Cross-analisi esempio (dati reali)

Dai compose emerge:

| Indicatore | Valore |
|---|---|
| Nord-Est PIL pro-capite | 38.623€ |
| Sud PIL pro-capite | 22.783€ (56% del NE) |
| Milano reati per milione notti turistiche | 10.674 |
| Bolzano reati per milione notti turistiche | 247 |
| Italia dipendenza anziani | 39% (1ª in EU) |
| Italia giovani under 14 | 12% (ultima in EU) |