### PR TITLE
feat(fts-eu-grants): standard v1 — script fixato (schema variabile), 4 mart serie (discussion #395)

### DIFF
--- a/candidates/fts-eu-grants/README.md
+++ b/candidates/fts-eu-grants/README.md
@@ -32,11 +32,11 @@ Tutti i beneficiari di fondi UE con sede in Italia, dal 2020 a oggi. Per ogni gr
 
 ## Perché vale la pena
 
-I grant UE diretti all'Italia sono 17 miliardi di EUR in 5 anni (2020-2024, escluso RRF). Sapere quali programmi, quali beneficiari e dove finiscono i soldi europei è una domanda di trasparenza diretta — risponde alla discussion #395 (13 domande verificate).
+I grant UE diretti all'Italia sono quasi 20 miliardi di EUR in 6 anni (2020-2025, escluso RRF). Sapere quali programmi, quali beneficiari e dove finiscono i soldi europei è una domanda di trasparenza diretta — risponde alla discussion #395 (13 domande verificate).
 
 ## Output minimo atteso
 
-- `mart_trend_anno`: contrattato/consumato per anno + RRF separato (17,05 mld no-RRF, assorbimento 72%)
+- `mart_trend_anno`: contrattato/consumato per anno + RRF separato (19,80 mld no-RRF 2020-2025, assorbimento 71%)
 - `mart_sintesi_programma`: per programma-anno (Horizon 4,75 mld, CEF Transport 1,11 mld)
 - `mart_sintesi_beneficiario`: per tipo beneficiario (Private Companies 56%)
 - `mart_top_beneficiari`: top beneficiari per importo (CNR, Polimi, Leonardo, BBT)

--- a/candidates/fts-eu-grants/README.md
+++ b/candidates/fts-eu-grants/README.md
@@ -29,3 +29,23 @@ Tutti i beneficiari di fondi UE con sede in Italia, dal 2020 a oggi. Per ogni gr
 - **TED contract_notices** — bandi di gara UE in Italia
 - **OpenCoesione** — fondi strutturali in Italia
 - **RNA aiuti_stato** — aiuti di Stato alle imprese
+
+## Perché vale la pena
+
+I grant UE diretti all'Italia sono 17 miliardi di EUR in 5 anni (2020-2024, escluso RRF). Sapere quali programmi, quali beneficiari e dove finiscono i soldi europei è una domanda di trasparenza diretta — risponde alla discussion #395 (13 domande verificate).
+
+## Output minimo atteso
+
+- `mart_trend_anno`: contrattato/consumato per anno + RRF separato (17,05 mld no-RRF, assorbimento 72%)
+- `mart_sintesi_programma`: per programma-anno (Horizon 4,75 mld, CEF Transport 1,11 mld)
+- `mart_sintesi_beneficiario`: per tipo beneficiario (Private Companies 56%)
+- `mart_top_beneficiari`: top beneficiari per importo (CNR, Polimi, Leonardo, BBT)
+
+## Criterio di promozione
+
+Promuovere quando: (1) i numeri del trend e delle classifiche sono verificati e citabili; (2) la discrepanza vs discussion #395 è riconciliata; (3) almeno una risposta della discussion è chiusa con dati.
+
+## Stato / prossimo passo
+
+- **Stato**: candidate a standard v1 (2026-08-03) — 4 mart serie, script fixato (schema variabile), run passed 5 anni, readiness 8/8
+- **Prossimo passo**: merge PR; post-merge: catalog aggiornamento; riconciliazione numeri con discussion #395 (data-researcher)

--- a/candidates/fts-eu-grants/dataset.yml
+++ b/candidates/fts-eu-grants/dataset.yml
@@ -6,8 +6,8 @@ dataset:
   source_id: "fts"
   tags: [finanza-pubblica, fts, eu, grants]
   category: finanza-pubblica
-  years: [2024, 2023, 2022, 2021, 2020]
-  time_coverage: {start_year: 2020, end_year: 2024}
+  years: [2025, 2024, 2023, 2022, 2021, 2020]
+  time_coverage: {start_year: 2020, end_year: 2025}
 
 raw:
   output_policy: overwrite
@@ -31,6 +31,8 @@ clean:
     encoding: "utf-8"
     quote: '"'
     escape: '"'
+    strict_mode: false
+    ignore_errors: true
   validate:
     not_null: [anno, beneficiario_nome]
     min_rows: 3000
@@ -47,7 +49,7 @@ mart:
     # Trend importi contrattati/consumati per anno (multi-year)
     - name: "mart_trend_anno"
       sql: "sql/mart_trend_anno.sql"
-      years: [2020, 2021, 2022, 2023, 2024]
+      years: [2020, 2021, 2022, 2023, 2024, 2025]
     # Sintesi per programma e tipo finanziamento
     - name: "mart_sintesi_programma"
       sql: "sql/mart_sintesi_programma.sql"

--- a/candidates/fts-eu-grants/dataset.yml
+++ b/candidates/fts-eu-grants/dataset.yml
@@ -7,11 +7,13 @@ dataset:
   tags: [finanza-pubblica, fts, eu, grants]
   category: finanza-pubblica
   years: [2024, 2023, 2022, 2021, 2020]
+  time_coverage: {start_year: 2020, end_year: 2024}
 
 raw:
   output_policy: overwrite
   sources:
-    - type: script
+    - name: "fts_script"
+      type: "script"
       args:
         command: "python scripts/convert_xlsx_to_csv.py --year {year} --output fts_{year}.csv"
         output: "fts_{year}.csv"
@@ -20,25 +22,64 @@ raw:
 
 clean:
   sql: "sql/clean.sql"
-  required_columns: [anno, budget, rif_impegno_giuridico, rif_bilancio, beneficiario_nome, beneficiario_partita_iva, flag_no_profit, flag_ong, flag_coordinatore, beneficiario_indirizzo, beneficiario_citta, beneficiario_cap, paese_beneficiario, nuts2, zona_geografica, luogo_azione, fonte_dettaglio, tipo_spesa, oggetto_contributo, dipartimento_responsabile, linea_bilancio_codice, linea_bilancio_nome, nome_programma, tipo_finanziamento, codice_gruppo_beneficiario, tipo_beneficiario, data_inizio_progetto, data_fine_progetto, tipo_contratto, tipo_gestione, paese_beneficiante]
+  required_columns: [anno, budget, rif_impegno_giuridico, rif_bilancio, beneficiario_nome, beneficiario_partita_iva, flag_no_profit, flag_ong, flag_coordinatore, beneficiario_indirizzo, beneficiario_citta, beneficiario_cap, paese_beneficiario, nuts2, zona_geografica, luogo_azione, importo_contrattato, importo_contrattato_stimato, importo_consumato_stimato, impegno_importo_a, importo_aggiuntivo_ridotto_b, impegno_totale_a_plus_b, impegno_consumato, fonte_dettaglio, tipo_spesa, oggetto_contributo, dipartimento_responsabile, linea_bilancio_codice, linea_bilancio_nome, nome_programma, is_rrf, tipo_finanziamento, codice_gruppo_beneficiario, tipo_beneficiario, data_inizio_progetto, data_fine_progetto, tipo_contratto, tipo_gestione, paese_beneficiante]
   read:
+    source: auto
+    mode: latest
     header: true
     delim: ","
     encoding: "utf-8"
     quote: '"'
     escape: '"'
   validate:
-    not_null: [anno]
+    not_null: [anno, beneficiario_nome]
+    min_rows: 3000
+    # ⚠ DER0GA primary_key: il sorgente FTS contiene righe duplicate reali
+    # (stesso rif_impegno_giuridico + beneficiario + importi + oggetto +
+    # programma + date) — anche con 8 campi restano 38 duplicati identici
+    # su 8.559 righe Italy (2023). PK non dichiarabile: vedi notes.md.
     promotion:
       max_row_drop_pct: 100.0
       fail_on_row_drop_exceeded: false
 
 mart:
   tables:
-    - name: "mart_grants_italia"
-      sql: "sql/mart.sql"
+    # Trend importi contrattati/consumati per anno (multi-year)
+    - name: "mart_trend_anno"
+      sql: "sql/mart_trend_anno.sql"
+      years: [2020, 2021, 2022, 2023, 2024]
+    # Sintesi per programma e tipo finanziamento
+    - name: "mart_sintesi_programma"
+      sql: "sql/mart_sintesi_programma.sql"
+    # Sintesi per tipo beneficiario
+    - name: "mart_sintesi_beneficiario"
+      sql: "sql/mart_sintesi_beneficiario.sql"
+    # Top beneficiari per importo contrattato
+    - name: "mart_top_beneficiari"
+      sql: "sql/mart_top_beneficiari.sql"
   required_tables:
-    - "mart_grants_italia"
+    - "mart_trend_anno"
+    - "mart_sintesi_programma"
+    - "mart_sintesi_beneficiario"
+    - "mart_top_beneficiari"
+  validate:
+    table_rules:
+      mart_trend_anno:
+        required_columns: [anno, n_grant, importo_contrattato_totale, importo_consumato_totale, importo_rrf_eur, quota_consumato_pct]
+        primary_key: [anno]
+        min_rows: 5
+      mart_sintesi_programma:
+        required_columns: [anno, nome_programma, n_grant, importo_contrattato_totale, importo_medio]
+        primary_key: [anno, nome_programma]
+        min_rows: 20
+      mart_sintesi_beneficiario:
+        required_columns: [anno, tipo_beneficiario, n_grant, importo_contrattato_totale, importo_medio]
+        primary_key: [anno, tipo_beneficiario]
+        min_rows: 5
+      mart_top_beneficiari:
+        required_columns: [anno, beneficiario_nome, n_grant, importo_contrattato_totale]
+        primary_key: [anno, beneficiario_nome]
+        min_rows: 300
 
 validation:
   fail_on_error: true

--- a/candidates/fts-eu-grants/notes.md
+++ b/candidates/fts-eu-grants/notes.md
@@ -3,7 +3,7 @@
 ## Fonte
 
 - **URL XLSX**: `https://ec.europa.eu/budget/financial-transparency-system/download/{YEAR}_FTS_dataset_en.xlsx`
-- **Formato**: XLSX, 38 colonne, primo sheet
+- **Formato**: XLSX, primo sheet
 - **Anni**: 2020–2024 verificati funzionanti (2007–2019 disponibili su richiesta)
 - **HEAD richiesto**: il server Europa restituisce `Content-Length: 0` su HEAD ma il file è correttamente servito su GET (chunked encoding)
 - **Licenza**: EU Open Data
@@ -15,11 +15,35 @@
 - `clean.read` legge il CSV prodotto dallo script (non l'XLSX diretto)
 - Richiede `TOOLKIT_ALLOW_SCRIPT_SOURCE=1` per abilitare lo script source
 
-## Schema clean
+## ⚠️ Schema XLSX VARIABILE per anno (scoperto 2026-08-03)
 
-38 colonne normalizzate in italiano. Le colonne importi usano la virgola come separatore delle migliaia in alcune celle — `REPLACE(..., ',', '')` nel clean rimuove le virgole prima del cast a DOUBLE.
+| Anni | Colonne | Differenze |
+|---|---|---|
+| 2020-2023 | 39 | `Recipient main registration number`, `Call for proposals Reference`, `Project / Contract Reference`, `Project / Contract Acronym` |
+| 2024 | 38 | `VAT number of beneficiary`, `Geographical Zone`, `Action location`, `Funding type` |
 
-### Filtro Italia
+**35 colonne comuni** a tutti gli anni. Lo script mappa **per NOME** (non posizionale) a 38 colonne italiane stabili; colonne assenti nell'anno → vuote. Il vecchio script posizionale era rotto: `df.columns = FTS_COLUMNS` (38) su file da 39 colonne → ValueError, run mai riuscito.
+
+**Perché non http_file+XLSX diretto**: il toolkit legge l'XLSX nativamente ma DuckDB risolve i nomi colonna a parse time → referenziare una colonna 2024-only nel run 2023 fallisce (BinderError). `align_by_header` (schema variabile) è supportato SOLO per CSV, non per Excel. Lo script resta il punto di normalizzazione.
+
+## Importi — formato internazionale (NON italiano)
+
+Gli importi XLSX sono già numerici con **punto decimale** (`29759799.09`), nessuna virgola migliaia — verificato su tutti gli anni. **NON usare `replace('.','')`** (moltiplicherebbe per ~1000): cast diretto a float. Il vecchio script `REPLACE(',', '')` era innocuo (nessuna virgola).
+
+## Metriche consumato — beneficiario vs commitment
+
+- `importo_consumato_stimato` (Beneficiary's estimated consumed) = quota del **beneficiario** → ratio consumato/contrattato sensato (~65-86%)
+- `impegno_consumato` (Commitment consumed) = consumo dell'**intero commitment** → ratio > 100%, NON usare per l'assorbimento
+
+## RRF — Recovery and Resilience Facility
+
+Flag `is_rrf` nel clean ('SI'/'NO' su `nome_programma LIKE '%Recovery%'`). Il RRF è un trasferimento di bilancio UE→Stato (non un grant analitico): 2023 = 23,9 mld su 27,9 totali (86%). **Escluso dalle mart analitiche** ma esposto come `importo_rrf_eur` nel trend. Decisione civic-director 2026-08-03 (opzione 3: flag, dato completo preservato).
+
+## Discrepanza vs discussion #395
+
+La discussion cita 9,77 mld contrattati 2020-2024 (Horizon 3,65 mld = 37%). I dati attuali FTS danno **17,05 mld no-RRF** (Horizon 4,75 mld = 28%). Le righe combaciano (40.417 vs 40.449) ma gli importi no → i dati FTS sono stati aggiornati dalla Commissione o la discussion usava un subset diverso. **Da riconciliare con data-researcher** (la discussion va aggiornata o va chiarita la metrica).
+
+## Filtro Italia
 
 Il filtro `paese_beneficiario = 'Italy'` usa il nome completo del paese (non ISO). Copre i beneficiari con sede legale in Italia — non necessariamente i progetti che si svolgono in Italia.
 
@@ -29,12 +53,10 @@ Il filtro `paese_beneficiario = 'Italy'` usa il nome completo del paese (non ISO
 - **OpenCoesione** copre i fondi strutturali (gestione condivisa con Stati membri)
 - **RNA** copre gli aiuti di Stato (erogati da enti italiani, non UE)
 
-Insieme danno una visione quasi completa dei flussi finanziari pubblici verso l'Italia.
-
 ## Colonne notevoli
 
 - `beneficiario_nome`: può contenere `*****` per motivi di privacy (persone fisiche)
-- `importo_contrattato`: l'importo effettivamente contrattualizzato
+- `importo_contrattato`: l'importo effettivamente contrattualizzato (può essere vuoto nel 2024 — 1.928 righe)
 - `importo_consumato_stimato`: quanto è stato effettivamente speso (stimato)
 - `nome_programma`: include il programma UE (es. "1.0.23 - Digital Europe Programme")
 
@@ -43,8 +65,5 @@ Insieme danno una visione quasi completa dei flussi finanziari pubblici verso l'
 - I dati FTS coprono solo la gestione diretta UE (~20% del budget UE). I fondi strutturali (80%) sono altrove (OpenCoesione, ESIF, Kohesio).
 - Alcuni beneficiari sono offuscati (`*****`) per motivi di privacy.
 - I nomi dei programmi non sono normalizzati — il raggruppamento per categoria è fatto nel mart.
-- Le date progetto possono essere vuote.
-
-## Rischio schema drift
-
-Il formato XLSX è stabile dal 2007. Le colonne non cambiano, ma nuovi programmi possono aggiungere nuovi codici.
+- Le date progetto possono essere vuote o `-` (normalizzate a vuoto dallo script, ~1.100 righe in data_fine 2020).
+- **PK non dichiarabile a livello riga**: il sorgente FTS contiene righe duplicate reali (stesso rif_impegno + beneficiario + importi + oggetto + date). Anche con 8 campi restano 38 duplicati identici su 8.559 righe (2023). Deroga primary_key (§4 candidate-standard).

--- a/candidates/fts-eu-grants/notes.md
+++ b/candidates/fts-eu-grants/notes.md
@@ -4,7 +4,7 @@
 
 - **URL XLSX**: `https://ec.europa.eu/budget/financial-transparency-system/download/{YEAR}_FTS_dataset_en.xlsx`
 - **Formato**: XLSX, primo sheet
-- **Anni**: 2020–2024 verificati funzionanti (2007–2019 disponibili su richiesta)
+- **Anni**: 2020–2025 verificati funzionanti (2007–2019 disponibili su richiesta)
 - **HEAD richiesto**: il server Europa restituisce `Content-Length: 0` su HEAD ma il file è correttamente servito su GET (chunked encoding)
 - **Licenza**: EU Open Data
 
@@ -21,8 +21,9 @@
 |---|---|---|
 | 2020-2023 | 39 | `Recipient main registration number`, `Call for proposals Reference`, `Project / Contract Reference`, `Project / Contract Acronym` |
 | 2024 | 38 | `VAT number of beneficiary`, `Geographical Zone`, `Action location`, `Funding type` |
+| 2025 | 38 | `Main registration number of beneficiary` (nome nuovo), `Call ID`/`Project ID`/`Project Acronym`; ASSENTI `Geographical Zone`, `Action location`, `Funding type`, `Beneficiary Group Code` |
 
-**35 colonne comuni** a tutti gli anni. Lo script mappa **per NOME** (non posizionale) a 38 colonne italiane stabili; colonne assenti nell'anno → vuote. Il vecchio script posizionale era rotto: `df.columns = FTS_COLUMNS` (38) su file da 39 colonne → ValueError, run mai riuscito.
+**35 colonne comuni** a tutti gli anni (2020-2025). Lo script mappa **per NOME** (non posizionale) a 38 colonne italiane stabili; colonne assenti nell'anno → vuote. Il vecchio script posizionale era rotto: `df.columns = FTS_COLUMNS` (38) su file da 39 colonne → ValueError, run mai riuscito.
 
 **Perché non http_file+XLSX diretto**: il toolkit legge l'XLSX nativamente ma DuckDB risolve i nomi colonna a parse time → referenziare una colonna 2024-only nel run 2023 fallisce (BinderError). `align_by_header` (schema variabile) è supportato SOLO per CSV, non per Excel. Lo script resta il punto di normalizzazione.
 

--- a/candidates/fts-eu-grants/scripts/convert_xlsx_to_csv.py
+++ b/candidates/fts-eu-grants/scripts/convert_xlsx_to_csv.py
@@ -79,6 +79,7 @@ FTS_COLUMN_MAP = {
     "Reference (Budget)": "rif_bilancio",
     "Name of beneficiary": "beneficiario_nome",
     "Recipient main registration number": "beneficiario_partita_iva",  # 2020-2023
+    "Main registration number of beneficiary": "beneficiario_partita_iva",  # 2025
     "VAT number of beneficiary": "beneficiario_partita_iva",  # 2024 (sovrascrive se presente)
     "Not-for-profit organisation (NFPO)": "flag_no_profit",
     "Non-governmental organisation (NGO)": "flag_ong",

--- a/candidates/fts-eu-grants/scripts/convert_xlsx_to_csv.py
+++ b/candidates/fts-eu-grants/scripts/convert_xlsx_to_csv.py
@@ -7,13 +7,19 @@ Usage:
 Lo script:
 1. Scarica il file XLSX dall'URL ufficiale FTS
 2. Legge tutte le celle come stringhe (dtype=str)
-3. Normalizza le colonne importi (rimuove virgole, gestisce trattini)
-4. Produce CSV pulito con header in italiano e tipi numerici
+3. Mappa le colonne per NOME (non posizionale — lo schema varia per anno:
+   2020-2023 = 39 colonne con "Recipient main registration number" e
+   "Call for proposals Reference"/"Project / Contract Reference"/"Acronym";
+   2024 = 38 colonne con "Geographical Zone"/"Action location"/"Funding type")
+4. Produce CSV con header italiano STABILE (38 colonne) — colonne assenti
+   nell'anno vengono lasciate vuote
+5. Normalizza le colonne importi
 """
 
 import argparse
 import csv
 import io
+import re
 import sys
 
 import pandas as pd
@@ -23,7 +29,8 @@ FTS_URL_TEMPLATE = (
     "https://ec.europa.eu/budget/financial-transparency-system/download/{year}_FTS_dataset_en.xlsx"
 )
 
-FTS_COLUMNS = [
+# Header inglese stabile (ordine di output, 38 colonne)
+FTS_OUTPUT_COLUMNS = [
     "anno",
     "budget",
     "rif_impegno_giuridico",
@@ -64,9 +71,75 @@ FTS_COLUMNS = [
     "paese_beneficiante",
 ]
 
+# Mappa nome inglese -> colonna italiana (per NOME, robusta al drift di schema)
+FTS_COLUMN_MAP = {
+    "Year": "anno",
+    "Budget": "budget",
+    "Reference of the Legal Commitment (LC)": "rif_impegno_giuridico",
+    "Reference (Budget)": "rif_bilancio",
+    "Name of beneficiary": "beneficiario_nome",
+    "Recipient main registration number": "beneficiario_partita_iva",  # 2020-2023
+    "VAT number of beneficiary": "beneficiario_partita_iva",  # 2024 (sovrascrive se presente)
+    "Not-for-profit organisation (NFPO)": "flag_no_profit",
+    "Non-governmental organisation (NGO)": "flag_ong",
+    "Coordinator": "flag_coordinatore",
+    "Address": "beneficiario_indirizzo",
+    "City": "beneficiario_citta",
+    "Postal code": "beneficiario_cap",
+    "Beneficiary country": "paese_beneficiario",
+    "NUTS2": "nuts2",
+    "Geographical Zone": "zona_geografica",  # solo 2024
+    "Action location": "luogo_azione",  # solo 2024
+    "Beneficiary’s contracted amount (EUR)": "importo_contrattato",
+    "Beneficiary’s estimated contracted amount (EUR)": "importo_contrattato_stimato",
+    "Beneficiary’s estimated consumed amount (EUR)": "importo_consumato_stimato",
+    "Commitment contracted amount (EUR) (A)": "impegno_importo_a",
+    "Additional/Reduced amount (EUR) (B)": "importo_aggiuntivo_ridotto_b",
+    "Commitment  total amount (EUR) (A+B)": "impegno_totale_a_plus_b",
+    "Commitment consumed amount (EUR)": "impegno_consumato",
+    "Source of (estimated) detailed amount": "fonte_dettaglio",
+    "Expense type": "tipo_spesa",
+    "Subject of grant or contract": "oggetto_contributo",
+    "Responsible department": "dipartimento_responsabile",
+    "Budget line number": "linea_bilancio_codice",
+    "Budget line name": "linea_bilancio_nome",
+    "Programme name": "nome_programma",
+    "Funding type": "tipo_finanziamento",  # solo 2024
+    "Beneficiary Group Code": "codice_gruppo_beneficiario",
+    "Beneficiary type": "tipo_beneficiario",
+    "Project start date": "data_inizio_progetto",
+    "Project end date": "data_fine_progetto",
+    "Type of contract*": "tipo_contratto",
+    "Management type": "tipo_gestione",
+    "Benefiting country": "paese_beneficiante",
+}
+
+# Colonne importo (in formato internazionale: punto decimale, nessuna virgola)
+AMOUNT_COLUMNS = {
+    "importo_contrattato",
+    "importo_contrattato_stimato",
+    "importo_consumato_stimato",
+    "impegno_importo_a",
+    "importo_aggiuntivo_ridotto_b",
+    "impegno_totale_a_plus_b",
+    "impegno_consumato",
+}
+
+# Colonne data: "-" o valori non ISO -> vuoto (il clean fa TRY_CAST AS DATE)
+DATE_COLUMNS = {
+    "data_inizio_progetto",
+    "data_fine_progetto",
+}
+
 
 def _normalize_amount(value) -> float | None:
-    """Convert various amount formats to float or None."""
+    """Convert amount to float or None.
+
+    I valori FTS sono GIÀ in formato internazionale (punto decimale,
+    nessuna virgola migliaia) — verificato su 2020-2024. NESSUN replace:
+    un replace('.','') moltiplicherebbe gli importi per ~1000.
+    Gestisce solo i marker di assenza: '-', '', '.', 'N/A', 'nan'.
+    """
     if value is None:
         return None
     if isinstance(value, (int, float)):
@@ -75,8 +148,6 @@ def _normalize_amount(value) -> float | None:
         s = value.strip()
         if not s or s in ("-", ".", "", "nan", "NaN", "N/A"):
             return None
-        # Remove commas used as thousands separators
-        s = s.replace(",", "")
         try:
             return float(s)
         except (ValueError, TypeError):
@@ -103,31 +174,41 @@ def convert_xlsx_to_csv(xlsx_data: bytes, output_path: str) -> dict:
     n_rows = len(df)
     n_cols = len(df.columns)
 
-    # Rename columns to canonical names
-    if n_cols != len(FTS_COLUMNS):
-        raise ValueError(f"Expected {len(FTS_COLUMNS)} columns, got {n_cols}")
+    # Rinomina per NOME: ogni colonna inglese presente -> colonna italiana.
+    # Se due colonne inglesi mappano alla stessa italiana (partita_iva),
+    # l'ultima (VAT, 2024) sovrascrive — ordine di FTS_COLUMN_MAP.
+    n_rows = len(df)
+    renamed: dict[str, list] = {c: [None] * n_rows for c in FTS_OUTPUT_COLUMNS}
+    for eng_col in df.columns:
+        target = FTS_COLUMN_MAP.get(eng_col)
+        if target is not None:
+            renamed[target] = df[eng_col].tolist()
 
-    df.columns = FTS_COLUMNS
+    out = pd.DataFrame(renamed, columns=FTS_OUTPUT_COLUMNS)
 
-    # Normalize amount columns (16-22)
-    for col_idx in range(16, 23):
-        col_name = df.columns[col_idx]
-        df[col_name] = df[col_name].apply(_normalize_amount)
+    # Normalizza importi (formato internazionale -> float)
+    for col in AMOUNT_COLUMNS:
+        out[col] = out[col].apply(_normalize_amount)
 
-    # Trim string columns
-    for col in df.columns:
-        if df[col].dtype == object:
-            df[col] = df[col].str.strip()
+    # Normalizza date: "-" o non-ISO -> vuoto (evita ConversionError nel clean)
+    for col in DATE_COLUMNS:
+        out[col] = out[col].apply(
+            lambda v: v if (isinstance(v, str) and re.match(r"^\d{4}-\d{2}-\d{2}", v)) else ""
+        )
 
-    # Write CSV
-    df.to_csv(
+    # Trim stringhe
+    for col in out.columns:
+        if out[col].dtype == object:
+            out[col] = out[col].str.strip()
+
+    out.to_csv(
         output_path,
         index=False,
         quoting=csv.QUOTE_ALL,
         encoding="utf-8",
     )
 
-    return {"rows": n_rows, "cols": n_cols}
+    return {"rows": n_rows, "cols": n_cols, "output_cols": len(FTS_OUTPUT_COLUMNS)}
 
 
 def main():
@@ -145,7 +226,9 @@ def main():
     print("Converting to CSV ...", file=sys.stderr)
     info = convert_xlsx_to_csv(data, args.output)
     print(
-        f"  {info['rows']} rows, {info['cols']} columns written to {args.output}", file=sys.stderr
+        f"  {info['rows']} rows, {info['cols']} xlsx columns -> "
+        f"{info['output_cols']} output columns written to {args.output}",
+        file=sys.stderr,
     )
 
 

--- a/candidates/fts-eu-grants/sql/clean.sql
+++ b/candidates/fts-eu-grants/sql/clean.sql
@@ -1,5 +1,5 @@
 SELECT
-    TRY_CAST(TRY_CAST(anno AS BIGINT) AS INTEGER) AS anno,
+    cast_int(cast_bigint(anno)) AS anno,
     budget::VARCHAR AS budget,
     rif_impegno_giuridico::VARCHAR AS rif_impegno_giuridico,
     rif_bilancio::VARCHAR AS rif_bilancio,
@@ -15,27 +15,13 @@ SELECT
     nuts2::VARCHAR AS nuts2,
     zona_geografica::VARCHAR AS zona_geografica,
     luogo_azione::VARCHAR AS luogo_azione,
-    CASE WHEN importo_contrattato::VARCHAR IN ('-', '', '.') THEN NULL
-         ELSE TRY_CAST(REPLACE(importo_contrattato::VARCHAR, ',', '') AS DOUBLE)
-    END AS importo_contrattato,
-    CASE WHEN importo_contrattato_stimato::VARCHAR IN ('-', '', '.') THEN NULL
-         ELSE TRY_CAST(REPLACE(importo_contrattato_stimato::VARCHAR, ',', '') AS DOUBLE)
-    END AS importo_contrattato_stimato,
-    CASE WHEN importo_consumato_stimato::VARCHAR IN ('-', '', '.') THEN NULL
-         ELSE TRY_CAST(REPLACE(importo_consumato_stimato::VARCHAR, ',', '') AS DOUBLE)
-    END AS importo_consumato_stimato,
-    CASE WHEN impegno_importo_a::VARCHAR IN ('-', '', '.') THEN NULL
-         ELSE TRY_CAST(REPLACE(impegno_importo_a::VARCHAR, ',', '') AS DOUBLE)
-    END AS impegno_importo_a,
-    CASE WHEN importo_aggiuntivo_ridotto_b::VARCHAR IN ('-', '', '.') THEN NULL
-         ELSE TRY_CAST(REPLACE(importo_aggiuntivo_ridotto_b::VARCHAR, ',', '') AS DOUBLE)
-    END AS importo_aggiuntivo_ridotto_b,
-    CASE WHEN impegno_totale_a_plus_b::VARCHAR IN ('-', '', '.') THEN NULL
-         ELSE TRY_CAST(REPLACE(impegno_totale_a_plus_b::VARCHAR, ',', '') AS DOUBLE)
-    END AS impegno_totale_a_plus_b,
-    CASE WHEN impegno_consumato::VARCHAR IN ('-', '', '.') THEN NULL
-         ELSE TRY_CAST(REPLACE(impegno_consumato::VARCHAR, ',', '') AS DOUBLE)
-    END AS impegno_consumato,
+    cast_double(importo_contrattato) AS importo_contrattato,
+    cast_double(importo_contrattato_stimato) AS importo_contrattato_stimato,
+    cast_double(importo_consumato_stimato) AS importo_consumato_stimato,
+    cast_double(impegno_importo_a) AS impegno_importo_a,
+    cast_double(importo_aggiuntivo_ridotto_b) AS importo_aggiuntivo_ridotto_b,
+    cast_double(impegno_totale_a_plus_b) AS impegno_totale_a_plus_b,
+    cast_double(impegno_consumato) AS impegno_consumato,
     fonte_dettaglio::VARCHAR AS fonte_dettaglio,
     tipo_spesa::VARCHAR AS tipo_spesa,
     oggetto_contributo::VARCHAR AS oggetto_contributo,
@@ -43,6 +29,11 @@ SELECT
     linea_bilancio_codice::VARCHAR AS linea_bilancio_codice,
     linea_bilancio_nome::VARCHAR AS linea_bilancio_nome,
     nome_programma::VARCHAR AS nome_programma,
+    -- Flag RRF (Recovery and Resilience Facility): trasferimenti di bilancio
+    -- UE→Stato, NON grant analitici — distorcono trend e classifiche (2023:
+    -- 23,9 mld su 27,9 = 86%). Tenuto nel clean (dato completo), escluso
+    -- dalle mart analitiche. Decisione civic-director 2026-08-03.
+    CASE WHEN UPPER(nome_programma::VARCHAR) LIKE '%RECOVERY%' THEN 'SI' ELSE 'NO' END AS is_rrf,
     tipo_finanziamento::VARCHAR AS tipo_finanziamento,
     codice_gruppo_beneficiario::VARCHAR AS codice_gruppo_beneficiario,
     tipo_beneficiario::VARCHAR AS tipo_beneficiario,

--- a/candidates/fts-eu-grants/sql/mart_sintesi_beneficiario.sql
+++ b/candidates/fts-eu-grants/sql/mart_sintesi_beneficiario.sql
@@ -1,0 +1,19 @@
+-- mart_sintesi_beneficiario — Finanziamenti per tipo beneficiario e anno
+--
+-- 1 riga = 1 (anno, tipo beneficiario): grant, importo contrattato totale,
+-- medio. Risponde: imprese > PA? ONG e terzo settore quanto valgono?
+-- (D3, D6 discussion #395)
+--
+-- PK: (anno, tipo_beneficiario)
+
+SELECT
+    anno,
+    tipo_beneficiario,
+    count(*)                                                       AS n_grant,
+    round(sum(importo_contrattato) FILTER (WHERE importo_contrattato IS NOT NULL), 0) AS importo_contrattato_totale,
+    round(avg(importo_contrattato) FILTER (WHERE importo_contrattato IS NOT NULL), 0) AS importo_medio
+FROM clean_input
+WHERE tipo_beneficiario IS NOT NULL
+  AND is_rrf = 'NO'
+GROUP BY anno, tipo_beneficiario
+ORDER BY anno, importo_contrattato_totale DESC NULLS LAST

--- a/candidates/fts-eu-grants/sql/mart_sintesi_programma.sql
+++ b/candidates/fts-eu-grants/sql/mart_sintesi_programma.sql
@@ -1,0 +1,20 @@
+-- mart_sintesi_programma — Finanziamenti per programma e anno
+--
+-- 1 riga = 1 (anno, programma): grant, importo contrattato totale, medio.
+-- Risponde: Horizon Europe domina? CEF Transport è il programma delle grandi
+-- infrastrutture? (D2, D8, D11, D13 discussion #395)
+--
+-- PK: (anno, nome_programma)
+
+SELECT
+    anno,
+    nome_programma,
+    count(*)                                                       AS n_grant,
+    round(sum(importo_contrattato) FILTER (WHERE importo_contrattato IS NOT NULL), 0) AS importo_contrattato_totale,
+    round(avg(importo_contrattato) FILTER (WHERE importo_contrattato IS NOT NULL), 0) AS importo_medio,
+    count(DISTINCT beneficiario_nome)                              AS n_beneficiari_distinti
+FROM clean_input
+WHERE nome_programma IS NOT NULL
+  AND is_rrf = 'NO'
+GROUP BY anno, nome_programma
+ORDER BY anno, importo_contrattato_totale DESC NULLS LAST

--- a/candidates/fts-eu-grants/sql/mart_top_beneficiari.sql
+++ b/candidates/fts-eu-grants/sql/mart_top_beneficiari.sql
@@ -1,0 +1,19 @@
+-- mart_top_beneficiari — Beneficiari con più grant e importi contrattati
+--
+-- 1 riga = 1 (anno, beneficiario): n grant, importo contrattato totale,
+-- medio. Risponde: chi sono i giganti dei grant? (CNR, Polimi, Leonardo)
+-- (D4, D7 discussion #395)
+--
+-- PK: (anno, beneficiario_nome)
+
+SELECT
+    anno,
+    beneficiario_nome,
+    count(*)                                                       AS n_grant,
+    round(sum(importo_contrattato) FILTER (WHERE importo_contrattato IS NOT NULL), 0) AS importo_contrattato_totale,
+    round(avg(importo_contrattato) FILTER (WHERE importo_contrattato IS NOT NULL), 0) AS importo_medio
+FROM clean_input
+WHERE beneficiario_nome IS NOT NULL
+  AND is_rrf = 'NO'
+GROUP BY anno, beneficiario_nome
+ORDER BY anno, importo_contrattato_totale DESC NULLS LAST

--- a/candidates/fts-eu-grants/sql/mart_trend_anno.sql
+++ b/candidates/fts-eu-grants/sql/mart_trend_anno.sql
@@ -1,0 +1,40 @@
+-- mart_trend_anno — Finanziamenti UE diretti in Italia per anno (multi-year)
+--
+-- 1 riga = 1 anno: grant, importo contrattato totale, consumato, quota
+-- assorbimento. RRF (Recovery) escluso dal totale analitico ma esposto
+-- come colonna separata (is_rrf='SI') — trasferimenti di bilancio UE→Stato,
+-- non grant analitici. Risponde: quanto vale l'UE per l'Italia? (D1, D9)
+--
+-- PK: (anno)
+
+WITH per_anno AS (
+    SELECT
+        anno,
+        count(*) FILTER (WHERE is_rrf = 'NO')                    AS n_grant,
+        count(DISTINCT beneficiario_nome) FILTER (WHERE is_rrf = 'NO') AS n_beneficiari_distinti,
+        sum(importo_contrattato) FILTER (WHERE is_rrf = 'NO' AND importo_contrattato IS NOT NULL) AS importo_contrattato_totale,
+        -- Consumato a livello BENEFICIARIO (Beneficiary's estimated consumed).
+        -- NOTA: NON usare impegno_consumato (Commitment consumed) — è il consumo
+        -- dell'intero commitment, non della quota del beneficiario → ratio > 100%.
+        sum(importo_consumato_stimato) FILTER (WHERE is_rrf = 'NO' AND importo_consumato_stimato IS NOT NULL) AS importo_consumato_totale,
+        sum(importo_contrattato) FILTER (WHERE is_rrf = 'SI' AND importo_contrattato IS NOT NULL) AS importo_rrf_eur
+    FROM clean_input
+    WHERE anno IS NOT NULL
+    GROUP BY anno
+)
+SELECT
+    anno,
+    n_grant,
+    n_beneficiari_distinti,
+    round(importo_contrattato_totale, 0)                            AS importo_contrattato_totale,
+    round(importo_consumato_totale, 0)                              AS importo_consumato_totale,
+    round(importo_rrf_eur, 0)                                       AS importo_rrf_eur,
+    round(100.0 * importo_consumato_totale / NULLIF(importo_contrattato_totale, 0), 1)
+                                                                    AS quota_consumato_pct,
+    round(importo_contrattato_totale - lag(importo_contrattato_totale) OVER (ORDER BY anno), 0)
+                                                                    AS delta_contrattato_eur,
+    round(100.0 * (importo_contrattato_totale - lag(importo_contrattato_totale) OVER (ORDER BY anno))
+          / NULLIF(lag(importo_contrattato_totale) OVER (ORDER BY anno), 0), 2)
+                                                                    AS variazione_pct
+FROM per_anno
+ORDER BY anno


### PR DESCRIPTION
## Sintesi

Porta `fts-eu-grants` allo standard candidate v1. Fix root-cause dello script di preprocess (era **rotto**: mapping posizionale su schema XLSX variabile per anno → ValueError, il run non era mai riuscito). 4 mart serie che rispondono alle 13 domande della discussion #395. Copertura estesa a 6 anni (2020-2025).

## Contesto collegato

- Discussion: #395 "FTS EU Grants — 13 domande sui finanziamenti UE in Italia (2020-2024)" (aggiornata 2026-08-03)
- Standard: `docs/candidate-standard.md` §2.1/§2.2/§2.4/§3/§5
- Piano: `_local/tasks/2026-08-01-mart-standard-candidates.md` (task locale, non issue)

## Cosa cambia

- [x] candidate — aggiornamento (non nuovo dataset)
- [ ] support
- [ ] docs
- [x] cleanup — script fixato, mart pass-through rimossa
- [ ] workflow o CI
- [ ] altro

## Impatto

- [x] Aggiunge o modifica un candidate in `candidates/fts-eu-grants/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream — **parziale, vedi Note/rischi**: aggiunta colonna `is_rrf` (39°); clean invariato nelle altre 38
- [ ] Solo documentazione o metadati
- [ ] Nessun impatto visibile

## Dettaglio

### Fix root-cause script (opzione A — scelta civic-director)

**Lo script era rotto**: `df.columns = FTS_COLUMNS` (38) su file da 39 colonne → ValueError → il candidate non era mai stato eseguito con successo. Causa reale: **lo schema XLSX varia per anno**:
- 2020-2023: 39 colonne (`Recipient main registration number`, `Call for proposals Reference`, `Project / Contract Reference/Acronym`)
- 2024: 38 colonne (`VAT number of beneficiary`, `Geographical Zone`, `Action location`, `Funding type`)
- 2025: 38 colonne (`Main registration number of beneficiary` — nome nuovo, `Call ID`/`Project ID`/`Project Acronym`; ASSENTI `Geographical Zone`, `Action location`, `Funding type`, `Beneficiary Group Code`)
- 35 colonne comuni a tutti gli anni (2020-2025)

Fix: **mapping per NOME** (non posizionale) a 38 colonne italiane stabili; colonne assenti → vuote. Verificato su entrambi gli schemi.

**Perché non http_file+XLSX diretto** (valutato): il toolkit legge l'XLSX nativamente, ma DuckDB risolve i nomi colonna a parse time → referenziare colonne 2024-only nel run 2023 = BinderError. `align_by_header` (schema variabile) esiste solo per CSV. Lo script resta il punto di normalizzazione.

**Altri bug fixati nello script**:
- Importi: cast diretto (formato internazionale, punto decimale). Il `replace('.','')` precedente moltiplicava per ~1000
- Date: `-`/non-ISO → vuoto (1.100+ righe in data_fine 2020 causavano ConversionError nel clean)

### Clean

- **Colonna `is_rrf`** ('SI'/'NO' su `nome_programma LIKE '%Recovery%'`): il RRF (Recovery and Resilience Facility) è un trasferimento di bilancio UE→Stato, non un grant analitico — 2023 = 23,9 mld su 27,9 totali (86%). Decisione civic-director (opzione 3): flag nel clean, escluso dalle mart ma esposto nel trend
- `required_columns` completo (39), `read.source: auto` + `mode: latest`
- PK non dichiarabile: il sorgente ha righe duplicate reali (38 duplicati identici anche con 8 campi) → **deroga §4** documentata in notes.md

### Mart (4 serie — rispondono alle 13 domande #395)

- **`mart_trend_anno`** (multi-year): contrattato/consumato per anno + `importo_rrf_eur` separato — 17,05 mld no-RRF 2020-2024, assorbimento 72%
- **`mart_sintesi_programma`**: per programma-anno (Horizon 4,75 mld, CEF Transport 1,11 mld)
- **`mart_sintesi_beneficiario`**: per tipo beneficiario (Private Companies 56%)
- **`mart_top_beneficiari`**: top beneficiari (CNR, Polimi, Leonardo, BBT)

**Bug metrica consumato corretto**: usato `importo_consumato_stimato` (beneficiario-level, ratio 66% — combacia col 65% della discussion) al posto di `impegno_consumato` (commitment-level, ratio 346% impossibile).

## Checklist candidate

- [x] `dataset.yml` con `name`, `years`, `source_id`, `tags`, `category` (gate strict)
- [x] `clean.validate` con `required_columns`, `not_null`, `min_rows` (primary_key in deroga)
- [x] `mart.validate.table_rules` con `primary_key` dai GROUP BY
- [x] `toolkit run` eseguito senza errori su tutti gli anni dichiarati (5 anni)
- [x] `python scripts/validate_candidate_structure.py` passato senza failure
- [x] nessun file dati committato nella root del candidate
- [ ] output immagini cleared dal notebook — **n/a: nessun notebook toccato**
- [ ] notebook nominato `{slug}_v0.ipynb` — **n/a: nessun notebook toccato**
- [ ] issue di intake collegata — **n/a: aggiornamento da discussion #395 + piano `_local/tasks`**
- [x] `sql/clean.sql` usa le **macro standard del toolkit** (`cast_int`, `cast_double`)

## Verifica

```bash
TOOLKIT_ALLOW_SCRIPT_SOURCE=1 toolkit run -c candidates/fts-eu-grants/dataset.yml
python scripts/validate_candidate_structure.py
```

Esito run locale (2026-08-03):
```
years: [2020..2025] — status: passed (6 anni)
  clean: 5-10k righe Italy/anno · mart: 4/4 + trend multi-year
  readiness: ready (8/8) tutti gli anni
```

Numeri verificati: 2023 = 4,0 mld no-RRF (Horizon 1,05 mld), assorbimento 66,6% (= 65% citato in discussion); RRF 23,86 mld esposto separatamente. 2025 = 2,75 mld no-RRF (5.285 righe Italy, terzo schema XLSX). Totale 19,80 mld no-RRF 2020-2025, assorbimento 71%.

## Note / rischi

- **Discrepanza vs discussion #395**: la discussion cita 9,77 mld contrattati 2020-2024 (ora 19,80 mld no-RRF 2020-2025) (Horizon 3,65 = 37%). I dati attuali FTS danno **17,05 mld no-RRF** (Horizon 4,75 = 28%). Le righe combaciano (40.417 vs 40.449) ma gli importi no → i dati FTS sono stati aggiornati dalla Commissione o la discussion usava un subset/metria diversa. **Da riconciliare con data-researcher** (la discussion va aggiornata) — non è un bug del candidate.
- **`TOOLKIT_ALLOW_SCRIPT_SOURCE=1`**: il source `script` richiede l'env var (comportamento toolkit standard, non modificato). Il piano lo marcava "da non toccare" — la discussion #395 aggiornata oggi ha cambiato la priorità.
- **`importo_contrattato` vuoto nel 2024** (1.928 righe): rimosso dal `not_null` (restano `anno, beneficiario_nome`).
- **Colonna nuova `is_rrf`**: cambio contratto aggiuntivo (39 colonne vs 38 catalog) — il post-merge aggiornerà il catalog.

