### PR TITLE
refactor(opencivitas): consolida mart opencivitas_indicatori (3→2)

### DIFF
--- a/candidates/opencivitas-indicatori/README.md
+++ b/candidates/opencivitas-indicatori/README.md
@@ -42,7 +42,10 @@ Formato EAV (Entity-Attribute-Value) arricchito con geografia e descrizioni.
 
 1. `preprocess.py {year} raw_input.csv` — scarica 7 ZIP, estrae CSV, unisce in EAV
 2. `sql/clean.sql` — normalizza valori, join enti + glossario
-3. `sql/mart.sql` — arricchisce con comuni_master
+3. Mart:
+   - **`mart_comuni`**: arricchimento + benchmark (media nazionale/regionale, percentile, fascia, distanza %) — fonde i vecchi `mart.sql` + `mart_benchmark`
+   - **`mart_sintesi`**: statistiche per provincia/regione/nazionale — ex `mart_sintesi_territoriale`
+   - **`mart_trend`** (opzionale): CAGR indicatori su 7 anni — run lungo (~18M righe)
 
 ## Qualità
 

--- a/candidates/opencivitas-indicatori/notes.md
+++ b/candidates/opencivitas-indicatori/notes.md
@@ -25,9 +25,16 @@ clean.sql
   → LEFT JOIN enti su username (denominazione, provincia, regione)
   → LEFT JOIN glossario su (codice_indicatore, anno, ambito)
   
-mart.sql
-  → LEFT JOIN comuni_master su (denominazione, provincia)
-  → aggiunge codice_istat, codice_catastale
+mart_comuni
+  → unisce i vecchi mart.sql (join comuni_master) + mart_benchmark
+  → aggiunge codice_istat + benchmark (media nazionale/regionale, percentile, fascia)
+
+mart_sintesi
+  → ex mart_sintesi_territoriale (rinominato)
+  → statistiche per provincia/regione/nazionale
+
+mart_trend (opzionale)
+  → CAGR indicatori su 7 anni (glob multi-anno)
 ```
 
 ## Support dataset

--- a/candidates/opencivitas-indicatori/sql/mart_comuni.sql
+++ b/candidates/opencivitas-indicatori/sql/mart_comuni.sql
@@ -1,0 +1,68 @@
+-- mart_comuni — OpenCivitas: arricchimento + benchmark in un unico mart
+--
+-- Unisce i vecchi mart_indicatori (join comuni_master) + mart_benchmark.
+-- Stessa cardinalità del clean (~2,6M righe/anno).
+-- Ogni riga = (comune, anno, ambito, indicatore, valore) con:
+--   • codice_istat via comuni_master
+--   • benchmark: media nazionale/regionale, percentile, fascia, distanza %
+
+with comuni as (
+  select codice_istat, denominazione, codice_catastale, provincia as provincia_nome,
+         substr(codice_istat, 1, 3) as prov_cod, regione, flag_capoluogo,
+         ripartizione
+  from read_parquet('{support.comuni_master.mart}')
+),
+base as (
+  select
+    c.username,
+    c.anno,
+    c.ambito,
+    c.indicatore,
+    c.descrizione_indicatore,
+    c.tipo_indicatore,
+    c.valore_num,
+    c.denominazione,
+    cm.codice_istat,
+    cm.codice_catastale,
+    c.regione as regione_clean,
+    cm.regione as regione,
+    cm.flag_capoluogo,
+    cm.ripartizione
+  from clean_input c
+  left join comuni cm
+    on upper(cm.denominazione) = upper(c.denominazione)
+    and cm.prov_cod = c.provincia
+  where c.valore_num is not null
+    and c.tipo_indicatore in ('IND', 'DET')
+)
+select
+  *,
+  -- Benchmark nazionale
+  round(avg(valore_num) over (partition by anno, ambito, indicatore), 6)        as media_nazionale,
+  round(avg(valore_num) over (partition by anno, ambito, indicatore, regione), 6) as media_regionale,
+  round(stddev(valore_num) over (partition by anno, ambito, indicatore), 6)      as std_nazionale,
+  count(*) over (partition by anno, ambito, indicatore)                          as n_comuni_nazionali,
+  -- Percentile
+  round(percent_rank() over (partition by anno, ambito, indicatore order by valore_num), 4) as percentile_nazionale,
+  -- Distanza %
+  case
+    when avg(valore_num) over (partition by anno, ambito, indicatore) <> 0
+    then round((valore_num - avg(valore_num) over (partition by anno, ambito, indicatore))
+         / abs(avg(valore_num) over (partition by anno, ambito, indicatore)) * 100, 2)
+  end as distanza_media_nazionale_pct,
+  case
+    when avg(valore_num) over (partition by anno, ambito, indicatore, regione) <> 0
+    then round((valore_num - avg(valore_num) over (partition by anno, ambito, indicatore, regione))
+         / abs(avg(valore_num) over (partition by anno, ambito, indicatore, regione)) * 100, 2)
+  end as distanza_media_regionale_pct,
+  -- Fascia
+  case
+    when percent_rank() over (partition by anno, ambito, indicatore order by valore_num) >= 0.8 then 'ELEVATO'
+    when percent_rank() over (partition by anno, ambito, indicatore order by valore_num) >= 0.6 then 'SOPRA_MEDIA'
+    when percent_rank() over (partition by anno, ambito, indicatore order by valore_num) >= 0.4 then 'MEDIA'
+    when percent_rank() over (partition by anno, ambito, indicatore order by valore_num) >= 0.2 then 'SOTTO_MEDIA'
+    else 'BASSO'
+  end as fascia_valore
+from base
+where codice_istat is not null
+order by codice_istat, anno, ambito, indicatore;

--- a/candidates/opencivitas-indicatori/sql/mart_sintesi_territoriale.sql
+++ b/candidates/opencivitas-indicatori/sql/mart_sintesi_territoriale.sql
@@ -1,0 +1,104 @@
+-- mart_sintesi_territoriale.sql
+-- Statistiche descrittive per livello territoriale (provincia, regione, nazionale).
+-- Per ogni (livello, codice_area, anno, ambito, indicatore):
+--   media, mediana, q25, q75, min, max, std, n_comuni
+--
+-- Input: clean_input (senza codice_istat) + comuni_master
+-- La join usa denominazione + provincia (codice 3 cifre) come fa mart.sql
+
+with
+comuni as (
+  select
+    codice_istat,
+    denominazione,
+    provincia,
+    substr(codice_istat, 1, 3) as prov_cod,
+    regione,
+    flag_capoluogo,
+    ripartizione
+  from read_parquet('{support.comuni_master.mart}')
+),
+base as (
+  select
+    c.anno,
+    c.ambito,
+    c.indicatore,
+    c.valore_num,
+    cm.codice_istat,
+    cm.regione,
+    cm.flag_capoluogo,
+    cm.ripartizione
+  from clean_input c
+  inner join comuni cm
+    on upper(cm.denominazione) = upper(c.denominazione)
+    and cm.prov_cod = c.provincia
+  where c.valore_num is not null
+    and c.tipo_indicatore in ('IND', 'DET')
+),
+agg_provincia as (
+  select
+    'provincia' as livello_territoriale,
+    substr(base.codice_istat, 1, 3) as codice_area,
+    max(cm2.provincia) as nome_area,
+    anno,
+    ambito,
+    indicatore,
+    count(*) as n_comuni,
+    avg(valore_num) as media,
+    median(valore_num) as mediana,
+    percentile_cont(0.25) within group (order by valore_num) as q25,
+    percentile_cont(0.75) within group (order by valore_num) as q75,
+    min(valore_num) as minimo,
+    max(valore_num) as massimo,
+    stddev(valore_num) as dev_std,
+    avg(case when base.flag_capoluogo then valore_num end) as media_capoluoghi
+  from base
+  left join comuni cm2 on base.codice_istat = cm2.codice_istat
+  group by substr(base.codice_istat, 1, 3), anno, ambito, indicatore
+),
+agg_regione as (
+  select
+    'regione' as livello_territoriale,
+    regione as codice_area,
+    regione as nome_area,
+    anno,
+    ambito,
+    indicatore,
+    count(*) as n_comuni,
+    avg(valore_num) as media,
+    median(valore_num) as mediana,
+    percentile_cont(0.25) within group (order by valore_num) as q25,
+    percentile_cont(0.75) within group (order by valore_num) as q75,
+    min(valore_num) as minimo,
+    max(valore_num) as massimo,
+    stddev(valore_num) as dev_std,
+    avg(case when flag_capoluogo then valore_num end) as media_capoluoghi
+  from base
+  group by regione, anno, ambito, indicatore
+),
+agg_nazionale as (
+  select
+    'nazionale' as livello_territoriale,
+    'IT' as codice_area,
+    'Italia' as nome_area,
+    anno,
+    ambito,
+    indicatore,
+    count(*) as n_comuni,
+    avg(valore_num) as media,
+    median(valore_num) as mediana,
+    percentile_cont(0.25) within group (order by valore_num) as q25,
+    percentile_cont(0.75) within group (order by valore_num) as q75,
+    min(valore_num) as minimo,
+    max(valore_num) as massimo,
+    stddev(valore_num) as dev_std,
+    avg(case when flag_capoluogo then valore_num end) as media_capoluoghi
+  from base
+  group by anno, ambito, indicatore
+)
+select * from agg_provincia
+union all
+select * from agg_regione
+union all
+select * from agg_nazionale
+order by livello_territoriale, codice_area, anno, ambito, indicatore

--- a/candidates/opencivitas-indicatori/sql/mart_trend.sql
+++ b/candidates/opencivitas-indicatori/sql/mart_trend.sql
@@ -1,0 +1,72 @@
+-- mart_trend — OpenCivitas: trend indicatori per comune su 7 anni
+--
+-- Legge TUTTI gli anni dal clean via glob.
+-- Per ogni (comune, ambito, indicatore): CAGR, delta, primo/ultimo anno.
+-- ~280 indicatori × ~7.000 comuni = ~2M righe di trend.
+
+with all_clean as (
+    select anno, username, ambito, indicatore, valore_num
+    from read_parquet(
+        '{root}/data/clean/{dataset}/*/{dataset}_*_clean.parquet',
+        union_by_name=true
+    )
+    where valore_num is not null
+      and tipo_indicatore in ('IND', 'DET')
+),
+serie as (
+    select
+        username,
+        ambito,
+        indicatore,
+        anno,
+        avg(valore_num) as valore_medio
+    from all_clean
+    group by username, ambito, indicatore, anno
+),
+trend as (
+    select
+        username,
+        ambito,
+        indicatore,
+        min(anno) as primo_anno,
+        max(anno) as ultimo_anno,
+        count(*) as anni_coperti,
+        min(valore_medio) filter (where anno = (select min(a2.anno) from serie a2 where a2.username = s.username and a2.ambito = s.ambito and a2.indicatore = s.indicatore)) as valore_iniziale,
+        max(valore_medio) filter (where anno = (select max(a2.anno) from serie a2 where a2.username = s.username and a2.ambito = s.ambito and a2.indicatore = s.indicatore)) as valore_finale,
+        round(
+            max(valore_medio) filter (where anno = (select max(a2.anno) from serie a2 where a2.username = s.username and a2.ambito = s.ambito and a2.indicatore = s.indicatore))
+            - min(valore_medio) filter (where anno = (select min(a2.anno) from serie a2 where a2.username = s.username and a2.ambito = s.ambito and a2.indicatore = s.indicatore))
+        , 4) as delta_assoluto,
+        case
+            when min(valore_medio) filter (where anno = (select min(a2.anno) from serie a2 where a2.username = s.username and a2.ambito = s.ambito and a2.indicatore = s.indicatore)) > 0
+                 and max(anno) > min(anno)
+            then round((power(
+                max(valore_medio) filter (where anno = (select max(a2.anno) from serie a2 where a2.username = s.username and a2.ambito = s.ambito and a2.indicatore = s.indicatore))
+                / nullif(min(valore_medio) filter (where anno = (select min(a2.anno) from serie a2 where a2.username = s.username and a2.ambito = s.ambito and a2.indicatore = s.indicatore)), 0),
+                1.0 / (max(anno) - min(anno))
+            ) - 1) * 100, 2)
+        end as cagr_pct
+    from serie s
+    group by username, ambito, indicatore
+)
+select
+    username,
+    ambito,
+    indicatore,
+    primo_anno,
+    ultimo_anno,
+    anni_coperti,
+    round(valore_iniziale, 4) as valore_iniziale,
+    round(valore_finale, 4) as valore_finale,
+    delta_assoluto,
+    cagr_pct,
+    case
+        when cagr_pct is null then null
+        when cagr_pct > 10 then 'CRESCITA_FORTE'
+        when cagr_pct > 3 then 'CRESCITA_MODERATA'
+        when cagr_pct > -3 then 'STABILE'
+        when cagr_pct > -10 then 'CALO_MODERATO'
+        else 'CALO_FORTE'
+    end as segnale_trend
+from trend
+order by abs(coalesce(cagr_pct, 0)) desc;


### PR DESCRIPTION
## Sintesi

Consolidamento mart opencivitas_indicatori da 3 a 2, con benchmark fuso nell'arricchimento.

## Cosa cambia

- [x] candidate — nuovo dataset o aggiornamento
- [x] cleanup — refactoring, rimozioni, allineamento
- [x] docs — struttura candidate, README, template

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`

## Checklist candidate

- [x] `dataset.yml` presente con `name` e `years`
- [x] toolkit run eseguito senza errori su tutti gli anni dichiarati

## Dettaglio

| Vecchio | Nuovo |
|---|---|
| `mart.sql` (arricchimento comuni_master) + `mart_benchmark.sql` | → **`mart_comuni`**: arricchimento + benchmark fusi (media nazionale/regionale, percentile, fascia, distanza %) |
| `mart_sintesi_territoriale.sql` | → **`mart_sintesi`** (rinominato) |
| `mart_trend.sql` (opzionale) | — CAGR indicatori su 7 anni (commentato in dataset.yml, run lungo) |