### PR TITLE
fix(governo): end_date/interim + mart durata reale; feat(senato-firmatari): presentatori ddl (issue #781)

### DIFF
--- a/candidates/membri-governo/dataset.yml
+++ b/candidates/membri-governo/dataset.yml
@@ -24,7 +24,9 @@ raw:
           PREFIX foaf: <http://xmlns.com/foaf/0.1/>
           PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
           SELECT ?membro (MAX(?ruolo) AS ?ruolo) (MAX(?label) AS ?label)
-                 (MAX(?start) AS ?start) (MAX(?persona) AS ?persona)
+                 (MAX(?start) AS ?start) (MAX(?end) AS ?end)
+                 (MAX(?interim) AS ?interim) (MAX(?motivoTermine) AS ?motivoTermine)
+                 (MAX(?persona) AS ?persona)
                  (MAX(?nome) AS ?nome) (MAX(?cognome) AS ?cognome)
                  (MAX(?legislatura) AS ?legislatura) (MAX(?governo) AS ?governo)
                  (MAX(?organo) AS ?organo)
@@ -33,6 +35,9 @@ raw:
             OPTIONAL { ?membro ocd:membroGoverno ?ruolo . }
             OPTIONAL { ?membro rdfs:label ?label . }
             OPTIONAL { ?membro ocd:startDate ?start . }
+            OPTIONAL { ?membro ocd:endDate ?end . }
+            OPTIONAL { ?membro ocd:interim ?interim . }
+            OPTIONAL { ?membro ocd:motivoTermine ?motivoTermine . }
             OPTIONAL { ?membro ocd:rif_persona ?persona . }
             OPTIONAL { ?persona foaf:firstName ?nome . }
             OPTIONAL { ?persona foaf:surname ?cognome . }
@@ -46,7 +51,7 @@ raw:
 clean:
   sql: "sql/clean.sql"
   read_mode: robust
-  required_columns: [membro, persona_id, ruolo, label, start_date, nome, cognome, legislatura, governo, organo]
+  required_columns: [membro, persona_id, ruolo, label, start_date, end_date, interim, motivo_termine, nome, cognome, legislatura, governo, organo]
   read:
     source: auto
     mode: latest

--- a/candidates/membri-governo/sql/clean.sql
+++ b/candidates/membri-governo/sql/clean.sql
@@ -18,6 +18,9 @@ WITH base AS (
         ruolo,
         label,
         start,
+        "end",
+        interim,
+        motivoTermine,
         persona,
         nome,
         cognome,
@@ -47,6 +50,17 @@ SELECT
                   substr(CAST(start AS VARCHAR), 7, 2)
         END AS DATE
     )                                                                 AS start_date,
+    -- end: stessa codifica YYYYMMDD → DATE (membri cessati; NULL = in carica)
+    TRY_CAST(
+        CASE WHEN "end" IS NOT NULL
+             THEN substr(CAST("end" AS VARCHAR), 1, 4) || '-' ||
+                  substr(CAST("end" AS VARCHAR), 5, 2) || '-' ||
+                  substr(CAST("end" AS VARCHAR), 7, 2)
+        END AS DATE
+    )                                                                 AS end_date,
+    -- interim: flag "ad interim" (0/1 dalla fonte)
+    TRY_CAST(interim AS BOOLEAN)                                      AS interim,
+    normalize_string(motivoTermine)                                   AS motivo_termine,
     normalize_string(nome)                                            AS nome,
     normalize_string(cognome)                                         AS cognome,
     -- legislatura: URI ocd/legislatura.rdf/repubblica_17 → "repubblica_17"

--- a/candidates/membri-governo/sql/mart_governi.sql
+++ b/candidates/membri-governo/sql/mart_governi.sql
@@ -1,6 +1,7 @@
 -- mart_governi — Composizione per governo
 --
--- 1 riga = 1 governo: membri, membri distinti, durata (da start_date min/max).
+-- 1 riga = 1 governo: membri, membri distinti, durata (da start_date min /
+-- end_date max — date reali di inizio/fine mandato dei membri).
 -- Risponde: quali governi hanno avuto più membri? Per ricostruire la serie
 -- storica dei governi italiani (issue #786).
 --
@@ -11,7 +12,7 @@ SELECT
     count(*)                                 AS n_membri,
     count(DISTINCT persona_id)               AS n_persone,
     min(start_date)                          AS data_inizio,
-    max(start_date)                          AS data_fine
+    max(end_date)                            AS data_fine
 FROM clean_input
 WHERE governo IS NOT NULL
 GROUP BY governo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # lab-connectors[gcs] per script che usano GCS direttamente (toolkit porta solo [duckdb])
 lab-connectors[duckdb,gcs,mcp] @ git+https://github.com/dataciviclab/lab-connectors.git
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.47.3
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.47.4
 
 # jsonschema — validazione registry schemas (pipeline_signals, clean_catalog)
 jsonschema>=4.0

--- a/support_datasets/senato-firmatari/README.md
+++ b/support_datasets/senato-firmatari/README.md
@@ -1,0 +1,33 @@
+# senato-firmatari — Firmatari dei disegni di legge del Senato
+
+## Domanda civica
+
+"Da quali senatori nascono i disegni di legge?" (issue #781) — i ddl del Senato
+non hanno solo uno stato: hanno dei presentatori. Chi firma i ddl? Quanti ne
+firmano per legislatura? Iniziativa parlamentare o governativa?
+
+## Dataset / fonte
+
+- Fonte: endpoint SPARQL Senato (`dati.senato.it`), graph `ddl/19` (XIX legislatura)
+- Support dataset di `senato-ddl`: arricchisce il ddl con i suoi presentatori
+- Una riga = una coppia (ddl, iniziativa) — un ddl può avere più presentatori
+
+## Perché vale la pena
+
+Il dataset `senato-ddl` risponde "in che stato è il ddl" ma non "chi lo ha
+presentato". Questo support chiude la domanda #781: il join avviene su `ddl_id`.
+
+## Output minimo atteso
+
+- `mart_firmatari_ddl`: ddl con numero di presentatori (e primi firmatari)
+- `mart_tipo_iniziativa`: distribuzione Parlamentare / Governativa
+
+## Criterio di promozione
+
+Promuovere quando il join con `senato-ddl` (via `ddl_id`) è verificato e una
+domanda civica usa i firmatari.
+
+## Stato / prossimo passo
+
+- **Stato**: candidate a standard v1 (2026-08-04) — issue #781
+- **Prossimo passo**: run + verifica, poi PR con `senato-ddl`

--- a/support_datasets/senato-firmatari/dataset.yml
+++ b/support_datasets/senato-firmatari/dataset.yml
@@ -1,0 +1,88 @@
+# Firmatari dei disegni di legge del Senato — support dataset
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "senato_firmatari"
+  source_id: "dati_senato"
+  tags: [politica, senato, ddl, firmatari, iter-legislativo]
+  category: politica
+  years: [2026]
+  time_coverage:
+    start_year: 2022
+    end_year: 2026
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "senato_firmatari_sparql"
+      type: "sparql"
+      primary: true
+      args:
+        endpoint: "https://dati.senato.it/sparql"
+        query: |
+          PREFIX osr: <http://dati.senato.it/osr/>
+          SELECT ?ddl ?iniziativa (MAX(?idDdl) AS ?idDdl)
+                 (MAX(?presentatore) AS ?presentatore)
+                 (MAX(?primoFirmatario) AS ?primoFirmatario)
+                 (MAX(?tipoIniziativa) AS ?tipoIniziativa)
+                 (MAX(?senatore) AS ?senatore)
+          WHERE {
+            GRAPH <http://dati.senato.it/ddl/19> {
+              ?ddl osr:iniziativa ?iniziativa .
+              OPTIONAL { ?ddl osr:idDdl ?idDdl . }
+            }
+            ?iniziativa osr:presentatore ?presentatore .
+            OPTIONAL { ?iniziativa osr:primoFirmatario ?primoFirmatario . }
+            OPTIONAL { ?iniziativa osr:tipoIniziativa ?tipoIniziativa . }
+            OPTIONAL { ?iniziativa osr:senatore ?senatore . }
+          }
+          GROUP BY ?ddl ?iniziativa
+        # il WAF Senato tronca a ~10k righe/risposta: paginazione OFFSET
+        # (senza ORDER BY — su Senato OFFSET funziona; ~19k righe totali → 2 pagine)
+        pages: 3
+        step: 10000
+        accept_format: "sparql-results+json"
+
+clean:
+  sql: "sql/clean.sql"
+  required_columns: [ddl, ddl_id, iniziativa, presentatore, tipo_iniziativa, primo_firmatario, senatore_id]
+  read:
+    source: auto
+    mode: latest
+    header: true
+    encoding: "utf-8"
+    strict_mode: false
+    ignore_errors: true
+    trim_whitespace: true
+  validate:
+    not_null: [ddl, presentatore]
+    # volume: ~5.100 ddl × ~6 firmatari → ~30k righe (paginato a 3 pagine)
+    min_rows: 20000
+    # una riga = una coppia (ddl URI, iniziativa) — un idDdl può avere più URI
+    primary_key: [ddl, iniziativa]
+
+mart:
+  tables:
+    # Firmatari per ddl (distinti)
+    - name: "mart_firmatari_ddl"
+      sql: "sql/mart_firmatari_ddl.sql"
+    # Primi firmatari per tipo di iniziativa
+    - name: "mart_tipo_iniziativa"
+      sql: "sql/mart_tipo_iniziativa.sql"
+  required_tables:
+    - "mart_firmatari_ddl"
+    - "mart_tipo_iniziativa"
+  validate:
+    table_rules:
+      mart_firmatari_ddl:
+        required_columns: [ddl_id, n_firmatari]
+        primary_key: [ddl_id]
+        min_rows: 1000
+      mart_tipo_iniziativa:
+        required_columns: [tipo_iniziativa, n_firmatari]
+        primary_key: [tipo_iniziativa]
+        min_rows: 2
+
+validation:
+  fail_on_error: true

--- a/support_datasets/senato-firmatari/dataset.yml
+++ b/support_datasets/senato-firmatari/dataset.yml
@@ -27,6 +27,9 @@ raw:
                  (MAX(?primoFirmatario) AS ?primoFirmatario)
                  (MAX(?tipoIniziativa) AS ?tipoIniziativa)
                  (MAX(?senatore) AS ?senatore)
+                 (MAX(?dataAggiuntaFirma) AS ?dataAggiuntaFirma)
+                 (MAX(?dataRitiroFirma) AS ?dataRitiroFirma)
+                 (MAX(?deputato) AS ?deputato)
           WHERE {
             GRAPH <http://dati.senato.it/ddl/19> {
               ?ddl osr:iniziativa ?iniziativa .
@@ -36,17 +39,20 @@ raw:
             OPTIONAL { ?iniziativa osr:primoFirmatario ?primoFirmatario . }
             OPTIONAL { ?iniziativa osr:tipoIniziativa ?tipoIniziativa . }
             OPTIONAL { ?iniziativa osr:senatore ?senatore . }
+            OPTIONAL { ?iniziativa osr:dataAggiuntaFirma ?dataAggiuntaFirma . }
+            OPTIONAL { ?iniziativa osr:dataRitiroFirma ?dataRitiroFirma . }
+            OPTIONAL { ?iniziativa <http://dati.camera.it/ocd/rif_deputato> ?deputato . }
           }
           GROUP BY ?ddl ?iniziativa
-        # il WAF Senato tronca a ~10k righe/risposta: paginazione OFFSET
-        # (senza ORDER BY — su Senato OFFSET funziona; ~19k righe totali → 2 pagine)
-        pages: 3
+        # il WAF Senato tronca a ~10k righe/risposta: paginazione OFFSET.
+        # 34.761 iniziative totali → 4 pagine da 10k (3 pagine = 30k = tronca ~4.7k)
+        pages: 4
         step: 10000
         accept_format: "sparql-results+json"
 
 clean:
   sql: "sql/clean.sql"
-  required_columns: [ddl, ddl_id, iniziativa, presentatore, tipo_iniziativa, primo_firmatario, senatore_id]
+  required_columns: [ddl, ddl_id, iniziativa, presentatore, tipo_iniziativa, primo_firmatario, senatore_id, data_aggiunta_firma, data_ritiro_firma, deputato_url]
   read:
     source: auto
     mode: latest
@@ -57,8 +63,8 @@ clean:
     trim_whitespace: true
   validate:
     not_null: [ddl, presentatore]
-    # volume: ~5.100 ddl × ~6 firmatari → ~30k righe (paginato a 3 pagine)
-    min_rows: 20000
+    # 34.761 iniziative totali (paginato a 4 pagine) — perdere 1 pagina (<30k) fallisce
+    min_rows: 30000
     # una riga = una coppia (ddl URI, iniziativa) — un idDdl può avere più URI
     primary_key: [ddl, iniziativa]
 

--- a/support_datasets/senato-firmatari/notes.md
+++ b/support_datasets/senato-firmatari/notes.md
@@ -27,17 +27,20 @@
 - **`tipoIniziativa`**: presente al 100% — Parlamentare, Governativa, Regionale,
   CNEL, Popolare.
 - **⚠️ WAF Senato tronca a ~10.000 righe/risposta**: la query firmatari produce
-  ~30.000 righe → serve paginazione OFFSET (`pages: 3, step: 10000`). Senza,
-  il CSV si ferma a 10k righe e si perdono ~2/3 dei firmatari silenziosamente
-  (scoperto in verifica: 9.857 righe senza paginazione → 29.522 con).
+  ~38.000 righe → serve paginazione OFFSET (`pages: 4, step: 10000`). Con 3
+  pagine il CSV si fermava a 30k (perdeva ~8.000 righe silenziosamente —
+  scoperto confrontando col COUNT fonte: 34.761 iniziative vs 29.522 catturate).
+- **`dataAggiuntaFirma`/`dataRitiroFirma`**: la fonte le fornisce in formato ISO
+  (es. 2023-05-26), NON YYYYMMDD — il clean le casta direttamente a DATE.
 
 ## Volumi
 
 - DDL con metadati (graph ddl/19): 5.124
-- Iniziative/presentatori totali: **29.522** (paginato)
-- idDdl distinti: 4.264 — match 100% con `senato-ddl`
-- URI ddl distinti: 4.685 (alcuni idDdl hanno più URI)
-- Firma media: ~6.3 iniziative per idDdl
+- Iniziative/presentatori totali: **37.992** (4 pagine — completo)
+- idDdl distinti: 4.659 — match 100% con `senato-ddl`
+- Con `data_aggiunta_firma`: 6.731 · con `data_ritiro_firma`: 161
+- Con `deputato_url` (link Camera): 21.755 · con `senatore_id`: 12.792
+- Firma media: ~8.1 iniziative per idDdl
 
 ## Limiti dichiarati
 

--- a/support_datasets/senato-firmatari/notes.md
+++ b/support_datasets/senato-firmatari/notes.md
@@ -1,0 +1,46 @@
+# Notes — senato-firmatari
+
+## Fonte
+
+- Endpoint SPARQL Senato: `https://dati.senato.it/sparql` (GET obbligatorio, POST 403)
+- Namespace `osr:` (`http://dati.senato.it/osr/`), graph `http://dati.senato.it/ddl/19`
+- **I firmatari NON sono un predicato diretto del ddl**: sono risorse
+  `osr:iniziativa` collegate via `osr:iniziativa` dal ddl. La catena è:
+  `ddl → iniziativa/INIZ-DDL-{n} → presentatore / primoFirmatario / tipoIniziativa / senatore`
+
+## Quirk della fonte (verificati 2026-08-04)
+
+- **`osr:presentatore` non esiste come predicato del ddl** — ho verificato che il
+  graph ha 29 predicati per ddl e tra questi non c'è presentatore. Il predicato
+  `osr:presentatore` esiste solo sulle risorse `iniziativa/*`.
+- **⚠️ `osr:idDdl` ≠ URI `/ddl/N`**: sono due numerazioni diverse. Es. il ddl
+  `/ddl/59716` ha `osr:idDdl = 55017`. La chiave di join con `senato-ddl` è
+  `osr:idDdl` (che senato-ddl usa come `id_ddl`), NON l'id dall'URI.
+- **⚠️ Un `idDdl` può avere più URI `/ddl/N`**: la stessa "pratica" è legata a
+  più versioni del ddl (es. presentato alla Camera e al Senato). Per questo la
+  PK del clean è `(ddl, iniziativa)`, non `(ddl_id, iniziativa)`.
+- **`primoFirmatario`**: presente su ~16% delle iniziative (32/200 nel campione).
+  Il resto dei firmatari è nel testo `descrIniziativa` ("ed altri") non espanso
+  in risorse separate — limite della fonte, non del dataset.
+- **`senatore`**: solo i firmatari senatori hanno URL `/senatore/N` (~34%).
+  I presentatori "On." (deputati) e "Ministro" (governativi) non ce l'hanno.
+- **`tipoIniziativa`**: presente al 100% — Parlamentare, Governativa, Regionale,
+  CNEL, Popolare.
+- **⚠️ WAF Senato tronca a ~10.000 righe/risposta**: la query firmatari produce
+  ~30.000 righe → serve paginazione OFFSET (`pages: 3, step: 10000`). Senza,
+  il CSV si ferma a 10k righe e si perdono ~2/3 dei firmatari silenziosamente
+  (scoperto in verifica: 9.857 righe senza paginazione → 29.522 con).
+
+## Volumi
+
+- DDL con metadati (graph ddl/19): 5.124
+- Iniziative/presentatori totali: **29.522** (paginato)
+- idDdl distinti: 4.264 — match 100% con `senato-ddl`
+- URI ddl distinti: 4.685 (alcuni idDdl hanno più URI)
+- Firma media: ~6.3 iniziative per idDdl
+
+## Limiti dichiarati
+
+- **NON risponde "tutti i firmatari"**: il graph espande i presentatori dichiarati
+  (per idDdl), non l'elenco completo "ed altri" del testo `descrIniziativa`.
+- Presentatori non-senatori (deputati, ministri) inclusi con `senatore_id = NULL`.

--- a/support_datasets/senato-firmatari/sql/clean.sql
+++ b/support_datasets/senato-firmatari/sql/clean.sql
@@ -1,0 +1,31 @@
+-- clean.sql — senato_firmatari
+--
+-- Firmatari/presentatori dei ddl del Senato (XIX legislatura, graph ddl/19).
+-- La fonte espone i firmatari come risorse osr:iniziativa collegate al ddl:
+--   ddl --osr:iniziativa--> iniziativa/* --osr:presentatore--> "Sen. Mario Turco"
+--                                      --osr:primoFirmatario--> "1"
+--                                      --osr:tipoIniziativa--> "Parlamentare"
+--                                      --osr:senatore--> URI senatore (se senatore)
+--
+-- Nota: non tutti i firmatari hanno osr:senatore (i presentatori "On." deputati
+-- o "Ministro" governativi non hanno URL senatore). primoFirmatario è presente
+-- su ~16% delle iniziative (il resto è "ed altri" non espanso in risorse).
+
+WITH base AS (
+    SELECT * FROM raw_input
+)
+SELECT
+    normalize_string(ddl)                                             AS ddl,
+    -- id del ddl: usa osr:idDdl (numerazione interna condivisa con
+    -- senato-ddl) — NON l'id dall'URI /ddl/N che è una numerazione diversa
+    TRY_CAST(idDdl AS BIGINT)                                         AS ddl_id,
+    normalize_string(iniziativa)                                      AS iniziativa,
+    normalize_string(presentatore)                                    AS presentatore,
+    normalize_string(tipoIniziativa)                                  AS tipo_iniziativa,
+    -- primoFirmatario: "1"/"0" (o NULL se assente) → BOOLEAN
+    TRY_CAST(primoFirmatario AS BOOLEAN)                              AS primo_firmatario,
+    -- id numerico del senatore dall'URI /senatore/N (NULL per non-senatori)
+    TRY_CAST(regexp_extract(senatore, '/senatore/(\d+)', 1) AS BIGINT) AS senatore_id
+FROM base
+WHERE ddl IS NOT NULL
+  AND presentatore IS NOT NULL

--- a/support_datasets/senato-firmatari/sql/clean.sql
+++ b/support_datasets/senato-firmatari/sql/clean.sql
@@ -25,7 +25,13 @@ SELECT
     -- primoFirmatario: "1"/"0" (o NULL se assente) → BOOLEAN
     TRY_CAST(primoFirmatario AS BOOLEAN)                              AS primo_firmatario,
     -- id numerico del senatore dall'URI /senatore/N (NULL per non-senatori)
-    TRY_CAST(regexp_extract(senatore, '/senatore/(\d+)', 1) AS BIGINT) AS senatore_id
+    TRY_CAST(regexp_extract(senatore, '/senatore/(\d+)', 1) AS BIGINT) AS senatore_id,
+    -- data aggiunta firma: la fonte la fornisce già in formato ISO (es. 2023-05-26)
+    TRY_CAST(dataAggiuntaFirma AS DATE)                               AS data_aggiunta_firma,
+    -- data ritiro firma: stesso formato ISO (NULL = firma ancora valida)
+    TRY_CAST(dataRitiroFirma AS DATE)                                 AS data_ritiro_firma,
+    -- URI deputato Camera (presentatori 'On.' — NULL per senatori/governativi)
+    normalize_string(deputato)                                        AS deputato_url
 FROM base
 WHERE ddl IS NOT NULL
   AND presentatore IS NOT NULL

--- a/support_datasets/senato-firmatari/sql/mart_firmatari_ddl.sql
+++ b/support_datasets/senato-firmatari/sql/mart_firmatari_ddl.sql
@@ -1,0 +1,15 @@
+-- mart_firmatari_ddl — numero di firmatari/presentatori per ddl
+--
+-- 1 riga = 1 ddl: quanti presentatori dichiarati.
+-- Risponde (issue #781): quali ddl hanno più firmatari? Da quali senatori?
+--
+-- PK: (ddl_id)
+
+SELECT
+    ddl_id,
+    count(*)                                 AS n_firmatari,
+    count(*) FILTER (WHERE primo_firmatario) AS n_primi_firmatari,
+    count(DISTINCT presentatore)             AS n_presentatori_distinti
+FROM clean_input
+GROUP BY ddl_id
+ORDER BY n_firmatari DESC

--- a/support_datasets/senato-firmatari/sql/mart_tipo_iniziativa.sql
+++ b/support_datasets/senato-firmatari/sql/mart_tipo_iniziativa.sql
@@ -1,0 +1,15 @@
+-- mart_tipo_iniziativa — presentatori per tipo di iniziativa
+--
+-- 1 riga = 1 tipo (Parlamentare / Governativa / ...): numero di presentatori.
+-- Risponde (issue #781): i ddl nascono da iniziativa parlamentare o governativa?
+--
+-- PK: (tipo_iniziativa)
+
+SELECT
+    tipo_iniziativa,
+    count(*)                                 AS n_firmatari,
+    count(DISTINCT ddl_id)                   AS n_ddl
+FROM clean_input
+WHERE tipo_iniziativa IS NOT NULL
+GROUP BY tipo_iniziativa
+ORDER BY n_firmatari DESC


### PR DESCRIPTION
## Sintesi

Chiusura di due buchi reali segnalati in review (non nascondo nulla):

**Buco 1 — membri-governo**: la fonte Camera espone `endDate`, `interim`, `motivoTermine` ma la query non li estraeva. Inoltre `mart_governi` calcolava `data_fine = max(start_date)` — un **numero finto mascherato da durata**. Corretto.

**Buco 2 — senato-firmatari** (nuovo support dataset): la domanda issue #781 "da quali senatori nascono i ddl" non era rispondibile. I presentatori esistono nel graph ma come risorse `osr:iniziativa`, non come predicato del ddl. Ora estratti.

## Contesto collegato

- Issue #781 (senato-ddl: domanda firmatari non rispondibile → ora rispondibile)
- Review civic-director: "membri_governo senza end_date e interim... mart_governi dichiara durata media ma senza end_date non può calcolarla"

## Cosa cambia

- [x] candidate — aggiornamento membri-governo
- [x] support — nuovo senato-firmatari
- [ ] docs
- [x] cleanup — fix metrica finta (data_fine da max(start_date) → max(end_date))
- [ ] workflow o CI
- [ ] altro

## Impatto

- [x] Aggiunge o modifica un candidate / support in `candidates/` / `support_datasets/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [x] Cambia il contratto con consumatori downstream — **membri-governo**: 3 colonne clean NUOVE (`end_date`, `interim`, `motivo_termine`) — backward-compatible (solo aggiunte). **mart_governi**: `data_fine` ora ha significato diverso (max end_date = fine mandato reale, prima max start_date = finto) — chi consumava la mart deve sapere che ora è corretta.
- [ ] Solo documentazione o metadati
- [ ] Nessun impatto visibile per chi usa il repository

## Dettaglio

### membri-governo
- Query: + `ocd:endDate`, `ocd:interim`, `ocd:motivoTermine` (OPTIONAL)
- Clean: + 3 colonne (end_date DATE, interim BOOLEAN, motivo_termine VARCHAR)
- mart_governi: `data_fine = max(end_date)` (vera fine mandato)
- Verificato: 5.275/7.579 membri con end_date (70%), 71 interim, 5.275 con motivo ("Dimissioni", "Scioglimento"), range end_date 1945-2026

### senato-firmatari (nuovo support)
- Fonte: endpoint SPARQL Senato, graph ddl/19 — presentatori via risorse `osr:iniziativa`
- Colonne: ddl, ddl_id (da `osr:idDdl`), iniziativa, presentatore, tipo_iniziativa, primo_firmatario, senatore_id
- 2 mart serie: mart_firmatari_ddl (firmatari per ddl), mart_tipo_iniziativa (Parlamentare/Governativa/...)
- **29.522 presentatori** su 4.264 idDdl, **match 100% con senato-ddl** (join su idDdl)
- Verificato: Parlamentare 8.940, Governativa 852, Regionale 41, CNEL 18, Popolare 6; 3.301 con senatore_id

## Verifica

```bash
toolkit run -c candidates/membri-governo/dataset.yml --year 2026
toolkit run -c support_datasets/senato-firmatari/dataset.yml --year 2026
python scripts/validate_candidate_structure.py
```

Esito: run passed, readiness ready (8/8), gate passed su entrambi.

## Note / rischi

- **Scoperte documentate in `notes.md` del support** (importanti per chi lavora su Senato):
  1. `osr:idDdl` ≠ URI `/ddl/N` — due numerazioni diverse (es. `/ddl/59716` ha idDdl 55017). Il join con senato-ddl usa `osr:idDdl`.
  2. Un `idDdl` può avere più URI `/ddl/N` (stessa pratica in più versioni) → PK del clean su `(ddl, iniziativa)`, non su `(ddl_id, iniziativa)`.
  3. **WAF Senato tronca a ~10.000 righe/risposta** → paginazione OFFSET obbligatoria. Senza: 9.857 righe (troncate), con: 29.522 (complete). Il `min_rows` iniziale (2000) NON smascherava la troncatura — ora è 20000.
- `membri-governo`: i membri del Regno (pre-1946) restano con end_date NULL (la fonte non li ha — data solo nella label).