### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -5282,7 +5282,13 @@
         "multi_file": true
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "giustizia",
+        "giustizia-amministrativa",
+        "contenzioso"
+      ],
+      "category": "giustizia"
     },
     {
       "slug": "ga_ordinanze",
@@ -5407,7 +5413,13 @@
         "multi_file": true
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "giustizia",
+        "giustizia-amministrativa",
+        "contenzioso"
+      ],
+      "category": "giustizia"
     },
     {
       "slug": "ga_sentenze",
@@ -5532,7 +5544,13 @@
         "multi_file": true
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "giustizia",
+        "giustizia-amministrativa",
+        "contenzioso"
+      ],
+      "category": "giustizia"
     },
     {
       "slug": "giustizia_penale_indicatori",
@@ -11147,7 +11165,13 @@
         "multi_file": true
       },
       "stage": "incubating",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "giustizia",
+        "giustizia-amministrativa",
+        "contenzioso"
+      ],
+      "category": "giustizia"
     },
     {
       "slug": "openga_ricorsi_cds",
@@ -11205,7 +11229,13 @@
         "multi_file": true
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "giustizia",
+        "giustizia-amministrativa",
+        "contenzioso"
+      ],
+      "category": "giustizia"
     },
     {
       "slug": "penale_flussi",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1366,9 +1366,26 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "27878799069",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27878799069",
-        "checked_at": "2026-06-20",
+        "run_id": "30641695862",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30641695862",
+        "checked_at": "2026-07-31",
+        "duration_seconds": 4.5,
+        "row_counts": {
+          "raw": 84,
+          "clean": 84,
+          "mart": 8
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
         "years": [
           2023,
           2024,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `openga-ricorsi-cds` (candidate, `candidates/openga-ricorsi-cds`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/openga-ricorsi-cds/dataset.yml` -> artifact `sample-run-openga-ricorsi-cds`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
