### PR TITLE
fix(graph): ripristina colonna di join dei bridge e dedup relazioni

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2139,7 +2139,8 @@
           "name": "esercizio_finanziario",
           "type": "INTEGER",
           "role": "dimension",
-          "description": "Anno di riferimento"
+          "description": "Anno di riferimento",
+          "semantic_type": "year"
         },
         {
           "name": "codice_titolo",
@@ -2398,7 +2399,8 @@
           "name": "esercizio_finanziario",
           "type": "INTEGER",
           "role": "dimension",
-          "description": "Anno di riferimento"
+          "description": "Anno di riferimento",
+          "semantic_type": "year"
         },
         {
           "name": "stato_previsione",

--- a/registry/entity_graph.json
+++ b/registry/entity_graph.json
@@ -1599,9 +1599,21 @@
           "semantic_type": "month"
         },
         {
+          "slug": "bdap_entrate_stato",
+          "name": "BDAP Entrate Stato - Serie Storica",
+          "column": "esercizio_finanziario",
+          "semantic_type": "year"
+        },
+        {
           "slug": "bdap_lea",
           "name": "Bdap Lea",
           "column": "anno_riferimento",
+          "semantic_type": "year"
+        },
+        {
+          "slug": "bdap_spese_stato",
+          "name": "BDAP Spese Stato",
+          "column": "esercizio_finanziario",
           "semantic_type": "year"
         },
         {
@@ -2038,7 +2050,7 @@
         }
       ],
       "types": {
-        "year": 70,
+        "year": 72,
         "month": 10
       }
     }
@@ -2053,7 +2065,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_bandi_gara",
-        "on": "",
+        "on": "cig",
         "semantic_type": "municipality_code"
       }
     },
@@ -2066,20 +2078,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_bandi_gara",
-        "on": "",
-        "semantic_type": "municipality_code"
-      }
-    },
-    {
-      "from": {
-        "entity": "Gara",
-        "dataset": "anac_aggiudicazioni",
-        "via": "cig_code"
-      },
-      "to": {
-        "entity": "Comune",
-        "bridge": "anac_bandi_gara",
-        "on": "",
+        "on": "cig",
         "semantic_type": "municipality_code"
       }
     },
@@ -2092,7 +2091,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_bandi_gara",
-        "on": "",
+        "on": "cig",
         "semantic_type": "municipality_code"
       }
     },
@@ -2105,7 +2104,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_cup",
-        "on": "",
+        "on": "cup",
         "semantic_type": "municipality_code"
       }
     },
@@ -2118,33 +2117,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_bandi_gara",
-        "on": "",
-        "semantic_type": "municipality_code"
-      }
-    },
-    {
-      "from": {
-        "entity": "Gara",
-        "dataset": "anac_bandi_gara",
-        "via": "cig_code"
-      },
-      "to": {
-        "entity": "Comune",
-        "bridge": "anac_bandi_gara",
-        "on": "",
-        "semantic_type": "municipality_code"
-      }
-    },
-    {
-      "from": {
-        "entity": "Gara",
-        "dataset": "anac_bandi_gara",
-        "via": "cig_code"
-      },
-      "to": {
-        "entity": "Comune",
-        "bridge": "anac_bandi_gara",
-        "on": "",
+        "on": "cig",
         "semantic_type": "municipality_code"
       }
     },
@@ -2157,7 +2130,7 @@
       "to": {
         "entity": "Ente (o Impresa)",
         "bridge": "bdap_anagrafe_enti",
-        "on": "",
+        "on": "codice_ente_ipa",
         "semantic_type": "fiscal_code"
       }
     },
@@ -2170,7 +2143,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_bandi_gara",
-        "on": "",
+        "on": "cig",
         "semantic_type": "municipality_code"
       }
     },
@@ -2183,7 +2156,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_bandi_gara",
-        "on": "",
+        "on": "cig",
         "semantic_type": "municipality_code"
       }
     },
@@ -2196,7 +2169,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_cup",
-        "on": "",
+        "on": "cup",
         "semantic_type": "municipality_code"
       }
     },
@@ -2209,7 +2182,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_bandi_gara",
-        "on": "",
+        "on": "cig",
         "semantic_type": "municipality_code"
       }
     },
@@ -2222,7 +2195,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_bandi_gara",
-        "on": "",
+        "on": "cig",
         "semantic_type": "municipality_code"
       }
     },
@@ -2235,7 +2208,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_bandi_gara",
-        "on": "",
+        "on": "cig",
         "semantic_type": "municipality_code"
       }
     },
@@ -2248,7 +2221,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "bdap_anagrafe_enti",
-        "on": "",
+        "on": "codice_ente_miur",
         "semantic_type": "municipality_code"
       }
     },
@@ -2261,7 +2234,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "bdap_anagrafe_enti",
-        "on": "",
+        "on": "codice_ente_ssn",
         "semantic_type": "municipality_code"
       }
     },
@@ -2274,7 +2247,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "bdap_anagrafe_enti",
-        "on": "",
+        "on": "codice_ente_ssn",
         "semantic_type": "municipality_code"
       }
     },
@@ -2287,7 +2260,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_cup",
-        "on": "",
+        "on": "cup",
         "semantic_type": "municipality_code"
       }
     },
@@ -2300,7 +2273,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "opencivitas_fsc_enti_rso",
-        "on": "",
+        "on": "username",
         "semantic_type": "municipality_name"
       }
     },
@@ -2313,7 +2286,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "opencivitas_fsc_enti_rso",
-        "on": "",
+        "on": "username",
         "semantic_type": "municipality_name"
       }
     },
@@ -2326,7 +2299,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "opencivitas_fsc_enti_rso",
-        "on": "",
+        "on": "username",
         "semantic_type": "municipality_name"
       }
     },
@@ -2339,7 +2312,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_cup",
-        "on": "",
+        "on": "cup",
         "semantic_type": "municipality_code"
       }
     },
@@ -2352,7 +2325,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_bandi_gara",
-        "on": "",
+        "on": "cig",
         "semantic_type": "municipality_code"
       }
     },
@@ -2365,7 +2338,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_cup",
-        "on": "",
+        "on": "cup",
         "semantic_type": "municipality_code"
       }
     },
@@ -2378,7 +2351,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_cup",
-        "on": "",
+        "on": "cup",
         "semantic_type": "municipality_code"
       }
     },
@@ -2391,7 +2364,7 @@
       "to": {
         "entity": "Comune",
         "bridge": "anac_cup",
-        "on": "",
+        "on": "cup",
         "semantic_type": "municipality_code"
       }
     },
@@ -2404,13 +2377,13 @@
       "to": {
         "entity": "Comune",
         "bridge": "bdap_anagrafe_enti",
-        "on": "",
+        "on": "codice_ente_siope",
         "semantic_type": "municipality_code"
       }
     }
   ],
   "summary": {
     "total_entities": 16,
-    "total_relations": 28
+    "total_relations": 25
   }
 }

--- a/registry/semantic_types.yaml
+++ b/registry/semantic_types.yaml
@@ -10,6 +10,8 @@
 #     normalizers: espressioni SQL per normalizzare la colonna del dataset al formato hub
 #   bridge: se il join è indiretto (opzionale)
 #     via: hub/dataset intermedio
+#     on_column: colonna del bridge su cui avviene il join
+#                (NOTA: non usare "on" — in YAML 1.1 "on:" è parsificato come booleano True)
 #     to: tipo semantico di arrivo
 #   validators: hint per validazione (opzionale)
 
@@ -152,7 +154,7 @@ types:
     aliases: [cig, codice_cig, cig_accordo_quadro, CIG_PROG_ESTERNA, CIG_COLLEGAMENTO]
     bridge:
       via: anac_bandi_gara
-      on: cig
+      on_column: cig
       to: municipality_code
     weight: 25
 
@@ -162,7 +164,7 @@ types:
     aliases: [cup, codice_cup]
     bridge:
       via: anac_cup
-      on: cup
+      on_column: cup
       to: municipality_code
     weight: 20
 
@@ -172,7 +174,7 @@ types:
     aliases: [codice_ausa, ausa]
     bridge:
       via: bdap_anagrafe_enti
-      on: codice_ente_ipa
+      on_column: codice_ente_ipa
       to: fiscal_code
     weight: 15
 
@@ -203,7 +205,7 @@ types:
     aliases: [codice_ente]
     bridge:
       via: bdap_anagrafe_enti
-      on: codice_ente_siope
+      on_column: codice_ente_siope
       to: municipality_code
     weight: 15
 
@@ -213,7 +215,7 @@ types:
     aliases: [codice_ente_miur, codice_ente_miur]
     bridge:
       via: bdap_anagrafe_enti
-      on: codice_ente_miur
+      on_column: codice_ente_miur
       to: municipality_code
     weight: 15
 
@@ -223,7 +225,7 @@ types:
     aliases: [codice_ente_ssn]
     bridge:
       via: bdap_anagrafe_enti
-      on: codice_ente_ssn
+      on_column: codice_ente_ssn
       to: municipality_code
     weight: 15
 
@@ -233,7 +235,7 @@ types:
     aliases: [username]
     bridge:
       via: opencivitas_fsc_enti_rso
-      on: username
+      on_column: username
       to: municipality_name
     weight: 10
 
@@ -256,7 +258,7 @@ types:
   year:
     description: "Anno di riferimento"
     entity: Tempo
-    aliases: [anno, year, anno_di_imposta, anno_riferimento]
+    aliases: [anno, year, anno_di_imposta, anno_riferimento, esercizio_finanziario]
     weight: 1
 
   month:

--- a/tests/test_clean_query_build_relationship_map.py
+++ b/tests/test_clean_query_build_relationship_map.py
@@ -65,6 +65,47 @@ class TestEntityGraph:
         bdap_bridges = [b for b in bridges if "bdap" in str(b).lower()]
         assert len(bdap_bridges) > 0, "Nessun bridge BDAP trovato"
 
+    def test_bridges_have_on_column(self):
+        """Ogni bridge deve dichiarare la colonna di join (`to.on`).
+
+        Regressione: la chiave YAML `on:` veniva parsificata come booleano
+        True da YAML 1.1, quindi `bridge.get("on", "")` restituiva sempre ""
+        e il grafo perdeva la colonna di join (CIG, CUP, ...).
+        """
+        graph = _load()
+        bridges = graph.get("bridges", [])
+        assert bridges, "Nessun bridge da verificare"
+        empty_on = [b for b in bridges if not b.get("to", {}).get("on")]
+        assert not empty_on, (
+            f"{len(empty_on)} bridge con colonna di join vuota: "
+            f"{[b['from']['dataset'] for b in empty_on[:5]]}"
+        )
+
+    def test_bridges_no_duplicates(self):
+        """Non devono esistere relazioni duplicate (stesso dataset → stesso bridge).
+
+        Regressione: il builder generava una relazione per ogni colonna con
+        lo stesso semantic_type (es. anac_bandi_gara con 3 colonne cig_code
+        produceva 3 bridge identici).
+        """
+        graph = _load()
+        bridges = graph.get("bridges", [])
+        seen = set()
+        dups = []
+        for b in bridges:
+            key = (
+                b["from"]["entity"],
+                b["from"]["dataset"],
+                b["from"]["via"],
+                b["to"]["entity"],
+                b["to"]["bridge"],
+                b["to"]["semantic_type"],
+            )
+            if key in seen:
+                dups.append(key)
+            seen.add(key)
+        assert not dups, f"{len(dups)} relazioni duplicate trovate: {dups[:5]}"
+
     def test_entity_has_required_fields(self):
         """Ogni dataset in un'entità deve avere slug, column, semantic_type."""
         graph = _load()

--- a/tools/graph/build_graph.py
+++ b/tools/graph/build_graph.py
@@ -110,23 +110,24 @@ def build_graph() -> dict:
             bridge = type_info.get("bridge")
             if bridge:
                 via = bridge.get("via", "")
-                on = bridge.get("on", "")
+                on = bridge.get("on_column", "")
                 to_st = bridge.get("to", "")
                 to_info = types_info.get(to_st, {})
                 to_entity = to_info.get("entity", "Sconosciuto")
 
                 if to_entity and to_entity != entity:
-                    relations.append(
-                        {
-                            "from": {"entity": entity, "dataset": slug, "via": st},
-                            "to": {
-                                "entity": to_entity,
-                                "bridge": via,
-                                "on": on,
-                                "semantic_type": to_st,
-                            },
-                        }
-                    )
+                    rel = {
+                        "from": {"entity": entity, "dataset": slug, "via": st},
+                        "to": {
+                            "entity": to_entity,
+                            "bridge": via,
+                            "on": on,
+                            "semantic_type": to_st,
+                        },
+                    }
+                    # Evita relazioni duplicate (stessa coppia dataset→bridge)
+                    if rel not in relations:
+                        relations.append(rel)
 
     # Ordina dataset per slug
     for entity in nodes:


### PR DESCRIPTION
## Sintesi

Corregge due bug del grafo entità→dataset (`entity_graph.json` / MCP `dataset_graph`):

1. **Colonna di join persa**: la chiave YAML `on:` nel vocabolario bridge veniva parsificata come booleano `True` da YAML 1.1 → `build_graph.py` leggeva `bridge.get("on")` e otteneva sempre `""` → tutti i 28 bridge avevano `on: ""` (join non eseguibile).
2. **Relazioni duplicate**: il builder generava una relazione per ogni colonna con lo stesso semantic_type (es. `anac_bandi_gara` con 3 colonne `cig_code` produceva 3 bridge identici) → 28 relazioni dichiarate, 25 uniche.

## Contesto collegato

Nessuna issue aperta — emerso da verifica MCP del grafo (28 bridge con `on` vuoto, 3 duplicati).

## Cosa cambia

- [ ] candidate — nuovo dataset o aggiornamento
- [ ] support — dataset di supporto
- [ ] docs — struttura candidate, README, template
- [x] cleanup — refactoring, rimozioni, allineamento
- [ ] workflow o CI
- [ ] altro

### Root fix
- `registry/semantic_types.yaml`: `on:` → `on_column:` (chiave non riservata YAML) in tutti i 7 bridge + nota docstring per chi aggiunge bridge futuri. Bonus: alias `esercizio_finanziario` → `year` (2 dataset BDAP orfani dal grafo).
- `tools/graph/build_graph.py`: legge `bridge.on_column` e dedup relazioni identiche.
- Test di regressione: `test_bridges_have_on_column` (on vuoto) + `test_bridges_no_duplicates` (duplicati).

## Impatto

- [ ] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi)
- [x] Solo documentazione o metadati
- [x] Nessun impatto visibile per chi usa il repository

Schema di `entity_graph.json` invariato (stessi campi, valori ora corretti). `semantic_types.yaml` cambia chiave `on`→`on_column`, consumato solo da `build_graph.py` (aggiornato) e dal derive (non tocca i bridge).

## Verifica

```bash
python scripts/build_clean_catalog.py --derive --write
python tools/graph/build_graph.py --json
python -m pytest tests/ -q
ruff check tools/graph/build_graph.py tests/test_clean_query_build_relationship_map.py
```

- Grafo rigenerato: 16 entità, 25 relazioni (3 duplicati rimossi), 0 bridge con `on` vuoto
- `bdap_entrate_stato` / `bdap_spese_stato` ora nel grafo (entità Tempo)
- Suite completa verde (34+ test), ruff pulito, pre-commit passato
- [x] `toolkit run` eseguito senza errori (n/a — nessun candidate toccato)
- [x] `python scripts/validate_candidate_structure.py` passato (n/a)

## Note / rischi

- Il derive richiede accesso GCS (già usato dal post-merge): il fix sul catalogo (`esercizio_finanziario` → year) si propaga alla prossima rigenerazione in CI.
- Nessun bridge nuovo aggiunto: il dominio territorio resta senza bridge esplicito Comune→Provincia/Regione (decisione di design, non urgente).