### PR TITLE
chore(post-merge): aggiorna registry per PR #764

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -135,9 +135,26 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "28370691002",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28370691002",
-        "checked_at": "2026-06-29",
+        "run_id": "30702611494",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30702611494",
+        "checked_at": "2026-08-01",
+        "duration_seconds": 0.98,
+        "row_counts": {
+          "raw": 22176,
+          "clean": 22176,
+          "mart": 2362
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
         "years": [
           2026
         ],


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #764 — feat(anpr-mobilita-residenziale): standard v1 — mart serie saldi/corridoi/mensile

Changed candidate/support roots:

- `anpr-mobilita-residenziale` (candidate, `candidates/anpr-mobilita-residenziale`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/anpr-mobilita-residenziale/dataset.yml` -> artifact `sample-run-anpr-mobilita-residenziale`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
