### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -59,9 +59,16 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "26462812456",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26462812456",
-        "checked_at": "2026-05-26",
+        "run_id": "30524438404",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30524438404",
+        "checked_at": "2026-07-30",
+        "duration_seconds": 10.113,
+        "readiness": "needs-review",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 7,
+          "fail": 1
+        },
         "years": [
           2018,
           2019,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `aifa-spesa-consumo` (candidate, `candidates/aifa-spesa-consumo`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/aifa-spesa-consumo/dataset.yml` -> artifact `sample-run-aifa-spesa-consumo`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
