### PR TITLE
feat(anpr-mobilita-residenziale): standard v1 — mart serie saldi/corridoi/mensile

### DIFF
--- a/candidates/anpr-mobilita-residenziale/README.md
+++ b/candidates/anpr-mobilita-residenziale/README.md
@@ -20,14 +20,21 @@
 | `cod_regione_arrivo` | VARCHAR | Codice ISTAT regione arrivo |
 | `totale` | INTEGER | Numero trasferimenti di residenza |
 
+## Mart
+
+- **`mart_saldi_regionali`** — arrivi, partenze, saldo netto, flussi interni e quota interni per regione × anno. Include ESTERO.
+- **`mart_corridoi`** — trasferimenti per coppia origine → destinazione × anno. Include ESTERO.
+- **`mart_trend_mensile`** — totale trasferimenti per anno × mese con quota % sul totale annuo.
+
+Rispondono alle 13 domande della [discussion #393](https://github.com/orgs/dataciviclab/discussions/393) (saldi, corridoi Sud→Nord, stagionalità, ESTERO).
+
 ## Esecuzione
 
 ```bash
 cd dataset-incubator
-python -m toolkit.cli.app run full \
-  --config candidates/anpr-mobilita-residenziale/dataset.yml
+toolkit run -c candidates/anpr-mobilita-residenziale/dataset.yml
 ```
 
 ## Issue di riferimento
 
-- Intake: [#555](https://github.com/dataciviclab/dataset-incubator/issues/555)
+- Intake: [#554](https://github.com/dataciviclab/dataset-incubator/issues/554)

--- a/candidates/anpr-mobilita-residenziale/dataset.yml
+++ b/candidates/anpr-mobilita-residenziale/dataset.yml
@@ -23,7 +23,7 @@ raw:
 
 clean:
   sql: "sql/clean.sql"
-  required_columns: [anno, mese, partenza, cod_regione_partenza, arrivo, cod_regione_arrivo]
+  required_columns: [anno, mese, partenza, cod_regione_partenza, arrivo, cod_regione_arrivo, totale]
   read:
     source: auto
     mode: latest
@@ -31,19 +31,38 @@ clean:
     encoding: "utf-8"
     trim_whitespace: true
   validate:
-    not_null: [anno]
+    not_null: [anno, partenza, arrivo]
     min_rows: 1000
+    primary_key: [anno, mese, partenza, arrivo]
 
 mart:
   tables:
-    - name: "mart_flussi_regionali"
-      sql: "sql/mart.sql"
+    # Saldo migratorio per regione x anno (arrivi, partenze, interno)
+    - name: "mart_saldi_regionali"
+      sql: "sql/mart_saldi_regionali.sql"
+    # Flussi tra coppie origine -> destinazione per anno
+    - name: "mart_corridoi"
+      sql: "sql/mart_corridoi.sql"
+    # Totale trasferimenti per anno x mese (stagionalita')
+    - name: "mart_trend_mensile"
+      sql: "sql/mart_trend_mensile.sql"
   required_tables:
-    - "mart_flussi_regionali"
+    - "mart_saldi_regionali"
+    - "mart_corridoi"
   validate:
     table_rules:
-      mart_flussi_regionali:
+      mart_saldi_regionali:
+        required_columns: [anno, regione, arrivi, partenze, saldo_netto, flussi_interni]
+        primary_key: [anno, regione]
+        min_rows: 100
+      mart_corridoi:
+        required_columns: [anno, partenza, arrivo, trasferimenti]
+        primary_key: [anno, partenza, arrivo]
         min_rows: 1000
+      mart_trend_mensile:
+        required_columns: [anno, mese, trasferimenti, quota_mensile_pct]
+        primary_key: [anno, mese]
+        min_rows: 50
 
 validation:
   fail_on_error: true

--- a/candidates/anpr-mobilita-residenziale/notes.md
+++ b/candidates/anpr-mobilita-residenziale/notes.md
@@ -2,7 +2,8 @@
 
 ## Stato
 
-Candidate v0. Run passato con years: [2026]. 21.750 righe, 7 colonne.
+Candidate a standard v1 (2026-08-01): mart analitiche serie (saldi / corridoi /
+trend mensile). Run passed con years: [2026]. 22.176 righe, 7 colonne.
 
 ## Copertura per anno
 
@@ -14,6 +15,25 @@ Candidate v0. Run passato con years: [2026]. 21.750 righe, 7 colonne.
 | 2025 | 5.118 | Completo |
 | 2026 | 2.552 | Gen-Giu (dati parziali) |
 
+## Note tecniche
+
+- Fonte: http_file standard (GitHub raw, ANPR opendata)
+- clean.sql: macro standard (cast_int, normalize_string, LPAD codici ISTAT)
+- Il dataset è un file unico con tutti gli anni: le mart leggono `FROM clean_input`
+  (nessun multi-year necessario — i 5 anni sono nello stesso parquet)
+- ESTERO è una entità valida (arrivo e partenza) — non filtrata
+- primary_key clean: [anno, mese, partenza, arrivo]
+
+## Decisioni metodologiche (2026-08-01)
+
+- Mart pass-through rimosso: il dato grezzo è una matrice origine→destinazione;
+  le 3 mart serie rispondono alle 13 domande della discussion #393
+- `quota_interni_pct` in mart_saldi: flussi interni / (arrivi + partenze - interni)
+  — misura l'autosufficienza regionale (D4)
+- I saldi cumulati multi-anno non coincidono coi saldi di un singolo anno
+  citati nella discussion (es. Lombardia cumulato +80.6k vs +81.4k 2025):
+  differenza attesa, sono metriche diverse
+
 ## Saldi netti interregionali 2025 (escluso ESTERO)
 
 | Regione | Uscite | Entrate | Saldo |
@@ -23,17 +43,3 @@ Candidate v0. Run passato con years: [2026]. 21.750 righe, 7 colonne.
 | Puglia | 28.295 | 19.723 | -8.572 |
 | Calabria | 20.113 | 12.583 | -7.530 |
 | … | … | … | … |
-| Lombardia | 63.203 | 77.870 | **+14.667** |
-| Emilia Romagna | 33.750 | 44.646 | **+10.896** |
-
-## Fonte
-
-Repo GitHub ufficiale: `italia/anpr-opendata`
-File: `data/cambi_residenza.csv` — aggiornato automaticamente via GitHub Actions.
-
-## Note
-
-- Dato aggiornato quasi in tempo reale (ANPR, non ISTAT con 2 anni di ritardo)
-- Subentro ANPR parziale nel 2022: possibile sottostima comuni minori del Sud
-- Include flussi con ESTERO (cancellazioni/iscrizioni anagrafiche)
-- Il file è unico e contiene tutta la serie storica

--- a/candidates/anpr-mobilita-residenziale/sql/clean.sql
+++ b/candidates/anpr-mobilita-residenziale/sql/clean.sql
@@ -1,14 +1,16 @@
 -- clean.sql — anpr_mobilita_residenziale
 -- Flussi mensili di cambio residenza tra regioni italiane (ANPR)
+-- Macro standard: cast_int per anno/mese/totale, normalize_string per
+-- le regioni, LPAD per i codici ISTAT.
 
 SELECT
-    CAST(ANNO AS INTEGER)                                       AS anno,
-    CAST(MESE AS INTEGER)                                       AS mese,
-    TRIM(CAST(PARTENZA AS VARCHAR))                              AS partenza,
-    LPAD(TRIM(CAST(COD_ISTAT_REGIONE_DI_PARTENZA AS VARCHAR)), 3, '0') AS cod_regione_partenza,
-    TRIM(CAST(ARRIVO AS VARCHAR))                                AS arrivo,
-    LPAD(TRIM(CAST(COD_ISTAT_REGIONE_DI_ARRIVO AS VARCHAR)), 3, '0')   AS cod_regione_arrivo,
-    CAST(TOTALE AS INTEGER)                                     AS totale
+    cast_int(ANNO)                                                  AS anno,
+    cast_int(MESE)                                                  AS mese,
+    normalize_string(PARTENZA)                                      AS partenza,
+    LPAD(normalize_string(COD_ISTAT_REGIONE_DI_PARTENZA), 3, '0')   AS cod_regione_partenza,
+    normalize_string(ARRIVO)                                        AS arrivo,
+    LPAD(normalize_string(COD_ISTAT_REGIONE_DI_ARRIVO), 3, '0')     AS cod_regione_arrivo,
+    cast_int(TOTALE)                                                AS totale
 
 FROM raw_input
 WHERE TOTALE IS NOT NULL

--- a/candidates/anpr-mobilita-residenziale/sql/mart.sql
+++ b/candidates/anpr-mobilita-residenziale/sql/mart.sql
@@ -1,9 +1,0 @@
--- mart.sql — anpr_mobilita_residenziale
--- Dati pass-through con arrotondamenti
-
-SELECT
-    anno, mese,
-    partenza, cod_regione_partenza,
-    arrivo, cod_regione_arrivo,
-    totale
-FROM clean_input

--- a/candidates/anpr-mobilita-residenziale/sql/mart_corridoi.sql
+++ b/candidates/anpr-mobilita-residenziale/sql/mart_corridoi.sql
@@ -1,0 +1,20 @@
+-- mart_corridoi — Flussi tra coppie origine → destinazione per anno
+--
+-- 1 riga = 1 corridoio (partenza × arrivo) × anno, con totale trasferimenti.
+-- Serve per: esodo Sud→Nord (D2), controesodo Nord→Sud (D3), verso estero
+-- (D8), coppie simmetriche "gemelli demografici" (D9), trend dei grandi
+-- corridoi (D13).
+--
+-- PK: (partenza, arrivo, anno)
+
+SELECT
+    anno,
+    partenza,
+    arrivo,
+    SUM(totale) AS trasferimenti
+FROM clean_input
+WHERE totale IS NOT NULL
+  AND partenza IS NOT NULL
+  AND arrivo IS NOT NULL
+GROUP BY anno, partenza, arrivo
+ORDER BY anno, trasferimenti DESC

--- a/candidates/anpr-mobilita-residenziale/sql/mart_saldi_regionali.sql
+++ b/candidates/anpr-mobilita-residenziale/sql/mart_saldi_regionali.sql
@@ -1,0 +1,52 @@
+-- mart_saldi_regionali — Saldo migratorio per regione × anno
+--
+-- 1 riga = 1 regione × anno: arrivi, partenze, saldo netto,
+-- flussi interni (dentro la stessa regione) e quota flussi interni.
+-- Include ESTERO come entità (flussi da/verso l'estero).
+-- Serve per: regioni che perdono/attraggono (D1), Lombardia hub (D6),
+-- regioni spugna (D10), Sardegna saldo ~0 (D11), autosufficienza (D4).
+--
+-- PK: (regione, anno)
+
+WITH arrivi AS (
+    SELECT anno, arrivo AS regione, SUM(totale) AS arrivi
+    FROM clean_input
+    WHERE totale IS NOT NULL AND arrivo IS NOT NULL
+    GROUP BY anno, arrivo
+),
+partenze AS (
+    SELECT anno, partenza AS regione, SUM(totale) AS partenze
+    FROM clean_input
+    WHERE totale IS NOT NULL AND partenza IS NOT NULL
+    GROUP BY anno, partenza
+),
+interni AS (
+    SELECT anno, partenza AS regione, SUM(totale) AS flussi_interni
+    FROM clean_input
+    WHERE totale IS NOT NULL AND partenza IS NOT NULL AND partenza = arrivo
+    GROUP BY anno, partenza
+),
+tutte AS (
+    SELECT anno, regione FROM arrivi
+    UNION
+    SELECT anno, regione FROM partenze
+    UNION
+    SELECT anno, regione FROM interni
+)
+SELECT
+    t.anno,
+    t.regione,
+    COALESCE(a.arrivi, 0) AS arrivi,
+    COALESCE(p.partenze, 0) AS partenze,
+    COALESCE(a.arrivi, 0) - COALESCE(p.partenze, 0) AS saldo_netto,
+    COALESCE(i.flussi_interni, 0) AS flussi_interni,
+    ROUND(
+        100.0 * COALESCE(i.flussi_interni, 0)
+        / NULLIF(COALESCE(a.arrivi, 0) + COALESCE(p.partenze, 0) - COALESCE(i.flussi_interni, 0), 0),
+        1
+    ) AS quota_interni_pct
+FROM tutte t
+LEFT JOIN arrivi a USING (anno, regione)
+LEFT JOIN partenze p USING (anno, regione)
+LEFT JOIN interni i USING (anno, regione)
+ORDER BY t.anno, saldo_netto DESC

--- a/candidates/anpr-mobilita-residenziale/sql/mart_trend_mensile.sql
+++ b/candidates/anpr-mobilita-residenziale/sql/mart_trend_mensile.sql
@@ -1,0 +1,30 @@
+-- mart_trend_mensile — Totale trasferimenti per anno × mese
+--
+-- 1 riga = 1 anno × mese: totale nazionale trasferimenti di residenza
+-- e quota % sul totale annuo. Serve per: stagionalità della mobilità (D5),
+-- effetto 2026 anno parziale (D7).
+--
+-- PK: (anno, mese)
+
+WITH mensile AS (
+    SELECT
+        anno,
+        mese,
+        SUM(totale) AS trasferimenti
+    FROM clean_input
+    WHERE totale IS NOT NULL AND mese IS NOT NULL
+    GROUP BY anno, mese
+),
+annuo AS (
+    SELECT anno, SUM(trasferimenti) AS totale_anno
+    FROM mensile
+    GROUP BY anno
+)
+SELECT
+    m.anno,
+    m.mese,
+    m.trasferimenti,
+    ROUND(100.0 * m.trasferimenti / NULLIF(a.totale_anno, 0), 1) AS quota_mensile_pct
+FROM mensile m
+JOIN annuo a USING (anno)
+ORDER BY m.anno, m.mese


### PR DESCRIPTION
## Sintesi

Porta `anpr-mobilita-residenziale` allo standard candidate v1 con mart analitiche serie. Il pass-through (selezione colonne senza aggregazione) è rimosso; 3 mart serie rispondono alle 13 domande pubbliche della discussion #393.

## Contesto collegato

- Closes #554 (intake anpr-mobilita-residenziale)
- Standard: `docs/candidate-standard.md` §2.4 (pattern mart) + §3 (contratto SQL)
- Piano di allineamento mart: `_local/tasks/2026-08-01-mart-standard-candidates.md` (Lotto 1)

## Cosa cambia

- [x] candidate — aggiornamento (non nuovo dataset)
- [ ] support
- [ ] docs
- [x] cleanup — rimosso pass-through
- [ ] workflow o CI
- [ ] altro

## Impatto

- [x] Aggiunge o modifica un candidate in `candidates/anpr-mobilita-residenziale/`
- [ ] Cambia la struttura attesa dei candidate
- [ ] Cambia il contratto con consumatori downstream — no: clean invariato (stesse colonne), mart nuove
- [ ] Solo documentazione o metadati
- [ ] Nessun impatto visibile

## Dettaglio

### Mart (rimpiazzano il pass-through)

Il dataset è una matrice origine→destinazione per mese (21.750 righe, 20 regioni + ESTERO, 5 anni). Il pass-through non aggiungeva valore; le 3 mart serie rispondono alle domande pubbliche:

- **`mart_saldi_regionali`** — per regione × anno: arrivi, partenze, saldo netto, flussi interni, quota interni (autosufficienza). → D1 (saldi), D4 (autosufficienza), D6 (Lombardia hub), D10 (regioni spugna), D11 (Sardegna ~0)
- **`mart_corridoi`** — per coppia origine → destinazione × anno: trasferimenti. → D2 (esodo Sud→Nord), D3 (controesodo), D8 (verso ESTERO), D9 (coppie simmetriche), D13 (corridoi principali)
- **`mart_trend_mensile`** — per anno × mese: totale e quota % mensile. → D5 (stagionalità), D7 (2026 parziale)

### Allineamento standard

- `clean.sql`: macro standard (`cast_int`, `normalize_string`) al posto di `CAST` diretto
- `dataset.yml`: `primary_key` [anno, mese, partenza, arrivo] (dichiarabile, chiude una deroga), `required_tables`, `table_rules` con PK dai GROUP BY
- README/notes: mart documentate, decisioni metodologiche (ESTERO come entità, quota interni, saldi cumulati vs annui)

## Checklist candidate

- [x] `dataset.yml` con `name`, `years`, `source_id`, `tags`, `category` (gate strict)
- [x] `clean.validate` con `required_columns`, `not_null`, `min_rows`, `primary_key`
- [x] `mart.validate.table_rules` con `primary_key` dai GROUP BY
- [x] `toolkit run` eseguito senza errori (2026: passed, clean 22176 righe 0% drop, mart 3/3)
- [x] `python scripts/validate_candidate_structure.py` passato senza failure
- [x] nessun file dati committato nella root del candidate
- [x] `sql/clean.sql` usa le **macro standard del toolkit**
- [x] issue di intake collegata (#554)

## Verifica

```bash
toolkit run -c candidates/anpr-mobilita-residenziale/dataset.yml
python scripts/validate_candidate_structure.py
```

Esito run locale (2026-08-01):
```
2026: run=ok validate=passed
     raw: qs=100 · clean: qs=100 (22176 righe, 0% drop) · mart: qs=100 (3/3)
     readiness: ready (8/8)
```

Numeri verificati: saldo Lombardia cumulato +80.6k (discussion D1 citava +81.4k per il 2025 — differenza attesa tra cumulato e anno singolo), corridoi dominati dai flussi interni (atteso), stagionalità coerente.