### PR TITLE
align(toolkit): adatta DI al nuovo CLI (run default, validate rimosso)

### DIFF
--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -122,7 +122,7 @@ jobs:
       - name: "Toolkit SQL dry-run (valida sintassi SQL senza eseguire)"
         id: dry_run
         run: |
-          toolkit run all \
+          toolkit run \
             --config "${{ matrix.config.config_path }}" \
             --dry-run \
             > dry_run.log 2>&1; ec=$?

--- a/.github/workflows/pr-toolkit-check.yml
+++ b/.github/workflows/pr-toolkit-check.yml
@@ -172,5 +172,5 @@ jobs:
             echo "❌ Some candidates failed — individual artifacts in 'pr-toolkit-*' above" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "> Il dry-run valida sintassi SQL e struttura config. Per run completo (download + clean + mart),"
-            echo "> usa il merge o esegui: toolkit run all --config <path>" >> "$GITHUB_STEP_SUMMARY"
+            echo "> usa il merge o esegui: toolkit run --config <path>" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/smoke-weekly.yml
+++ b/.github/workflows/smoke-weekly.yml
@@ -35,7 +35,55 @@ jobs:
       - name: Weekly probe — raggiungibilità fonti
         id: probe
         run: |
-          python -m toolkit.cli.app batch --configs /tmp/current_batch.txt --step probe --json > /tmp/probe_report.json 2>/tmp/probe_stderr.log
+          # toolkit run preflight per ogni candidate (probe + reachability).
+          # Il vecchio "batch --step probe" non esiste più (batch deprecato).
+          python3 - <<'PY'
+          import json, subprocess, sys
+
+          rows = []
+          stderr_log = []
+          with open("/tmp/current_batch.txt") as f:
+              configs = [l.strip() for l in f if l.strip() and not l.startswith("#")]
+
+          for cfg in configs:
+              try:
+                  r = subprocess.run(
+                      ["toolkit", "run", "preflight", "--config", cfg, "--json"],
+                      capture_output=True, text=True, timeout=90,
+                  )
+                  if r.returncode != 0:
+                      rows.append({"config": cfg, "dataset": cfg.split("/")[-2],
+                                   "status": "FAILED", "error": r.stderr[:200]})
+                      stderr_log.append(f"{cfg}: {r.stderr[:200]}")
+                      continue
+                  d = json.loads(r.stdout)
+                  srcs = d.get("sources") or []
+                  n_reach = sum(1 for s in srcs if s.get("reachable"))
+                  rows.append({
+                      "config": cfg,
+                      "dataset": d.get("dataset", cfg.split("/")[-2]),
+                      "status": "SUCCESS" if n_reach == len(srcs) and len(srcs) > 0 else "FAILED",
+                      "reachable": f"{n_reach}/{len(srcs)}",
+                  })
+              except Exception as e:
+                  rows.append({"config": cfg, "dataset": cfg.split("/")[-2],
+                               "status": "FAILED", "error": str(e)[:200]})
+                  stderr_log.append(f"{cfg}: {e}")
+
+          report = {
+              "summary": {
+                  "total": len(rows),
+                  "passed": sum(1 for r in rows if r["status"] == "SUCCESS"),
+                  "failed": sum(1 for r in rows if r["status"] != "SUCCESS"),
+              },
+              "rows": rows,
+          }
+          with open("/tmp/probe_report.json", "w") as f:
+              json.dump(report, f, indent=2)
+          with open("/tmp/probe_stderr.log", "w") as f:
+              f.write("\n".join(stderr_log))
+          print(f"passed={report['summary']['passed']} failed={report['summary']['failed']} total={report['summary']['total']}")
+          PY
           echo "passed=$(python3 -c "import json;d=json.load(open('/tmp/probe_report.json'));print(d['summary']['passed'])")" >> "$GITHUB_OUTPUT"
           echo "failed=$(python3 -c "import json;d=json.load(open('/tmp/probe_report.json'));print(d['summary']['failed'])")" >> "$GITHUB_OUTPUT"
           echo "total=$(python3 -c "import json;d=json.load(open('/tmp/probe_report.json'));print(d['summary']['total'])")" >> "$GITHUB_OUTPUT"
@@ -62,21 +110,12 @@ jobs:
           python3 -c "
           import json
           d = json.load(open('/tmp/probe_report.json'))
-          # Raggruppa per slug (un candidate ha più anni)
-          slugs = {}
           for r in d['rows']:
-              slug = r['dataset']
-              if slug not in slugs:
-                  slugs[slug] = {'ok': 0, 'total': 0}
-              slugs[slug]['total'] += 1
-              if r['status'] == 'SUCCESS':
-                  slugs[slug]['ok'] += 1
-          for slug, info in sorted(slugs.items()):
-              icon = '✅' if info['ok'] == info['total'] else '⚠️'
-              print(f'{icon} {slug:35s} {info[\"ok\"]}/{info[\"total\"]} anni ok')
+              icon = '✅' if r['status'] == 'SUCCESS' else '🔴'
+              extra = r.get('reachable', '')
+              err = f\" — {r.get('error', '')[:80]}\" if r.get('error') else ''
+              print(f'{icon} {r[\"dataset\"]:35s} {extra}{err}')
           " >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Durata: $(python3 -c "import json;d=json.load(open('/tmp/probe_report.json'));print(round(d['summary']['duration_seconds'],1))")s" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ -s /tmp/probe_stderr.log ]; then
             echo "### Warning (stderr)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/smoke-weekly.yml
+++ b/.github/workflows/smoke-weekly.yml
@@ -59,11 +59,15 @@ jobs:
                   d = json.loads(r.stdout)
                   srcs = d.get("sources") or []
                   n_reach = sum(1 for s in srcs if s.get("reachable"))
+                  # Criterio: status "passed" da preflight (config ok + fonti
+                  # raggiungibili). Un candidate senza fonti remote (local_file)
+                  # non deve finire FAILED per il solo conteggio fonti.
+                  ok = d.get("status") == "passed" and len(srcs) > 0 and n_reach == len(srcs)
                   rows.append({
                       "config": cfg,
                       "dataset": d.get("dataset", cfg.split("/")[-2]),
-                      "status": "SUCCESS" if n_reach == len(srcs) and len(srcs) > 0 else "FAILED",
-                      "reachable": f"{n_reach}/{len(srcs)}",
+                      "status": "SUCCESS" if ok else "FAILED",
+                      "reachable": f"{n_reach}/{len(srcs)}" if srcs else "-",
                   })
               except Exception as e:
                   rows.append({"config": cfg, "dataset": cfg.split("/")[-2],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # lab-connectors[gcs] per script che usano GCS direttamente (toolkit porta solo [duckdb])
 lab-connectors[duckdb,gcs,mcp] @ git+https://github.com/dataciviclab/lab-connectors.git
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.46.1
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.47.0
 
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0

--- a/scripts/post_merge_runner.py
+++ b/scripts/post_merge_runner.py
@@ -5,7 +5,7 @@ Estratto dalla logica inline Python nei job sample_run e build-and-pr
 del workflow GHA post-merge-candidate.yml.
 
 Subcommands:
-    sample-run    Esegue toolkit run full + GCS push + catalog rebuild
+    sample-run    Esegue toolkit run + GCS push + catalog rebuild
                   per ogni config rilevato in detect_output.json.
                   Sostituisce il blocco inline 'Process each detected config'.
 
@@ -88,7 +88,7 @@ def _resolve_years(config_path: str, root: str) -> list[int]:
 def _extract_run_metrics(root: str, slug: str, years: list[int]) -> dict[str, Any]:
     """Legge metriche di run dai run_report.json prodotti dal toolkit.
 
-    I report sono scritti da toolkit run full in:
+    I report sono scritti da toolkit run in:
       {root}/data/_reports/{slug}/{year}_run_report.json
     oppure in {root}/out/data/_reports/{slug}/{year}_run_report.json
     (quando il root del dataset.yml è ./out).
@@ -262,12 +262,13 @@ def cmd_sample_run(args: argparse.Namespace) -> None:
 
         years_str = ",".join(str(y) for y in all_years)
 
-        # --- Toolkit run full (run + validate + readiness + support) ---
+        # --- Toolkit run (run + validate + readiness + support) ---
         # Se un candidate ha bisogno di proxy per raggiungere la fonte,
         # impostalo via os.environ nello script di download.
-        print(f"  toolkit run full --years {years_str}")
+        # Il comando "run" (default) sostituisce il vecchio "run full".
+        print(f"  toolkit run --years {years_str}")
         run_ok, run_stdout = _run_with_retry(
-            ["toolkit", "run", "full", "--config", config_path, "--years", years_str, "--json"],
+            ["toolkit", "run", "--config", config_path, "--years", years_str, "--json"],
             cwd=root,
             attempts=args.retry,
         )
@@ -405,9 +406,7 @@ def main() -> None:
     sub = parser.add_subparsers(dest="command", required=True)
 
     # sample-run
-    p_sample = sub.add_parser(
-        "sample-run", help="Esegui toolkit run full + GCS push per ogni config"
-    )
+    p_sample = sub.add_parser("sample-run", help="Esegui toolkit run + GCS push per ogni config")
     p_sample.add_argument(
         "--detect-json",
         default="detect_output.json",

--- a/scripts/post_merge_runner.py
+++ b/scripts/post_merge_runner.py
@@ -278,6 +278,24 @@ def cmd_sample_run(args: argparse.Namespace) -> None:
         # Estrai metriche dal run record su disco (prodotto dal toolkit)
         run_metrics = _extract_run_metrics(root, slug, all_years)
 
+        # Readiness: calcolata via toolkit (non nel run record).
+        # Il pipeline_signals la consuma per l'ACB senza dover chiamare il toolkit.
+        readiness_payload: dict[str, Any] = {}
+        try:
+            from toolkit.domain.readiness import review_readiness
+
+            rr = review_readiness(config_path, all_years[0] if all_years else None)
+            readiness_payload["readiness"] = rr.get("readiness")
+            readiness_payload["readiness_checks"] = {
+                "total": rr.get("check_count", 0),
+                "ok": rr.get("ok_count", 0),
+                "fail": rr.get("fail_count", 0),
+            }
+        except Exception:
+            # readiness opzionale — non blocca il post-merge se il toolkit
+            # non la espone (es. versioni precedenti)
+            pass
+
         status = "passed" if run_ok else "failed"
         if status == "failed":
             failed_configs.append(slug)
@@ -297,6 +315,7 @@ def cmd_sample_run(args: argparse.Namespace) -> None:
             "run_url": f"https://github.com/{repo}/actions/runs/{run_id}",
             "checked_at": datetime.now(timezone.utc).date().isoformat(),
             **run_metrics,
+            **readiness_payload,
         }
         out_dir = f"sample_run_artifacts/{artifact_name}"
         Path(out_dir).mkdir(parents=True, exist_ok=True)

--- a/scripts/post_merge_runner.py
+++ b/scripts/post_merge_runner.py
@@ -86,79 +86,81 @@ def _resolve_years(config_path: str, root: str) -> list[int]:
 
 
 def _extract_run_metrics(root: str, slug: str, years: list[int]) -> dict[str, Any]:
-    """Legge metriche di run dai run_report.json prodotti dal toolkit.
+    """Legge metriche di run dai run record prodotti dal toolkit.
 
-    I report sono scritti da toolkit run in:
-      {root}/data/_reports/{slug}/{year}_run_report.json
-    oppure in {root}/out/data/_reports/{slug}/{year}_run_report.json
+    I run record sono scritti da toolkit run in:
+      {root}/data/_runs/{slug}/{year}/*.json
+    oppure in {root}/out/data/_runs/{slug}/{year}/*.json
     (quando il root del dataset.yml è ./out).
-    Lo slug nella directory report può usare underscore (terna_capacita)
+
+    Lo slug nella directory run può usare underscore (terna_capacita)
     mentre lo slug del candidate usa trattini (terna-capacita).
-    Contiene duration_seconds, readiness, row_counts, quality_scores.
+
+    Il run record contiene duration_seconds, layers[].metrics,
+    validations[].quality_score e validations[].summary.stats.
+    (In precedenza lo script leggeva da _reports/, rimosso dal toolkit.)
     """
     metrics: dict[str, Any] = {}
     root_path = Path(root)
     # Cerca in root e in root/out (dove toolkit scrive con root=./out)
-    report_dirs = [
-        root_path / "data" / "_reports",
-        root_path / "out" / "data" / "_reports",
+    run_dirs = [
+        root_path / "data" / "_runs",
+        root_path / "out" / "data" / "_runs",
     ]
-    # Lo slug del report potrebbe usare underscore invece di trattini
+    # Lo slug del run potrebbe usare underscore invece di trattini
     slug_variants = [slug, slug.replace("-", "_")]
     latest_duration = None
     total_row_counts: dict[str, int] = {}
-    latest_readiness = None
-    latest_checks = None
     all_qs: dict[str, float] = {}
 
     for year in years:
-        report_path = None
-        for base in report_dirs:
+        run_record = None
+        for base in run_dirs:
             for s in slug_variants:
-                candidate = base / s / f"{year}_run_report.json"
-                if candidate.exists():
-                    report_path = candidate
-                    break
-            if report_path:
+                year_dir = base / s / str(year)
+                if not year_dir.exists():
+                    continue
+                run_files = sorted(year_dir.glob("*.json"))
+                if not run_files:
+                    continue
+                # Ultimo run dell'anno (ordinamento lessicografico dei run_id ISO)
+                run_record = run_files[-1]
                 break
-        if report_path is None:
-            continue
+            if run_record:
+                break
+        if run_record is None:
             continue
         try:
-            report = json.loads(report_path.read_text(encoding="utf-8"))
+            record = json.loads(run_record.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             continue
 
-        dur = report.get("duration_seconds")
+        dur = record.get("duration_seconds")
         if dur is not None:
             latest_duration = dur
-        rd = report.get("readiness")
-        if rd:
-            latest_readiness = rd
-        rc = report.get("readiness_checks")
-        if rc:
-            latest_checks = rc
 
-        layers = report.get("layers", {})
+        layers = record.get("layers", {})
+        validations = record.get("validations", {})
         for layer_name in ("raw", "clean", "mart"):
             ln = layers.get(layer_name) or {}
-            # row_count: prima dal campo uniforme a livello layer (nuovo),
-            # poi fallback su validation per report vecchi
-            row_count = ln.get("row_count") or (ln.get("validation") or {}).get("row_count")
+            lv = validations.get(layer_name) or {}
+            # row_count: dal summary.stats (nuovo run record) o dal layer
+            summary_block = lv.get("summary") or {}
+            stats = summary_block.get("stats") or {}
+            row_count = (
+                stats.get("clean_rows")
+                or stats.get("raw_rows")
+                or (ln.get("metrics") or {}).get("output_rows")
+            )
             if row_count is not None:
                 total_row_counts[layer_name] = total_row_counts.get(layer_name, 0) + int(row_count)
-            # quality_score: dal validation del layer (non da preflight,
-            # che ha null per fonti unreachable)
-            qs = (ln.get("validation") or {}).get("quality_score")
+            # quality_score: dal validation del layer
+            qs = lv.get("quality_score")
             if qs is not None:
                 all_qs[layer_name] = float(qs)
 
     if latest_duration is not None:
         metrics["duration_seconds"] = latest_duration
-    if latest_readiness:
-        metrics["readiness"] = latest_readiness
-    if latest_checks:
-        metrics["readiness_checks"] = latest_checks
     if total_row_counts:
         metrics["row_counts"] = total_row_counts
     if all_qs:
@@ -273,7 +275,7 @@ def cmd_sample_run(args: argparse.Namespace) -> None:
             attempts=args.retry,
         )
 
-        # Estrai metriche dal run_report.json su disco (prodotto dal toolkit)
+        # Estrai metriche dal run record su disco (prodotto dal toolkit)
         run_metrics = _extract_run_metrics(root, slug, all_years)
 
         status = "passed" if run_ok else "failed"

--- a/scripts/validate_candidate_structure.py
+++ b/scripts/validate_candidate_structure.py
@@ -170,11 +170,11 @@ def check_clean_validation_config(dataset_yml: Path, warnings: list[str]) -> Non
 
     clean_validate = cfg.clean.validate
     missing: list[str] = []
-    if not clean_validate.not_null:
+    if not clean_validate or not clean_validate.not_null:
         missing.append("clean.validate.not_null")
     if not cfg.clean.required_columns:
         missing.append("clean.required_columns")
-    if not clean_validate.primary_key:
+    if not clean_validate or not clean_validate.primary_key:
         missing.append(
             "clean.validate.primary_key (utile ma opzionale — deroga se PK non dichiarabile)"
         )

--- a/skills/README.md
+++ b/skills/README.md
@@ -9,8 +9,10 @@ Sono il riferimento umano per il comportamento della pipeline toolkit e delle Gi
 | Skill | Quando |
 |---|---|
 | `intake-candidate.md` | Valutare se un caso è maturo per entrare in DI e creare la struttura minima |
-| `run-candidate.md` | Eseguire un candidate e chiuderlo con stato (`runnable`, `scaffolded_with_blocker`, `wait`) |
+| `run-candidate.md` | Eseguire un candidate e chiuderlo con stato (`runnable`, `scaffolded_with_blocker`, `wait`) — inspect come gate |
 | `post-merge-candidate.md` | Checklist maintainer dopo il merge: run completo, push GCS, clean catalog |
+
+> **Gate**: dopo ogni run, `toolkit inspect` mostra il verdict readiness (ready / needs-review / incomplete) con i check. Un candidate si chiude `runnable` solo con `ready` o con `needs-review` motivato per il perimetro del dataset.
 
 ## GitHub Actions (pipeline automatica)
 

--- a/skills/intake-candidate.md
+++ b/skills/intake-candidate.md
@@ -11,7 +11,7 @@ metadata:
 # Skill: intake-candidate
 
 Skill canonico di `dataset-incubator`.
-Versione: 0.7 — 2026-07-30 — CLI allineata a toolkit v1.46
+Versione: 0.7 — 2026-07-31 — inspect come gate con readiness
 
 ## Obiettivo
 
@@ -86,21 +86,22 @@ Prima di runnare, revisiona velocemente:
 - `dataset.yml` — campi `clean.read` e `sql` coerenti col source profile
 - boundary clean/mart — clean raw-faithful, mart analitico
 
-Poi:
+Poi, **un anno per volta**:
 
 ```bash
-toolkit run -c candidates/{slug}/dataset.yml --years 2024
+toolkit run -c candidates/{slug}/dataset.yml --year 2024
 ```
 
-Unico comando. Esegue raw + clean + mart + validate + readiness.
+Esegue raw + clean + mart + validate + readiness. A fine run mostra il
+verdict sintetico (es. `readiness: needs-review (7/8)`).
 
-### 5. Verifica
+### 5. Verifica — inspect è il gate
 
 Prima lascia che la pipeline dica se è tutto ok, poi controlla che i dati abbiano senso.
 
 ```bash
-# 1. Stato pipeline
-toolkit inspect -c candidates/{slug}/dataset.yml -y 2024 --json
+# 1. Stato + verdict readiness con check (comando unico)
+toolkit inspect -c candidates/{slug}/dataset.yml -y 2024
 
 # 2. Dati — conta righe e vedi un campione
 toolkit inspect config -c candidates/{slug}/dataset.yml -l clean -m sql --sql "SELECT count(*) FROM data"
@@ -112,7 +113,10 @@ toolkit inspect config -c candidates/{slug}/dataset.yml -l mart -m sql --sql "SE
 toolkit inspect config -c candidates/{slug}/dataset.yml -l mart -m preview --limit 5
 ```
 
-I numeri sono nel range atteso? Le colonne sono quelle giuste? Se sì → candidate ok.
+I numeri sono nel range atteso? Le colonne sono quelle giuste?
+Se `readiness: ready` → candidate ok.
+Se `needs-review` → guarda quale check fallisce e decidi se è un blocker
+reale o un check da allineare al perimetro.
 
 Se la pipeline fallisce → diagnostica rapida:
 
@@ -128,6 +132,8 @@ toolkit inspect config -c candidates/{slug}/dataset.yml -l clean -m schema --jso
 toolkit inspect config -c candidates/{slug}/dataset.yml --diff --json
 ```
 
+Ciclo fix → run → inspect fino a `ready` (o blocker documentato).
+
 Blocker specifico documentato, non formulaico.
 
 ### 6. PR
@@ -136,7 +142,7 @@ Apri PR con:
 - branch da `main`
 - perimetro stretto
 - issue collegata
-- esito del run in descrizione (passed / failed / blocker)
+- esito del run + verdict readiness in descrizione (ready / needs-review motivato / blocker)
 
 ## Definition of done
 

--- a/skills/run-candidate.md
+++ b/skills/run-candidate.md
@@ -1,9 +1,9 @@
 ---
 name: run-candidate
-description: Skill canonico per eseguire un candidate esistente e verificarne lo stato.
+description: Skill canonico per eseguire un candidate esistente e verificarlo end-to-end con readiness come gate.
 license: MIT
 metadata:
-  version: "0.6"
+  version: "0.7"
   owner: "DataCivicLab"
   tags: [dataset-incubator, run, candidate]
 ---
@@ -11,7 +11,7 @@ metadata:
 # Skill: run-candidate
 
 Skill canonico di `dataset-incubator`.
-Versione: 0.6 — 2026-07-30 — CLI allineata a toolkit v1.46
+Versione: 0.7 — 2026-07-31 — flusso end-to-end con readiness come gate
 
 ## Obiettivo
 
@@ -21,36 +21,45 @@ Eseguire un candidate già presente in `candidates/` e chiudere con stato:
 ## Entry point
 
 - `candidates/{slug}/dataset.yml` esistente
-- Toolkit accessibile
+- Toolkit accessibile (v1.46+)
 
 Stop: candidate immaturo, boundary clean/mart assente, problema di fase precedente.
 
+## Regole
+
+1. **Mai guardare solo l'exit code** — `run` può passare con warning. `inspect` mostra i check.
+2. **Un anno per volta** durante lo sviluppo, non tutti gli anni configurati.
+3. **`inspect` è il gate** — il run ti dice "è andato", `inspect` ti dice "è buono".
+4. **Blocker > formula** — se qualcosa fallisce, documenta il *perché* preciso, non "non funziona".
+
 ## Procedura
 
-### 1. Pre-flight
+### 1. Pre-flight — capire dove siamo
 
 ```bash
-toolkit inspect -c candidates/{slug}/dataset.yml -y 2024 --json
+toolkit inspect -c candidates/{slug}/dataset.yml -y 2024
 ```
 
-Oppure MCP: `toolkit_status(config_path)` → sezioni `paths_info` + `run_stats`.
+Il comando unico mostra: run status, righe/colonne per layer, raw hints e
+**verdict readiness con check**. Risponde a: il dataset è mai stato runnato?
+è pronto? cosa manca?
 
-### 2. Run
+Oppure MCP: `toolkit_status(config_path)` → sezione readiness.
+
+### 2. Run — un anno per volta
 
 ```bash
-toolkit run -c candidates/{slug}/dataset.yml --years 2024
+toolkit run -c candidates/{slug}/dataset.yml --year 2024
 ```
 
-Unico comando. Esegue raw + clean + mart + validate + readiness in sequenza.
+Esegue raw + clean + mart + validazione + readiness. A fine run mostra il
+verdict sintetico: `readiness: needs-review (7/8)`.
 
-### 3. Verifica
-
-Prima lo stato pipeline, poi controlla che i dati abbiano senso.
+### 3. Verifica — inspect è il gate
 
 ```bash
-# Stato pipeline
-toolkit inspect -c candidates/{slug}/dataset.yml -y 2024 --json
-# Oppure MCP: toolkit_status(config_path) → sezione readiness
+# Stato + verdict + check (comando unico)
+toolkit inspect -c candidates/{slug}/dataset.yml -y 2024
 
 # Ispezione dati — conta righe e campione
 toolkit inspect config -c candidates/{slug}/dataset.yml -l clean -m sql --sql "SELECT count(*) FROM data"
@@ -62,7 +71,12 @@ toolkit inspect config -c candidates/{slug}/dataset.yml -l mart -m sql --sql "SE
 toolkit inspect config -c candidates/{slug}/dataset.yml -l mart -m preview --limit 5
 ```
 
-### 4. Diagnostica (se fallisce)
+Se `readiness: ready` → chiudi con `runnable`.
+Se `needs-review` → guarda **quale check fallisce** nell'output di inspect
+(es. `validation_rules_coverage`) e decidi: è un blocker reale o un check
+da allineare al perimetro del dataset?
+
+### 4. Diagnostica (se fallisce o il verdict non torna)
 
 ```bash
 # MCP (raccomandato)
@@ -77,23 +91,28 @@ toolkit inspect config -c candidates/{slug}/dataset.yml -l clean -m schema --jso
 toolkit inspect config -c candidates/{slug}/dataset.yml --diff --json
 ```
 
-Se il blocker è isolato → documentalo e chiudi con `scaffolded_with_blocker`.
+### 5. Ciclo fino a ready
 
-### 5. Chiudi con stato
+fix → run → inspect → fix → run → inspect.
+Fermati quando `readiness: ready`, oppure `needs-review` con blocker
+documentato con precisione.
 
-- `runnable` — run passa, output leggibili
+### 6. Chiudi con stato
+
+- `runnable` — run passa, `readiness: ready` o `needs-review` motivato
 - `scaffolded_with_blocker` — blocker preciso documentato
 
 ## Definition of done
 
-- run eseguito senza errori oppure blocker documentato
-- esito netto, prossimo passo esplicito
+- run eseguito, inspect conferma il verdict
+- esito netto (ready / blocker documentato), prossimo passo esplicito
 
 ## Errori tipici
 
-- lanciare compose prima dei source layer
-- guardare solo exit code, non gli output reali
+- lanciare tutti gli anni invece di un anno singolo
+- guardare solo exit code, non il verdict readiness né gli output reali
 - cambiare troppe cose dopo il primo errore
+- chiudere `runnable` con check falliti non motivati
 
 ## Dove orientarsi
 

--- a/skills/run-candidate.md
+++ b/skills/run-candidate.md
@@ -21,7 +21,7 @@ Eseguire un candidate già presente in `candidates/` e chiudere con stato:
 ## Entry point
 
 - `candidates/{slug}/dataset.yml` esistente
-- Toolkit accessibile (v1.46+)
+- Toolkit accessibile (v1.47+)
 
 Stop: candidate immaturo, boundary clean/mart assente, problema di fase precedente.
 

--- a/tests/test_toolkit_integration.py
+++ b/tests/test_toolkit_integration.py
@@ -1,6 +1,6 @@
 """Integration test: lancia toolkit su un candidate minimo e verifica output.
 
-Contratto: toolkit run full produce output CLEAN e MART su un candidate minimo.
+Contratto: toolkit run produce output CLEAN e MART su un candidate minimo.
 Skip automatico se toolkit non e' disponibile.
 
 Prova del fuoco: se cancello questi test, un refactor di toolkit o del formato
@@ -88,13 +88,13 @@ validation:
 
         # Esegui toolkit
         result = subprocess.run(
-            ["toolkit", "run", "all", "--config", str(yml), "--years", "2024"],
+            ["toolkit", "run", "--config", str(yml), "--years", "2024"],
             capture_output=True,
             text=True,
             timeout=120,
         )
         if result.returncode != 0:
-            pytest.fail(f"toolkit run all fallito:\nSTDOUT:{result.stdout}\nSTDERR:{result.stderr}")
+            pytest.fail(f"toolkit run fallito:\nSTDOUT:{result.stdout}\nSTDERR:{result.stderr}")
 
         # Verifica output CLEAN
         clean_parquet = (
@@ -113,7 +113,12 @@ validation:
         mart_parquet = dst / "out" / "data" / "mart" / "test_intg" / "2024" / "mart_intg.parquet"
         assert mart_parquet.exists(), f"Mart parquet non trovato: {mart_parquet}"
 
-        # Verifica summary.ok in metadata.json
-        meta_dir = mart_parquet.parent
-        meta = json.loads((meta_dir / "metadata.json").read_text(encoding="utf-8"))
-        assert meta.get("summary", {}).get("ok") is True
+        # Verifica validazione nel run record (fonte di verità da toolkit #436:
+        # la validazione è in memoria nel run record, non più in metadata.json)
+        runs_dir = dst / "out" / "data" / "_runs" / "test_intg" / "2024"
+        run_files = sorted(runs_dir.glob("*.json"))
+        assert run_files, f"Run record non trovato in {runs_dir}"
+        run_rec = json.loads(run_files[-1].read_text(encoding="utf-8"))
+        assert run_rec["status"] == "SUCCESS"
+        assert run_rec["validations"]["clean"]["passed"] is True
+        assert run_rec["validations"]["mart"]["passed"] is True


### PR DESCRIPTION
## Sintesi

Allinea DI al nuovo CLI del toolkit (9 commit dopo v1.46.1): `run full` e `run all` sono stati sostituiti dal default `run`, `validate` è stato rimosso.

## Cosa cambia

- `post_merge_runner.py`: `toolkit run full` → `toolkit run`
- `pr-toolkit-check.yml`: `toolkit run all --dry-run` → `toolkit run --dry-run`
- `validate_candidate_structure.py`: gestisce `clean.validate=None` (refactor #435 modelli Pydantic → dataclass)

## Verifica

- `validate_candidate_structure.py` → exit 0
- dry-run con toolkit nuovo → `sql_validation: OK` per 10 anni
- `build_clean_catalog.py`, `detect_candidates.py`, `build_pipeline_signals.py` → già compatibili (verificato)