### PR TITLE
chore(post-merge): aggiorna registry per PR #753

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2823,7 +2823,12 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "giustizia",
+        "statistiche-giudiziarie"
+      ],
+      "category": "giustizia"
     },
     {
       "slug": "comuni_master",
@@ -5590,7 +5595,12 @@
         "multi_file": true
       },
       "stage": "incubating",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "giustizia",
+        "statistiche-giudiziarie"
+      ],
+      "category": "giustizia"
     },
     {
       "slug": "inps_pensioni_trimestrale",
@@ -5868,7 +5878,12 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "giustizia",
+        "statistiche-giudiziarie"
+      ],
+      "category": "giustizia"
     },
     {
       "slug": "ipa_aree_organizzative_omogenee",
@@ -10286,7 +10301,12 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "giustizia",
+        "statistiche-giudiziarie"
+      ],
+      "category": "giustizia"
     },
     {
       "slug": "mur_contribuzione_universitaria",
@@ -11254,7 +11274,12 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "giustizia",
+        "statistiche-giudiziarie"
+      ],
+      "category": "giustizia"
     },
     {
       "slug": "pensioni_pa_dag",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -273,9 +273,25 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "26036106012",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26036106012",
-        "checked_at": "2026-05-18",
+        "run_id": "30628794316",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30628794316",
+        "checked_at": "2026-07-31",
+        "duration_seconds": 28.05,
+        "row_counts": {
+          "clean": 123203,
+          "mart": 324
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
         "years": [
           2025
         ],
@@ -585,9 +601,26 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "29842353692",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/29842353692",
-        "checked_at": "2026-07-21",
+        "run_id": "30628794316",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30628794316",
+        "checked_at": "2026-07-31",
+        "duration_seconds": 2.77,
+        "row_counts": {
+          "raw": 10488,
+          "clean": 10478,
+          "mart": 1251
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
         "years": [
           2025
         ],
@@ -639,9 +672,25 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "29842353692",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/29842353692",
-        "checked_at": "2026-07-21",
+        "run_id": "30628794316",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30628794316",
+        "checked_at": "2026-07-31",
+        "duration_seconds": 1.55,
+        "row_counts": {
+          "clean": 3952,
+          "mart": 1560
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
         "years": [
           2025
         ],
@@ -1130,9 +1179,25 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "29842353692",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/29842353692",
-        "checked_at": "2026-07-21",
+        "run_id": "30628794316",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30628794316",
+        "checked_at": "2026-07-31",
+        "duration_seconds": 31.49,
+        "row_counts": {
+          "clean": 140969,
+          "mart": 2340
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 95.0,
+          "mart": 100.0
+        },
         "years": [
           2025
         ],
@@ -1322,9 +1387,25 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "29842353692",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/29842353692",
-        "checked_at": "2026-07-21",
+        "run_id": "30628794316",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30628794316",
+        "checked_at": "2026-07-31",
+        "duration_seconds": 3.87,
+        "row_counts": {
+          "clean": 17652,
+          "mart": 2196
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
         "years": [
           2025
         ],


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #753 — batch(giustizia): allinea 5 candidate a contratti toolkit v1.47

Changed candidate/support roots:

- `civile-flussi` (candidate, `candidates/civile-flussi`)
- `giustizia-penale-indicatori` (candidate, `candidates/giustizia-penale-indicatori`)
- `intercettazioni` (candidate, `candidates/intercettazioni`)
- `monitoraggio-mensile-civile` (candidate, `candidates/monitoraggio-mensile-civile`)
- `penale-flussi` (candidate, `candidates/penale-flussi`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/civile-flussi/dataset.yml` -> artifact `sample-run-civile-flussi`
- `candidates/giustizia-penale-indicatori/dataset.yml` -> artifact `sample-run-giustizia-penale-indicatori`
- `candidates/intercettazioni/dataset.yml` -> artifact `sample-run-intercettazioni`
- `candidates/monitoraggio-mensile-civile/dataset.yml` -> artifact `sample-run-monitoraggio-mensile-civile`
- `candidates/penale-flussi/dataset.yml` -> artifact `sample-run-penale-flussi`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
