### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1410,9 +1410,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "28290057933",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28290057933",
-        "checked_at": "2026-06-27",
+        "run_id": "30383075205",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30383075205",
+        "checked_at": "2026-07-28",
         "years": [
           2017,
           2018,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `rna-aiuti-stato` (candidate, `candidates/rna-aiuti-stato`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/rna-aiuti-stato/dataset.yml` -> artifact `sample-run-rna-aiuti-stato`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
