### PR TITLE
chore(post-merge): aggiorna registry per PR #723

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -650,9 +650,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "27899103827",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27899103827",
-        "checked_at": "2026-06-21",
+        "run_id": "30347354104",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30347354104",
+        "checked_at": "2026-07-28",
         "years": [
           2019,
           2020,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #723 — refactor(irpef): consolida mart irpef_comunale (7→4)

Changed candidate/support roots:

- `irpef-comunale` (candidate, `candidates/irpef-comunale`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/irpef-comunale/dataset.yml` -> artifact `sample-run-irpef-comunale`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
