### PR TITLE
chore(post-merge): aggiorna registry per PR #774

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1192,9 +1192,26 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "26683614225",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26683614225",
-        "checked_at": "2026-05-30",
+        "run_id": "30757771202",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30757771202",
+        "checked_at": "2026-08-02",
+        "duration_seconds": 189.27,
+        "row_counts": {
+          "raw": 3155723,
+          "clean": 3155723,
+          "mart": 121019
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
         "years": [
           2016,
           2017,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #774 — feat(mim-alunni-corso-eta): mart SQL esplicite al posto di hierarchy

Changed candidate/support roots:

- `mim-alunni-corso-eta` (candidate, `candidates/mim-alunni-corso-eta`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/mim-alunni-corso-eta/dataset.yml` -> artifact `sample-run-mim-alunni-corso-eta`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
