### PR TITLE
chore(post-merge): aggiorna registry per PR #725

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -12839,12 +12839,6 @@
       },
       "columns": [
         {
-          "name": "lato",
-          "type": "VARCHAR",
-          "role": "dimension",
-          "description": "Lato contabile: entrate o uscite"
-        },
-        {
           "name": "codice_comparto",
           "type": "VARCHAR",
           "role": "dimension",
@@ -12975,6 +12969,12 @@
           "type": "DOUBLE",
           "role": "metric",
           "description": "Importo in euro"
+        },
+        {
+          "name": "lato",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Lato contabile: entrate o uscite"
         }
       ],
       "location": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1523,13 +1523,13 @@
       "source_id": "siope",
       "status": "ok",
       "label": "siope-bilancio-unificato",
-      "detail": "anni 2021-2026 — fonte: siope_bilancio_unificato_gcs — mart: sì",
+      "detail": "anni 2021-2026 — fonte: siope_entrate — mart: sì",
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "28660435830",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28660435830",
-        "checked_at": "2026-07-03",
+        "run_id": "30353110961",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30353110961",
+        "checked_at": "2026-07-28",
         "years": [
           2021,
           2022,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #725 — refactor(siope): consolida mart siope (1→3) con benchmark enti e trend

Changed candidate/support roots:

- `siope-bilancio-unificato` (candidate, `candidates/siope-bilancio-unificato`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/siope-bilancio-unificato/dataset.yml` -> artifact `sample-run-siope-bilancio-unificato`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
