### PR TITLE
perf(post-merge): derive solo lo slug del candidate, non tutto il bucket

### DIFF
--- a/scripts/build_clean_catalog.py
+++ b/scripts/build_clean_catalog.py
@@ -81,6 +81,11 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    # Normalizza lo slug a underscore: i nomi candidate usano trattini
+    # (sbarchi-migranti-italia) ma GCS usa underscore (sbarchi_migranti_italia/)
+    if args.slug:
+        args.slug = args.slug.replace("-", "_")
+
     # Il catalogo di partenza: vuoto se --derive, altrimenti da file
     if args.derive:
         raw: dict[str, Any] = {"datasets": []}

--- a/scripts/build_clean_catalog.py
+++ b/scripts/build_clean_catalog.py
@@ -68,6 +68,13 @@ def main() -> int:
         "Usa --write per salvare (--derive senza --write è dry-run).",
     )
     parser.add_argument(
+        "--slug",
+        type=str,
+        default=None,
+        help="Limita il derive a un singolo slug (es. sbarchi_migranti_italia). "
+        "Scansiona solo quel prefisso nel bucket — molto più veloce del derive completo.",
+    )
+    parser.add_argument(
         "--check-gcs",
         action="store_true",
         help="Verify that public GCS paths resolve to at least one parquet.",
@@ -83,7 +90,7 @@ def main() -> int:
                 print(f"[derive] Caricati metadata editoriali da {args.catalog}", file=sys.stderr)
             except Exception:
                 print(f"[derive] WARN: cannot read {args.catalog}, starting fresh", file=sys.stderr)
-        catalog, derive_errors = derive_catalog_from_gcs(raw, args.refresh_date)
+        catalog, derive_errors = derive_catalog_from_gcs(raw, args.refresh_date, slug=args.slug)
     else:
         original_text = args.catalog.read_text(encoding="utf-8")
         catalog = json.loads(original_text)
@@ -290,11 +297,14 @@ def _enrich_tags_and_category(catalog: dict[str, Any], root: Path) -> None:
 
 
 def derive_catalog_from_gcs(
-    existing: dict[str, Any], refresh_date: bool = False
+    existing: dict[str, Any],
+    refresh_date: bool = False,
+    slug: str | None = None,
 ) -> tuple[dict[str, Any], list[str]]:
     """Deriva il catalogo scansionando GCS e leggendo schemi parquet.
 
     1. Scansiona ``gs://dataciviclab-clean/`` per scoprire slug + anni
+       (se ``slug`` è dato, limita la scansione a quel prefisso)
     2. Per ogni slug, legge lo schema del parquet più recente
     3. Costruisce location usando il path contract
     4. Fonde con metadata editoriali dal catalogo esistente
@@ -313,11 +323,16 @@ def derive_catalog_from_gcs(
     slug_index: dict[str, set[str]] = {}
     bucket = "dataciviclab-clean"
 
-    print(f"[derive] Scansione GCS bucket {bucket}...", file=sys.stderr)
+    # Se slug è dato, scansiona solo quel prefisso — evita la scansione
+    # completa del bucket (decine di migliaia di oggetti).
+    prefix = f"{slug}/" if slug else ""
+    print(
+        f"[derive] Scansione GCS bucket {bucket} (prefix={prefix or 'tutto'})...", file=sys.stderr
+    )
 
     # 1. Scansiona bucket per scoprire slug + anni
     try:
-        objects = list_objects(bucket, auth=False)
+        objects = list_objects(bucket, prefix=prefix, auth=False)
     except Exception as exc:
         print(f"[derive] ERRORE: impossibile leggere GCS: {exc}", file=sys.stderr)
         return existing, [f"GCS unreachable: {exc}"]
@@ -326,11 +341,14 @@ def derive_catalog_from_gcs(
         name: str = obj["name"]
         parts = name.split("/")
         if len(parts) == 3 and parts[2].endswith("_clean.parquet"):
-            slug, year = parts[0], parts[1]
-            slug_index.setdefault(slug, set()).add(year)
+            slug_found, year = parts[0], parts[1]
+            slug_index.setdefault(slug_found, set()).add(year)
 
     if not slug_index:
-        print(f"[derive] Nessun parquet pulito trovato in {bucket}", file=sys.stderr)
+        print(
+            f"[derive] Nessun parquet pulito trovato in {bucket} (prefix={prefix or 'tutto'})",
+            file=sys.stderr,
+        )
         return existing, []
 
     print(f"[derive] Trovati {len(slug_index)} slug su GCS", file=sys.stderr)

--- a/scripts/post_merge_runner.py
+++ b/scripts/post_merge_runner.py
@@ -204,12 +204,16 @@ def _push_mart_to_gcs(slug: str, root: str) -> bool:
     return r.returncode == 0
 
 
-def _rebuild_clean_catalog(root: str) -> None:
-    """Rebuild clean_catalog.json after GCS push."""
-    r = subprocess.run(
-        ["python", "scripts/build_clean_catalog.py", "--derive", "--write"],
-        cwd=root,
-    )
+def _rebuild_clean_catalog(root: str, slug: str | None = None) -> None:
+    """Rebuild clean_catalog.json after GCS push.
+
+    Con ``slug`` deriva solo quel prefisso dal bucket (veloce) invece di
+    scansionare tutto GCS. Il derive completo resta per uso schedulato/manuale.
+    """
+    cmd = ["python", "scripts/build_clean_catalog.py", "--derive", "--write"]
+    if slug:
+        cmd += ["--slug", slug]
+    r = subprocess.run(cmd, cwd=root)
     if r.returncode != 0:
         print(f"  WARN: build_clean_catalog --derive --write fallito (code {r.returncode})")
 
@@ -347,7 +351,7 @@ def cmd_sample_run(args: argparse.Namespace) -> None:
     # --- Clean catalog rebuild ---
     if gcs_push_ok:
         print("\n  Rebuilding clean catalog...")
-        _rebuild_clean_catalog(root)
+        _rebuild_clean_catalog(root, slug=slug)
     else:
         print("\n  Skip clean catalog rebuild: nessun GCS push riuscito")
 

--- a/scripts/post_merge_runner.py
+++ b/scripts/post_merge_runner.py
@@ -328,10 +328,13 @@ def cmd_sample_run(args: argparse.Namespace) -> None:
             json.dump(payload, pf, indent=2)
         print(f"  {status}")
 
+        # push_slug: slug GCS normalizzato (trattini → underscore)
+        # usato sia per il push che per il rebuild del catalogo
+        push_slug = cfg.get("push_slug", slug).replace("-", "_")
+
         # --- GCS push ---
         if status == "passed" and os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
             print(f"  GCS push per {slug}...")
-            push_slug = cfg.get("push_slug", slug)
 
             # Push clean parquet (obbligatorio)
             if _push_clean_to_gcs(push_slug, root):
@@ -351,7 +354,7 @@ def cmd_sample_run(args: argparse.Namespace) -> None:
     # --- Clean catalog rebuild ---
     if gcs_push_ok:
         print("\n  Rebuilding clean catalog...")
-        _rebuild_clean_catalog(root, slug=slug)
+        _rebuild_clean_catalog(root, slug=push_slug)
     else:
         print("\n  Skip clean catalog rebuild: nessun GCS push riuscito")
 


### PR DESCRIPTION
## Sintesi

Il post-merge dopo ogni merge candidate scansiona tutto il bucket GCS (112 slug) per derivare il catalogo — ~minuti. Ora deriva solo lo slug del candidate appena pushato.

## Cosa cambia

- `build_clean_catalog.py`: nuovo flag `--slug` — limita la scansione GCS a un prefisso
- `post_merge_runner.py`: `_rebuild_clean_catalog` passa lo slug del candidate mergiato

## Verifica

```bash
python scripts/build_clean_catalog.py --derive --slug sbarchi_migranti_italia
# → Catalogo: 106 dataset (1 derivato + 105 preservati editoriali), veloce
```

## Note

Il derive completo resta disponibile (senza `--slug`) per uso schedulato/manuale — necessario per scoprire slug nuovi su GCS senza dataset.yml.