### PR TITLE
feat(membri-governo): issue #786 — membri dei governi italiani 1862-2026

### DIFF
--- a/candidates/membri-governo/README.md
+++ b/candidates/membri-governo/README.md
@@ -1,0 +1,25 @@
+# membri-governo
+
+**Domanda guida:** Chi ha governato l'Italia? Quanti governi si sono succeduti dal Regno d'Italia (1862) a oggi, chi ne faceva parte, con quale ruolo, per quanto tempo e in quale legislatura?
+
+**Fonte:** Camera dei Deputati — OpenData SPARQL (`https://dati.camera.it/sparql`)
+**Dataset:** `ocd:membroGoverno` (7.579 membri, 160 anni di governi)
+**Licenza:** CC BY 3.0
+
+## Perché vale la pena
+
+Il Lab ha DAIT (amministratori locali) e Camera (deputati), ma zero dati sui governi nazionali. Questo chiude il cerchio "chi governa": 160 anni di governi dal Regno alla Repubblica, con nomi, ruoli e date. Join naturale con `camera_deputati_legislature` via `persona_id`.
+
+## Output minimo atteso
+
+- `mart_legislatura`: membri/governi per legislatura (serie storica)
+- `mart_governi`: composizione per governo (membri, durata)
+
+## Criterio di promozione
+
+Promuovere quando: (1) la serie storica per legislatura è verificata; (2) il join con deputati per persona_id è stabile; (3) una domanda civica usa i dati (es. durata media dei governi).
+
+## Stato / prossimo passo
+
+- **Stato**: candidate a standard v1 (2026-08-03) — issue #786
+- **Prossimo passo**: run + verifica, poi PR

--- a/candidates/membri-governo/dataset.yml
+++ b/candidates/membri-governo/dataset.yml
@@ -1,0 +1,85 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "membri_governo"
+  source_id: "dati_camera"
+  tags: [politica, governo, ministri, legislature]
+  category: politica
+  years: [2026]
+  time_coverage:
+    start_year: 1862
+    end_year: 2026
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "membri_governo_sparql"
+      type: "sparql"
+      primary: true
+      args:
+        endpoint: "https://dati.camera.it/sparql"
+        query: |
+          PREFIX ocd: <http://dati.camera.it/ocd/>
+          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+          PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+          SELECT ?membro (MAX(?ruolo) AS ?ruolo) (MAX(?label) AS ?label)
+                 (MAX(?start) AS ?start) (MAX(?persona) AS ?persona)
+                 (MAX(?nome) AS ?nome) (MAX(?cognome) AS ?cognome)
+                 (MAX(?legislatura) AS ?legislatura) (MAX(?governo) AS ?governo)
+                 (MAX(?organo) AS ?organo)
+          WHERE {
+            ?membro a ocd:membroGoverno .
+            OPTIONAL { ?membro ocd:membroGoverno ?ruolo . }
+            OPTIONAL { ?membro rdfs:label ?label . }
+            OPTIONAL { ?membro ocd:startDate ?start . }
+            OPTIONAL { ?membro ocd:rif_persona ?persona . }
+            OPTIONAL { ?persona foaf:firstName ?nome . }
+            OPTIONAL { ?persona foaf:surname ?cognome . }
+            OPTIONAL { ?membro ocd:rif_leg ?legislatura . }
+            OPTIONAL { ?membro ocd:rif_governo ?governo . }
+            OPTIONAL { ?membro ocd:rif_organoGoverno ?organo . }
+          }
+          GROUP BY ?membro
+        accept_format: "sparql-results+json"
+
+clean:
+  sql: "sql/clean.sql"
+  read_mode: robust
+  required_columns: [membro, persona_id, ruolo, label, start_date, nome, cognome, legislatura, governo, organo]
+  read:
+    source: auto
+    mode: latest
+    header: true
+    encoding: "utf-8"
+    strict_mode: false
+    ignore_errors: true
+    trim_whitespace: true
+  validate:
+    not_null: [membro]
+    min_rows: 1000
+
+mart:
+  tables:
+    # Membri per legislatura (serie storica)
+    - name: "mart_legislatura"
+      sql: "sql/mart_legislatura.sql"
+    # Durata media dei governi
+    - name: "mart_governi"
+      sql: "sql/mart_governi.sql"
+  required_tables:
+    - "mart_legislatura"
+    - "mart_governi"
+  validate:
+    table_rules:
+      mart_legislatura:
+        required_columns: [legislatura, n_membri]
+        primary_key: [legislatura]
+        min_rows: 15
+      mart_governi:
+        required_columns: [governo, n_membri]
+        primary_key: [governo]
+        min_rows: 50
+
+validation:
+  fail_on_error: false

--- a/candidates/membri-governo/notes.md
+++ b/candidates/membri-governo/notes.md
@@ -1,0 +1,51 @@
+# Notes — membri-governo
+
+## Fonte
+
+- Endpoint SPARQL: `https://dati.camera.it/sparql` (Virtuoso)
+- Graph: default (le query su GRAPH esplicito con OPTIONAL danno risultati falsi — lezione da camera-votazioni)
+- Licenza: CC BY 3.0
+
+## Query produzione
+
+- `GROUP BY ?membro` + `MAX(...)` per ogni campo (fix duplicati da OPTIONAL multipli — pattern consolidato)
+- Una sola query: 7.579 righe < soglia WAF 10k → nessuna paginazione
+- `accept_format: sparql-results+json` (con "csv" l'endpoint restituisce Turtle — lezione da camera-deputati)
+
+## Volumi (verificati 2026-08-03)
+
+- Membri governo: **7.579** (match esatto issue #786)
+- Copre dal Regno d'Italia (regno_19, 1862) alla Repubblica (repubblica_06+)
+
+## URI e persona_id
+
+- Membri: `membroGoverno.rdf/mg5660_6_25` (Repubblica) vs `mgr19_16_21` (Regno, con 'r')
+- Persona: `persona.rdf/p5660` (Repubblica) vs `persona.rdf/pr20` (Regno, con 'r')
+- `persona_id`: id numerico dall'URI (regexp con pattern dedicato per `pr`) —
+  **stessa normalizzazione di camera_deputati_legislature** → join per persona_id
+
+## Regno vs Repubblica
+
+- Membri del Regno (URI `mgr...`): `ruolo` e `start_date` NON valorizzati —
+  la data è solo nella label ("dal 21.06.1894 al 01.12.1894")
+- Decisione: ruolo/start_date NULL per il Regno (parsing label opzionale futuro)
+- La colonna `ruolo` usa `ocd:membroGoverno` (predicato, non il tipo) — verificato
+
+## Gender
+
+- Il grafo governo NON espone foaf:gender sulla persona → non incluso
+- Il gender si ottiene con join a `camera_deputati_legislature` per persona_id
+
+## Join
+
+- `persona_id` → join con `camera_deputati_legislature` (deputati) e futuro senato/governo
+- `governo` → URI ocd/governo.rdf/g25 (anagrafica governi non estratta)
+- `organo` → URI ocd/organoGoverno.rdf/og25_1 (dicastero)
+
+## 2026-08-03 — infrastruttura Camera degradata (500/502/503)
+
+Le pagine .rdf individuali (es. .../membroGoverno.rdf/mg302351_...) danno 500
+con errore interno: "Connection to http://dati.camera.it refused" — la
+dereferenziazione usa un path interno http:// (non https) rotto. L'endpoint
+SPARQL alterna 200/502/503 (già documentato). NON impatta la pipeline (usiamo
+l'endpoint, non la dereferenziazione) — i raw scaricati restano validi.

--- a/candidates/membri-governo/sql/clean.sql
+++ b/candidates/membri-governo/sql/clean.sql
@@ -1,0 +1,61 @@
+-- clean.sql — membri_governo
+--
+-- Membri e organi dei Governi italiani dal Regno d'Italia (1862) alla XIX
+-- legislatura. Input: CSV da endpoint SPARQL dati.camera.it (una riga = un
+-- membro del governo, già deduplicato con GROUP BY + MAX lato query).
+--
+-- persona_id: chiave standard del sistema parlamentare (id numerico
+-- dall'URI persona.rdf/p5660 → 5660, pr20 → 20) — ponte verso deputati,
+-- senato, incarichi. Stessa normalizzazione di camera_deputati_legislature.
+--
+-- Nota: i membri del Regno (URI mgr...) hanno ruolo e start_date NON
+-- valorizzati — la data è solo nella label ("dal 21.06.1894 al 01.12.1894").
+-- Decisione: ruolo/start_date NULL per il Regno (parsing label opzionale futuro).
+
+WITH base AS (
+    SELECT
+        membro,
+        ruolo,
+        label,
+        start,
+        persona,
+        nome,
+        cognome,
+        legislatura,
+        governo,
+        organo
+    FROM raw_input
+)
+SELECT
+    normalize_string(membro)                                          AS membro,
+    -- id numerico della persona dall'URI (p5660 Repubblica, pr20 Regno)
+    TRY_CAST(
+        CASE
+            WHEN persona LIKE '%/persona.rdf/p%' AND persona NOT LIKE '%/persona.rdf/pr%' THEN
+                regexp_extract(persona, 'persona\.rdf/p(\d+)', 1)
+            WHEN persona LIKE '%/persona.rdf/pr%' THEN
+                regexp_extract(persona, 'persona\.rdf/pr(\d+)', 1)
+        END AS BIGINT
+    )                                                                 AS persona_id,
+    normalize_string(ruolo)                                           AS ruolo,
+    normalize_string(label)                                           AS label,
+    -- start: YYYYMMDD (BIGINT da sniff DuckDB, stringhe vuote → NULL) → DATE
+    TRY_CAST(
+        CASE WHEN start IS NOT NULL
+             THEN substr(CAST(start AS VARCHAR), 1, 4) || '-' ||
+                  substr(CAST(start AS VARCHAR), 5, 2) || '-' ||
+                  substr(CAST(start AS VARCHAR), 7, 2)
+        END AS DATE
+    )                                                                 AS start_date,
+    normalize_string(nome)                                            AS nome,
+    normalize_string(cognome)                                         AS cognome,
+    -- legislatura: URI ocd/legislatura.rdf/repubblica_17 → "repubblica_17"
+    CASE
+        WHEN legislatura LIKE '%/legislatura.rdf/%' THEN
+            substring(legislatura, strpos(legislatura, '/legislatura.rdf/') + 17)
+        ELSE legislatura
+    END                                                               AS legislatura,
+    normalize_string(governo)                                         AS governo,
+    normalize_string(organo)                                          AS organo
+FROM base
+WHERE membro IS NOT NULL

--- a/candidates/membri-governo/sql/mart_governi.sql
+++ b/candidates/membri-governo/sql/mart_governi.sql
@@ -1,0 +1,18 @@
+-- mart_governi — Composizione per governo
+--
+-- 1 riga = 1 governo: membri, membri distinti, durata (da start_date min/max).
+-- Risponde: quali governi hanno avuto più membri? Per ricostruire la serie
+-- storica dei governi italiani (issue #786).
+--
+-- PK: (governo)
+
+SELECT
+    governo,
+    count(*)                                 AS n_membri,
+    count(DISTINCT persona_id)               AS n_persone,
+    min(start_date)                          AS data_inizio,
+    max(start_date)                          AS data_fine
+FROM clean_input
+WHERE governo IS NOT NULL
+GROUP BY governo
+ORDER BY n_membri DESC

--- a/candidates/membri-governo/sql/mart_legislatura.sql
+++ b/candidates/membri-governo/sql/mart_legislatura.sql
@@ -1,0 +1,18 @@
+-- mart_legislatura — Membri del governo per legislatura
+--
+-- 1 riga = 1 legislatura: membri, governi distinti.
+-- Risponde: quanti membri del governo per legislatura? Serie storica
+-- dal Regno alla Repubblica (issue #786).
+-- Nota: il gender si ottiene con join a camera_deputati_legislature
+-- per persona_id (non incluso qui — il grafo governo non espone foaf:gender).
+--
+-- PK: (legislatura)
+
+SELECT
+    legislatura,
+    count(*)                                 AS n_membri,
+    count(DISTINCT governo)                  AS n_governi
+FROM clean_input
+WHERE legislatura IS NOT NULL
+GROUP BY legislatura
+ORDER BY legislatura


### PR DESCRIPTION
## Sintesi

Nuovo candidate `membri_governo` (issue #786): tutti i membri dei Governi italiani dal Regno d'Italia (1862) alla XIX legislatura — 7.579 membri, 2.470 persone, 97 legislature. Completa il quadro "chi governa" del Lab (DAIT comunale + Camera + Governo), joinabile per `persona_id` (chiave standard del sistema parlamentare).

## Contesto collegato

Closes #786

## Cosa cambia

- [x] candidate — nuovo `membri-governo`
- [ ] support
- [ ] docs
- [ ] cleanup
- [ ] workflow o CI
- [ ] altro

## Impatto

- [x] Aggiunge o modifica un candidate in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream — **no**: nuovo dataset
- [ ] Solo documentazione o metadati
- [ ] Nessun impatto visibile

## Dettaglio

### Fonte e perimetro

- Endpoint SPARQL Camera (`dati.camera.it`), classe `ocd:membroGoverno`
- **Una sola query** (7.579 righe < WAF 10k) con `GROUP BY ?membro` + `MAX()` (fix duplicati OPTIONAL — pattern consolidato)
- `accept_format: sparql-results+json` (con "csv" l'endpoint restituisce Turtle — lezione da camera-deputati)
- Copre dal Regno d'Italia (1862) alla XIX legislatura — 97 legislature

### Clean

- **`persona_id`** normalizzato dall'URI persona (`p5660` Repubblica, `pr20` Regno) — **stessa chiave di camera_deputati/incarichi** → join e ponte verso senato
- `legislatura` uniforme (`repubblica_17` / `regno_21` / `costituente`)
- date `YYYYMMDD` → DATE
- **`read_mode: robust` top-level** (non in `read:`): il CSV non quotato del plugin SPARQL perdeva 74 righe con apostrofi nei cognomi (`D'INCA'`, `CLO'`) — robust le recupera (7.579 righe complete)

### Regno vs Repubblica (decisione documentata)

- Membri del Regno (URI `mgr...`): `ruolo` e `start_date` NON valorizzati (la data è solo nella label "dal 21.06.1894") → NULL, parsing label opzionale futuro
- Gender non esposto dal grafo governo → join con `camera_deputati_legislature` per persona_id

### Mart serie

- `mart_legislatura`: membri/governi per legislatura (serie storica 160 anni)
- `mart_governi`: composizione per governo (membri, persone, durata da start_date)

## Checklist candidate

- [x] `dataset.yml` con `name`, `years`, `source_id`, `tags`, `category` (gate strict)
- [x] `clean.validate` con `required_columns`, `not_null`, `min_rows`
- [x] `mart.validate.table_rules` con `primary_key` dai GROUP BY
- [x] `toolkit run` eseguito senza errori (anni dichiarati)
- [x] `python scripts/validate_candidate_structure.py` passato senza failure
- [x] nessun file dati committato nella root del candidate
- [ ] output immagini cleared dal notebook — **n/a: nessun notebook toccato**
- [ ] notebook nominato `{slug}_v0.ipynb` — **n/a: nessun notebook toccato**
- [x] issue di intake collegata — #786
- [x] `sql/clean.sql` usa le **macro standard del toolkit** (`normalize_string`, `TRY_CAST`)

## Verifica

```bash
toolkit run -c candidates/membri-governo/dataset.yml --year 2026
python scripts/validate_candidate_structure.py
```

Esito run locale (2026-08-03):
```
membri_governo: status=passed, readiness=ready (8/8), 7.579 righe
validate_candidate_structure: passed
```

Numeri verificati: 7.579 membri (match issue), 2.470 persone, 97 legislature; top: governo gr68 (257 membri), legislatura repubblica_08 (509).

## Note / rischi

- **Infrastruttura Camera degradata (2026-08-03)**: le pagine .rdf danno 500 ("Connection to http://dati.camera.it refused" — path interno http rotto); l'endpoint SPARQL alterna 200/502/503 (intermittente noto). NON impatta la pipeline (usiamo l'endpoint, non la dereferenziazione) — i raw scaricati restano validi. La CI potrebbe fallire sul fetch se l'endpoint è giù (retry già presente).
- **`read_mode: robust`**: necessario per il CSV non quotato del plugin SPARQL (apostrofi nei cognomi) — senza, si perdono 74 righe silenziosamente
- **Regno**: ruolo/start_date NULL (solo nella label) — parsing label = estensione futura
