### PR TITLE
chore(post-merge): aggiorna registry per PR #796

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -10209,6 +10209,24 @@
           "description": "Data inizio incarico (NULL per il Regno — data solo nella label)"
         },
         {
+          "name": "end_date",
+          "type": "DATE",
+          "role": "dimension",
+          "description": "Data fine incarico (membri cessati; NULL = in carica). Non disponibile per i membri del Regno (data solo nella label)."
+        },
+        {
+          "name": "interim",
+          "type": "BOOLEAN",
+          "role": "dimension",
+          "description": "Flag ad interim (TRUE se l'incarico è reggenza temporanea)."
+        },
+        {
+          "name": "motivo_termine",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Motivo della cessazione (es. Dimissioni, Scioglimento, Decesso)."
+        },
+        {
           "name": "nome",
           "type": "VARCHAR",
           "role": "dimension",
@@ -14180,8 +14198,8 @@
     {
       "slug": "senato_firmatari",
       "name": "Senato Firmatari",
-      "description": "",
-      "source": "",
+      "description": "Presentatori/firmatari dei disegni di legge del Senato (XIX legislatura): chi ha presentato ogni ddl, tipo di iniziativa (Parlamentare/Governativa), data di firma, link al senatore o al deputato. Support dataset di senato-ddl — join su ddl_id. Fonte: dati.senato.it SPARQL, 37.992 presentatori.",
+      "source": "Senato della Repubblica — SPARQL endpoint (dati.senato.it)",
       "source_id": "dati_senato",
       "period": {
         "start": 2022,
@@ -14192,61 +14210,61 @@
           "name": "ddl",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "URI del disegno di legge nel graph Senato"
         },
         {
           "name": "ddl_id",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "Identificativo numerico del ddl (osr:idDdl — numerazione interna condivisa con senato-ddl; NON è l'id dell'URI /ddl/N)"
         },
         {
           "name": "iniziativa",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "URI della risorsa iniziativa (una per presentatore/firmatario)"
         },
         {
           "name": "presentatore",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Nome del presentatore (es. \"Sen. Mario Turco\", \"On. Alberto Bagnai\", \"Ministro...\")"
         },
         {
           "name": "tipo_iniziativa",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Tipo di iniziativa: Parlamentare, Governativa, Regionale, CNEL, Popolare"
         },
         {
           "name": "primo_firmatario",
           "type": "BOOLEAN",
           "role": "dimension",
-          "description": ""
+          "description": "Flag primo firmatario (TRUE se il presentatore è il primo firmatario)"
         },
         {
           "name": "senatore_id",
           "type": "BIGINT",
           "role": "metric",
-          "description": ""
+          "description": "ID numerico del senatore dall'URI /senatore/N (NULL per presentatori non-senatori)"
         },
         {
           "name": "data_aggiunta_firma",
           "type": "DATE",
           "role": "dimension",
-          "description": ""
+          "description": "Data in cui il firmatario ha aggiunto la firma"
         },
         {
           "name": "data_ritiro_firma",
           "type": "DATE",
           "role": "dimension",
-          "description": ""
+          "description": "Data di ritiro della firma (NULL = firma ancora valida)"
         },
         {
           "name": "deputato_url",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "URI del deputato Camera (per presentatori \"On.\"; NULL per senatori/governativi)"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -14178,6 +14178,94 @@
       "category": "politica"
     },
     {
+      "slug": "senato_firmatari",
+      "name": "Senato Firmatari",
+      "description": "",
+      "source": "",
+      "source_id": "dati_senato",
+      "period": {
+        "start": 2022,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "ddl",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "ddl_id",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "iniziativa",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "presentatore",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "tipo_iniziativa",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "primo_firmatario",
+          "type": "BOOLEAN",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "senatore_id",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_aggiunta_firma",
+          "type": "DATE",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "data_ritiro_firma",
+          "type": "DATE",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "deputato_url",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/senato_firmatari/2026/senato_firmatari_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto",
+      "tags": [
+        "politica",
+        "senato",
+        "ddl",
+        "firmatari",
+        "iter-legislativo"
+      ],
+      "category": "politica"
+    },
+    {
       "slug": "silos_infrastrutture",
       "name": "Infrastrutture strategiche e prioritarie (SILOS)",
       "description": "Censimento delle infrastrutture strategiche e prioritarie in Italia. Report annuale del Servizio Studi della Camera dei Deputati. Per ogni opera: CUP, denominazione, soggetto competente, localizzazione, stato di attuazione, costi, disponibilità finanziaria e fabbisogno residuo in milioni di euro.",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -4,9 +4,9 @@
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 112,
+    "total": 113,
     "by_status": {
-      "ok": 112,
+      "ok": 113,
       "warn": 0,
       "error": 0
     }
@@ -1277,10 +1277,10 @@
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "30924328812",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30924328812",
+        "run_id": "30934746986",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30934746986",
         "checked_at": "2026-08-04",
-        "duration_seconds": 3.21,
+        "duration_seconds": 3.15,
         "row_counts": {
           "raw": 7505,
           "clean": 7579,
@@ -2473,6 +2473,41 @@
           2025
         ],
         "config_path": "support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml"
+      }
+    },
+    {
+      "id": "senato-firmatari",
+      "source_id": "dati_senato",
+      "status": "ok",
+      "label": "senato-firmatari",
+      "detail": "anni: ? — fonte: ? — mart: sì",
+      "action": "",
+      "latest_run": {
+        "status": "passed",
+        "run_id": "30934746986",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30934746986",
+        "checked_at": "2026-08-04",
+        "duration_seconds": 35.31,
+        "row_counts": {
+          "raw": 37992,
+          "clean": 37992,
+          "mart": 4664
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
+        "years": [
+          2026
+        ],
+        "config_path": "support_datasets/senato-firmatari/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #796 — fix(governo): end_date/interim + mart durata reale; feat(senato-firmatari): presentatori ddl (issue #781)

Changed candidate/support roots:

- `membri-governo` (candidate, `candidates/membri-governo`)
- `senato-firmatari` (support_dataset, `support_datasets/senato-firmatari`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/membri-governo/dataset.yml` -> artifact `sample-run-membri-governo`
- `support_datasets/senato-firmatari/dataset.yml` -> artifact `sample-run-senato-firmatari`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
