### PR TITLE
feat(rna-misure): standard v1 — mart serie per tipo/attive/top

### DIFF
--- a/candidates/rna-misure/README.md
+++ b/candidates/rna-misure/README.md
@@ -13,4 +13,21 @@ Questo candidate esiste per registrare il dataset nel catalogo Lab.
 
 - Parquet unico su GCS (`gs://dataciviclab-clean/rna-aiuti-stato/misure/misure.parquet`)
 - Il deploy su GCS avviene tramite CI di dataset-incubator (post-merge)
-- MART passthrough (nessuna aggregazione — dataset piccolo)
+- **`car` non è unico**: la stessa misura ha più finestre di validità (es. car 1924 con periodo 2007-2021 e 2015-2030). PK = `car + data_inizio_misura`.
+
+## Mart
+
+| Mart | Descrizione |
+|---|---|
+| `mart_misure_per_tipo` | Conteggi e importi (prestiti garantiti + ad hoc) per tipo di misura |
+| `mart_misure_attive` | Misure ancora attive per anno di istituzione |
+| `mart_top_misure` | Top misure per importo totale, con stato attiva/scaduta |
+
+Rispondono alla domanda D11 della [discussion #405](https://github.com/orgs/dataciviclab/discussions/405) (quali misure hanno erogato di più, misure dimenticate ma attive). NOTA: l'importo è il plafond della misura, non l'erogato effettivo (l'erogato si calcola dal join con `rna_aiuti_stato` via `car`).
+
+## Esecuzione
+
+```bash
+cd dataset-incubator
+toolkit run -c candidates/rna-misure/dataset.yml
+```

--- a/candidates/rna-misure/dataset.yml
+++ b/candidates/rna-misure/dataset.yml
@@ -7,6 +7,7 @@ dataset:
   tags: [finanza-pubblica, rna, misure]
   category: finanza-pubblica
   years: [2023]
+  time_coverage: {start_year: 1994, end_year: 2023}
 
 raw:
   output_policy: "overwrite"
@@ -20,18 +21,45 @@ raw:
 
 clean:
   sql: "sql/clean.sql"
-  required_columns: [car, car_padre, car_attivo, titolo_misura, des_tipo_misura, cod_tipo_misura, data_inizio_misura, data_fine_misura, base_giuridica_nazionale, stato_membro, cod_amm, des_autorita, autorita_concedente, link_aiuto, flag_quadro, flag_modifica_regime, anno, mese]
+  required_columns: [car, car_padre, car_attivo, titolo_misura, des_tipo_misura, cod_tipo_misura, data_inizio_misura, data_fine_misura, base_giuridica_nazionale, stato_membro, cod_amm, des_autorita, autorita_concedente, importo_prestiti_garantiti, importo_aiuto_ad_hoc, link_aiuto, flag_quadro, flag_modifica_regime, anno, mese]
   read:
     source: auto
     mode: latest
   validate:
     not_null: [anno]
     min_rows: 10000
+    # car non è unico: la stessa misura ha più finestre di validità
+    # (es. car 1924 con periodo 2007-2021 e 2015-2030) — PK car+inizio
+    primary_key: [car, data_inizio_misura]
 
 mart:
   tables:
-    - name: "mart_misure"
-      sql: "sql/mart.sql"
+    # Misure per tipo (regime, ad hoc, quadro) con importi
+    - name: "mart_misure_per_tipo"
+      sql: "sql/mart_misure_per_tipo.sql"
+    # Misure ancora attive per anno di istituzione
+    - name: "mart_misure_attive"
+      sql: "sql/mart_misure_attive.sql"
+    # Top misure per importo (D11 discussion #405)
+    - name: "mart_top_misure"
+      sql: "sql/mart_top_misure.sql"
   required_tables:
-    - "mart_misure"
-  validate: {}
+    - "mart_misure_per_tipo"
+    - "mart_top_misure"
+  validate:
+    table_rules:
+      mart_misure_per_tipo:
+        required_columns: [des_tipo_misura, n_misure, prestiti_garantiti_eur, aiuto_ad_hoc_eur, totale_eur]
+        primary_key: [des_tipo_misura]
+        min_rows: 3
+      mart_misure_attive:
+        required_columns: [anno, n_misure_istituite, ancora_attive, quota_attive_pct]
+        primary_key: [anno]
+        min_rows: 10
+      mart_top_misure:
+        required_columns: [car, titolo_misura, des_tipo_misura, totale_eur, stato]
+        primary_key: [car, data_inizio_misura]
+        min_rows: 10000
+
+validation:
+  fail_on_error: true

--- a/candidates/rna-misure/notes.md
+++ b/candidates/rna-misure/notes.md
@@ -13,3 +13,16 @@
 - **GCS**: `gs://dataciviclab-clean/rna-aiuti-stato/misure/misure.parquet`
 - **Deploy su GCS**: tramite CI di dataset-incubator (post-merge)
 - **Forma**: unico parquet cumulativo (non partizionato per anno)
+
+## Aggiornamento 2026-08-01 (standard v1)
+
+- Mart flat passthrough rimossa; 3 mart analitiche serie (per_tipo, attive,
+  top) — rispondono a D11 discussion #405
+- PK clean = car + data_inizio_misura: car NON unico (stessa misura con più
+  finestre di validità, es. car 1924: 2007-2021 e 2015-2030). Verificato:
+  1 gruppo duplicato su car, 0 su car+inizio
+- required_columns completato: mancavano importo_prestiti_garantiti e
+  importo_aiuto_ad_hoc (le 2 metriche)
+- Numeri chiave: regimi 177 mld, ad hoc 103 mld, Garanzia SupportItalia
+  23 mld (COVID); 35 misure istituite nel 2020 ancora attive
+- NOTA: importo = plafond misura, non erogato (join con rna_aiuti_stato via car)

--- a/candidates/rna-misure/sql/mart.sql
+++ b/candidates/rna-misure/sql/mart.sql
@@ -1,2 +1,0 @@
--- RNA Misure — MART passthrough
-SELECT * FROM clean_input

--- a/candidates/rna-misure/sql/mart_misure_attive.sql
+++ b/candidates/rna-misure/sql/mart_misure_attive.sql
@@ -1,0 +1,36 @@
+-- mart_misure_attive — Misure ancora attive per anno di inizio
+--
+-- 1 riga = 1 anno di inizio validità: totale misure create, di cui ancora
+-- attive (fine validità nel futuro o data aperta 9999). Serve per:
+-- misure "dimenticate" ma ancora in vigore (D11 #405).
+--
+-- PK: (anno)
+
+SELECT
+    anno,
+    COUNT(*) AS n_misure_istituite,
+    SUM(
+        CASE
+            WHEN data_fine_misura IS NULL
+                 OR data_fine_misura = ''
+                 OR data_fine_misura LIKE '9999%'
+                 OR data_fine_misura > '2026-01-01'
+            THEN 1 ELSE 0
+        END
+    ) AS ancora_attive,
+    ROUND(
+        100.0 * SUM(
+            CASE
+                WHEN data_fine_misura IS NULL
+                     OR data_fine_misura = ''
+                     OR data_fine_misura LIKE '9999%'
+                     OR data_fine_misura > '2026-01-01'
+                THEN 1 ELSE 0
+            END
+        ) / NULLIF(COUNT(*), 0),
+        1
+    ) AS quota_attive_pct
+FROM clean_input
+WHERE anno IS NOT NULL
+GROUP BY anno
+ORDER BY anno DESC

--- a/candidates/rna-misure/sql/mart_misure_per_tipo.sql
+++ b/candidates/rna-misure/sql/mart_misure_per_tipo.sql
@@ -1,0 +1,18 @@
+-- mart_misure_per_tipo — Misure di aiuto per tipo
+--
+-- 1 riga = 1 tipo di misura (Regime di aiuti, Aiuto ad hoc, Regime Quadro):
+-- conteggi, prestiti garantiti e aiuti ad hoc (EUR). Serve per:
+-- composizione del registro per tipo (D11 #405), peso dei regimi vs ad hoc.
+--
+-- PK: (des_tipo_misura)
+
+SELECT
+    des_tipo_misura,
+    COUNT(*) AS n_misure,
+    ROUND(SUM(importo_prestiti_garantiti), 0) AS prestiti_garantiti_eur,
+    ROUND(SUM(importo_aiuto_ad_hoc), 0) AS aiuto_ad_hoc_eur,
+    ROUND(SUM(importo_prestiti_garantiti) + SUM(importo_aiuto_ad_hoc), 0) AS totale_eur
+FROM clean_input
+WHERE des_tipo_misura IS NOT NULL
+GROUP BY des_tipo_misura
+ORDER BY totale_eur DESC

--- a/candidates/rna-misure/sql/mart_top_misure.sql
+++ b/candidates/rna-misure/sql/mart_top_misure.sql
@@ -1,0 +1,30 @@
+-- mart_top_misure — Top misure per importo (prestiti garantiti + ad hoc)
+--
+-- 1 riga = 1 misura: importi totali, tipo, autorità concedente, periodo.
+-- Serve per: le misure che hanno erogato di più (D11 #405), top 10,
+-- misure con importi rilevanti ancora attive.
+-- NOTA: l'importo è il plafond della misura, non l'erogato effettivo
+-- (l'erogato si calcola dal join con rna_aiuti_stato via car).
+--
+-- PK: (car)
+
+SELECT
+    car,
+    titolo_misura,
+    des_tipo_misura,
+    des_autorita,
+    autorita_concedente,
+    data_inizio_misura,
+    ROUND(importo_prestiti_garantiti, 0) AS prestiti_garantiti_eur,
+    ROUND(importo_aiuto_ad_hoc, 0) AS aiuto_ad_hoc_eur,
+    ROUND(importo_prestiti_garantiti + importo_aiuto_ad_hoc, 0) AS totale_eur,
+    CASE
+        WHEN data_fine_misura IS NULL
+             OR data_fine_misura = ''
+             OR data_fine_misura LIKE '9999%'
+             OR data_fine_misura > '2026-01-01'
+        THEN 'attiva' ELSE 'scaduta'
+    END AS stato
+FROM clean_input
+WHERE car IS NOT NULL
+ORDER BY totale_eur DESC


### PR DESCRIPTION
## Sintesi

Porta `rna-misure` allo standard candidate v1 con mart analitiche serie. Rimossa la mart flat (passthrough `SELECT * FROM clean_input`), sostituita da 3 mart serie che rispondono alla domanda D11 della discussion #405 (quali misure hanno erogato di più, misure ancora attive).

## Contesto collegato

- Standard: `docs/candidate-standard.md` §2.4 (pattern mart) + §3 (contratto SQL)
- Piano di allineamento mart: `_local/tasks/2026-08-01-mart-standard-candidates.md` (Lotto 1)
- Discussion #405 (RNA Aiuti di Stato — D11 su rna_misure)

## Cosa cambia

- [x] candidate — aggiornamento (non nuovo dataset)
- [ ] support
- [ ] docs
- [x] cleanup — rimosso pass-through
- [ ] workflow o CI
- [ ] altro

## Impatto

- [x] Aggiunge o modifica un candidate in `candidates/rna-misure/`
- [ ] Cambia la struttura attesa dei candidate
- [ ] Cambia il contratto con consumatori downstream — no: clean invariato (stesse colonne), mart nuove
- [ ] Solo documentazione o metadati
- [ ] Nessun impatto visibile

## Dettaglio

### Mart (rimpiazzano la flat passthrough)

La mart era `SELECT * FROM clean_input` — copia del clean senza valore. Ora 3 mart serie:

- **`mart_misure_per_tipo`** — conteggi e importi (prestiti garantiti + aiuti ad hoc) per tipo di misura (Regime / Aiuto ad hoc / Regime Quadro)
- **`mart_misure_attive`** — misure ancora attive per anno di istituzione (fine validità futura o data aperta 9999)
- **`mart_top_misure`** — top misure per importo totale, con stato attiva/scaduta

### Allineamento standard

- `dataset.yml`: `required_columns` completo (mancavano le 2 metriche `importo_prestiti_garantiti` e `importo_aiuto_ad_hoc`), `primary_key` corretto, `table_rules` con PK dai GROUP BY
- README/notes aggiornati

### PK corretta (scoperta sul dato)

`car` **non è unico**: la stessa misura ha più finestre di validità (es. car 1924 con periodo 2007-2021 e 2015-2030 — verificato 1 gruppo duplicato su car, 0 su car+inizio). PK clean e mart_top = `car + data_inizio_misura`.

## Checklist candidate

- [x] `dataset.yml` con `name`, `years`, `source_id`, `tags`, `category` (gate strict)
- [x] `clean.validate` con `required_columns`, `not_null`, `min_rows`, `primary_key`
- [x] `mart.validate.table_rules` con `primary_key` dai GROUP BY
- [x] `toolkit run` eseguito senza errori (2023: passed, clean 12874 righe 0% drop, mart 3/3)
- [x] `python scripts/validate_candidate_structure.py` passato senza failure
- [x] nessun file dati committato nella root del candidate
- [x] issue di intake collegata

## Verifica

```bash
toolkit run -c candidates/rna-misure/dataset.yml
python scripts/validate_candidate_structure.py
```

Esito run locale (2026-08-01):
```
2023: run=ok validate=passed
     raw: qs=100 · clean: qs=100 (12874 righe, 0% drop) · mart: qs=100 (3/3)
     readiness: ready (8/8)
```

Numeri verificati: regimi 177 mld, aiuti ad hoc 103 mld; top misure con Garanzia SupportItalia 23 mld (COVID); 35 misure istituite nel 2020 ancora attive.

Nota metodologica: l'importo nelle mart è il **plafond** della misura, non l'erogato effettivo (l'erogato si calcola dal join con `rna_aiuti_stato` via `car`) — documentato in README/notes.