### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1607,9 +1607,9 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "27063027962",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27063027962",
-        "checked_at": "2026-06-06",
+        "run_id": "30500875904",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30500875904",
+        "checked_at": "2026-07-29",
         "years": [
           2015,
           2016,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `terna-capacita-rinnovabile` (candidate, `candidates/terna-capacita-rinnovabile`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/terna-capacita-rinnovabile/dataset.yml` -> artifact `sample-run-terna-capacita-rinnovabile`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
