### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -4139,110 +4139,110 @@
     },
     {
       "slug": "elezioni_voto",
-      "name": "Elezioni Voto",
-      "description": "",
-      "source": "",
-      "source_id": "",
+      "name": "Elezioni Voto — risultati comunali, europee e regionali",
+      "description": "Vista unificata del voto in Italia per elezioni comunali, europee e regionali. 23 tornate (1979-2024), 1.35M righe. Schema normalizzato con tipo_elezione come dimensione. Fonte: Eligendo — DAIT Ministero dell'Interno.",
+      "source": "Eligendo — DAIT Ministero dell'Interno",
+      "source_id": "dataciviclab_composite",
       "period": {
-        "start": 2026,
-        "end": 2026
+        "start": 1979,
+        "end": 2024
       },
       "columns": [
         {
           "name": "data_elezione",
           "type": "DATE",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data dell'elezione"
         },
         {
           "name": "tipo_elezione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipo di elezione: comunali, europee, regionali"
         },
         {
           "name": "regione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Regione"
         },
         {
           "name": "provincia",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Provincia"
         },
         {
           "name": "comune",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Comune"
         },
         {
           "name": "circoscrizione",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Circoscrizione elettorale (solo europee e regionali)"
         },
         {
           "name": "elettori",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Elettori aventi diritto"
         },
         {
           "name": "votanti",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Votanti totali"
         },
         {
           "name": "schede_bianche",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Schede bianche"
         },
         {
           "name": "affluenza_pct",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Percentuale di affluenza (votanti/elettori * 100)"
         },
         {
           "name": "lista",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Lista elettorale o coalizione"
         },
         {
           "name": "voti_lista",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Voti ottenuti dalla lista"
         },
         {
           "name": "candidato",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Nome del candidato (solo comunali e regionali)"
         },
         {
           "name": "voti_candidato",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Voti ottenuti dal candidato (solo comunali e regionali)"
         },
         {
           "name": "turno",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Turno di votazione: 1=primo, 2=ballottaggio (solo comunali)"
         },
         {
           "name": "seggi_lista",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Seggi assegnati alla lista (solo comunali)"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-07-28",
+  "updated_at": "2026-07-29",
   "datasets": [
     {
       "slug": "aci_prime_iscrizioni_autovetture",
@@ -4135,6 +4135,122 @@
         "multi_file": true
       },
       "stage": "incubating",
+      "registry_source": "derive_auto"
+    },
+    {
+      "slug": "elezioni_voto",
+      "name": "Elezioni Voto",
+      "description": "",
+      "source": "",
+      "source_id": "",
+      "period": {
+        "start": 2026,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "data_elezione",
+          "type": "DATE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "tipo_elezione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "regione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "provincia",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "comune",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "circoscrizione",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "elettori",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "votanti",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "schede_bianche",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "affluenza_pct",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "lista",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "voti_lista",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "candidato",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "voti_candidato",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "turno",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "seggi_lista",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/elezioni_voto/2026/elezioni_voto_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
       "registry_source": "derive_auto"
     },
     {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-28",
+  "generated_at": "2026-07-29",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 108,
+    "total": 109,
     "by_status": {
-      "ok": 108,
+      "ok": 109,
       "warn": 0,
       "error": 0
     }
@@ -423,9 +423,9 @@
       "action": "",
       "sample_run": {
         "status": "passed",
-        "run_id": "28938898117",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28938898117",
-        "checked_at": "2026-07-08",
+        "run_id": "30454985257",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30454985257",
+        "checked_at": "2026-07-29",
         "years": [
           1995,
           1997,
@@ -2054,6 +2054,14 @@
         ],
         "config_path": "compose/costituzione-master/dataset.yml"
       }
+    },
+    {
+      "id": "compose:elezioni-voto",
+      "source_id": "dataciviclab_composite",
+      "status": "ok",
+      "label": "compose:elezioni-voto",
+      "detail": "anno 2026 — fonte: ? — mart: sì",
+      "action": ""
     },
     {
       "id": "compose:eurostat-demography",


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `elezioni-referendum` (candidate, `candidates/elezioni-referendum`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/elezioni-referendum/dataset.yml` -> artifact `sample-run-elezioni-referendum`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
