### PR TITLE
chore(post-merge): aggiorna registry per PR #778

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -9117,7 +9117,7 @@
         },
         {
           "name": "quota_soggetto_privato",
-          "type": "VARCHAR",
+          "type": "DOUBLE",
           "role": "dimension",
           "description": "Quota di partecipazione di soggetto privato"
         },

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1091,9 +1091,26 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "25865950424",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/25865950424",
-        "checked_at": "2026-05-14",
+        "run_id": "30763582907",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30763582907",
+        "checked_at": "2026-08-02",
+        "duration_seconds": 93.49,
+        "row_counts": {
+          "raw": 210145,
+          "clean": 210145,
+          "mart": 35396
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 95.0,
+          "mart": 100.0
+        },
         "years": [
           2020,
           2021,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #778 — feat(mef-partecipazioni): standard v1 — mart serie, fix quota_soggetto_privato

Changed candidate/support roots:

- `mef-partecipazioni` (candidate, `candidates/mef-partecipazioni`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/mef-partecipazioni/dataset.yml` -> artifact `sample-run-mef-partecipazioni`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
