### PR TITLE
chore(post-merge): aggiorna registry per PR #721

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-07-27",
+  "updated_at": "2026-07-28",
   "datasets": [
     {
       "slug": "aci_prime_iscrizioni_autovetture",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-27",
+  "generated_at": "2026-07-28",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -673,9 +673,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "28328572853",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28328572853",
-        "checked_at": "2026-06-28",
+        "run_id": "30345539085",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30345539085",
+        "checked_at": "2026-07-28",
         "years": [
           2024
         ],
@@ -709,9 +709,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "28322705604",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28322705604",
-        "checked_at": "2026-06-28",
+        "run_id": "30345539085",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30345539085",
+        "checked_at": "2026-07-28",
         "years": [
           2010,
           2011,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #721 — refactor(ispra): consolida mart ispra_ru_base (5→3) e ispra_consumo_suolo (4→2)

Changed candidate/support roots:

- `ispra-consumo-suolo` (candidate, `candidates/ispra-consumo-suolo`)
- `ispra-ru-base` (candidate, `candidates/ispra-ru-base`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/ispra-consumo-suolo/dataset.yml` -> artifact `sample-run-ispra-consumo-suolo`
- `candidates/ispra-ru-base/dataset.yml` -> artifact `sample-run-ispra-ru-base`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
