### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -2061,7 +2061,17 @@
       "status": "ok",
       "label": "compose:elezioni-voto",
       "detail": "anno 2026 — fonte: ? — mart: sì",
-      "action": ""
+      "action": "",
+      "sample_run": {
+        "status": "passed",
+        "run_id": "30456214276",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30456214276",
+        "checked_at": "2026-07-29",
+        "years": [
+          2026
+        ],
+        "config_path": "compose/elezioni-voto/dataset.yml"
+      }
     },
     {
       "id": "compose:eurostat-demography",


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `elezioni-voto` (compose, `compose/elezioni-voto`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `compose/elezioni-voto/dataset.yml` -> artifact `sample-run-elezioni-voto`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
