### PR TITLE
batch(giustizia): allinea 5 candidate a contratti toolkit v1.47

### DIFF
--- a/candidates/civile-flussi/dataset.yml
+++ b/candidates/civile-flussi/dataset.yml
@@ -4,6 +4,8 @@ schema_version: 1
 dataset:
   name: "civile_flussi"
   source_id: "giustizia_statistiche"
+  tags: [giustizia, statistiche-giudiziarie]
+  category: giustizia
   # Chiave di snapshot per il run: il file contiene gia l'intera serie 2014-2025.
   years: [2025]
   time_coverage:
@@ -26,14 +28,22 @@ clean:
     mode: latest
     header: true
     sheet_name: "Data"
+  required_columns: [anno, fonte, tipo_ufficio, distretto, sede, macromateria, materia, dettaglio, sopravvenuti, definiti_totale]
   validate:
     min_rows: 100000
+    not_null: [anno, fonte, tipo_ufficio, distretto]
 
 mart:
   tables:
     - name: "mart_summary"
       sql: "sql/mart.sql"
-  validate: {}
+  required_tables:
+    - "mart_summary"
+  validate:
+    table_rules:
+      mart_summary:
+        primary_key: [anno, livello_aggregazione, distretto]
+        min_rows: 1
 
 validation:
   fail_on_error: true

--- a/candidates/civile-flussi/sql/clean.sql
+++ b/candidates/civile-flussi/sql/clean.sql
@@ -1,16 +1,16 @@
 select
-  try_cast("Anno" as integer) as anno,
-  trim("Fonte") as fonte,
-  trim("Tipo ufficio") as tipo_ufficio,
-  trim("Distretto") as distretto,
-  trim("Sede") as sede,
-  trim("Macromateria") as macromateria,
-  trim("Materia") as materia,
-  trim("Dettaglio") as dettaglio,
-  try_cast("Sopravvenuti" as double) as sopravvenuti,
-  try_cast("Definiti - totale" as double) as definiti_totale,
-  try_cast("Definiti con sentenza" as double) as definiti_con_sentenza,
-  try_cast("Pendenti finali" as double) as pendenti_finali
+  cast_int("Anno") as anno,
+  normalize_string("Fonte") as fonte,
+  normalize_string("Tipo ufficio") as tipo_ufficio,
+  normalize_string("Distretto") as distretto,
+  normalize_string("Sede") as sede,
+  normalize_string("Macromateria") as macromateria,
+  normalize_string("Materia") as materia,
+  normalize_string("Dettaglio") as dettaglio,
+  cast_double("Sopravvenuti") as sopravvenuti,
+  cast_double("Definiti - totale") as definiti_totale,
+  cast_double("Definiti con sentenza") as definiti_con_sentenza,
+  cast_double("Pendenti finali") as pendenti_finali
 from raw_input
-where try_cast("Anno" as integer) is not null
-  and trim(coalesce("Fonte", '')) <> ''
+where cast_int("Anno") is not null
+  and coalesce(normalize_string("Fonte"), '') <> ''

--- a/candidates/giustizia-penale-indicatori/dataset.yml
+++ b/candidates/giustizia-penale-indicatori/dataset.yml
@@ -11,6 +11,8 @@ schema_version: 1
 dataset:
   name: "giustizia_penale_indicatori"
   source_id: "giustizia_statistiche"
+  tags: [giustizia, statistiche-giudiziarie]
+  category: giustizia
   years: [2025]
   time_coverage:
     start_year: 2014
@@ -28,12 +30,15 @@ raw:
 
 clean:
   read:
+    source: auto
+    mode: latest
     delim: ","
     encoding: "utf-8"
     header: true
     skip: 0
   read_mode: strict
   sql: "sql/clean.sql"
+  required_columns: [anno, tipo_ufficio, distretto, sede, sezione, clearance_rate, disposition_time_gg]
   validate:
     min_rows: 10000
     not_null:
@@ -48,4 +53,5 @@ mart:
   validate:
     table_rules:
       giustizia_penale_indicatori:
+        primary_key: ['anno', 'distretto', 'tipo_ufficio']
         min_rows: 1

--- a/candidates/intercettazioni/dataset.yml
+++ b/candidates/intercettazioni/dataset.yml
@@ -10,6 +10,8 @@ schema_version: 1
 dataset:
   name: "intercettazioni"
   source_id: "giustizia_statistiche"
+  tags: [giustizia, statistiche-giudiziarie]
+  category: giustizia
   years: [2025]
   time_coverage:
     start_year: 2014
@@ -53,6 +55,7 @@ mart:
   validate:
     table_rules:
       intercettazioni:
+        primary_key: ['anno', 'distretto', 'tipologia_intercettazione']
         min_rows: 1
 
 validation:

--- a/candidates/monitoraggio-mensile-civile/dataset.yml
+++ b/candidates/monitoraggio-mensile-civile/dataset.yml
@@ -10,6 +10,8 @@ schema_version: 1
 dataset:
   name: "monitoraggio_mensile_civile"
   source_id: "giustizia_statistiche"
+  tags: [giustizia, statistiche-giudiziarie]
+  category: giustizia
   years: [2025]
   time_coverage:
     start_year: 2019
@@ -56,6 +58,7 @@ mart:
   validate:
     table_rules:
       monitoraggio_mensile_civile:
+        primary_key: ['anno', 'mese', 'area', 'distretto']
         min_rows: 1
 
 validation:

--- a/candidates/monitoraggio-mensile-civile/dataset.yml
+++ b/candidates/monitoraggio-mensile-civile/dataset.yml
@@ -43,9 +43,12 @@ clean:
   required_columns:
     - anno
     - mese
+    - fonte
+    - tipo_ufficio
     - distretto
     - sede
     - materia
+    - area
     - iscritti
     - definiti
 

--- a/candidates/penale-flussi/dataset.yml
+++ b/candidates/penale-flussi/dataset.yml
@@ -11,6 +11,8 @@ schema_version: 1
 dataset:
   name: "penale_flussi"
   source_id: "giustizia_statistiche"
+  tags: [giustizia, statistiche-giudiziarie]
+  category: giustizia
   years: [2025]
   time_coverage:
     start_year: 2014
@@ -56,6 +58,7 @@ mart:
   validate:
     table_rules:
       penale_flussi:
+        primary_key: ['anno', 'tipo_ufficio', 'distretto']
         min_rows: 1
 
 validation:

--- a/candidates/penale-flussi/dataset.yml
+++ b/candidates/penale-flussi/dataset.yml
@@ -44,7 +44,9 @@ clean:
   required_columns:
     - anno
     - tipo_ufficio
+    - sezione
     - distretto
+    - sede
     - sopravvenuti
     - definiti_totale
     - pendenti_finali


### PR DESCRIPTION
## Sintesi

Batch fonte `giustizia_statistiche`: allinea i 5 candidate ai contratti toolkit v1.47 (tags/category, validazioni, macros, read config).

## Dataset

- `civile-flussi`
- `giustizia-penale-indicatori`
- `intercettazioni`
- `monitoraggio-mensile-civile`
- `penale-flussi`

## Cosa cambia per dataset

- **tags/category**: `[giustizia, statistiche-giudiziarie]` / `giustizia` (5)
- **required_columns + not_null**: civile-flussi, giustizia-penale-indicatori
- **primary_key** nei mart table_rules (5, derivati dai GROUP BY)
- **civile-flussi**: clean.sql migrato a macro standard (`cast_int`, `cast_double`, `normalize_string`)
- **giustizia-penale-indicatori**: fix `clean.read` (`source: auto`, `mode: latest`) — era rotto col toolkit nuovo (No CLEAN input files)

## Verifica

- `validate_candidate_structure.py` → 5/5 pass
- run sample-rows: civile-flussi ✅, giustizia-penale-indicatori ✅
- dry-run SQL: 5/5 OK