### PR TITLE
fix(catalog): enrich metadati anche su support_datasets e compose

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -401,7 +401,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "appalti",
+        "anac",
+        "aggiudicatari"
+      ],
+      "category": "appalti"
     },
     {
       "slug": "anac_aggiudicazioni",
@@ -834,7 +840,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "appalti",
+        "anac",
+        "master"
+      ],
+      "category": "appalti"
     },
     {
       "slug": "anac_bandi_gara",
@@ -1305,7 +1317,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "appalti",
+        "anac",
+        "collaudo"
+      ],
+      "category": "appalti"
     },
     {
       "slug": "anac_cup",
@@ -1339,7 +1357,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "appalti",
+        "anac",
+        "cup"
+      ],
+      "category": "appalti"
     },
     {
       "slug": "anac_partecipanti",
@@ -1391,7 +1415,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "appalti",
+        "anac",
+        "partecipanti"
+      ],
+      "category": "appalti"
     },
     {
       "slug": "anac_stati_avanzamento",
@@ -1478,7 +1508,14 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "appalti",
+        "anac",
+        "stati",
+        "avanzamento"
+      ],
+      "category": "appalti"
     },
     {
       "slug": "anac_subappalti",
@@ -1592,7 +1629,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "appalti",
+        "anac",
+        "subappalti"
+      ],
+      "category": "appalti"
     },
     {
       "slug": "anpr_mobilita_residenziale",
@@ -2072,7 +2115,14 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "pa",
+        "bdap",
+        "anagrafe",
+        "enti"
+      ],
+      "category": "pa"
     },
     {
       "slug": "bdap_entrate_stato",
@@ -3164,7 +3214,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "pa",
+        "comuni",
+        "master"
+      ],
+      "category": "pa"
     },
     {
       "slug": "consip_consumi_convenzione",
@@ -3377,7 +3433,15 @@
         "multi_file": true
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "pa",
+        "conto",
+        "annuale",
+        "profilo",
+        "ente"
+      ],
+      "category": "pa"
     },
     {
       "slug": "costituzione_master",
@@ -3469,7 +3533,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "normativa",
+        "costituzione",
+        "master"
+      ],
+      "category": "normativa"
     },
     {
       "slug": "dait_amministratori_locali",
@@ -4480,7 +4550,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "politica",
+        "elezioni",
+        "voto"
+      ],
+      "category": "politica"
     },
     {
       "slug": "eurostat_demography",
@@ -4610,7 +4686,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "welfare-lavoro",
+        "eurostat",
+        "demography"
+      ],
+      "category": "welfare-lavoro"
     },
     {
       "slug": "eurostat_economy",
@@ -4788,7 +4870,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "economia",
+        "eurostat",
+        "economy"
+      ],
+      "category": "economia"
     },
     {
       "slug": "eurostat_territory",
@@ -4876,7 +4964,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "ambiente",
+        "eurostat",
+        "territory"
+      ],
+      "category": "ambiente"
     },
     {
       "slug": "farmacie",
@@ -5847,7 +5941,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "welfare-lavoro",
+        "inps",
+        "pensioni"
+      ],
+      "category": "welfare-lavoro"
     },
     {
       "slug": "inps_rdc_pdc",
@@ -6228,7 +6328,15 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "pa",
+        "ipa",
+        "aree",
+        "organizzative",
+        "omogenee"
+      ],
+      "category": "pa"
     },
     {
       "slug": "ipa_enti",
@@ -6433,7 +6541,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "pa",
+        "ipa",
+        "enti"
+      ],
+      "category": "pa"
     },
     {
       "slug": "ipa_unita_organizzative",
@@ -6612,7 +6726,14 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "pa",
+        "ipa",
+        "unita",
+        "organizzative"
+      ],
+      "category": "pa"
     },
     {
       "slug": "irpef_comunale",
@@ -7588,7 +7709,14 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "pa",
+        "istat",
+        "elenco",
+        "comuni"
+      ],
+      "category": "pa"
     },
     {
       "slug": "istat_gini_regionale",
@@ -8074,7 +8202,14 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "economia",
+        "istat",
+        "pil",
+        "territoriale"
+      ],
+      "category": "economia"
     },
     {
       "slug": "iva_regionale",
@@ -10088,7 +10223,15 @@
         "multi_file": false
       },
       "stage": "incubating",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "istruzione",
+        "mim",
+        "anagrafica",
+        "scuole",
+        "statali"
+      ],
+      "category": "istruzione"
     },
     {
       "slug": "mim_scuola_infanzia",
@@ -10322,7 +10465,13 @@
         "multi_file": false
       },
       "stage": "incubating",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "ambiente",
+        "mit",
+        "incidentalita"
+      ],
+      "category": "ambiente"
     },
     {
       "slug": "mit_opere_incompiute_2020",
@@ -10889,14 +11038,20 @@
         "multi_file": true
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "finanza-pubblica",
+        "opencivitas",
+        "fsc"
+      ],
+      "category": "finanza-pubblica"
     },
     {
       "slug": "opencivitas_fsc_enti_rso",
       "name": "Opencivitas Fsc Enti Rso",
       "description": "Anagrafica enti FSC 2025 — mapping username → comune/provincia/regione (solo support, non pubblicato)",
       "source": "",
-      "source_id": "",
+      "source_id": "opencivitas",
       "period": {
         "start": 2025,
         "end": 2025
@@ -10943,7 +11098,14 @@
         "multi_file": false
       },
       "stage": "incubating",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "finanza-pubblica",
+        "opencivitas",
+        "fsc",
+        "enti"
+      ],
+      "category": "finanza-pubblica"
     },
     {
       "slug": "opencivitas_glossario",
@@ -11012,7 +11174,13 @@
         "multi_file": true
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "finanza-pubblica",
+        "opencivitas",
+        "glossario"
+      ],
+      "category": "finanza-pubblica"
     },
     {
       "slug": "opencivitas_indicatori",
@@ -12441,7 +12609,13 @@
         "multi_file": true
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "welfare-lavoro",
+        "popolazione",
+        "istat"
+      ],
+      "category": "welfare-lavoro"
     },
     {
       "slug": "posti_letto_stabilimento",
@@ -15170,7 +15344,13 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "pa",
+        "unified",
+        "comuni"
+      ],
+      "category": "pa"
     },
     {
       "slug": "who_is_who_pa",
@@ -15411,7 +15591,14 @@
         "multi_file": false
       },
       "stage": "published",
-      "registry_source": "derive_auto"
+      "registry_source": "derive_auto",
+      "tags": [
+        "pa",
+        "who",
+        "is",
+        "who"
+      ],
+      "category": "pa"
     }
   ]
 }

--- a/scripts/build_clean_catalog.py
+++ b/scripts/build_clean_catalog.py
@@ -165,30 +165,50 @@ def normalize_catalog(catalog: dict[str, Any], *, refresh_date: bool = False) ->
     return normalized
 
 
-def _enrich_source_ids(catalog: dict[str, Any], root: Path) -> None:
-    """Legge source_id dai dataset.yml dei candidati e li fonde nel catalogo.
+def _iter_dataset_ymls(root: Path):
+    """Itera i dataset.yml di candidates/, support_datasets/ e compose/.
 
-    Per ogni dataset nel catalogo, se esiste un candidate dataset.yml con source_id,
-    lo aggiunge al catalogo (non sovrascrive se già presente).
+    Allineato allo standard candidate: i metadati (source_id, tags, category)
+    valgono per tutte e tre le sezioni, non solo per i candidate.
     """
-    candidates_dir = root / "candidates"
-    if not candidates_dir.is_dir():
-        return
-
-    slug_to_source: dict[str, str] = {}
-    for cand_dir in sorted(candidates_dir.iterdir()):
-        yml_path = cand_dir / "dataset.yml"
-        if not yml_path.is_file():
+    for section in ("candidates", "support_datasets", "compose"):
+        section_dir = root / section
+        if not section_dir.is_dir():
             continue
+        for entry_dir in sorted(section_dir.iterdir()):
+            yml_path = entry_dir / "dataset.yml"
+            if yml_path.is_file():
+                yield yml_path
+
+
+def _manifest_key(manifest: dict[str, Any]) -> str:
+    """Chiave di match col catalogo: dataset.name (underscore), con fallback slug.
+
+    Il catalogo usa lo slug del nome dataset (es. inps_pensioni_trimestrale),
+    non il nome directory del candidate (inps-pensioni): matchnare su name
+    evita i falsi negativi dell'enrich.
+    """
+    key = manifest.get("name") or manifest.get("slug") or ""
+    return key.replace("-", "_")
+
+
+def _enrich_source_ids(catalog: dict[str, Any], root: Path) -> None:
+    """Legge source_id dai dataset.yml e li fonde nel catalogo.
+
+    Per ogni dataset nel catalogo, se esiste un dataset.yml (candidate,
+    support o compose) con source_id, lo aggiunge al catalogo (non
+    sovrascrive se già presente).
+    """
+    slug_to_source: dict[str, str] = {}
+    for yml_path in _iter_dataset_ymls(root):
         try:
             manifest = load_dataset_manifest(yml_path)
         except Exception:
             continue
         sid = manifest.get("source_id")
-        slug = manifest.get("slug") or manifest.get("name") or ""
-        if sid and slug:
-            di_slug = slug.replace("-", "_")
-            slug_to_source[di_slug] = sid
+        key = _manifest_key(manifest)
+        if sid and key:
+            slug_to_source[key] = sid
 
     if not slug_to_source:
         return
@@ -213,24 +233,16 @@ def _enrich_period_from_coverage(catalog: dict[str, Any], root: Path) -> None:
     evita che period rifletta solo gli anni di cui abbiamo un parquet su GCS,
     il che sarebbe fuorviante per dataset con file snapshot multi-anno.
     """
-    candidates_dir = root / "candidates"
-    if not candidates_dir.is_dir():
-        return
-
     slug_to_period: dict[str, dict[str, int]] = {}
-    for cand_dir in sorted(candidates_dir.iterdir()):
-        yml_path = cand_dir / "dataset.yml"
-        if not yml_path.is_file():
-            continue
+    for yml_path in _iter_dataset_ymls(root):
         try:
             manifest = load_dataset_manifest(yml_path)
         except Exception:
             continue
         tc = manifest.get("time_coverage")
-        slug = manifest.get("slug") or manifest.get("name") or ""
-        if tc and slug and "start_year" in tc and "end_year" in tc:
-            di_slug = slug.replace("-", "_")
-            slug_to_period[di_slug] = {
+        key = _manifest_key(manifest)
+        if tc and key and "start_year" in tc and "end_year" in tc:
+            slug_to_period[key] = {
                 "start": tc["start_year"],
                 "end": tc["end_year"],
             }
@@ -257,29 +269,20 @@ def _enrich_tags_and_category(catalog: dict[str, Any], root: Path) -> None:
     all'entry del catalogo, se presenti nel dataset.yml.
     Non sovrascrive se già presenti (l'editoriale ha precedenza).
     """
-    candidates_dir = root / "candidates"
-    if not candidates_dir.is_dir():
-        return
-
     slug_to_tags: dict[str, list[str]] = {}
     slug_to_category: dict[str, str | None] = {}
-    for cand_dir in sorted(candidates_dir.iterdir()):
-        yml_path = cand_dir / "dataset.yml"
-        if not yml_path.is_file():
-            continue
+    for yml_path in _iter_dataset_ymls(root):
         try:
             manifest = load_dataset_manifest(yml_path)
         except Exception:
             continue
-        slug = manifest.get("slug") or manifest.get("name") or ""
+        key = _manifest_key(manifest)
         tags = manifest.get("tags") or []
         category = manifest.get("category")
-        if tags and slug:
-            di_slug = slug.replace("-", "_")
-            slug_to_tags[di_slug] = tags
-        if category and slug:
-            di_slug = slug.replace("-", "_")
-            slug_to_category[di_slug] = category
+        if tags and key:
+            slug_to_tags[key] = tags
+        if category and key:
+            slug_to_category[key] = category
 
     if not slug_to_tags and not slug_to_category:
         return


### PR DESCRIPTION
## Sintesi

Fix dell'enrich in `build_clean_catalog.py`: i metadati dai dataset.yml (source_id, period da time_coverage, tags, category) ora vengono applicati anche a **support_datasets** e **compose**, e il match col catalogo avviene su `dataset.name` (underscore) invece che sullo slug della directory (trattini).

Emerso da verifica MCP post-merge: `clean-query find` mostrava `tags: []`/`category: null` su support e candidate con name ≠ slug.

## Contesto collegato

- PR #759 (standard candidate + migrazione 109 dataset) — merged. Il bug rendeva il catalogo incoerente con i metadati migrati.

## Cosa cambia

- [ ] candidate — nuovo dataset o aggiornamento
- [ ] support — dataset di supporto
- [ ] docs — struttura candidate, README, template
- [x] cleanup — refactoring, rimozioni, allineamento
- [ ] workflow o CI
- [ ] altro

## Impatto

Segna solo quello che si applica.

- [ ] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi) — no: stesso schema catalog, più metadati
- [x] Solo documentazione o metadati
- [ ] Nessun impatto visibile per chi usa il repository

## Checklist candidate

Se tocchi `candidates/` (standard: `docs/candidate-standard.md`):

- [ ] `dataset.yml` con `name`, `years`, `source_id`, `tags`, `category` (non toccati)
- [x] `python scripts/validate_candidate_structure.py` passato senza failure

## Verifica

```bash
python scripts/build_clean_catalog.py --derive --write
# [enrich] tags aggiunto a 106 dataset da dataset.yml
# [enrich] category aggiunta a 106 dataset da dataset.yml
python tools/graph/build_graph.py   # 16 entità, 28 bridge (stabile)
python -m pytest tests/ -q          # suite verde
ruff check scripts/build_clean_catalog.py
```

- [x] `toolkit run` eseguito senza errori (n/a — nessun candidate toccato)
- [x] `python scripts/validate_candidate_structure.py` passato
- [x] Perimetro stretto: fix mirato

Dettaglio:
- Prima: tags/category 77/106 · period 33 · source_id parziale
- Dopo: **tags/category 106/106** · period 46 · source_id completo
- Campioni: `anac_aggiudicatari`→appalti, `ipa_enti`→pa, `inps_pensioni_trimestrale`→welfare-lavoro, `anac_appalti_master`→appalti

## Note / rischi

- Il derive richiede accesso GCS (già usato dal post-merge): il fix rende il post-merge coerente con i metadati standard.
- Schema catalog invariato — solo più metadati popolati.
