### PR TITLE
feat(candidate): add tags and category to terna-capacita-rinnovabile and terna-electrical-energy-by-sector

### DIFF
--- a/candidates/terna-capacita-rinnovabile/dataset.yml
+++ b/candidates/terna-capacita-rinnovabile/dataset.yml
@@ -5,6 +5,8 @@ dataset:
   name: "terna_capacita_rinnovabile"
   source_id: "terna_opendata"
   years: [2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024]
+  tags: [energia, elettricità, fonti-rinnovabili]
+  category: energia
 
 raw:
   sources:

--- a/candidates/terna-electrical-energy-by-sector/dataset.yml
+++ b/candidates/terna-electrical-energy-by-sector/dataset.yml
@@ -5,6 +5,8 @@ dataset:
   name: "terna_electrical_energy_by_sector"
   source_id: "terna_opendata"
   years: [2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024]
+  tags: [energia, elettricità, fonti-rinnovabili]
+  category: energia
 
 raw:
   sources:


### PR DESCRIPTION
## Sintesi

Aggiunge `tags: [energia, elettricità, fonti-rinnovabili]` e `category: energia` ai due dataset Terna mancanti, allineandoli a terna-electricity-by-source (già popolato).

## Cosa cambia

- `candidates/terna-capacita-rinnovabile/dataset.yml` — +2 righe
- `candidates/terna-electrical-energy-by-sector/dataset.yml` — +2 righe
- `registry/clean_catalog.json` — rigenerato (enrich tags/category)

## Verifica

```bash
python scripts/build_clean_catalog.py
```

- [x] tags e category presenti nel catalogo dopo enrich