### PR TITLE
chore(post-merge): aggiorna registry per PR #776

### DIFF
--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1236,9 +1236,26 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "28333078359",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28333078359",
-        "checked_at": "2026-06-28",
+        "run_id": "30758781036",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30758781036",
+        "checked_at": "2026-08-02",
+        "duration_seconds": 12.74,
+        "row_counts": {
+          "raw": 104662,
+          "clean": 104662,
+          "mart": 40406
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
         "years": [
           2018,
           2019,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #776 — feat(mim-scuola-infanzia): standard v1 — mart serie cittadinanza

Changed candidate/support roots:

- `mim-scuola-infanzia` (candidate, `candidates/mim-scuola-infanzia`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/mim-scuola-infanzia/dataset.yml` -> artifact `sample-run-mim-scuola-infanzia`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
