### PR TITLE
chore(post-merge): aggiorna registry per PR #750

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -13114,7 +13114,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "immigrazione",
+        "migranti",
+        "sbarchi"
+      ],
+      "category": "immigrazione"
     },
     {
       "slug": "silos_infrastrutture",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1514,9 +1514,26 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "28816214267",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28816214267",
-        "checked_at": "2026-07-06",
+        "run_id": "30625809178",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30625809178",
+        "checked_at": "2026-07-31",
+        "duration_seconds": 0.41,
+        "row_counts": {
+          "raw": 4352,
+          "clean": 4348,
+          "mart": 73
+        },
+        "readiness": "incomplete",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 6,
+          "fail": 2
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 95.0,
+          "mart": 100.0
+        },
         "years": [
           2025
         ],


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #750 — feat(candidate): add tags and category to sbarchi-migranti-italia

Changed candidate/support roots:

- `sbarchi-migranti-italia` (candidate, `candidates/sbarchi-migranti-italia`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/sbarchi-migranti-italia/dataset.yml` -> artifact `sample-run-sbarchi-migranti-italia`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
