### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-07-29",
+  "updated_at": "2026-07-30",
   "datasets": [
     {
       "slug": "aci_prime_iscrizioni_autovetture",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-29",
+  "generated_at": "2026-07-30",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -1607,9 +1607,9 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "30500875904",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30500875904",
-        "checked_at": "2026-07-29",
+        "run_id": "30501562348",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30501562348",
+        "checked_at": "2026-07-30",
         "years": [
           2015,
           2016,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `terna-capacita-rinnovabile` (candidate, `candidates/terna-capacita-rinnovabile`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/terna-capacita-rinnovabile/dataset.yml` -> artifact `sample-run-terna-capacita-rinnovabile`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
