### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1345,9 +1345,26 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "29862613823",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/29862613823",
-        "checked_at": "2026-07-21",
+        "run_id": "30641958825",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30641958825",
+        "checked_at": "2026-07-31",
+        "duration_seconds": 270.13,
+        "row_counts": {
+          "raw": 2420,
+          "clean": 9692,
+          "mart": 2037
+        },
+        "readiness": "needs-review",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 7,
+          "fail": 1
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
         "years": [
           2023,
           2024,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `openga-ricorsi-appalto` (candidate, `candidates/openga-ricorsi-appalto`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/openga-ricorsi-appalto/dataset.yml` -> artifact `sample-run-openga-ricorsi-appalto`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
