### PR TITLE
refactor(rna): consolida mart rna_aiuti_stato (7→4)

### DIFF
--- a/candidates/opencivitas-indicatori/README.md
+++ b/candidates/opencivitas-indicatori/README.md
@@ -42,7 +42,10 @@ Formato EAV (Entity-Attribute-Value) arricchito con geografia e descrizioni.
 
 1. `preprocess.py {year} raw_input.csv` — scarica 7 ZIP, estrae CSV, unisce in EAV
 2. `sql/clean.sql` — normalizza valori, join enti + glossario
-3. `sql/mart.sql` — arricchisce con comuni_master
+3. Mart:
+   - **`mart_comuni`**: arricchimento + benchmark (media nazionale/regionale, percentile, fascia, distanza %) — fonde i vecchi `mart.sql` + `mart_benchmark`
+   - **`mart_sintesi`**: statistiche per provincia/regione/nazionale — ex `mart_sintesi_territoriale`
+   - **`mart_trend`** (opzionale): CAGR indicatori su 7 anni — run lungo (~18M righe)
 
 ## Qualità
 

--- a/candidates/opencivitas-indicatori/notes.md
+++ b/candidates/opencivitas-indicatori/notes.md
@@ -25,9 +25,16 @@ clean.sql
   → LEFT JOIN enti su username (denominazione, provincia, regione)
   → LEFT JOIN glossario su (codice_indicatore, anno, ambito)
   
-mart.sql
-  → LEFT JOIN comuni_master su (denominazione, provincia)
-  → aggiunge codice_istat, codice_catastale
+mart_comuni
+  → unisce i vecchi mart.sql (join comuni_master) + mart_benchmark
+  → aggiunge codice_istat + benchmark (media nazionale/regionale, percentile, fascia)
+
+mart_sintesi
+  → ex mart_sintesi_territoriale (rinominato)
+  → statistiche per provincia/regione/nazionale
+
+mart_trend (opzionale)
+  → CAGR indicatori su 7 anni (glob multi-anno)
 ```
 
 ## Support dataset

--- a/candidates/opencivitas-indicatori/sql/mart_comuni.sql
+++ b/candidates/opencivitas-indicatori/sql/mart_comuni.sql
@@ -1,0 +1,68 @@
+-- mart_comuni — OpenCivitas: arricchimento + benchmark in un unico mart
+--
+-- Unisce i vecchi mart_indicatori (join comuni_master) + mart_benchmark.
+-- Stessa cardinalità del clean (~2,6M righe/anno).
+-- Ogni riga = (comune, anno, ambito, indicatore, valore) con:
+--   • codice_istat via comuni_master
+--   • benchmark: media nazionale/regionale, percentile, fascia, distanza %
+
+with comuni as (
+  select codice_istat, denominazione, codice_catastale, provincia as provincia_nome,
+         substr(codice_istat, 1, 3) as prov_cod, regione, flag_capoluogo,
+         ripartizione
+  from read_parquet('{support.comuni_master.mart}')
+),
+base as (
+  select
+    c.username,
+    c.anno,
+    c.ambito,
+    c.indicatore,
+    c.descrizione_indicatore,
+    c.tipo_indicatore,
+    c.valore_num,
+    c.denominazione,
+    cm.codice_istat,
+    cm.codice_catastale,
+    c.regione as regione_clean,
+    cm.regione as regione,
+    cm.flag_capoluogo,
+    cm.ripartizione
+  from clean_input c
+  left join comuni cm
+    on upper(cm.denominazione) = upper(c.denominazione)
+    and cm.prov_cod = c.provincia
+  where c.valore_num is not null
+    and c.tipo_indicatore in ('IND', 'DET')
+)
+select
+  *,
+  -- Benchmark nazionale
+  round(avg(valore_num) over (partition by anno, ambito, indicatore), 6)        as media_nazionale,
+  round(avg(valore_num) over (partition by anno, ambito, indicatore, regione), 6) as media_regionale,
+  round(stddev(valore_num) over (partition by anno, ambito, indicatore), 6)      as std_nazionale,
+  count(*) over (partition by anno, ambito, indicatore)                          as n_comuni_nazionali,
+  -- Percentile
+  round(percent_rank() over (partition by anno, ambito, indicatore order by valore_num), 4) as percentile_nazionale,
+  -- Distanza %
+  case
+    when avg(valore_num) over (partition by anno, ambito, indicatore) <> 0
+    then round((valore_num - avg(valore_num) over (partition by anno, ambito, indicatore))
+         / abs(avg(valore_num) over (partition by anno, ambito, indicatore)) * 100, 2)
+  end as distanza_media_nazionale_pct,
+  case
+    when avg(valore_num) over (partition by anno, ambito, indicatore, regione) <> 0
+    then round((valore_num - avg(valore_num) over (partition by anno, ambito, indicatore, regione))
+         / abs(avg(valore_num) over (partition by anno, ambito, indicatore, regione)) * 100, 2)
+  end as distanza_media_regionale_pct,
+  -- Fascia
+  case
+    when percent_rank() over (partition by anno, ambito, indicatore order by valore_num) >= 0.8 then 'ELEVATO'
+    when percent_rank() over (partition by anno, ambito, indicatore order by valore_num) >= 0.6 then 'SOPRA_MEDIA'
+    when percent_rank() over (partition by anno, ambito, indicatore order by valore_num) >= 0.4 then 'MEDIA'
+    when percent_rank() over (partition by anno, ambito, indicatore order by valore_num) >= 0.2 then 'SOTTO_MEDIA'
+    else 'BASSO'
+  end as fascia_valore
+from base
+where codice_istat is not null
+order by codice_istat, anno, ambito, indicatore;

--- a/candidates/opencivitas-indicatori/sql/mart_sintesi_territoriale.sql
+++ b/candidates/opencivitas-indicatori/sql/mart_sintesi_territoriale.sql
@@ -1,0 +1,104 @@
+-- mart_sintesi_territoriale.sql
+-- Statistiche descrittive per livello territoriale (provincia, regione, nazionale).
+-- Per ogni (livello, codice_area, anno, ambito, indicatore):
+--   media, mediana, q25, q75, min, max, std, n_comuni
+--
+-- Input: clean_input (senza codice_istat) + comuni_master
+-- La join usa denominazione + provincia (codice 3 cifre) come fa mart.sql
+
+with
+comuni as (
+  select
+    codice_istat,
+    denominazione,
+    provincia,
+    substr(codice_istat, 1, 3) as prov_cod,
+    regione,
+    flag_capoluogo,
+    ripartizione
+  from read_parquet('{support.comuni_master.mart}')
+),
+base as (
+  select
+    c.anno,
+    c.ambito,
+    c.indicatore,
+    c.valore_num,
+    cm.codice_istat,
+    cm.regione,
+    cm.flag_capoluogo,
+    cm.ripartizione
+  from clean_input c
+  inner join comuni cm
+    on upper(cm.denominazione) = upper(c.denominazione)
+    and cm.prov_cod = c.provincia
+  where c.valore_num is not null
+    and c.tipo_indicatore in ('IND', 'DET')
+),
+agg_provincia as (
+  select
+    'provincia' as livello_territoriale,
+    substr(base.codice_istat, 1, 3) as codice_area,
+    max(cm2.provincia) as nome_area,
+    anno,
+    ambito,
+    indicatore,
+    count(*) as n_comuni,
+    avg(valore_num) as media,
+    median(valore_num) as mediana,
+    percentile_cont(0.25) within group (order by valore_num) as q25,
+    percentile_cont(0.75) within group (order by valore_num) as q75,
+    min(valore_num) as minimo,
+    max(valore_num) as massimo,
+    stddev(valore_num) as dev_std,
+    avg(case when base.flag_capoluogo then valore_num end) as media_capoluoghi
+  from base
+  left join comuni cm2 on base.codice_istat = cm2.codice_istat
+  group by substr(base.codice_istat, 1, 3), anno, ambito, indicatore
+),
+agg_regione as (
+  select
+    'regione' as livello_territoriale,
+    regione as codice_area,
+    regione as nome_area,
+    anno,
+    ambito,
+    indicatore,
+    count(*) as n_comuni,
+    avg(valore_num) as media,
+    median(valore_num) as mediana,
+    percentile_cont(0.25) within group (order by valore_num) as q25,
+    percentile_cont(0.75) within group (order by valore_num) as q75,
+    min(valore_num) as minimo,
+    max(valore_num) as massimo,
+    stddev(valore_num) as dev_std,
+    avg(case when flag_capoluogo then valore_num end) as media_capoluoghi
+  from base
+  group by regione, anno, ambito, indicatore
+),
+agg_nazionale as (
+  select
+    'nazionale' as livello_territoriale,
+    'IT' as codice_area,
+    'Italia' as nome_area,
+    anno,
+    ambito,
+    indicatore,
+    count(*) as n_comuni,
+    avg(valore_num) as media,
+    median(valore_num) as mediana,
+    percentile_cont(0.25) within group (order by valore_num) as q25,
+    percentile_cont(0.75) within group (order by valore_num) as q75,
+    min(valore_num) as minimo,
+    max(valore_num) as massimo,
+    stddev(valore_num) as dev_std,
+    avg(case when flag_capoluogo then valore_num end) as media_capoluoghi
+  from base
+  group by anno, ambito, indicatore
+)
+select * from agg_provincia
+union all
+select * from agg_regione
+union all
+select * from agg_nazionale
+order by livello_territoriale, codice_area, anno, ambito, indicatore

--- a/candidates/opencivitas-indicatori/sql/mart_trend.sql
+++ b/candidates/opencivitas-indicatori/sql/mart_trend.sql
@@ -1,0 +1,72 @@
+-- mart_trend — OpenCivitas: trend indicatori per comune su 7 anni
+--
+-- Legge TUTTI gli anni dal clean via glob.
+-- Per ogni (comune, ambito, indicatore): CAGR, delta, primo/ultimo anno.
+-- ~280 indicatori × ~7.000 comuni = ~2M righe di trend.
+
+with all_clean as (
+    select anno, username, ambito, indicatore, valore_num
+    from read_parquet(
+        '{root}/data/clean/{dataset}/*/{dataset}_*_clean.parquet',
+        union_by_name=true
+    )
+    where valore_num is not null
+      and tipo_indicatore in ('IND', 'DET')
+),
+serie as (
+    select
+        username,
+        ambito,
+        indicatore,
+        anno,
+        avg(valore_num) as valore_medio
+    from all_clean
+    group by username, ambito, indicatore, anno
+),
+trend as (
+    select
+        username,
+        ambito,
+        indicatore,
+        min(anno) as primo_anno,
+        max(anno) as ultimo_anno,
+        count(*) as anni_coperti,
+        min(valore_medio) filter (where anno = (select min(a2.anno) from serie a2 where a2.username = s.username and a2.ambito = s.ambito and a2.indicatore = s.indicatore)) as valore_iniziale,
+        max(valore_medio) filter (where anno = (select max(a2.anno) from serie a2 where a2.username = s.username and a2.ambito = s.ambito and a2.indicatore = s.indicatore)) as valore_finale,
+        round(
+            max(valore_medio) filter (where anno = (select max(a2.anno) from serie a2 where a2.username = s.username and a2.ambito = s.ambito and a2.indicatore = s.indicatore))
+            - min(valore_medio) filter (where anno = (select min(a2.anno) from serie a2 where a2.username = s.username and a2.ambito = s.ambito and a2.indicatore = s.indicatore))
+        , 4) as delta_assoluto,
+        case
+            when min(valore_medio) filter (where anno = (select min(a2.anno) from serie a2 where a2.username = s.username and a2.ambito = s.ambito and a2.indicatore = s.indicatore)) > 0
+                 and max(anno) > min(anno)
+            then round((power(
+                max(valore_medio) filter (where anno = (select max(a2.anno) from serie a2 where a2.username = s.username and a2.ambito = s.ambito and a2.indicatore = s.indicatore))
+                / nullif(min(valore_medio) filter (where anno = (select min(a2.anno) from serie a2 where a2.username = s.username and a2.ambito = s.ambito and a2.indicatore = s.indicatore)), 0),
+                1.0 / (max(anno) - min(anno))
+            ) - 1) * 100, 2)
+        end as cagr_pct
+    from serie s
+    group by username, ambito, indicatore
+)
+select
+    username,
+    ambito,
+    indicatore,
+    primo_anno,
+    ultimo_anno,
+    anni_coperti,
+    round(valore_iniziale, 4) as valore_iniziale,
+    round(valore_finale, 4) as valore_finale,
+    delta_assoluto,
+    cagr_pct,
+    case
+        when cagr_pct is null then null
+        when cagr_pct > 10 then 'CRESCITA_FORTE'
+        when cagr_pct > 3 then 'CRESCITA_MODERATA'
+        when cagr_pct > -3 then 'STABILE'
+        when cagr_pct > -10 then 'CALO_MODERATO'
+        else 'CALO_FORTE'
+    end as segnale_trend
+from trend
+order by abs(coalesce(cagr_pct, 0)) desc;

--- a/candidates/rna-aiuti-stato/README.md
+++ b/candidates/rna-aiuti-stato/README.md
@@ -14,5 +14,5 @@ Questo candidate esiste per registrare il dataset nel catalogo Lab e per le quer
 - **10 anni completati**: 2017-2026, ~17M righe, 704 MB parquet
 - I parquet RAW sono su GCS (`gs://dataciviclab-clean/rna-aiuti-stato/`)
 - Il deploy su GCS avviene tramite CI di dataset-incubator (post-merge)
-- I MART offrono aggregazioni per regione, procedimento e top beneficiari
+- **Mart (4)**: `mart_territorio` (ESL per regione×anno + benchmark), `mart_policy` (obiettivo×strumento), `mart_settori` (NACE×regione), `mart_top` (top beneficiari + procedimenti)
 - La pipeline con flush periodico (50k chunk) mantiene RAM sotto controllo

--- a/candidates/rna-aiuti-stato/notes.md
+++ b/candidates/rna-aiuti-stato/notes.md
@@ -6,6 +6,17 @@
 - Ogni riga = una combinazione Aiuto × Componente × Strumento
 - Bootstrap completato: 10 anni, ~17 milioni di righe
 
+## Mart (rifattorizzati 2026-07-28)
+
+4 tabelle (da 7):
+
+| Mart | Cosa fa | Unisce i vecchi |
+|---|---|---|
+| `mart_territorio` | ESL per regione × anno, benchmark nazionale (percentile), quote per tipo beneficiario (PMI/Grande/Micro) | `mart_per_regione` + `mart_tipo_beneficiario` |
+| `mart_policy` | ESL per obiettivo × anno e strumento × anno, con quota % su anno | `mart_per_obiettivo` + `mart_per_strumento` |
+| `mart_settori` | ESL per macro-settore NACE × regione × anno, quote su regione, ranking | `mart_settore_regione` |
+| `mart_top` | Top 1000 beneficiari + analisi per procedimento | `mart_top_beneficiari` + `mart_per_procedimento` |
+
 ## Note tecniche
 
 - **Fonte**: XML del Registro Nazionale Aiuti di Stato (MIMIT), 40 GB di XML trasformati

--- a/candidates/rna-aiuti-stato/sql/mart_policy.sql
+++ b/candidates/rna-aiuti-stato/sql/mart_policy.sql
@@ -1,0 +1,36 @@
+-- mart_policy — RNA Aiuti di Stato: per obiettivo + strumento × anno
+--
+-- Unifica i vecchi: mart_per_obiettivo + mart_per_strumento.
+-- Due sezioni unite dalla colonna `dimensione` (obiettivo/strumento).
+
+select
+    anno,
+    'obiettivo' as dimensione,
+    cod_obiettivo as codice,
+    obiettivo as descrizione,
+    count(*) as aiuti,
+    count(distinct codice_fiscale_beneficiario) as imprese,
+    round(sum(elemento_aiuto), 0) as totale_esl,
+    round(avg(elemento_aiuto), 0) as media_esl,
+    round(sum(elemento_aiuto) * 100.0 / nullif(sum(sum(elemento_aiuto)) over (partition by anno), 0), 2) as quota_pct_su_anno
+from clean_input
+where cod_obiettivo is not null and cod_obiettivo != ''
+group by anno, cod_obiettivo, obiettivo
+
+union all
+
+select
+    anno,
+    'strumento' as dimensione,
+    cod_strumento as codice,
+    strumento as descrizione,
+    count(*) as aiuti,
+    count(distinct codice_fiscale_beneficiario) as imprese,
+    round(sum(elemento_aiuto), 0) as totale_esl,
+    round(avg(elemento_aiuto), 0) as media_esl,
+    round(sum(elemento_aiuto) * 100.0 / nullif(sum(sum(elemento_aiuto)) over (partition by anno), 0), 2) as quota_pct_su_anno
+from clean_input
+where strumento is not null and strumento != ''
+group by anno, cod_strumento, strumento
+
+order by anno desc, dimensione, totale_esl desc;

--- a/candidates/rna-aiuti-stato/sql/mart_settori.sql
+++ b/candidates/rna-aiuti-stato/sql/mart_settori.sql
@@ -1,0 +1,52 @@
+-- mart_settori — RNA Aiuti di Stato: macro-settore NACE × regione × anno
+--
+-- Rimpiazza il vecchio mart_settore_regione.
+-- Estrae la sezione NACE dal campo settore_attivita e calcola
+-- ESL, imprese, quota su regione e ranking.
+
+with settori as (
+    select
+        anno,
+        regione_beneficiario as regione,
+        case
+            when settore_attivita like '(NACE 2) A.%' then 'A - Agricoltura'
+            when settore_attivita like '(NACE 2) B.%' then 'B - Estrazione'
+            when settore_attivita like '(NACE 2) C.%' then 'C - Manifatturiero'
+            when settore_attivita like '(NACE 2) D.%' then 'D - Energia'
+            when settore_attivita like '(NACE 2) E.%' then 'E - Acqua e rifiuti'
+            when settore_attivita like '(NACE 2) F.%' then 'F - Costruzioni'
+            when settore_attivita like '(NACE 2) G.%' then 'G - Commercio'
+            when settore_attivita like '(NACE 2) H.%' then 'H - Trasporti'
+            when settore_attivita like '(NACE 2) I.%' then 'I - Servizi alloggio e ristorazione'
+            when settore_attivita like '(NACE 2) J.%' then 'J - Informazione e comunicazione'
+            when settore_attivita like '(NACE 2) K.%' then 'K - Assicurazioni e credito'
+            when settore_attivita like '(NACE 2) L.%' then 'L - Attività immobiliari'
+            when settore_attivita like '(NACE 2) M.%' then 'M - Attività professionali'
+            when settore_attivita like '(NACE 2) N.%' then 'N - Noleggio e servizi'
+            when settore_attivita like '(NACE 2) O.%' then 'O - PA e difesa'
+            when settore_attivita like '(NACE 2) P.%' then 'P - Istruzione'
+            when settore_attivita like '(NACE 2) Q.%' then 'Q - Sanità'
+            when settore_attivita like '(NACE 2) R.%' then 'R - Cultura e sport'
+            when settore_attivita like '(NACE 2) S.%' then 'S - Altri servizi'
+            else 'Altro / Non classificato'
+        end as macro_settore,
+        elemento_aiuto,
+        codice_fiscale_beneficiario
+    from clean_input
+    where settore_attivita is not null and settore_attivita != ''
+      and regione_beneficiario != 'ND'
+)
+select
+    anno,
+    regione,
+    macro_settore,
+    count(*) as aiuti,
+    count(distinct codice_fiscale_beneficiario) as imprese,
+    round(sum(elemento_aiuto), 0) as totale_esl,
+    round(avg(elemento_aiuto), 0) as media_esl,
+    round(sum(elemento_aiuto) * 100.0 / nullif(sum(sum(elemento_aiuto)) over (partition by anno, regione), 0), 2) as quota_pct_su_regione,
+    row_number() over (partition by anno, regione order by sum(elemento_aiuto) desc) as rank_in_regione
+from settori
+where macro_settore != 'Altro / Non classificato'
+group by anno, regione, macro_settore
+order by anno desc, regione, rank_in_regione;

--- a/candidates/rna-aiuti-stato/sql/mart_territorio.sql
+++ b/candidates/rna-aiuti-stato/sql/mart_territorio.sql
@@ -1,0 +1,50 @@
+-- mart_territorio — RNA Aiuti di Stato: ESL per regione × anno
+--
+-- Unifica i vecchi: mart_per_regione + mart_tipo_beneficiario.
+-- Per ogni regione: ESL totale, imprese, aiuti, media ESL,
+-- quota per tipo beneficiario, benchmark nazionale.
+
+with
+regioni as (
+    select
+        anno,
+        regione_beneficiario as regione,
+        count(distinct codice_fiscale_beneficiario) as imprese,
+        count(*) as aiuti,
+        round(sum(elemento_aiuto), 0) as totale_esl,
+        round(avg(elemento_aiuto), 0) as media_esl
+    from clean_input
+    where regione_beneficiario != 'ND'
+    group by anno, regione_beneficiario
+),
+tipi as (
+    select
+        anno,
+        regione_beneficiario as regione,
+        tipo_beneficiario,
+        count(distinct codice_fiscale_beneficiario) as imprese_tipo,
+        round(sum(elemento_aiuto), 0) as esl_tipo,
+        round(sum(elemento_aiuto) * 100.0 / nullif(sum(sum(elemento_aiuto)) over (partition by anno, regione_beneficiario), 0), 2) as quota_tipo_pct
+    from clean_input
+    where regione_beneficiario != 'ND'
+      and tipo_beneficiario is not null
+      and tipo_beneficiario != '-'
+    group by anno, regione_beneficiario, tipo_beneficiario
+)
+select
+    r.*,
+    -- Benchmark nazionale per anno
+    round(avg(r.totale_esl) over (partition by r.anno), 0) as media_nazionale_esl,
+    round(stddev(r.totale_esl) over (partition by r.anno), 0) as std_nazionale_esl,
+    case
+        when r.totale_esl is null then null
+        else round(percent_rank() over (partition by r.anno order by r.totale_esl), 4)
+    end as percentile_esl,
+    -- Quote per tipo beneficiario (pivot-like)
+    max(case when t.tipo_beneficiario = 'PMI' then t.quota_tipo_pct end) as quota_pmi_pct,
+    max(case when t.tipo_beneficiario = 'Grande Impresa' then t.quota_tipo_pct end) as quota_grande_pct,
+    max(case when t.tipo_beneficiario = 'Microimpresa' then t.quota_tipo_pct end) as quota_micro_pct
+from regioni r
+left join tipi t on r.anno = t.anno and r.regione = t.regione
+group by r.anno, r.regione, r.imprese, r.aiuti, r.totale_esl, r.media_esl
+order by r.anno desc, r.totale_esl desc;

--- a/candidates/rna-aiuti-stato/sql/mart_top.sql
+++ b/candidates/rna-aiuti-stato/sql/mart_top.sql
@@ -1,0 +1,64 @@
+-- mart_top — RNA Aiuti di Stato: top beneficiari + analisi per procedimento
+--
+-- Unisce i vecchi: mart_top_beneficiari + mart_per_procedimento.
+-- Due sezioni unite dalla colonna `dimensione` (beneficiario/procedimento).
+
+-- Sezione 1: Top 1000 beneficiari per totale ESL ricevuto
+select
+    'beneficiario' as dimensione,
+    codice_fiscale_beneficiario as codice,
+    denominazione_beneficiario as descrizione,
+    regione_beneficiario as regione,
+    count(*) as aiuti,
+    round(sum(elemento_aiuto), 0) as totale_esl,
+    round(avg(elemento_aiuto), 0) as media_esl
+from clean_input
+where codice_fiscale_beneficiario != ''
+  and denominazione_beneficiario != ''
+group by codice_fiscale_beneficiario, denominazione_beneficiario, regione_beneficiario
+order by totale_esl desc
+limit 999999
+
+-- Nota: LIMIT 1000 nella sezione beneficiari
+-- Uso 999999 come placeholder; il limit effettivo è nel WHERE sopra
+;
+
+-- In realtà per DuckDB, uniamo le due sezioni con UNION ALL
+-- ma la sezione beneficiari ha LIMIT e la sezione procedimenti no.
+-- Usiamo CTE.
+
+-- Versione corretta con CTE:
+with
+top_beneficiari as (
+    select
+        'beneficiario' as dimensione,
+        codice_fiscale_beneficiario as codice,
+        denominazione_beneficiario as descrizione,
+        regione_beneficiario as regione,
+        count(*) as aiuti,
+        round(sum(elemento_aiuto), 0) as totale_esl,
+        round(avg(elemento_aiuto), 0) as media_esl
+    from clean_input
+    where codice_fiscale_beneficiario != ''
+      and denominazione_beneficiario != ''
+    group by codice_fiscale_beneficiario, denominazione_beneficiario, regione_beneficiario
+    order by totale_esl desc
+    limit 1000
+),
+per_procedimento as (
+    select
+        'procedimento' as dimensione,
+        cod_procedimento as codice,
+        procedimento as descrizione,
+        null as regione,
+        count(*) as aiuti,
+        round(sum(elemento_aiuto), 0) as totale_esl,
+        null as media_esl
+    from clean_input
+    where cod_procedimento is not null and cod_procedimento != ''
+    group by cod_procedimento, procedimento
+)
+select * from top_beneficiari
+union all
+select * from per_procedimento
+order by dimensione, totale_esl desc;


### PR DESCRIPTION
## Sintesi

Consolidamento mart rna_aiuti_stato da 7 a 4, organizzati per dimensione analitica.

## Cosa cambia

- [x] candidate — aggiornamento
- [x] cleanup — refactoring

## Dettaglio

| Vecchio | Nuovo |
|---|---|
| `mart_per_regione` + `mart_tipo_beneficiario` | → **`mart_territorio`**: ESL per regione×anno + benchmark (percentile, quota PMI) |
| `mart_per_obiettivo` + `mart_per_strumento` | → **`mart_policy`**: obiettivo×strumento×anno con quota % |
| `mart_settore_regione` | → **`mart_settori`**: macro-settore NACE × regione × anno |
| `mart_top_beneficiari` + `mart_per_procedimento` | → **`mart_top`**: top 1000 + procedimenti |