### PR TITLE
chore(post-merge): aggiorna registry per PR #782

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-08-02",
+  "updated_at": "2026-08-03",
   "datasets": [
     {
       "slug": "aci_prime_iscrizioni_autovetture",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-08-02",
+  "generated_at": "2026-08-03",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
@@ -1186,9 +1186,26 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "28359395238",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28359395238",
-        "checked_at": "2026-06-29",
+        "run_id": "30807694862",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30807694862",
+        "checked_at": "2026-08-03",
+        "duration_seconds": 68.13,
+        "row_counts": {
+          "raw": 101534,
+          "clean": 101534,
+          "mart": 12757
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 95.0,
+          "mart": 100.0
+        },
         "years": [
           2018,
           2019,


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #782 — feat(mef-rappresentanti-partecipate): standard v1 — 4 mart serie (discussion #406)

Changed candidate/support roots:

- `mef-rappresentanti-partecipate` (candidate, `candidates/mef-rappresentanti-partecipate`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/mef-rappresentanti-partecipate/dataset.yml` -> artifact `sample-run-mef-rappresentanti-partecipate`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
