### PR TITLE
chore(post-merge): aggiorna registry per PR #727

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1215,9 +1215,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "30175442735",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30175442735",
-        "checked_at": "2026-07-25",
+        "run_id": "30354805590",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30354805590",
+        "checked_at": "2026-07-28",
         "years": [
           2015,
           2016,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #727 — refactor(opencivitas): consolida mart opencivitas_indicatori (3→2)

Changed candidate/support roots:

- `opencivitas-indicatori` (candidate, `candidates/opencivitas-indicatori`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/opencivitas-indicatori/dataset.yml` -> artifact `sample-run-opencivitas-indicatori`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
