### PR TITLE
refactor(siope): consolida mart siope (1→3) con benchmark enti e trend

### DIFF
--- a/candidates/siope-bilancio-unificato/dataset.yml
+++ b/candidates/siope-bilancio-unificato/dataset.yml
@@ -8,12 +8,20 @@ dataset:
 
 raw:
   sources:
-    - name: "siope_bilancio_unificato_gcs"
+    - name: "siope_entrate"
       type: "http_file"
       args:
-        url: "https://storage.googleapis.com/dataciviclab-mart/siope/siope_cross_comparto/{year}/siope_bilancio_unificato.parquet"
-        filename: "siope_bilancio_unificato_{year}.parquet"
-      primary: true
+        url: "https://storage.googleapis.com/dataciviclab-clean/siope/siope_entrate/{year}/siope_entrate_{year}_clean.parquet"
+        filename: "siope_entrate_{year}.parquet"
+      inject_column:
+        lato: "entrate"
+    - name: "siope_uscite"
+      type: "http_file"
+      args:
+        url: "https://storage.googleapis.com/dataciviclab-clean/siope/siope_uscite/{year}/siope_uscite_{year}_clean.parquet"
+        filename: "siope_uscite_{year}.parquet"
+      inject_column:
+        lato: "uscite"
 
 clean:
   sql: "sql/clean.sql"
@@ -61,42 +69,24 @@ clean:
 
 mart:
   tables:
-    - name: "siope_bilancio_unificato"
-      sql: "sql/mart.sql"
+    - name: "mart_sintesi"
+      sql: "sql/mart_sintesi.sql"
+    - name: "mart_trend"
+      sql: "sql/mart_trend.sql"
+    - name: "mart_enti"
+      sql: "sql/mart_enti.sql"
   required_tables:
-    - "siope_bilancio_unificato"
+    - "mart_sintesi"
+    - "mart_trend"
+    - "mart_enti"
   validate:
     table_rules:
-      siope_bilancio_unificato:
-        min_rows: 500000
-        required_columns:
-          - lato
-          - codice_comparto
-          - anno
-          - periodo
-          - codice_ente
-          - codice_voce
-          - denominazione_ente
-          - tipo_ente
-          - codice_istat_comune
-          - codice_provincia
-          - provincia
-          - regione
-          - descrizione_comparto
-          - is_titolo_9
-          - descrizione_codice
-          - has_codgest_match
-          - importo
-          - importo_eur
-        primary_key:
-          [
-            "lato",
-            "codice_comparto",
-            "anno",
-            "periodo",
-            "codice_ente",
-            "codice_voce",
-          ]
+      mart_sintesi:
+        min_rows: 10
+      mart_trend:
+        min_rows: 5
+      mart_enti:
+        min_rows: 100
 
 validation:
   fail_on_error: true

--- a/candidates/siope-bilancio-unificato/dataset.yml
+++ b/candidates/siope-bilancio-unificato/dataset.yml
@@ -13,15 +13,7 @@ raw:
       args:
         url: "https://storage.googleapis.com/dataciviclab-clean/siope/siope_entrate/{year}/siope_entrate_{year}_clean.parquet"
         filename: "siope_entrate_{year}.parquet"
-      inject_column:
-        lato: "entrate"
-    - name: "siope_uscite"
-      type: "http_file"
-      args:
-        url: "https://storage.googleapis.com/dataciviclab-clean/siope/siope_uscite/{year}/siope_uscite_{year}_clean.parquet"
-        filename: "siope_uscite_{year}.parquet"
-      inject_column:
-        lato: "uscite"
+      primary: true
 
 clean:
   sql: "sql/clean.sql"

--- a/candidates/siope-bilancio-unificato/notes.md
+++ b/candidates/siope-bilancio-unificato/notes.md
@@ -20,7 +20,7 @@ Il dato upstream proviene dai download open di [SIOPE](https://www.siope.it).
 
 Tutti i join (territorio, comparto, classificazione voci) sono già stati
 eseguiti a monte in open-siope. Il dato downstream è già arricchito.
-La colonna `lato` viene aggiunta all'ingresso tramite inject_column.
+La colonna `lato` viene aggiunta nel clean.sql durante la UNION ALL.
 
 ## Output
 
@@ -43,5 +43,5 @@ full si usa il clean (via clean-query MCP o direttamente da GCS).
 - I dati SIOPE vengono aggiornati mensilmente dalla fonte. Il candidate va
   rieseguito periodicamente per avere i dati freschi.
 - Le colonne divergenti tra entrate e uscite (`macro_categoria_v2` vs
-  `macro_area`/`macro_categoria`) vengono allineate automaticamente da
-  read_parquet(union_by_name=true).
+  `macro_area`/`macro_categoria`) vengono allineate esplicitamente con
+  CAST(NULL) nel clean.sql.

--- a/candidates/siope-bilancio-unificato/notes.md
+++ b/candidates/siope-bilancio-unificato/notes.md
@@ -2,9 +2,10 @@
 
 ## Fonte
 
-Parquet generato da [open-siope](https://github.com/dataciviclab/open-siope),
-pubblicato su GCS pubblico:
-`https://storage.googleapis.com/dataciviclab-mart/siope/siope_cross_comparto/{year}/siope_bilancio_unificato.parquet`
+Clean parquet generati da [open-siope](https://github.com/dataciviclab/open-siope),
+pubblicati su GCS pubblico:
+- `https://storage.googleapis.com/dataciviclab-clean/siope/siope_entrate/{year}/siope_entrate_{year}_clean.parquet`
+- `https://storage.googleapis.com/dataciviclab-clean/siope/siope_uscite/{year}/siope_uscite_{year}_clean.parquet`
 
 Il dato upstream proviene dai download open di [SIOPE](https://www.siope.it).
 
@@ -19,16 +20,28 @@ Il dato upstream proviene dai download open di [SIOPE](https://www.siope.it).
 
 Tutti i join (territorio, comparto, classificazione voci) sono già stati
 eseguiti a monte in open-siope. Il dato downstream è già arricchito.
+La colonna `lato` viene aggiunta all'ingresso tramite inject_column.
+
+## Output
+
+Il layer **clean** contiene il bilancio unificato completo (entrate+uscite,
+stessa granularità del dato upstream).
+
+I **mart** analitici sono tre:
+- `mart_sintesi`: entrate/uscite per comparto × regione × anno
+- `mart_trend`: CAGR entrate/uscite per comparto × regione
+- `mart_enti`: benchmark entrate/uscite per singolo ente
+
+Non esiste più un mart passthrough (`siope_bilancio_unificato`): per il dato
+full si usa il clean (via clean-query MCP o direttamente da GCS).
 
 ## Rischi
 
-- Il path GCS (`dataciviclab-mart/siope/siope_cross_comparto/`) è un contratto
-  con open-siope. Se cambia, il candidate si rompe.
+- Il path GCS dei clean (`dataciviclab-clean/siope/siope_entrate/` e
+  `siope_uscite/`) è un contratto con open-siope. Se cambia, il candidate
+  si rompe.
 - I dati SIOPE vengono aggiornati mensilmente dalla fonte. Il candidate va
   rieseguito periodicamente per avere i dati freschi.
-
-## Decisioni
-
-- Clean e mart sono pass-through: il dato è già pulito a monte.
-- Non ci sono notebook perche' il dataset e' già analitico (si puo' interrogare
-  direttamente via clean-query).
+- Le colonne divergenti tra entrate e uscite (`macro_categoria_v2` vs
+  `macro_area`/`macro_categoria`) vengono allineate automaticamente da
+  read_parquet(union_by_name=true).

--- a/candidates/siope-bilancio-unificato/sql/clean.sql
+++ b/candidates/siope-bilancio-unificato/sql/clean.sql
@@ -1,6 +1,45 @@
 -- clean: UNION ALL di entrate e uscite SIOPE
--- La colonna `lato` viene iniettata automaticamente dal raw tramite inject_column.
--- Le colonne divergenti (macro_categoria_v2 in entrate, macro_area/macro_categoria in uscite)
--- vengono allineate da read_parquet(union_by_name=true).
+-- raw_input = entrate (primary source)
+-- uscite letta direttamente da GCS
+-- Le colonne divergenti vengono allineate con NULL
 
-select * from raw_input;
+with entrate as (
+    select
+        codice_comparto, anno, periodo,
+        codice_ente, codice_voce,
+        denominazione_ente, tipo_ente,
+        codice_istat_comune,
+        codice_provincia, provincia, regione,
+        codice_sottocomparto, descrizione_sottocomparto,
+        descrizione_comparto,
+        is_titolo_9, macro_categoria_v2,
+        null::varchar as macro_area,
+        null::varchar as macro_categoria,
+        descrizione_codice,
+        has_codgest_match,
+        importo, importo_eur,
+        'entrate'::varchar as lato
+    from raw_input
+),
+uscite as (
+    select
+        codice_comparto, anno, periodo,
+        codice_ente, codice_voce,
+        denominazione_ente, tipo_ente,
+        codice_istat_comune,
+        codice_provincia, provincia, regione,
+        codice_sottocomparto, descrizione_sottocomparto,
+        descrizione_comparto,
+        is_titolo_9,
+        null::varchar as macro_categoria_v2,
+        macro_area,
+        macro_categoria,
+        descrizione_codice,
+        has_codgest_match,
+        importo, importo_eur,
+        'uscite'::varchar as lato
+    from read_parquet('https://storage.googleapis.com/dataciviclab-clean/siope/siope_uscite/{year}/siope_uscite_{year}_clean.parquet')
+)
+select * from entrate
+union all
+select * from uscite;

--- a/candidates/siope-bilancio-unificato/sql/clean.sql
+++ b/candidates/siope-bilancio-unificato/sql/clean.sql
@@ -1,1 +1,6 @@
+-- clean: UNION ALL di entrate e uscite SIOPE
+-- La colonna `lato` viene iniettata automaticamente dal raw tramite inject_column.
+-- Le colonne divergenti (macro_categoria_v2 in entrate, macro_area/macro_categoria in uscite)
+-- vengono allineate da read_parquet(union_by_name=true).
+
 select * from raw_input;

--- a/candidates/siope-bilancio-unificato/sql/mart.sql
+++ b/candidates/siope-bilancio-unificato/sql/mart.sql
@@ -1,1 +1,0 @@
-select * from clean_input;

--- a/candidates/siope-bilancio-unificato/sql/mart_enti.sql
+++ b/candidates/siope-bilancio-unificato/sql/mart_enti.sql
@@ -1,0 +1,57 @@
+-- mart_enti — SIOPE: benchmark entrate/uscite per ente × tipo_ente
+--
+-- Entrate/uscite totali per singolo ente (codice_ente).
+-- Benchmark per tipo_ente: media nazionale, percentile, fascia.
+-- Confronto tra enti dello stesso tipo (es. COMUNE vs COMUNE).
+
+with
+enti_bilancio as (
+    select
+        anno,
+        codice_ente,
+        denominazione_ente,
+        tipo_ente,
+        codice_istat_comune,
+        provincia,
+        regione,
+        descrizione_comparto as comparto,
+        round(sum(case when lato = 'entrate' then importo_eur end), 0) as entrate_eur,
+        round(sum(case when lato = 'uscite' then importo_eur end), 0) as uscite_eur,
+        round(
+            coalesce(sum(case when lato = 'entrate' then importo_eur end), 0)
+            - coalesce(sum(case when lato = 'uscite' then importo_eur end), 0)
+        , 0) as saldo_eur
+    from clean_input
+    where codice_ente is not null
+      and codice_ente != ''
+    group by anno, codice_ente, denominazione_ente, tipo_ente, codice_istat_comune, provincia, regione, descrizione_comparto
+)
+select
+    *,
+    -- Benchmark per tipo ente: media entrate
+    round(avg(entrate_eur) over (partition by anno, tipo_ente), 0) as media_entrate_per_tipo,
+    -- Media uscite per tipo ente
+    round(avg(uscite_eur) over (partition by anno, tipo_ente), 0) as media_uscite_per_tipo,
+    -- Deviazione standard entrate per tipo ente
+    round(stddev(entrate_eur) over (partition by anno, tipo_ente), 0) as std_entrate_per_tipo,
+    -- Percentile entrate per tipo ente
+    case
+        when entrate_eur is null then null
+        else round(percent_rank() over (partition by anno, tipo_ente order by entrate_eur), 4)
+    end as percentile_entrate,
+    -- Percentile uscite per tipo ente
+    case
+        when uscite_eur is null then null
+        else round(percent_rank() over (partition by anno, tipo_ente order by uscite_eur), 4)
+    end as percentile_uscite,
+    -- Fascia entrate
+    case
+        when entrate_eur is null then null
+        when percent_rank() over (partition by anno, tipo_ente order by entrate_eur) >= 0.8 then 'ELEVATO'
+        when percent_rank() over (partition by anno, tipo_ente order by entrate_eur) >= 0.6 then 'SOPRA_MEDIA'
+        when percent_rank() over (partition by anno, tipo_ente order by entrate_eur) >= 0.4 then 'MEDIA'
+        when percent_rank() over (partition by anno, tipo_ente order by entrate_eur) >= 0.2 then 'SOTTO_MEDIA'
+        else 'BASSO'
+    end as fascia_entrate
+from enti_bilancio
+order by anno desc, tipo_ente, entrate_eur desc;

--- a/candidates/siope-bilancio-unificato/sql/mart_sintesi.sql
+++ b/candidates/siope-bilancio-unificato/sql/mart_sintesi.sql
@@ -1,0 +1,52 @@
+-- mart_sintesi — SIOPE: entrate/uscite per comparto × regione × anno
+--
+-- Rimpiazza il vecchio mart.sql (SELECT *).
+-- ATTENZIONE: lato nel dato è minuscolo ("entrate"/"uscite").
+
+with
+-- Enti totali per (anno, regione, comparto) — senza lato
+enti_per_area as (
+    select
+        anno,
+        regione,
+        descrizione_comparto as comparto,
+        count(distinct codice_ente) as enti
+    from clean_input
+    where regione is not null and regione != ''
+    group by anno, regione, descrizione_comparto
+),
+-- Importi per (anno, regione, comparto, lato) — una riga per lato
+importi_per_lato as (
+    select
+        anno,
+        regione,
+        descrizione_comparto as comparto,
+        lato,
+        round(sum(importo_eur), 0) as totale_eur
+    from clean_input
+    where regione is not null and regione != ''
+    group by anno, regione, descrizione_comparto, lato
+)
+select
+    i.anno,
+    i.regione,
+    i.comparto,
+    e.enti,
+    round(sum(case when i.lato = 'entrate' then i.totale_eur end), 0) as entrate_eur,
+    round(sum(case when i.lato = 'uscite' then i.totale_eur end), 0) as uscite_eur,
+    round(
+        coalesce(sum(case when i.lato = 'entrate' then i.totale_eur end), 0)
+        - coalesce(sum(case when i.lato = 'uscite' then i.totale_eur end), 0)
+    , 0) as saldo_eur,
+    case
+        when sum(case when i.lato = 'entrate' then i.totale_eur end) > 0
+        then round(
+            sum(case when i.lato = 'uscite' then i.totale_eur end)
+            / sum(case when i.lato = 'entrate' then i.totale_eur end) * 100
+        , 1)
+    end as rapporto_uscite_entrate_pct
+from importi_per_lato i
+left join enti_per_area e
+    on i.anno = e.anno and i.regione = e.regione and i.comparto = e.comparto
+group by i.anno, i.regione, i.comparto, e.enti
+order by i.anno desc, i.regione, i.comparto;

--- a/candidates/siope-bilancio-unificato/sql/mart_trend.sql
+++ b/candidates/siope-bilancio-unificato/sql/mart_trend.sql
@@ -1,0 +1,80 @@
+-- mart_trend — SIOPE: CAGR entrate/uscite per comparto × regione
+--
+-- Legge TUTTI gli anni dal clean via glob.
+-- Solo comparti con entrate/uscite significative.
+
+with
+all_clean as (
+    select anno, regione, descrizione_comparto as comparto, lato, importo_eur
+    from read_parquet(
+        '{root}/data/clean/{dataset}/*/{dataset}_*_clean.parquet',
+        union_by_name=true
+    )
+    where regione is not null and regione != ''
+),
+per_anno as (
+    select
+        anno,
+        regione,
+        comparto,
+        round(sum(case when lato = 'entrate' then importo_eur end), 0) as entrate_eur,
+        round(sum(case when lato = 'uscite' then importo_eur end), 0) as uscite_eur
+    from all_clean
+    group by anno, regione, comparto
+),
+trend as (
+    select
+        regione,
+        comparto,
+        min(anno) as primo_anno,
+        max(anno) as ultimo_anno,
+        count(*) as anni_coperti,
+        min(entrate_eur) filter (where anno = (select min(a2.anno) from per_anno a2 where a2.regione = p.regione and a2.comparto = p.comparto)) as entrate_iniziali,
+        max(entrate_eur) filter (where anno = (select max(a2.anno) from per_anno a2 where a2.regione = p.regione and a2.comparto = p.comparto)) as entrate_finali,
+        round(
+            max(entrate_eur) filter (where anno = (select max(a2.anno) from per_anno a2 where a2.regione = p.regione and a2.comparto = p.comparto))
+            - min(entrate_eur) filter (where anno = (select min(a2.anno) from per_anno a2 where a2.regione = p.regione and a2.comparto = p.comparto))
+        , 0) as delta_entrate_eur,
+        case
+            when min(entrate_eur) filter (where anno = (select min(a2.anno) from per_anno a2 where a2.regione = p.regione and a2.comparto = p.comparto)) > 0
+                 and max(anno) > min(anno)
+            then round((power(
+                max(entrate_eur) filter (where anno = (select max(a2.anno) from per_anno a2 where a2.regione = p.regione and a2.comparto = p.comparto))
+                / nullif(min(entrate_eur) filter (where anno = (select min(a2.anno) from per_anno a2 where a2.regione = p.regione and a2.comparto = p.comparto)), 0),
+                1.0 / (max(anno) - min(anno))
+            ) - 1) * 100, 2)
+        end as cagr_entrate_pct,
+        case
+            when min(uscite_eur) filter (where anno = (select min(a2.anno) from per_anno a2 where a2.regione = p.regione and a2.comparto = p.comparto)) > 0
+                 and max(anno) > min(anno)
+            then round((power(
+                max(uscite_eur) filter (where anno = (select max(a2.anno) from per_anno a2 where a2.regione = p.regione and a2.comparto = p.comparto))
+                / nullif(min(uscite_eur) filter (where anno = (select min(a2.anno) from per_anno a2 where a2.regione = p.regione and a2.comparto = p.comparto)), 0),
+                1.0 / (max(anno) - min(anno))
+            ) - 1) * 100, 2)
+        end as cagr_uscite_pct
+    from per_anno p
+    group by regione, comparto
+)
+select
+    regione,
+    comparto,
+    primo_anno,
+    ultimo_anno,
+    anni_coperti,
+    round(entrate_iniziali / 1e9, 1) as entrate_iniziali_mld,
+    round(entrate_finali / 1e9, 1) as entrate_finali_mld,
+    round(delta_entrate_eur / 1e9, 1) as delta_entrate_mld,
+    cagr_entrate_pct,
+    cagr_uscite_pct,
+    case
+        when cagr_entrate_pct is null then null
+        when cagr_entrate_pct > 10 then 'CRESCITA_FORTE'
+        when cagr_entrate_pct > 3 then 'CRESCITA_MODERATA'
+        when cagr_entrate_pct > -3 then 'STABILE'
+        when cagr_entrate_pct > -10 then 'CALO_MODERATO'
+        else 'CALO_FORTE'
+    end as segnale_trend_entrate
+from trend
+where comparto not in ('STATO')
+order by abs(coalesce(delta_entrate_eur, 0)) desc;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # lab-connectors[gcs] per script che usano GCS direttamente (toolkit porta solo [duckdb])
 lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.45.0
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.46.0
 
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0


### PR DESCRIPTION
## Sintesi

Consolidamento mart siope da 1 a 3, con aggiunta di benchmark entrate/uscite per ente e trend CAGR.

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento
- [x] cleanup — refactoring, rimozioni, allineamento

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori su tutti gli anni dichiarati

## Verifica

```bash
toolkit run full --config candidates/siope-bilancio-unificato/dataset.yml --years 2024
```

Run completato con validation ok=True.

## Dettaglio

| Vecchio | Nuovo |
|---|---|
| `mart.sql` (SELECT *) | → **`mart_sintesi`**: entrate/uscite per comparto × regione × anno |
| — | **`mart_enti`**: benchmark entrate/uscite per ente × tipo_ente (media, percentile, fascia) |
| — | **`mart_trend`**: CAGR entrate/uscite per comparto × regione (multi-anno) |
| — | `clean.sql`: UNION ALL entrate + uscite (prima era SELECT * su sola entrate) |