### PR TITLE
feat(ispra-emissioni-ghg): candidate a standard v1 — mart analitiche serie (anti pass-through)

### DIFF
--- a/candidates/ispra-emissioni-ghg/dataset.yml
+++ b/candidates/ispra-emissioni-ghg/dataset.yml
@@ -8,11 +8,16 @@ dataset:
   tags: [ambiente, ispra, emissioni, ghg]
   category: ambiente
   years: [2023]
+  # Anno nominale: il file XLS copre l'intera serie 1990-2023 (34 anni).
+  # Non esistono file separati per anno: year=2023 e` il rilascio piu recente.
+  # Output in formato wide: una riga per anno, colonne per settore e totale.
+  time_coverage: {start_year: 1990, end_year: 2023}
 
 raw:
   output_policy: overwrite
   sources:
-    - type: script
+    - name: "ispra_emissioni_ghg_xls"
+      type: script
       args:
         command: "python preprocess.py raw_input.csv"
         output: "raw_input.csv"
@@ -20,17 +25,41 @@ raw:
       primary: true
 
 clean:
+  sql: "sql/clean.sql"
   read:
+    source: auto
+    mode: latest
     delim: ";"
     encoding: "utf-8"
     header: true
     decimal: "."
   required_columns: ["anno", "industrie_energetiche", "industrie_manifatturiere", "residenziale_e_servizi", "trasporti", "totale"]
-  sql: "sql/clean.sql"
   validate:
+    min_rows: 30
     not_null: [anno]
+    primary_key: [anno]
 
 mart:
   tables:
-    - name: "ispra_emissioni_ghg"
-      sql: "sql/mart.sql"
+    # Serie storica long: anno x settore con quota % sul totale nazionale
+    - name: "mart_settori_anno"
+      sql: "sql/mart_settori_anno.sql"
+    # Trend per settore: delta 1990->ultimo anno, CAGR, picco, benchmark
+    - name: "mart_trend_settori"
+      sql: "sql/mart_trend_settori.sql"
+  required_tables:
+    - "mart_settori_anno"
+    - "mart_trend_settori"
+  validate:
+    table_rules:
+      mart_settori_anno:
+        required_columns: [anno, settore, emissioni_mt, quota_pct]
+        primary_key: [anno, settore]
+        min_rows: 100
+      mart_trend_settori:
+        required_columns: [settore, emissioni_1990, emissioni_ultimo, delta_pct, cagr_annuale]
+        primary_key: [settore]
+        min_rows: 5
+
+validation:
+  fail_on_error: true

--- a/candidates/ispra-emissioni-ghg/sql/clean.sql
+++ b/candidates/ispra-emissioni-ghg/sql/clean.sql
@@ -1,15 +1,15 @@
 -- ISPRA Emissioni GHG per settore economico
 -- Fonte: Tabella 1 - Emissioni di gas serra da processi energetici per settore
--- Unità: Mt CO2 equivalente
+-- Unita: Mt CO2 equivalente
 -- Periodo: 1990-2023
 
 SELECT
-    TRY_CAST("anno" AS INTEGER) AS anno,
-    TRY_CAST("industrie_energetiche" AS DOUBLE) AS industrie_energetiche,
-    TRY_CAST("industrie_manifatturiere" AS DOUBLE) AS industrie_manifatturiere,
-    TRY_CAST("residenziale_e_servizi" AS DOUBLE) AS residenziale_e_servizi,
-    TRY_CAST("trasporti" AS DOUBLE) AS trasporti,
-    TRY_CAST("totale" AS DOUBLE) AS totale
+    cast_int("anno") AS anno,
+    cast_double("industrie_energetiche") AS industrie_energetiche,
+    cast_double("industrie_manifatturiere") AS industrie_manifatturiere,
+    cast_double("residenziale_e_servizi") AS residenziale_e_servizi,
+    cast_double("trasporti") AS trasporti,
+    cast_double("totale") AS totale
 FROM raw_input
-WHERE TRY_CAST("anno" AS INTEGER) IS NOT NULL
+WHERE cast_int("anno") IS NOT NULL
 ORDER BY anno

--- a/candidates/ispra-emissioni-ghg/sql/mart.sql
+++ b/candidates/ispra-emissioni-ghg/sql/mart.sql
@@ -1,3 +1,0 @@
--- Dati già analitici: serie storica per settore
-SELECT * FROM clean_input
-ORDER BY anno

--- a/candidates/ispra-emissioni-ghg/sql/mart_settori_anno.sql
+++ b/candidates/ispra-emissioni-ghg/sql/mart_settori_anno.sql
@@ -1,0 +1,46 @@
+-- mart_settori_anno — Emissioni GHG per settore x anno (formato long)
+--
+-- Trasforma il clean wide (1 riga = 1 anno, colonne per settore) in long:
+-- 1 riga = 1 settore x anno, con quota % sul totale nazionale.
+-- Serve per: ribaltamento quote settoriali (D5), effetto Covid (D6),
+-- gap verso obiettivi 2030/2050 (D9), rimbalzo 2022-23 (D10).
+--
+-- PK: (anno, settore)
+
+WITH settori AS (
+    SELECT
+        anno,
+        'industrie_energetiche' AS settore,
+        industrie_energetiche AS emissioni_mt,
+        totale
+    FROM clean_input
+    UNION ALL
+    SELECT
+        anno,
+        'industrie_manifatturiere',
+        industrie_manifatturiere,
+        totale
+    FROM clean_input
+    UNION ALL
+    SELECT
+        anno,
+        'residenziale_e_servizi',
+        residenziale_e_servizi,
+        totale
+    FROM clean_input
+    UNION ALL
+    SELECT
+        anno,
+        'trasporti',
+        trasporti,
+        totale
+    FROM clean_input
+)
+SELECT
+    anno,
+    settore,
+    ROUND(emissioni_mt, 2) AS emissioni_mt,
+    ROUND(100.0 * emissioni_mt / NULLIF(totale, 0), 2) AS quota_pct
+FROM settori
+WHERE emissioni_mt IS NOT NULL
+ORDER BY anno, settore

--- a/candidates/ispra-emissioni-ghg/sql/mart_trend_settori.sql
+++ b/candidates/ispra-emissioni-ghg/sql/mart_trend_settori.sql
@@ -1,0 +1,68 @@
+-- mart_trend_settori — Trend emissioni GHG per settore (1990 -> ultimo anno)
+--
+-- 1 riga = 1 settore (4 settori + totale) con metriche di trend:
+-- delta assoluto e % dalla baseline 1990, CAGR annuale, picco e minimo
+-- della serie con relativi anni. Serve per: riduzione totale (D1),
+-- picco 2005 (D2), -47% industrie energetiche (D3), trasporti in crescita
+-- (D4), residenziale stabile (D7), manifatturiero -45% (D8).
+--
+-- PK: (settore)
+
+WITH settori AS (
+    SELECT
+        anno,
+        'industrie_energetiche' AS settore,
+        industrie_energetiche AS emissioni_mt
+    FROM clean_input
+    UNION ALL
+    SELECT anno, 'industrie_manifatturiere', industrie_manifatturiere FROM clean_input
+    UNION ALL
+    SELECT anno, 'residenziale_e_servizi', residenziale_e_servizi FROM clean_input
+    UNION ALL
+    SELECT anno, 'trasporti', trasporti FROM clean_input
+    UNION ALL
+    SELECT anno, 'totale', totale FROM clean_input
+),
+con_finestre AS (
+    SELECT
+        anno,
+        settore,
+        emissioni_mt,
+        MIN(anno) OVER (PARTITION BY settore) AS anno_primo,
+        MAX(anno) OVER (PARTITION BY settore) AS anno_ultimo
+    FROM settori
+    WHERE emissioni_mt IS NOT NULL
+)
+SELECT
+    settore,
+    MIN(anno_primo) AS anno_primo,
+    MAX(anno_ultimo) AS anno_ultimo,
+    ROUND(SUM(CASE WHEN anno = anno_primo THEN emissioni_mt END), 1) AS emissioni_1990,
+    ROUND(SUM(CASE WHEN anno = anno_ultimo THEN emissioni_mt END), 1) AS emissioni_ultimo,
+    ROUND(
+        SUM(CASE WHEN anno = anno_ultimo THEN emissioni_mt END)
+        - SUM(CASE WHEN anno = anno_primo THEN emissioni_mt END),
+        1
+    ) AS delta_assoluto_mt,
+    ROUND(
+        100.0 * (
+            SUM(CASE WHEN anno = anno_ultimo THEN emissioni_mt END)
+            - SUM(CASE WHEN anno = anno_primo THEN emissioni_mt END)
+        ) / NULLIF(SUM(CASE WHEN anno = anno_primo THEN emissioni_mt END), 0),
+        1
+    ) AS delta_pct,
+    ROUND(
+        POWER(
+            SUM(CASE WHEN anno = anno_ultimo THEN emissioni_mt END)
+            / NULLIF(SUM(CASE WHEN anno = anno_primo THEN emissioni_mt END), 0),
+            1.0 / NULLIF(MAX(anno_ultimo) - MIN(anno_primo), 0)
+        ) - 1,
+        4
+    ) AS cagr_annuale,
+    ROUND(MAX(emissioni_mt), 1) AS emissioni_picco,
+    arg_max(anno, emissioni_mt) AS anno_picco,
+    ROUND(MIN(emissioni_mt), 1) AS emissioni_minimo,
+    arg_min(anno, emissioni_mt) AS anno_minimo
+FROM con_finestre
+GROUP BY settore
+ORDER BY settore


### PR DESCRIPTION
## Sintesi

Porta il candidate `ispra-emissioni-ghg` allo standard candidate v1 (`docs/candidate-standard.md`). Il punto centrale: la mart era un **pass-through puro** (`SELECT * FROM clean_input ORDER BY anno`) pubblicato su GCS senza valore aggiunto. Ora ci sono due mart analitiche serie che rispondono alle 10 domande della discussion #402.

## Contesto collegato

- Closes #491 (issue intake ispra-emissioni-ghg)
- Standard: `docs/candidate-standard.md` §2.4 (pattern mart) + §3 (contratto SQL)
- Piano di allineamento mart: `_local/tasks/2026-08-01-mart-standard-candidates.md` (Lotto 1, primo candidato)

## Cosa cambia

- [x] candidate — aggiornamento (non nuovo dataset)
- [ ] support
- [ ] docs
- [ ] cleanup
- [ ] workflow o CI
- [ ] altro

## Impatto

- [x] Aggiunge o modifica un candidate in `candidates/ispra-emissioni-ghg/`
- [ ] Cambia la struttura attesa dei candidate
- [ ] Cambia il contratto con consumatori downstream — no: stesse colonne clean, mart nuova (sostituisce pass-through inutile)
- [ ] Solo documentazione o metadati
- [ ] Nessun impatto visibile

## Dettaglio

**dataset.yml** — allineato a standard:
- `time_coverage: {1990, 2023}` (serie storica)
- `raw.sources[].name`, `clean.read.source: auto` + `read.mode`
- `clean.validate`: `min_rows`, `primary_key: [anno]` (dichiarabile, chiude una deroga)
- `mart`: `required_tables` + `validate.table_rules` con `primary_key` dai GROUP BY

**clean.sql** — macro standard (`cast_int`/`cast_double`) al posto di `TRY_CAST` diretto.

**mart** — rimosso `mart.sql` (pass-through), aggiunte due tabelle:
- `mart_settori_anno`: long format anno × settore + `quota_pct` sul totale nazionale (PK: anno, settore)
- `mart_trend_settori`: per settore, `emissioni_1990`, `emissioni_ultimo`, `delta_assoluto_mt`, `delta_pct`, `cagr_annuale`, picco/minimo con anni (PK: settore)

Verifica contenuto: i numeri prodotti combaciano con la discussion #402 (totale -27,5%, picco 488,4 nel 2005, trasporti +5,8%, industrie energetiche -47,3%, minimo Covid 300,0 nel 2020).

## Checklist candidate

- [x] `dataset.yml` con `name`, `years`, `source_id`, `tags`, `category` (gate strict)
- [x] `clean.validate` con `required_columns`, `not_null`, `min_rows`, `primary_key`
- [x] `mart.validate.table_rules` con `primary_key` dai GROUP BY
- [x] `toolkit run` eseguito senza errori (anno 2023: passed, mart 2/2, quality 100, readiness 8/8)
- [x] `python scripts/validate_candidate_structure.py` passato senza failure
- [x] nessun file dati committato nella root del candidate
- [x] `sql/clean.sql` usa le macro standard del toolkit
- [x] issue di intake collegata (#491)

Nota: `raw_input.csv` è già presente nel candidate (prodotto da preprocess.py); la source è `type: script`, abilitata con `TOOLKIT_ALLOW_SCRIPT_SOURCE=1` — comportamento standard del toolkit, non una regressione.

## Verifica

```bash
TOOLKIT_ALLOW_SCRIPT_SOURCE=1 toolkit run -c candidates/ispra-emissioni-ghg/dataset.yml
python scripts/validate_candidate_structure.py
```

Esito run locale (2026-08-01):
```
2023: run=ok validate=passed
     raw: qs=100  clean: qs=100  34 righe  mart: qs=100  2/2 tabelle
     readiness: ready (8/8)
```