### PR TITLE
chore(post-merge): aggiorna registry per PR #788

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2501,10 +2501,17 @@
           "description": "URI identificativo del deputato"
         },
         {
+          "name": "persona_id",
+          "type": "BIGINT",
+          "role": "dimension",
+          "description": "ID numerico della persona (chiave standard del sistema parlamentare, ponte verso senato/governo)",
+          "semantic_type": "person_id"
+        },
+        {
           "name": "cognome",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Cognome del deputato (da foaf:surname o parsing label per il Regno)"
         },
         {
           "name": "nome",
@@ -2513,21 +2520,45 @@
           "description": "Nome del deputato"
         },
         {
+          "name": "gender",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Genere del deputato"
+        },
+        {
           "name": "legislatura",
           "type": "VARCHAR",
           "role": "dimension",
           "description": "Numero della legislatura"
         },
         {
-          "name": "gender",
+          "name": "biografia",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": "Genere del deputato"
+          "description": "Biografia/titoli di studio dal profilo ufficiale (dc:description)"
+        },
+        {
+          "name": "foto_url",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "URL della foto ufficiale (foaf:depiction)"
+        },
+        {
+          "name": "mandato",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "URI del mandato Camera (ocd:rif_mandatoCamera)"
+        },
+        {
+          "name": "scheda_url",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "URL della scheda personale su camera.it (dcterms:isReferencedBy)"
         }
       ],
       "location": {
         "type": "gcs",
-        "path": "gs://dataciviclab-clean/camera_deputati_legislature/2024/camera_deputati_legislature_2024_clean.parquet",
+        "path": "gs://dataciviclab-clean/camera_deputati_legislature/2026/camera_deputati_legislature_2026_clean.parquet",
         "multi_file": false
       },
       "stage": "incubating",
@@ -2542,9 +2573,9 @@
     },
     {
       "slug": "camera_incarichi",
-      "name": "Camera Incarichi",
-      "description": "",
-      "source": "",
+      "name": "Incarichi nei Gruppi Parlamentari (Camera)",
+      "description": "Incarichi dei deputati nei gruppi parlamentari della Camera: ruolo (presidente, vicepresidente, capogruppo...), gruppo, legislatura e date inizio/fine. Join con camera_deputati_legislature via persona_id (chiave standard del sistema parlamentare). Fonte: dati.camera.it SPARQL, 3.096 incarichi.",
+      "source": "Camera dei Deputati — OpenData SPARQL endpoint",
       "source_id": "dati_camera",
       "period": {
         "start": 1946,
@@ -2555,55 +2586,56 @@
           "name": "incarico",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "URI dell'incarico"
         },
         {
           "name": "ruolo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Ruolo ricoperto nel gruppo (PRESIDENTE, VICEPRESIDENTE, CAPOGRUPPO...)"
         },
         {
           "name": "label",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Etichetta completa dell'incarico (ruolo + gruppo + deputato + date)"
         },
         {
           "name": "deputato",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "URI del deputato"
         },
         {
           "name": "persona_id",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "ID numerico della persona (chiave standard del sistema parlamentare, join con camera_deputati_legislature)",
+          "semantic_type": "person_id"
         },
         {
           "name": "gruppo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "URI del gruppo parlamentare"
         },
         {
           "name": "legislatura",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Legislatura (es. repubblica_17, regno_21, costituente)"
         },
         {
           "name": "start_date",
           "type": "DATE",
           "role": "dimension",
-          "description": ""
+          "description": "Data inizio incarico"
         },
         {
           "name": "end_date",
           "type": "DATE",
           "role": "dimension",
-          "description": ""
+          "description": "Data fine incarico (NULL se in corso)"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2490,8 +2490,8 @@
       "source": "Camera dei Deputati — OpenData SPARQL endpoint",
       "source_id": "dati_camera",
       "period": {
-        "start": 2024,
-        "end": 2024
+        "start": 1861,
+        "end": 2026
       },
       "columns": [
         {
@@ -2537,6 +2537,87 @@
         "camera",
         "deputati",
         "legislature"
+      ],
+      "category": "politica"
+    },
+    {
+      "slug": "camera_incarichi",
+      "name": "Camera Incarichi",
+      "description": "",
+      "source": "",
+      "source_id": "dati_camera",
+      "period": {
+        "start": 1946,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "incarico",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "ruolo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "label",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "deputato",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "persona_id",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "gruppo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "legislatura",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "start_date",
+          "type": "DATE",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "end_date",
+          "type": "DATE",
+          "role": "dimension",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/camera_incarichi/2026/camera_incarichi_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto",
+      "tags": [
+        "politica",
+        "camera",
+        "incarichi",
+        "gruppi-parlamentari"
       ],
       "category": "politica"
     },

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -4,9 +4,9 @@
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 109,
+    "total": 110,
     "by_status": {
-      "ok": 109,
+      "ok": 110,
       "warn": 0,
       "error": 0
     }
@@ -225,15 +225,32 @@
       "source_id": "dati_camera",
       "status": "ok",
       "label": "camera-deputati-legislature",
-      "detail": "anno 2024 — fonte: camera_deputati_sparql — mart: sì",
+      "detail": "anno 2026 — fonte: camera_deputati_sparql — mart: sì",
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "26682747895",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/26682747895",
-        "checked_at": "2026-05-30",
+        "run_id": "30837728630",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30837728630",
+        "checked_at": "2026-08-03",
+        "duration_seconds": 11.97,
+        "row_counts": {
+          "raw": 27764,
+          "clean": 27764,
+          "mart": 11326
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 95.0,
+          "mart": 100.0
+        },
         "years": [
-          2024
+          2026
         ],
         "config_path": "candidates/camera-deputati-legislature/dataset.yml"
       }
@@ -2161,6 +2178,41 @@
           2026
         ],
         "config_path": "support_datasets/bdap-anagrafe-enti/dataset.yml"
+      }
+    },
+    {
+      "id": "camera-incarichi",
+      "source_id": "dati_camera",
+      "status": "ok",
+      "label": "camera-incarichi",
+      "detail": "anni: ? — fonte: ? — mart: sì",
+      "action": "",
+      "latest_run": {
+        "status": "passed",
+        "run_id": "30837728630",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30837728630",
+        "checked_at": "2026-08-03",
+        "duration_seconds": 2.13,
+        "row_counts": {
+          "raw": 3096,
+          "clean": 3096,
+          "mart": 2196
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
+        "years": [
+          2026
+        ],
+        "config_path": "support_datasets/camera-incarichi/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #788 — feat(camera-deputati): issue #787 — anagrafica + persona_id, support incarichi

Changed candidate/support roots:

- `camera-deputati-legislature` (candidate, `candidates/camera-deputati-legislature`)
- `camera-incarichi` (support_dataset, `support_datasets/camera-incarichi`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/camera-deputati-legislature/dataset.yml` -> artifact `sample-run-camera-deputati-legislature`
- `support_datasets/camera-incarichi/dataset.yml` -> artifact `sample-run-camera-incarichi`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
