### PR TITLE
chore(post-merge): aggiorna registry per PR #766

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -344,9 +344,25 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "27638710012",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27638710012",
-        "checked_at": "2026-06-16",
+        "run_id": "30710469074",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30710469074",
+        "checked_at": "2026-08-01",
+        "duration_seconds": 3.05,
+        "row_counts": {
+          "clean": 124716,
+          "mart": 167
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
         "years": [
           2026
         ],


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #766 — feat(dait-amministratori-locali): standard v1 — mart serie profilo/territorio

Changed candidate/support roots:

- `dait-amministratori-locali` (candidate, `candidates/dait-amministratori-locali`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/dait-amministratori-locali/dataset.yml` -> artifact `sample-run-dait-amministratori-locali`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
