### PR TITLE
chore(post-merge): aggiorna registry per PR #

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -559,9 +559,26 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "29916534336",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/29916534336",
-        "checked_at": "2026-07-22",
+        "run_id": "30647757280",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30647757280",
+        "checked_at": "2026-07-31",
+        "duration_seconds": 248.74,
+        "row_counts": {
+          "raw": 15392,
+          "clean": 113828,
+          "mart": 5018
+        },
+        "readiness": "needs-review",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 7,
+          "fail": 1
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 95.0,
+          "mart": 100.0
+        },
         "years": [
           2023,
           2024,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: # — 

Changed candidate/support roots:

- `ga-ordinanze` (candidate, `candidates/ga-ordinanze`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/ga-ordinanze/dataset.yml` -> artifact `sample-run-ga-ordinanze`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
