### PR TITLE
chore(post-merge): aggiorna registry per PR #790

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -10167,6 +10167,93 @@
       "category": "finanza-pubblica"
     },
     {
+      "slug": "membri_governo",
+      "name": "Membri Governo",
+      "description": "",
+      "source": "",
+      "source_id": "dati_camera",
+      "period": {
+        "start": 1862,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "membro",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "persona_id",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "ruolo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "label",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "start_date",
+          "type": "DATE",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "nome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cognome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "legislatura",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "governo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "organo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/membri_governo/2026/membri_governo_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto",
+      "tags": [
+        "politica",
+        "governo",
+        "ministri",
+        "legislature"
+      ],
+      "category": "politica"
+    },
+    {
       "slug": "mim_alunni_corso_eta",
       "name": "Alunni per corso ed età — MIM",
       "description": "Alunni delle scuole statali italiane per ordine scolastico, anno di corso e fascia d'eta. Dato MIM a livello di singola scuola, arricchito con anagrafica scuole (regione, provincia, comune). Include gerarchia territoriale (nazionale → regione → provincia) per drill-down. Fonte: dati.istruzione.it.",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -10168,9 +10168,9 @@
     },
     {
       "slug": "membri_governo",
-      "name": "Membri Governo",
-      "description": "",
-      "source": "",
+      "name": "Membri dei Governi italiani (1862-2026)",
+      "description": "Membri e organi dei Governi italiani dal Regno d'Italia (1862) alla XIX legislatura: ruolo (Presidente del Consiglio, Ministro, Sottosegretario...), legislatura, governo e organo. Join con camera_deputati_legislature via persona_id (chiave standard del sistema parlamentare). Fonte: dati.camera.it SPARQL, 7.579 membri.",
+      "source": "Camera dei Deputati — OpenData SPARQL endpoint",
       "source_id": "dati_camera",
       "period": {
         "start": 1862,
@@ -10181,61 +10181,62 @@
           "name": "membro",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "URI del membro del governo"
         },
         {
           "name": "persona_id",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "ID numerico della persona (chiave standard del sistema parlamentare, ponte verso deputati/senato)",
+          "semantic_type": "person_id"
         },
         {
           "name": "ruolo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Ruolo ricoperto (MINISTRO, SOTTOSEGRETARIO DI STATO, PRESIDENTE DEL CONSIGLIO...) — NULL per il Regno"
         },
         {
           "name": "label",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Etichetta completa del ruolo (ruolo + dicastero + date)"
         },
         {
           "name": "start_date",
           "type": "DATE",
           "role": "dimension",
-          "description": ""
+          "description": "Data inizio incarico (NULL per il Regno — data solo nella label)"
         },
         {
           "name": "nome",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Nome della persona"
         },
         {
           "name": "cognome",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Cognome della persona"
         },
         {
           "name": "legislatura",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Legislatura (es. repubblica_17, regno_21, costituente)"
         },
         {
           "name": "governo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "URI del governo"
         },
         {
           "name": "organo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "URI dell'organo di governo (dicastero)"
         }
       ],
       "location": {

--- a/registry/entity_graph.json
+++ b/registry/entity_graph.json
@@ -787,6 +787,33 @@
         "country_code": 3
       }
     },
+    "Persona": {
+      "entity": "Persona",
+      "label": "Persona",
+      "datasets": [
+        {
+          "slug": "camera_deputati_legislature",
+          "name": "Camera Deputati Legislature",
+          "column": "persona_id",
+          "semantic_type": "person_id"
+        },
+        {
+          "slug": "camera_incarichi",
+          "name": "Incarichi nei Gruppi Parlamentari (Camera)",
+          "column": "persona_id",
+          "semantic_type": "person_id"
+        },
+        {
+          "slug": "membri_governo",
+          "name": "Membri dei Governi italiani (1862-2026)",
+          "column": "persona_id",
+          "semantic_type": "person_id"
+        }
+      ],
+      "types": {
+        "person_id": 3
+      }
+    },
     "Procedimento": {
       "entity": "Procedimento",
       "label": "Procedimento giudiziario",
@@ -1526,27 +1553,6 @@
       ],
       "types": {
         "region_code": 51
-      }
-    },
-    "Sconosciuto": {
-      "entity": "Sconosciuto",
-      "label": "Sconosciuto",
-      "datasets": [
-        {
-          "slug": "camera_deputati_legislature",
-          "name": "Camera Deputati Legislature",
-          "column": "persona_id",
-          "semantic_type": "person_id"
-        },
-        {
-          "slug": "camera_incarichi",
-          "name": "Incarichi nei Gruppi Parlamentari (Camera)",
-          "column": "persona_id",
-          "semantic_type": "person_id"
-        }
-      ],
-      "types": {
-        "person_id": 2
       }
     },
     "Scuola": {

--- a/registry/entity_graph.json
+++ b/registry/entity_graph.json
@@ -1528,6 +1528,27 @@
         "region_code": 51
       }
     },
+    "Sconosciuto": {
+      "entity": "Sconosciuto",
+      "label": "Sconosciuto",
+      "datasets": [
+        {
+          "slug": "camera_deputati_legislature",
+          "name": "Camera Deputati Legislature",
+          "column": "persona_id",
+          "semantic_type": "person_id"
+        },
+        {
+          "slug": "camera_incarichi",
+          "name": "Incarichi nei Gruppi Parlamentari (Camera)",
+          "column": "persona_id",
+          "semantic_type": "person_id"
+        }
+      ],
+      "types": {
+        "person_id": 2
+      }
+    },
     "Scuola": {
       "entity": "Scuola",
       "label": "Scuola",
@@ -2401,7 +2422,7 @@
     }
   ],
   "summary": {
-    "total_entities": 16,
+    "total_entities": 17,
     "total_relations": 25
   }
 }

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -4,9 +4,9 @@
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 110,
+    "total": 111,
     "by_status": {
-      "ok": 110,
+      "ok": 111,
       "warn": 0,
       "error": 0
     }
@@ -1250,6 +1250,41 @@
           2023
         ],
         "config_path": "candidates/mef-rappresentanti-partecipate/dataset.yml"
+      }
+    },
+    {
+      "id": "membri-governo",
+      "source_id": "dati_camera",
+      "status": "ok",
+      "label": "membri-governo",
+      "detail": "anno 2026 — fonte: membri_governo_sparql — mart: sì",
+      "action": "",
+      "latest_run": {
+        "status": "passed",
+        "run_id": "30855026928",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30855026928",
+        "checked_at": "2026-08-03",
+        "duration_seconds": 4.24,
+        "row_counts": {
+          "raw": 7505,
+          "clean": 7579,
+          "mart": 312
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
+        "years": [
+          2026
+        ],
+        "config_path": "candidates/membri-governo/dataset.yml"
       }
     },
     {

--- a/registry/semantic_types.yaml
+++ b/registry/semantic_types.yaml
@@ -268,6 +268,17 @@ types:
     weight: 1
 
   # ═══════════════════════════════════════════════════════════════════════
+  # PERSONE (sistema parlamentare e non solo)
+  # ═══════════════════════════════════════════════════════════════════════
+
+  person_id:
+    description: "ID numerico della persona fisica (es. 302103 da ocd/persona.rdf/p302103 — Camera/Senato/Governo)"
+    entity: Persona
+    aliases: [persona_id, person_id, id_persona, codice_persona]
+    weight: 15
+    note: "Chiave standard del sistema parlamentare (deputati, senatori, membri governo). Ponte tra rami via URI persona."
+
+  # ═══════════════════════════════════════════════════════════════════════
   # GIUSTIZIA
   # ═══════════════════════════════════════════════════════════════════════
 

--- a/tools/graph/build_graph.py
+++ b/tools/graph/build_graph.py
@@ -42,6 +42,7 @@ ENTITY_LABELS = {
     "Ente sanitario": "Ente sanitario",
     "Procedimento": "Procedimento giudiziario",
     "Categoria merceologica": "Categoria merceologica",
+    "Persona": "Persona",
 }
 
 


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #790 — feat(membri-governo): issue #786 — membri dei governi italiani 1862-2026

Changed candidate/support roots:

- `membri-governo` (candidate, `candidates/membri-governo`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/membri-governo/dataset.yml` -> artifact `sample-run-membri-governo`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
