### PR TITLE
chore(post-merge): aggiorna registry per PR #784

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -5336,7 +5336,7 @@
           "name": "is_rrf",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Flag RRF (Recovery and Resilience Facility): trasferimenti di bilancio UE→Stato, non grant analitici — esclusi dalle mart, esposti separatamente nel trend"
         },
         {
           "name": "tipo_finanziamento",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -5147,7 +5147,7 @@
       "source_id": "fts",
       "period": {
         "start": 2020,
-        "end": 2024
+        "end": 2025
       },
       "columns": [
         {
@@ -5331,6 +5331,12 @@
           "type": "VARCHAR",
           "role": "dimension",
           "description": "Nome del programma UE (es. Horizon Europe, Erasmus+)"
+        },
+        {
+          "name": "is_rrf",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
         },
         {
           "name": "tipo_finanziamento",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -545,19 +545,37 @@
       "source_id": "fts",
       "status": "ok",
       "label": "fts-eu-grants",
-      "detail": "anni 2020-2024 — fonte: ? — mart: sì",
+      "detail": "anni 2020-2025 — fonte: fts_script — mart: sì",
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "28519390869",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/28519390869",
-        "checked_at": "2026-07-01",
+        "run_id": "30823576972",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30823576972",
+        "checked_at": "2026-08-03",
+        "duration_seconds": 292.98,
+        "row_counts": {
+          "raw": 607815,
+          "clean": 45734,
+          "mart": 12626
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 95.0,
+          "mart": 100.0
+        },
         "years": [
           2020,
           2021,
           2022,
           2023,
-          2024
+          2024,
+          2025
         ],
         "config_path": "candidates/fts-eu-grants/dataset.yml"
       }


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #784 — feat(fts-eu-grants): standard v1 — script fixato (schema variabile), 4 mart serie (discussion #395)

Changed candidate/support roots:

- `fts-eu-grants` (candidate, `candidates/fts-eu-grants`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/fts-eu-grants/dataset.yml` -> artifact `sample-run-fts-eu-grants`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
