### PR TITLE
fix(sparql): guard rail volume + allineamento standard candidate SPARQL Camera

### DIFF
--- a/candidates/camera-deputati-legislature/dataset.yml
+++ b/candidates/camera-deputati-legislature/dataset.yml
@@ -48,7 +48,10 @@ raw:
             OPTIONAL { ?deputato dcterms:isReferencedBy ?scheda . }
           }
           GROUP BY ?deputato
-          LIMIT 30000
+        # Paginazione OFFSET: niente ORDER BY (Virtuoso di dati.camera.it rifiuta
+        # ORDER BY + OFFSET con SR353). La paginazione OFFSET senza ORDER BY è
+        # non-deterministica ma è il comportamento che l'endpoint supporta; la
+        # perdita di dati è protetta da min_rows + fail_on_error.
         pages: 3
         step: 10000
         accept_format: "sparql-results+json"
@@ -66,7 +69,8 @@ clean:
     trim_whitespace: true
   validate:
     not_null: [deputato]
-    min_rows: 1000
+    # volume reale 27.764 deputati (2026) — margine ~45% di perdita tollerato
+    min_rows: 15000
 
 mart:
   tables:
@@ -91,4 +95,4 @@ mart:
         min_rows: 500
 
 validation:
-  fail_on_error: false
+  fail_on_error: true

--- a/candidates/camera-votazioni-sparql/dataset.yml
+++ b/candidates/camera-votazioni-sparql/dataset.yml
@@ -7,7 +7,10 @@ dataset:
   source_id: "dati_camera"
   tags: [politica, camera, votazioni, sparql]
   category: politica
-  years: [2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025]
+  years: [2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026]
+  time_coverage:
+    start_year: 2018
+    end_year: 2026
 
 raw:
   output_policy: overwrite
@@ -49,7 +52,9 @@ raw:
             FILTER (STRSTARTS(?data, "{year}"))
           }
           GROUP BY ?votazione
-          LIMIT 20000
+        # obbligatorio: con Accept csv Camera risponde Turtle (res:ResultSet)
+        # per query con GROUP BY — serve sparql-results+json per bindings reali
+        accept_format: "sparql-results+json"
       primary: true
 
 clean:
@@ -57,8 +62,29 @@ clean:
   required_columns: [votazione, titolo, legislatura, seduta, atto_camera]
   validate:
     not_null: [votazione]
+    # volume minimo storico 2.121 (2022) — margine ~15% di perdita tollerato
+    min_rows: 1800
+    # una riga = una votazione (URI RDF univoco)
+    primary_key: [votazione]
 
 mart:
   tables:
+    # serie per anno — output multi-year unico (9 righe, una per anno)
     - name: "camera_votazioni"
       sql: "sql/mart.sql"
+      years: [2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026]
+  time_coverage:
+    start_year: 2018
+    end_year: 2026
+  required_tables:
+    - "camera_votazioni"
+  validate:
+    table_rules:
+      camera_votazioni:
+        required_columns: [anno, n_votazioni, media_votanti]
+        primary_key: [anno]
+        # 9 anni dichiarati — perdere più di 1 anno fallisce
+        min_rows: 8
+
+validation:
+  fail_on_error: true

--- a/candidates/camera-votazioni-sparql/sql/mart.sql
+++ b/candidates/camera-votazioni-sparql/sql/mart.sql
@@ -1,2 +1,23 @@
--- Mart votazioni Camera: tutti i dati puliti
-SELECT * FROM clean_input
+-- mart_votazioni_anno — serie per anno delle votazioni Camera
+-- Metriche dell'analisi pubblica "Camera votazioni 2018-2025":
+--   votazioni, media votanti, media favorevoli/contrari, fiducia,
+--   votazioni finali approvate, voto segreto.
+SELECT
+    year(data)                                                              AS anno,
+    count(*)                                                                AS n_votazioni,
+    round(avg(votanti), 1)                                                  AS media_votanti,
+    round(avg(favorevoli), 1)                                               AS media_favorevoli,
+    round(avg(contrari), 1)                                                 AS media_contrari,
+    round(avg(astenuti), 1)                                                 AS media_astenuti,
+    round(avg(presenti), 1)                                                 AS media_presenti,
+    sum(CASE WHEN richiesta_fiducia THEN 1 ELSE 0 END)                      AS n_fiducia,
+    sum(CASE WHEN votazione_finale THEN 1 ELSE 0 END)                       AS n_votazioni_finali,
+    sum(CASE WHEN votazione_finale AND approvato THEN 1 ELSE 0 END)         AS n_finali_approvate,
+    sum(CASE WHEN votazione_segreta THEN 1 ELSE 0 END)                      AS n_segrete,
+    round(
+        100.0 * sum(CASE WHEN votazione_finale AND approvato THEN 1 ELSE 0 END)
+        / NULLIF(sum(CASE WHEN votazione_finale THEN 1 ELSE 0 END), 0), 1
+    )                                                                       AS pct_finali_approvate
+FROM clean_input
+GROUP BY year(data)
+ORDER BY anno

--- a/candidates/membri-governo/dataset.yml
+++ b/candidates/membri-governo/dataset.yml
@@ -57,7 +57,8 @@ clean:
     trim_whitespace: true
   validate:
     not_null: [membro]
-    min_rows: 1000
+    # volume reale 7.579 membri (2026) — margine ~35% di perdita tollerato
+    min_rows: 5000
 
 mart:
   tables:
@@ -82,4 +83,4 @@ mart:
         min_rows: 50
 
 validation:
-  fail_on_error: false
+  fail_on_error: true

--- a/support_datasets/camera-incarichi/dataset.yml
+++ b/support_datasets/camera-incarichi/dataset.yml
@@ -52,7 +52,8 @@ clean:
     trim_whitespace: true
   validate:
     not_null: [incarico, deputato]
-    min_rows: 1000
+    # volume reale 3.096 incarichi (2026) — margine ~35% di perdita tollerato
+    min_rows: 2000
     primary_key: [incarico]
 
 mart:


### PR DESCRIPTION
## Sintesi

Allineamento dei 4 candidate SPARQL Camera allo standard v1 + guard rail di volume. La review del civic-director aveva rilevato che la pipeline può dare `ready (8/8)` anche con perdita silenziosa di dati (colonne 100% NULL o righe troncate): `fail_on_error: false` + `min_rows` troppo bassi o assenti su tutti i candidate da endpoint SPARQL.

## Contesto collegato

Correlata a toolkit issue #449 (paginazione SPARQL con break silenzioso su errore — perdita dati su endpoint instabile). I guard rail qui smascherano quel problema: senza `min_rows` calibrati, un CSV troncato (es. 10.000 righe su 27.764) passerebbe inosservato.

## Cosa cambia

- [x] candidate — aggiornamento 3 candidate + 1 support
- [ ] support
- [ ] docs
- [x] cleanup — rimozione LIMIT hardcoded inutili, mart pass-through sostituita
- [ ] workflow o CI
- [ ] altro

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi) — **no**: nessuna colonna clean rinominata/rimossa; la mart di votazioni è passata da pass-through a serie per anno (nuove metriche, stesse colonne clean)
- [ ] Solo documentazione o metadati
- [ ] Nessun impatto visibile per chi usa il repository

## Dettaglio per candidate

### camera-deputati-legislature
- **ORDER BY rimosso** dalla query: Virtuoso di `dati.camera.it` rifiuta `ORDER BY + OFFSET` con errore SR353 (max 10.000 righe ordinate). Ripristinata la paginazione OFFSET senza ORDER BY — comportamento che l'endpoint supporta (verificato live: `GROUP no ORDER: OK 10000`).
- `fail_on_error: false → true`
- `min_rows: 1000 → 15000` (volume reale 27.764 deputati; margine ~45% di perdita tollerato)

### camera-votazioni-sparql
- **Fix bug raw**: mancava `accept_format: "sparql-results+json"` → con Accept csv Camera risponde **Turtle** (`res:ResultSet`) per query con GROUP BY → CSV spazzatura → BinderError. Aggiunto.
- **Anno 2026 aggiunto**: la fonte è viva (3.183 votazioni al 3/8/2026). `years` + `time_coverage` 2018-2026.
- **Mart pass-through → mart serie multi-year** (`mart.sql` riscritta): 12 metriche per anno (n_votazioni, medie votanti/favorevoli/contrari/astenuti/presenti, fiducia, finali, approvate, segrete, % approvate). **Verificata contro l'analisi pubblica**: fiducia 114=114, finali 648=648, approvate 646=646.
- `LIMIT 20000` rimosso (max storico 5.903/anno — non tronca mai, nascondeva solo).
- Guard rail: `fail_on_error: true`, `min_rows: 1800` (minimo storico 2.121), `primary_key: [votazione]`, `table_rules` per la mart multi-year.

### membri-governo
- `fail_on_error: false → true`
- `min_rows: 1000 → 5000` (volume reale 7.579)

### camera-incarichi (support)
- `min_rows: 1000 → 2000` (volume reale 3.096; fail_on_error era già true)

## Verifica

Volumi lato fonte verificati con `COUNT(DISTINCT)` sull'endpoint (nessuna perdita reale — i "drop 50%" sono duplicati intrinseci: ogni entità ha 2 triple `a` nel graph, il GROUP BY dedup):

| Candidate | Fonte (DISTINCT) | Raw/clean | Drop |
|---|---|---|---|
| deputati | 27.764 | 27.764 | 0% |
| membri-governo | 7.579 | 7.579 | 0% |
| incarichi | 3.096 | 3.096 | 0% |
| votazioni (per anno) | 2.144–5.903 | = clean | 0% |

```bash
toolkit run -c candidates/camera-deputati-legislature/dataset.yml --year 2026
toolkit run -c candidates/camera-votazioni-sparql/dataset.yml --year 2026
toolkit run -c candidates/membri-governo/dataset.yml --year 2026
toolkit run -c support_datasets/camera-incarichi/dataset.yml --year 2026
python scripts/validate_candidate_structure.py
```

Esito: run passed su tutti, readiness ready (8/8), gate passed.

## Note / rischi

- **Paginazione OFFSET senza ORDER BY** (deputati) è non-deterministica per natura — è il comportamento che l'endpoint supporta. La perdita dati è protetta da `min_rows` + `fail_on_error`. L'alternativa deterministica (keyset) è implementata nel toolkit (issue #449, branch `fix/sparql-pagination-error`) ma NON usata qui: su questo endpoint l'OFFSET funziona e il keyset non è necessario.
- La mart multi-year di votazioni è validata dal run locale ma il gap toolkit #445 (validazione multi-year non eseguita) resta aperto — le `table_rules` restano come documentazione + validazione futura.