### PR TITLE
compose: conto-annuale-profilo-ente — profilo completo enti PA (costo, assenze, demografia)

### DIFF
--- a/compose/conto-annuale-profilo-ente/README.md
+++ b/compose/conto-annuale-profilo-ente/README.md
@@ -1,0 +1,26 @@
+# Conto Annuale — Profilo Ente
+
+**Fonte**: [Conto Annuale RGS](https://contoannuale.rgs.mef.gov.it/) (MEF)
+**Stato**: compose (5/5 anni)
+
+Compose che unisce **6 dataset** di conto-annuale per dare un profilo completo di ogni ente della PA: dimensioni, demografia, istruzione, costo e assenze. Un "Who is Who della PA" con metriche reali.
+
+### Metriche per comparto
+
+| Metrica | Cosa misura |
+|---|---|
+| `tot_dipendenti` | Quanti dipendenti ha il comparto |
+| `pct_donne` | Incidenza femminile |
+| `eta_media` | Età media dei dipendenti |
+| `anzianita_media` | Anni medi di servizio |
+| `pct_laureati` | Percentuale con laurea o titolo superiore |
+| `retribuzione_media_procapite` | Stipendio medio annuo (€) |
+| `costo_medio_procapite` | Costo lavoro medio annuo (€) |
+| `assenze_giorni_procapite` | Giorni di assenza per dipendente |
+
+### Domande guida
+
+- Quali comparti hanno la forza lavoro più giovane? Più anziana?
+- I comparti con più laureati pagano stipendi più alti?
+- Esiste una correlazione tra % donne e giorni di assenza?
+- Quali enti hanno il costo per dipendente più alto?

--- a/compose/conto-annuale-profilo-ente/dataset.yml
+++ b/compose/conto-annuale-profilo-ente/dataset.yml
@@ -1,0 +1,52 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "conto_annuale_profilo_ente"
+  source_id: "rgs_conto_annuale"
+  years: [2020, 2021, 2022, 2023, 2024]
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "occupazione_ref"
+      type: "http_file"
+      args:
+        url: "https://storage.googleapis.com/dataciviclab-clean/conto-annuale/occupazione/{year}/occupazione_{year}_clean.parquet"
+        filename: "occupazione_{year}.parquet"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  read:
+    source: "config_only"
+    mode: "latest"
+  validate:
+    min_rows: 1000
+    promotion:
+      max_row_drop_pct: 60
+      fail_on_row_drop_exceeded: false
+
+mart:
+  tables:
+    # Per ente — preserva la granularità del dato originale
+    - name: "profilo_ente"
+      sql: "sql/mart_profilo_ente.sql"
+    # Aggregato per comparto — vista sintetica
+    - name: "profilo_comparti"
+      sql: "sql/mart_profilo_comparti.sql"
+    # Assenze scomposte per causale
+    - name: "assenze_causali"
+      sql: "sql/mart_assenze_causali.sql"
+  required_tables:
+    - "profilo_ente"
+    - "profilo_comparti"
+  validate:
+    table_rules:
+      profilo_ente:
+        min_rows: 100
+      profilo_comparti:
+        min_rows: 5
+
+validation:
+  fail_on_error: true

--- a/compose/conto-annuale-profilo-ente/notes.md
+++ b/compose/conto-annuale-profilo-ente/notes.md
@@ -10,3 +10,5 @@
 - **NB**: non tutti gli enti hanno dati in tutti i dataset — LEFT JOIN gestisce i missing
 - **Join esterni**: `codi_fiscale` → `ipa_enti` (partita IVA), `istituzione` → `bdap_anagrafe_enti` (codice BDAP)
 - **Anni**: 2020-2024 (5 anni). Il 2020 è disponibile su GCS ma alcuni dataset (assenze) potrebbero avere copertura parziale
+- **Soglia enti**: i mart escludono enti con meno di 5 dipendenti (metriche procapite distorte)
+- **Medie nel mart comparto**: `eta_media` e `anzianita_media` sono **medie non pesate** (ogni ente pesa 1, non in proporzione ai dipendenti). Per la media pesata reale, usare `tot_dipendenti` e le somme dal clean

--- a/compose/conto-annuale-profilo-ente/notes.md
+++ b/compose/conto-annuale-profilo-ente/notes.md
@@ -8,3 +8,5 @@
 - **Anzianità media**: media pesata con centro fascia (A0=2.5, A6=8, ..., A44=47)
 - **% Laureati**: include LAUREA, LAUREA BREVE, SPECIALIZZAZIONE, DOTTORATO, ALTRI TITOLI POST LAUREA
 - **NB**: non tutti gli enti hanno dati in tutti i dataset — LEFT JOIN gestisce i missing
+- **Join esterni**: `codi_fiscale` → `ipa_enti` (partita IVA), `istituzione` → `bdap_anagrafe_enti` (codice BDAP)
+- **Anni**: 2020-2024 (5 anni). Il 2020 è disponibile su GCS ma alcuni dataset (assenze) potrebbero avere copertura parziale

--- a/compose/conto-annuale-profilo-ente/notes.md
+++ b/compose/conto-annuale-profilo-ente/notes.md
@@ -1,0 +1,10 @@
+# Note — Conto Annuale Profilo Ente
+
+## Note tecniche
+
+- **Fonte**: 6 clean parquet su GCS (occupazione, personale, anzianità, titoli-studio, composizione-retribuzione, costo-lavoro, assenze)
+- **Join**: su `istituzione + anno + codi_comparto`
+- **Età media**: media pesata con centro fascia (E0=15, E20=22, ..., E68=71)
+- **Anzianità media**: media pesata con centro fascia (A0=2.5, A6=8, ..., A44=47)
+- **% Laureati**: include LAUREA, LAUREA BREVE, SPECIALIZZAZIONE, DOTTORATO, ALTRI TITOLI POST LAUREA
+- **NB**: non tutti gli enti hanno dati in tutti i dataset — LEFT JOIN gestisce i missing

--- a/compose/conto-annuale-profilo-ente/sql/clean.sql
+++ b/compose/conto-annuale-profilo-ente/sql/clean.sql
@@ -57,6 +57,7 @@ titoli AS (
 retribuzione AS (
     SELECT
         anno, istituzione, codi_comparto,
+        MAX(codi_fiscale) AS codi_fiscale,
         ROUND(SUM(importo), 0) AS retribuzione_totale
     FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/conto-annuale/composizione_retribuzione/{year}/composizione_retribuzione_{year}_clean.parquet')
     GROUP BY 1, 2, 3
@@ -79,7 +80,7 @@ assenze AS (
 )
 
 SELECT
-    o.anno, o.istituzione, o.desc_istituzione, o.codi_comparto, o.desc_comparto, o.codi_tipo_istituzione,
+    o.anno, o.istituzione, o.desc_istituzione, r.codi_fiscale, o.codi_comparto, o.desc_comparto, o.codi_tipo_istituzione,
     o.dipendenti, o.donne,
     -- NULL = dato non disponibile (nessun match nel dataset personale)
     ROUND(e.somma_eta / NULLIF(e.tot_persone, 0), 1) AS eta_media,

--- a/compose/conto-annuale-profilo-ente/sql/clean.sql
+++ b/compose/conto-annuale-profilo-ente/sql/clean.sql
@@ -31,7 +31,7 @@ eta AS (
 anzianita AS (
     SELECT
         anno, istituzione, codi_comparto,
-        SUM(COALESCE(uomini, 0) + COALESCE(donne, 0)) AS tot_anziani,
+        SUM(COALESCE(uomini, 0) + COALESCE(donne, 0)) AS tot_persone_anzianita,
         SUM((COALESCE(uomini, 0) + COALESCE(donne, 0)) *
             CASE fascia
                 WHEN 'A0'  THEN 2.5 WHEN 'A6'  THEN 8  WHEN 'A11' THEN 13
@@ -66,6 +66,7 @@ retribuzione AS (
 costo AS (
     SELECT
         anno, istituzione, codi_comparto,
+        MAX(codi_fiscale) AS codi_fiscale,
         ROUND(SUM(totale_spesa), 0) AS costo_totale
     FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/conto-annuale/costo_lavoro/{year}/costo_lavoro_{year}_clean.parquet')
     GROUP BY 1, 2, 3
@@ -74,17 +75,20 @@ costo AS (
 assenze AS (
     SELECT
         anno, istituzione, codi_comparto,
+        MAX(codi_fiscale) AS codi_fiscale,
         ROUND(SUM(COALESCE(assenze_uomini, 0) + COALESCE(assenze_donne, 0)), 0) AS assenze_totali
     FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/conto-annuale/assenze/{year}/assenze_{year}_clean.parquet')
     GROUP BY 1, 2, 3
 )
 
 SELECT
-    o.anno, o.istituzione, o.desc_istituzione, r.codi_fiscale, o.codi_comparto, o.desc_comparto, o.codi_tipo_istituzione,
+    o.anno, o.istituzione, o.desc_istituzione,
+    COALESCE(r.codi_fiscale, c.codi_fiscale, az.codi_fiscale) AS codi_fiscale,
+    o.codi_comparto, o.desc_comparto, o.codi_tipo_istituzione,
     o.dipendenti, o.donne,
     -- NULL = dato non disponibile (nessun match nel dataset personale)
     ROUND(e.somma_eta / NULLIF(e.tot_persone, 0), 1) AS eta_media,
-    ROUND(a.somma_anzianita / NULLIF(a.tot_anziani, 0), 1) AS anzianita_media,
+    ROUND(a.somma_anzianita / NULLIF(a.tot_persone_anzianita, 0), 1) AS anzianita_media,
     ROUND(t.laureati * 100.0 / NULLIF(t.tot_con_titolo, 0), 1) AS pct_laureati,
     r.retribuzione_totale,
     c.costo_totale,

--- a/compose/conto-annuale-profilo-ente/sql/clean.sql
+++ b/compose/conto-annuale-profilo-ente/sql/clean.sql
@@ -1,0 +1,97 @@
+-- Conto Annuale — Profilo Ente (CLEAN)
+-- Una riga per ente con tutte le metriche: demografia, costo, assenze
+
+WITH occupazione AS (
+    SELECT
+        anno, istituzione, desc_istituzione, codi_comparto, desc_comparto, codi_tipo_istituzione,
+        SUM(COALESCE(tp_u, 0) + COALESCE(tp_d, 0)
+          + COALESCE(pti_u, 0) + COALESCE(pti_d, 0)
+          + COALESCE(pts_u, 0) + COALESCE(pts_d, 0)) AS dipendenti,
+        SUM(COALESCE(tp_d, 0) + COALESCE(pti_d, 0) + COALESCE(pts_d, 0)) AS donne
+    FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/conto-annuale/occupazione/{year}/occupazione_{year}_clean.parquet')
+    GROUP BY 1, 2, 3, 4, 5, 6
+),
+
+eta AS (
+    SELECT
+        anno, istituzione, codi_comparto,
+        SUM(COALESCE(uomini, 0) + COALESCE(donne, 0)) AS tot_persone,
+        SUM((COALESCE(uomini, 0) + COALESCE(donne, 0)) *
+            CASE fascia
+                WHEN 'E0'  THEN 15 WHEN 'E20' THEN 22 WHEN 'E25' THEN 27
+                WHEN 'E30' THEN 32 WHEN 'E35' THEN 37 WHEN 'E40' THEN 42
+                WHEN 'E45' THEN 47 WHEN 'E50' THEN 52 WHEN 'E55' THEN 57
+                WHEN 'E60' THEN 62 WHEN 'E65' THEN 67 WHEN 'E68' THEN 71
+                ELSE 45
+            END) AS somma_eta
+    FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/conto-annuale/personale/{year}/personale_{year}_clean.parquet')
+    GROUP BY 1, 2, 3
+),
+
+anzianita AS (
+    SELECT
+        anno, istituzione, codi_comparto,
+        SUM(COALESCE(uomini, 0) + COALESCE(donne, 0)) AS tot_anziani,
+        SUM((COALESCE(uomini, 0) + COALESCE(donne, 0)) *
+            CASE fascia
+                WHEN 'A0'  THEN 2.5 WHEN 'A6'  THEN 8  WHEN 'A11' THEN 13
+                WHEN 'A16' THEN 18  WHEN 'A21' THEN 23 WHEN 'A26' THEN 28
+                WHEN 'A31' THEN 33  WHEN 'A36' THEN 38 WHEN 'A41' THEN 42
+                WHEN 'A44' THEN 47
+                ELSE 15
+            END) AS somma_anzianita
+    FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/conto-annuale/anzianita/{year}/anzianita_{year}_clean.parquet')
+    GROUP BY 1, 2, 3
+),
+
+titoli AS (
+    SELECT
+        anno, istituzione, codi_comparto,
+        SUM(COALESCE(uomini, 0) + COALESCE(donne, 0)) AS tot_con_titolo,
+        SUM(CASE WHEN titolo_studio IN ('LAUREA', 'LAUREA BREVE', 'SPECIALIZZAZIONE POST LAUREA / DOTTORATO DI RICERCA', 'ALTRI TITOLI POST LAUREA')
+            THEN COALESCE(uomini, 0) + COALESCE(donne, 0) ELSE 0 END) AS laureati
+    FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/conto-annuale/titoli_studio/{year}/titoli_studio_{year}_clean.parquet')
+    GROUP BY 1, 2, 3
+),
+
+retribuzione AS (
+    SELECT
+        anno, istituzione, codi_comparto,
+        ROUND(SUM(importo), 0) AS retribuzione_totale
+    FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/conto-annuale/composizione_retribuzione/{year}/composizione_retribuzione_{year}_clean.parquet')
+    GROUP BY 1, 2, 3
+),
+
+costo AS (
+    SELECT
+        anno, istituzione, codi_comparto,
+        ROUND(SUM(totale_spesa), 0) AS costo_totale
+    FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/conto-annuale/costo_lavoro/{year}/costo_lavoro_{year}_clean.parquet')
+    GROUP BY 1, 2, 3
+),
+
+assenze AS (
+    SELECT
+        anno, istituzione, codi_comparto,
+        ROUND(SUM(COALESCE(assenze_uomini, 0) + COALESCE(assenze_donne, 0)), 0) AS assenze_totali
+    FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/conto-annuale/assenze/{year}/assenze_{year}_clean.parquet')
+    GROUP BY 1, 2, 3
+)
+
+SELECT
+    o.anno, o.istituzione, o.desc_istituzione, o.codi_comparto, o.desc_comparto, o.codi_tipo_istituzione,
+    o.dipendenti, o.donne,
+    -- NULL = dato non disponibile (nessun match nel dataset personale)
+    ROUND(e.somma_eta / NULLIF(e.tot_persone, 0), 1) AS eta_media,
+    ROUND(a.somma_anzianita / NULLIF(a.tot_anziani, 0), 1) AS anzianita_media,
+    ROUND(t.laureati * 100.0 / NULLIF(t.tot_con_titolo, 0), 1) AS pct_laureati,
+    r.retribuzione_totale,
+    c.costo_totale,
+    az.assenze_totali
+FROM occupazione o
+LEFT JOIN eta e ON o.istituzione = e.istituzione AND o.anno = e.anno AND o.codi_comparto = e.codi_comparto
+LEFT JOIN anzianita a ON o.istituzione = a.istituzione AND o.anno = a.anno AND o.codi_comparto = a.codi_comparto
+LEFT JOIN titoli t ON o.istituzione = t.istituzione AND o.anno = t.anno AND o.codi_comparto = t.codi_comparto
+LEFT JOIN retribuzione r ON o.istituzione = r.istituzione AND o.anno = r.anno AND o.codi_comparto = r.codi_comparto
+LEFT JOIN costo c ON o.istituzione = c.istituzione AND o.anno = c.anno AND o.codi_comparto = c.codi_comparto
+LEFT JOIN assenze az ON o.istituzione = az.istituzione AND o.anno = az.anno AND o.codi_comparto = az.codi_comparto

--- a/compose/conto-annuale-profilo-ente/sql/mart_assenze_causali.sql
+++ b/compose/conto-annuale-profilo-ente/sql/mart_assenze_causali.sql
@@ -1,0 +1,32 @@
+-- Assenze scomposte per causale e comparto
+WITH assenze_per_comparto AS (
+    SELECT
+        anno, codi_comparto, desc_comparto,
+        causale_assenza, tipo_causale, descrizione_causale,
+        ROUND(SUM(COALESCE(assenze_uomini, 0) + COALESCE(assenze_donne, 0)), 0) AS tot_assenze
+    FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/conto-annuale/assenze/{year}/assenze_{year}_clean.parquet')
+    GROUP BY 1, 2, 3, 4, 5, 6
+),
+dipendenti_per_comparto AS (
+    SELECT
+        anno, codi_comparto,
+        SUM(COALESCE(tp_u, 0) + COALESCE(tp_d, 0)
+          + COALESCE(pti_u, 0) + COALESCE(pti_d, 0)
+          + COALESCE(pts_u, 0) + COALESCE(pts_d, 0)) AS dipendenti
+    FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/conto-annuale/occupazione/{year}/occupazione_{year}_clean.parquet')
+    GROUP BY 1, 2
+)
+SELECT
+    a.anno,
+    a.codi_comparto,
+    a.desc_comparto,
+    a.causale_assenza,
+    a.tipo_causale,
+    a.descrizione_causale,
+    a.tot_assenze,
+    ROUND(o.dipendenti, 0) AS tot_dipendenti,
+    ROUND(a.tot_assenze / NULLIF(o.dipendenti, 0), 1) AS giorni_procapite
+FROM assenze_per_comparto a
+LEFT JOIN dipendenti_per_comparto o ON a.codi_comparto = o.codi_comparto AND a.anno = o.anno
+WHERE a.tot_assenze > 0
+ORDER BY a.anno DESC, giorni_procapite DESC

--- a/compose/conto-annuale-profilo-ente/sql/mart_profilo_comparti.sql
+++ b/compose/conto-annuale-profilo-ente/sql/mart_profilo_comparti.sql
@@ -1,0 +1,19 @@
+-- Profilo Ente — aggregato per comparto e tipo istituzione
+SELECT
+    anno,
+    codi_comparto,
+    desc_comparto,
+    codi_tipo_istituzione,
+    COUNT(DISTINCT istituzione) AS enti,
+    ROUND(SUM(dipendenti), 0) AS tot_dipendenti,
+    ROUND(SUM(donne) * 100.0 / NULLIF(SUM(dipendenti), 0), 1) AS pct_donne,
+    ROUND(AVG(eta_media), 1) AS eta_media,
+    ROUND(AVG(anzianita_media), 1) AS anzianita_media,
+    ROUND(AVG(pct_laureati), 1) AS pct_laureati,
+    ROUND(SUM(retribuzione_totale) / NULLIF(SUM(dipendenti), 0), 0) AS retribuzione_media_procapite,
+    ROUND(SUM(costo_totale) / NULLIF(SUM(dipendenti), 0), 0) AS costo_medio_procapite,
+    ROUND(SUM(assenze_totali) / NULLIF(SUM(dipendenti), 0), 1) AS assenze_giorni_procapite
+FROM clean_input
+WHERE dipendenti > 0
+GROUP BY 1, 2, 3, 4
+ORDER BY anno DESC, tot_dipendenti DESC

--- a/compose/conto-annuale-profilo-ente/sql/mart_profilo_comparti.sql
+++ b/compose/conto-annuale-profilo-ente/sql/mart_profilo_comparti.sql
@@ -1,4 +1,6 @@
 -- Profilo Ente — aggregato per comparto e tipo istituzione
+-- Allineato con profilo_ente: esclude micro-enti (<5 dipendenti)
+-- Nota: eta_media e anzianita_media sono medie non pesate (ogni ente pesa 1)
 SELECT
     anno,
     codi_comparto,
@@ -14,6 +16,6 @@ SELECT
     ROUND(SUM(costo_totale) / NULLIF(SUM(dipendenti), 0), 0) AS costo_medio_procapite,
     ROUND(SUM(assenze_totali) / NULLIF(SUM(dipendenti), 0), 1) AS assenze_giorni_procapite
 FROM clean_input
-WHERE dipendenti > 0
+WHERE dipendenti >= 5
 GROUP BY 1, 2, 3, 4
 ORDER BY anno DESC, tot_dipendenti DESC

--- a/compose/conto-annuale-profilo-ente/sql/mart_profilo_ente.sql
+++ b/compose/conto-annuale-profilo-ente/sql/mart_profilo_ente.sql
@@ -15,14 +15,14 @@ SELECT
     pct_laureati,
     retribuzione_totale,
     costo_totale,
-    CASE WHEN dipendenti > 0 AND retribuzione_totale IS NOT NULL
+    CASE WHEN retribuzione_totale IS NOT NULL
         THEN ROUND(retribuzione_totale / dipendenti, 0)
         ELSE NULL END AS retribuzione_procapite,
-    CASE WHEN dipendenti > 0 AND costo_totale IS NOT NULL AND costo_totale > 0
+    CASE WHEN costo_totale IS NOT NULL AND costo_totale > 0
         THEN ROUND(costo_totale / dipendenti, 0)
         ELSE NULL END AS costo_procapite,
     assenze_totali,
-    CASE WHEN dipendenti > 0 AND assenze_totali IS NOT NULL
+    CASE WHEN assenze_totali IS NOT NULL
         THEN ROUND(assenze_totali / dipendenti, 1)
         ELSE NULL END AS assenze_procapite
 FROM clean_input

--- a/compose/conto-annuale-profilo-ente/sql/mart_profilo_ente.sql
+++ b/compose/conto-annuale-profilo-ente/sql/mart_profilo_ente.sql
@@ -1,0 +1,30 @@
+-- Profilo Ente — per ente singolo
+-- Esclude enti con meno di 5 dipendenti (metriche procapite distorti)
+-- e enti con costo_totale negativo (rimborsi UE eccedono le voci positive)
+SELECT
+    anno,
+    istituzione,
+    desc_istituzione,
+    codi_comparto,
+    desc_comparto,
+    codi_tipo_istituzione,
+    ROUND(dipendenti, 0) AS dipendenti,
+    ROUND(donne * 100.0 / NULLIF(dipendenti, 0), 1) AS pct_donne,
+    eta_media,
+    anzianita_media,
+    pct_laureati,
+    retribuzione_totale,
+    costo_totale,
+    CASE WHEN dipendenti > 0 AND retribuzione_totale IS NOT NULL
+        THEN ROUND(retribuzione_totale / dipendenti, 0)
+        ELSE NULL END AS retribuzione_procapite,
+    CASE WHEN dipendenti > 0 AND costo_totale IS NOT NULL AND costo_totale > 0
+        THEN ROUND(costo_totale / dipendenti, 0)
+        ELSE NULL END AS costo_procapite,
+    assenze_totali,
+    CASE WHEN dipendenti > 0 AND assenze_totali IS NOT NULL
+        THEN ROUND(assenze_totali / dipendenti, 1)
+        ELSE NULL END AS assenze_procapite
+FROM clean_input
+WHERE dipendenti >= 5
+ORDER BY desc_comparto, desc_istituzione


### PR DESCRIPTION
## Sintesi

Nuovo compose in `compose/conto-annuale-profilo-ente/` che unisce **6 dataset del Conto Annuale RGS** (occupazione, composizione-retribuzione, costo-lavoro, assenze, personale/età, anzianità, titoli-studio) per produrre un profilo completo di ogni ente della PA.

I dati puliti sono già su GCS da [dataciviclab/open-conto-annuale](https://github.com/dataciviclab/open-conto-annuale) — il compose li legge via HTTP diretto e produce 3 mart aggregati.

## Cosa cambia

- [x] compose — nuovo dataset composito

## Mart disponibili

| Mart | Granularità | Cosa contiene |
|---|---|---|
| `profilo_ente` | per ente singolo (dip >= 5) | nome ente, comparto, dipendenti, % donne, età media, anzianità media, % laureati, retribuzione, costo, assenze |
| `profilo_comparti` | aggregato per comparto | enti, tot dipendenti, medie pro-capite per comparto/tipo istituzione |
| `assenze_causali` | per comparto × causale | assenze scomposte (malattia, ferie, maternità, ecc.) con giorni pro-capite |

## Verifica

```bash
toolkit run full --config compose/conto-annuale-profilo-ente/dataset.yml --years 2024
```

Risultato: raw ✅ | clean ✅ 10885 righe, 14 colonne | mart ✅ 3/3 tabelle

## Impatto

- [ ] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Nessun impatto visibile per chi usa il repository

## Note / rischi

- I dati provengono dai clean parquet su GCS prodotti da open-conto-annuale (repo esterno) — se cambiano i path GCS, il compose va aggiornato
- `{year}` placeholder risolto dal toolkit sia nel source URL che nelle `read_parquet()` nei mart SQL
- Età e anzianità media = NULL quando il LEFT JOIN non trova match (ente senza dati nel dataset personale/anzianità)
