### PR TITLE
feat(dait-amministratori-locali): standard v1 — mart serie profilo/territorio

### DIFF
--- a/candidates/dait-amministratori-locali/README.md
+++ b/candidates/dait-amministratori-locali/README.md
@@ -8,62 +8,39 @@ Anagrafe degli Amministratori Locali e Regionali (DAIT) — snapshot corrente (g
 
 ## Domanda
 
-*Chi sono gli amministratori locali italiani? Quali profili demografici (età, genere, titolo di studio, professione) hanno sindaci, assessori e consiglieri comunali? Come cambia la composizione della classe politica locale tra territori e nel tempo?*
+*Chi sono gli amministratori locali italiani? Quali profili demografici (età, genere, titolo di studio, professione) hanno sindaci, assessori e consiglieri comunali? Come cambia la composizione della classe politica locale tra territori?*
 
 Sotto-domande esplorative:
-- Quanto durano in carica i sindaci? Ci sono differenze Nord/Sud?
-- Quali professioni prevalgono tra gli amministratori locali?
-- Quante donne sono elette? La presenza femminile aumenta nel tempo?
-- Qual è l'età media di sindaci, assessori, consiglieri per regione?
+- Quante donne sono elette? La presenza femminile varia per carica?
+- Qual è l'età media di sindaci, assessori, consiglieri?
+- Ci sono differenze territoriali (Nord/Sud) nella composizione?
+- Quanto durano in carica i sindaci?
 
 ## Dataset
 
 - **Fonte**: `ammcom.csv` — Amministratori Comunali (DAIT)
 - **Granularità**: 1 riga = 1 amministratore in 1 carica
-- **Periodo**: snapshot corrente (2026). In futuro → serie storica 1991–2025
-- **Righe**: 116.054 amministratori in carica
-- **Colonne (19)**: anno, codice_regione, codice_provincia, codice_comune, denominazione_comune, sigla_provincia, popolazione_censita, cognome, nome, sesso, data_nascita, luogo_nascita, descrizione_carica (Sindaco/Assessore/Consigliere/Consigliere candidato sindaco), incarico (Vicesindaco, Presidente del consiglio, ecc.), data_elezione, data_entrata_in_carica, lista_appartenenza, titolo_studio, professione
+- **Periodo**: snapshot corrente (2026)
+- **Righe**: 124.716 amministratori in carica
+- **Colonne (20)**: anno, codice_regione, codice_provincia, codice_comune, codice_dait_completo, denominazione_comune, sigla_provincia, popolazione_censita, cognome, nome, sesso, data_nascita, luogo_nascita, descrizione_carica (Sindaco/Assessore/Consigliere/...), incarico, data_elezione, data_entrata_in_carica, lista_appartenenza, titolo_studio, professione
 
 ## Mart
 
 | Mart | Descrizione |
 |---|---|
-| `dait_amministratori_locali` | Tutti gli amministratori (schema flat, passthrough) |
+| `mart_profilo_carica` | Conteggi, età media, % femmine/maschi per carica |
+| `mart_profilo_demografico` | Distribuzione sesso × classe di età per carica |
+| `mart_territorio` | Composizione per regione × carica (quota femmine, età media) |
 
-Mart aggiuntivi (`dait_sindaci`, `dait_amministratori_territorio`) da sviluppare in fase successiva.
+Rispondono alle domande del README: profilo demografico della classe politica locale, presenza femminile per carica, differenze territoriali.
 
-## Perché vale la pena incubarlo
+## Esecuzione
 
-- **Primo dataset "anagrafico" del Lab**: primo dataset con persone fisiche (nome, cognome, età, professione, titolo di studio)
-- **Domanda civica forte e trasversale**: la composizione della classe politica locale interessa cittadini, giornalisti, ricercatori
-- **Potenziale di join**: i codici DAIT sono proprietari. Serve una mappatura verificata per join con dataset ISTAT/BDAP (es. via denominazione_comune + sigla_provincia)
-- **Unico nel catalogo**: nessun altro dataset dà il profilo socio-demografico dei politici locali
-- **Serie storica lunghissima**: 1991–2026 = 35 anni di dati, permette analisi di trend (fase 2)
-- **Fonte ufficiale e strutturale**: Ministero dell'Interno, aggiornamento annuale
+```bash
+cd dataset-incubator
+toolkit run -c candidates/dait-amministratori-locali/dataset.yml
+```
 
-## Output minimo atteso
+## Issue di riferimento
 
-- ✅ Tabella clean `dait_amministratori_locali` — 116.054 righe, 19 colonne
-- ✅ Run full RAW→CLEAN→MART superato (7.7s, readiness 5/5)
-- ✅ Notebook v0 con setup candidate
-- ⬜ Mart dimensionale territoriale (fase 2)
-- ⬜ Serie storica 1991–2025 (fase 2)
-
-## Criterio di promozione
-
-Superato il **review readiness** con run full (RAW→CLEAN→MART) su anno 2026:
-- `config_valid` ✅
-- `raw_output_present` ✅
-- `clean_output_readable` ✅ (116.054 righe)
-- `mart_outputs_readable` ✅
-- `run_record_coherent` ✅
-
-## Stato
-
-- intake
-
-## Prossimo passo
-
-- review PR e merge
-- eventuale estensione con `maggiororgano.csv` (sindaci) via inject_column
-- serie storica 1991–2025
+- Intake: [#349](https://github.com/dataciviclab/dataset-incubator/issues/349)

--- a/candidates/dait-amministratori-locali/dataset.yml
+++ b/candidates/dait-amministratori-locali/dataset.yml
@@ -7,6 +7,7 @@ dataset:
   tags: [politica, dait, amministratori, locali]
   category: politica
   years: [2026]
+  time_coverage: {start_year: 2026, end_year: 2026}
 
 # --- RAW LAYER ---
 raw:
@@ -22,7 +23,10 @@ raw:
 # --- CLEAN LAYER ---
 # Le prime 2 righe del CSV contengono metadati (titolo + data aggiornamento) — skip:2
 clean:
+  sql: "sql/clean.sql"
   read:
+    source: auto
+    mode: latest
     delim: ";"
     encoding: "utf-8"
     header: true
@@ -49,18 +53,41 @@ clean:
       "lista_appartenenza/collegamento": "VARCHAR"
       titolo_studio: "VARCHAR"
       professione: "VARCHAR"
-  required_columns: [anno, codice_regione, codice_provincia, codice_comune, codice_dait_completo, denominazione_comune, sigla_provincia, cognome, nome, sesso, data_nascita, luogo_nascita, descrizione_carica, incarico, data_elezione, data_entrata_in_carica, lista_appartenenza, titolo_studio, professione]
+  required_columns: [anno, codice_regione, codice_provincia, codice_comune, codice_dait_completo, denominazione_comune, sigla_provincia, popolazione_censita, cognome, nome, sesso, data_nascita, luogo_nascita, descrizione_carica, incarico, data_elezione, data_entrata_in_carica, lista_appartenenza, titolo_studio, professione]
   validate:
-    not_null: [anno]
-  read_mode: robust
-  sql: "sql/clean.sql"
+    not_null: [anno, descrizione_carica]
+    min_rows: 100000
 
 # --- MART LAYER ---
-# Tre mart:
-#   1) dait_amministratori_locali — tutti gli amministratori (passthrough del clean)
-#   2) dait_sindaci — solo sindaci (filtro su descrizione_carica)
-#   3) dait_amministratori_territorio — aggregazioni per provincia/regione
+# Mart analitiche serie (rimossa la flat passthrough):
+#   1) mart_profilo_carica — conteggi, eta media, % femmine per carica
+#   2) mart_profilo_demografico — distribuzione sesso x classe di eta per carica
+#   3) mart_territorio — composizione per regione x carica
 mart:
   tables:
-    - name: "dait_amministratori_locali"
-      sql: "sql/mart.sql"
+    - name: "mart_profilo_carica"
+      sql: "sql/mart_profilo_carica.sql"
+    - name: "mart_profilo_demografico"
+      sql: "sql/mart_profilo_demografico.sql"
+    - name: "mart_territorio"
+      sql: "sql/mart_territorio.sql"
+  required_tables:
+    - "mart_profilo_carica"
+    - "mart_territorio"
+  validate:
+    table_rules:
+      mart_profilo_carica:
+        required_columns: [descrizione_carica, n_amministratori, n_comuni, eta_media, quota_femmine_pct]
+        primary_key: [descrizione_carica]
+        min_rows: 5
+      mart_profilo_demografico:
+        required_columns: [descrizione_carica, sesso, n_amministratori, eta_media]
+        primary_key: [descrizione_carica, sesso]
+        min_rows: 5
+      mart_territorio:
+        required_columns: [codice_regione, descrizione_carica, n_amministratori, quota_femmine_pct]
+        primary_key: [codice_regione, descrizione_carica]
+        min_rows: 20
+
+validation:
+  fail_on_error: true

--- a/candidates/dait-amministratori-locali/notes.md
+++ b/candidates/dait-amministratori-locali/notes.md
@@ -71,3 +71,16 @@ Per unire file con schemi diversi servirebbe clean.sql manuale con UNION ALL e a
 - **Serie storica**: snapshot annuali hanno struttura e naming diversi tra anni → da verificare consistenza
 - **Dimensione**: 26.7 MB gestibile (~3 MB Parquet)
 - **Stato SO**: fonte `dait` è in `radar-only` — dopo intake si può valutare `catalog-watch`
+
+## Aggiornamento 2026-08-01 (standard v1)
+
+- Mart flat passthrough rimossa; 3 mart analitiche serie (profilo_carica,
+  profilo_demografico, territorio) — rispondono alle domande del README
+- Run passed: clean 124.716 righe (0% drop), mart 3/3, readiness 8/8
+- Numeri chiave: 7.769 sindaci su 7.768 comuni (~1:1); sindaci F 15,4%
+  (eta media 55,8) vs consiglieri F 35,9% (49,9); regione 03 (Lombardia)
+  1.492 sindaci
+- `codice_regione` è il codice DAIT (2 cifre), non ISTAT — join con dataset
+  ISTAT richiede mappatura (nota già presente nel clean.sql)
+- `popolazione_censita` e `codice_dait_completo` aggiunti a required_columns
+- read.mode al posto di read_mode (legacy)

--- a/candidates/dait-amministratori-locali/sql/mart.sql
+++ b/candidates/dait-amministratori-locali/sql/mart.sql
@@ -1,3 +1,0 @@
--- Mart: dait_amministratori_locali (passthrough del clean)
--- Tabella flat con tutti gli amministratori comunali in carica
-SELECT * FROM clean_input

--- a/candidates/dait-amministratori-locali/sql/mart_profilo_carica.sql
+++ b/candidates/dait-amministratori-locali/sql/mart_profilo_carica.sql
@@ -1,0 +1,20 @@
+-- mart_profilo_carica — Profilo degli amministratori per carica
+--
+-- 1 riga = 1 carica (Sindaco, Assessore, Consigliere, ...): conteggi,
+-- età media (al 2026-06-01), % femmine, n comuni.
+-- Serve per: composizione della classe politica locale (README domanda
+-- principale), quanti per carica, differenze demografiche per carica.
+--
+-- PK: (descrizione_carica)
+
+SELECT
+    descrizione_carica,
+    COUNT(*) AS n_amministratori,
+    COUNT(DISTINCT codice_dait_completo) AS n_comuni,
+    ROUND(AVG(DATE_DIFF('year', data_nascita, DATE '2026-06-01')), 1) AS eta_media,
+    ROUND(100.0 * SUM(CASE WHEN sesso = 'F' THEN 1 ELSE 0 END) / NULLIF(COUNT(*), 0), 1) AS quota_femmine_pct,
+    ROUND(100.0 * SUM(CASE WHEN sesso = 'M' THEN 1 ELSE 0 END) / NULLIF(COUNT(*), 0), 1) AS quota_maschi_pct
+FROM clean_input
+WHERE descrizione_carica IS NOT NULL
+GROUP BY descrizione_carica
+ORDER BY n_amministratori DESC

--- a/candidates/dait-amministratori-locali/sql/mart_profilo_demografico.sql
+++ b/candidates/dait-amministratori-locali/sql/mart_profilo_demografico.sql
@@ -1,0 +1,21 @@
+-- mart_profilo_demografico — Profilo demografico per carica
+--
+-- 1 riga = 1 carica: distribuzione per sesso e classe di età, età media.
+-- Serve per: quante donne elette (README), età media di sindaci/assessori/
+-- consiglieri, composizione anagrafica della classe politica locale.
+--
+-- PK: (descrizione_carica, sesso)
+
+SELECT
+    descrizione_carica,
+    sesso,
+    COUNT(*) AS n_amministratori,
+    ROUND(AVG(DATE_DIFF('year', data_nascita, DATE '2026-06-01')), 1) AS eta_media,
+    SUM(CASE WHEN DATE_DIFF('year', data_nascita, DATE '2026-06-01') < 30 THEN 1 ELSE 0 END) AS n_under_30,
+    SUM(CASE WHEN DATE_DIFF('year', data_nascita, DATE '2026-06-01') BETWEEN 30 AND 49 THEN 1 ELSE 0 END) AS n_30_49,
+    SUM(CASE WHEN DATE_DIFF('year', data_nascita, DATE '2026-06-01') BETWEEN 50 AND 64 THEN 1 ELSE 0 END) AS n_50_64,
+    SUM(CASE WHEN DATE_DIFF('year', data_nascita, DATE '2026-06-01') >= 65 THEN 1 ELSE 0 END) AS n_over_65
+FROM clean_input
+WHERE descrizione_carica IS NOT NULL AND sesso IS NOT NULL AND data_nascita IS NOT NULL
+GROUP BY descrizione_carica, sesso
+ORDER BY descrizione_carica, sesso

--- a/candidates/dait-amministratori-locali/sql/mart_territorio.sql
+++ b/candidates/dait-amministratori-locali/sql/mart_territorio.sql
@@ -1,0 +1,20 @@
+-- mart_territorio — Composizione amministratori per territorio
+--
+-- 1 riga = 1 regione × carica: conteggi, % femmine, età media, n comuni.
+-- Serve per: differenze Nord/Sud (README), quante donne per regione,
+-- distribuzione territoriale della classe politica.
+-- NOTA: la regione è il codice DAIT (2 cifre) — non è il codice ISTAT.
+--
+-- PK: (codice_regione, descrizione_carica)
+
+SELECT
+    codice_regione,
+    descrizione_carica,
+    COUNT(*) AS n_amministratori,
+    COUNT(DISTINCT codice_dait_completo) AS n_comuni,
+    ROUND(100.0 * SUM(CASE WHEN sesso = 'F' THEN 1 ELSE 0 END) / NULLIF(COUNT(*), 0), 1) AS quota_femmine_pct,
+    ROUND(AVG(DATE_DIFF('year', data_nascita, DATE '2026-06-01')), 1) AS eta_media
+FROM clean_input
+WHERE codice_regione IS NOT NULL AND descrizione_carica IS NOT NULL
+GROUP BY codice_regione, descrizione_carica
+ORDER BY codice_regione, n_amministratori DESC


### PR DESCRIPTION
## Sintesi

Porta `dait-amministratori-locali` allo standard candidate v1 con mart analitiche serie. Rimossa la mart flat (pass-through del clean, `SELECT * FROM clean_input`), sostituita da 3 mart serie che rispondono alle domande del README (profilo demografico della classe politica locale, presenza femminile, differenze territoriali).

## Contesto collegato

- Closes #349 (intake dait-amministratori-locali)
- Standard: `docs/candidate-standard.md` §2.4 (pattern mart) + §3 (contratto SQL)
- Piano di allineamento mart: `_local/tasks/2026-08-01-mart-standard-candidates.md` (Lotto 1)

## Cosa cambia

- [x] candidate — aggiornamento (non nuovo dataset)
- [ ] support
- [ ] docs
- [x] cleanup — rimosso pass-through
- [ ] workflow o CI
- [ ] altro

## Impatto

- [x] Aggiunge o modifica un candidate in `candidates/dait-amministratori-locali/`
- [ ] Cambia la struttura attesa dei candidate
- [ ] Cambia il contratto con consumatori downstream — no: clean invariato (stesse colonne), mart nuove
- [ ] Solo documentazione o metadati
- [ ] Nessun impatto visibile

## Dettaglio

### Mart (rimpiazzano la flat passthrough)

La mart era `SELECT * FROM clean_input` — copia del clean senza valore. Ora 3 mart serie:

- **`mart_profilo_carica`** — per carica (Sindaco/Assessore/Consigliere/...): conteggi, n comuni, età media, % femmine/maschi
- **`mart_profilo_demografico`** — per carica × sesso: età media, distribuzione per classe di età (under 30 / 30-49 / 50-64 / over 65)
- **`mart_territorio`** — per regione × carica: conteggi, n comuni, quota femmine, età media (differenze Nord/Sud)

### Allineamento standard

- `dataset.yml`: `read.mode: latest` (era `read_mode` legacy), `required_columns` completo (mancavano `popolazione_censita` e `codice_dait_completo`), `not_null`, `min_rows`, `time_coverage`, `table_rules` con PK dai GROUP BY
- README/notes aggiornati

## Checklist candidate

- [x] `dataset.yml` con `name`, `years`, `source_id`, `tags`, `category` (gate strict)
- [x] `clean.validate` con `required_columns`, `not_null`, `min_rows`
- [x] `mart.validate.table_rules` con `primary_key` dai GROUP BY
- [x] `toolkit run` eseguito senza errori (2026: passed, clean 124716 righe 0% drop, mart 3/3)
- [x] `python scripts/validate_candidate_structure.py` passato senza failure
- [x] nessun file dati committato nella root del candidate
- [x] issue di intake collegata (#349)

## Verifica

```bash
toolkit run -c candidates/dait-amministratori-locali/dataset.yml
python scripts/validate_candidate_structure.py
```

Esito run locale (2026-08-01):
```
2026: run=ok validate=passed
     raw: qs=100 · clean: qs=100 (124716 righe, 0% drop) · mart: qs=100 (3/3)
     readiness: ready (8/8)
```

Numeri verificati: 7.769 sindaci su 7.768 comuni (~1:1); sindaci F 15,4% (età media 55,8) vs consiglieri F 35,9% (49,9); Lombardia (codice DAIT 03) 1.492 sindaci.

Nota: `codice_regione` è il codice DAIT (2 cifre), non ISTAT — join con dataset ISTAT richiede mappatura (documentato nel clean.sql e notes).