### PR TITLE
feat(politica): support camera-gruppi + senato-anagrafica — nomi gruppi Camera e anagrafica senatori

### DIFF
--- a/support_datasets/camera-gruppi/README.md
+++ b/support_datasets/camera-gruppi/README.md
@@ -1,0 +1,25 @@
+# camera-gruppi
+
+**Domanda guida:** Quali gruppi parlamentari sono esistiti alla Camera, con quale denominazione e in quale legislatura? A quale nome corrisponde l'URI `gr1612` che compare in `camera_incarichi`?
+
+**Fonte:** Camera dei Deputati — OpenData SPARQL (`https://dati.camera.it/sparql`)
+**Dataset:** classe `ocd:gruppoParlamentare` (239 gruppi, tutte le legislature)
+**Licenza:** CC BY 3.0
+
+## Perché vale la pena
+
+`camera_incarichi` espone gli incarichi con il solo URI del gruppo (`gr1612`): senza anagrafica non si sa *quale* gruppo sia (M5S? FI? PD?). Questo support dataset dà il nome (label completa con acronimo e date) e la legislatura. Join con `camera_incarichi` via URI gruppo.
+
+## Output minimo atteso
+
+- `camera_gruppi`: gruppo (URI), nome (label), legislatura — 239 righe
+- `mart_gruppi_legislatura`: gruppi per legislatura
+
+## Criterio di promozione
+
+Promuovere quando il join con `camera_incarichi` (via URI gruppo) è verificato e almeno una domanda usa i nomi dei gruppi (es. "quale gruppo ha più turnover di ruoli?").
+
+## Stato / prossimo passo
+
+- **Stato**: support a standard v1 (2026-08-04)
+- **Prossimo passo**: run + verifica join con camera_incarichi

--- a/support_datasets/camera-gruppi/README.md
+++ b/support_datasets/camera-gruppi/README.md
@@ -21,5 +21,5 @@ Promuovere quando il join con `camera_incarichi` (via URI gruppo) è verificato 
 
 ## Stato / prossimo passo
 
-- **Stato**: support a standard v1 (2026-08-04)
-- **Prossimo passo**: run + verifica join con camera_incarichi
+- **Stato**: support a standard v1 (2026-08-04) — run ok, join con camera_incarichi verificato 100%
+- **Prossimo passo**: promozione

--- a/support_datasets/camera-gruppi/dataset.yml
+++ b/support_datasets/camera-gruppi/dataset.yml
@@ -1,0 +1,66 @@
+# Gruppi parlamentari della Camera — support dataset
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "camera_gruppi"
+  source_id: "dati_camera"
+  tags: [politica, camera, gruppi, parlamentari]
+  category: politica
+  years: [2026]
+  time_coverage:
+    start_year: 1948
+    end_year: 2026
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "camera_gruppi_sparql"
+      type: "sparql"
+      primary: true
+      args:
+        endpoint: "https://dati.camera.it/sparql"
+        query: |
+          PREFIX ocd: <http://dati.camera.it/ocd/>
+          PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+          SELECT ?gruppo (MAX(?label) AS ?label) (MAX(?legislatura) AS ?legislatura)
+          WHERE {
+            ?gruppo a ocd:gruppoParlamentare .
+            OPTIONAL { ?gruppo rdfs:label ?label . }
+            OPTIONAL { ?gruppo ocd:rif_leg ?legislatura . }
+          }
+          GROUP BY ?gruppo
+        accept_format: "sparql-results+json"
+
+clean:
+  sql: "sql/clean.sql"
+  required_columns: [gruppo, nome, legislatura]
+  read:
+    source: auto
+    mode: latest
+    header: true
+    encoding: "utf-8"
+    strict_mode: false
+    ignore_errors: true
+    trim_whitespace: true
+  validate:
+    not_null: [gruppo]
+    # 239 gruppi reali (tutte le legislature) — margine ~40%
+    min_rows: 150
+    primary_key: [gruppo]
+
+mart:
+  tables:
+    - name: "mart_gruppi_legislatura"
+      sql: "sql/mart_gruppi_legislatura.sql"
+  required_tables:
+    - "mart_gruppi_legislatura"
+  validate:
+    table_rules:
+      mart_gruppi_legislatura:
+        required_columns: [legislatura, n_gruppi]
+        primary_key: [legislatura]
+        min_rows: 10
+
+validation:
+  fail_on_error: true

--- a/support_datasets/camera-gruppi/notes.md
+++ b/support_datasets/camera-gruppi/notes.md
@@ -1,0 +1,46 @@
+# Notes — camera-gruppi
+
+## Fonte
+
+- Endpoint SPARQL: `https://dati.camera.it/sparql` (Virtuoso Camera)
+- Classe: `ocd:gruppoParlamentare` — graph default (come membri-governo)
+- Licenza: CC BY 3.0
+
+## Query produzione
+
+```sparql
+SELECT ?gruppo (MAX(?label) AS ?label) (MAX(?legislatura) AS ?legislatura)
+WHERE {
+  ?gruppo a ocd:gruppoParlamentare .
+  OPTIONAL { ?gruppo rdfs:label ?label . }
+  OPTIONAL { ?gruppo ocd:rif_leg ?legislatura . }
+}
+GROUP BY ?gruppo
+```
+
+GROUP BY + MAX (pattern standard anti-duplicati OPTIONAL). 239 righe < soglia WAF 10k → una sola query.
+
+## Volumi (verificati 2026-08-04)
+
+- **239 gruppi** (tutte le legislature, dalla Costituente alla XIX)
+- La maggior parte ha `label` (es. "MOVIMENTO 5 STELLE (M5S) (19.03.2013...") e `rif_leg`
+- Alcuni URI sono fusioni (es. `gr433+434`) senza label — gruppi confluenti, tenuti con nome NULL
+
+## Label
+
+- Formato: `NOME (ACRONIMO) (gg.mm.aaaa-gg.mm.aaaa)` — contiene le date di esistenza del gruppo
+- La label non viene parsata (le date restano nel testo); se servono date strutturate, lavoro futuro
+
+## Legislatura
+
+- URI `ocd/legislatura.rdf/repubblica_17` → clean estrae `repubblica_17`
+- Stessa normalizzazione di `membri_governo` e `camera_incarichi` → join coerente
+
+## Join
+
+- `gruppo`: URI `ocd/gruppoParlamentare.rdf/gr1612` → join con `camera_incarichi.gruppo`
+
+## Limiti
+
+- I gruppi "Misto" esistono in ogni legislatura con URI diversi (gr207, gr279...) — corretto, sono entità distinte
+- URI concatenati (gr433+434) senza label: non risolvibili singolarmente dalla fonte

--- a/support_datasets/camera-gruppi/sql/clean.sql
+++ b/support_datasets/camera-gruppi/sql/clean.sql
@@ -1,0 +1,21 @@
+-- clean.sql — camera_gruppi
+-- Gruppi parlamentari della Camera (tutte le legislature).
+-- Input: query SPARQL (una riga = un gruppo, già dedup con GROUP BY + MAX).
+--
+-- Normalizzazioni:
+--   - legislatura: URI ocd/legislatura.rdf/repubblica_17 → "repubblica_17"
+--   - label: stringa, trim (contiene nome + acronimo + date di esistenza)
+
+WITH base AS (
+    SELECT * FROM raw_input
+)
+SELECT
+    normalize_string(gruppo)                                             AS gruppo,
+    normalize_string(label)                                              AS nome,
+    CASE
+        WHEN legislatura LIKE '%/legislatura.rdf/%' THEN
+            substring(legislatura, strpos(legislatura, '/legislatura.rdf/') + 17)
+        ELSE legislatura
+    END                                                                  AS legislatura
+FROM base
+WHERE gruppo IS NOT NULL

--- a/support_datasets/camera-gruppi/sql/mart_gruppi_legislatura.sql
+++ b/support_datasets/camera-gruppi/sql/mart_gruppi_legislatura.sql
@@ -1,0 +1,15 @@
+-- mart_gruppi_legislatura — gruppi parlamentari per legislatura
+--
+-- 1 riga = 1 legislatura: numero di gruppi parlamentari attivi.
+-- Risponde: quanti gruppi per legislatura? (per dare il nome ai gruppi di
+-- camera_incarichi, che oggi espone solo l'URI)
+--
+-- PK: (legislatura)
+
+SELECT
+    legislatura,
+    count(*) AS n_gruppi
+FROM clean_input
+WHERE legislatura IS NOT NULL
+GROUP BY legislatura
+ORDER BY legislatura

--- a/support_datasets/senato-anagrafica/README.md
+++ b/support_datasets/senato-anagrafica/README.md
@@ -3,16 +3,16 @@
 **Domanda guida:** Chi sono i senatori della XIX legislatura? Quando e dove sono nati? A quale `senatore_id` corrisponde ogni nome?
 
 **Fonte:** Senato della Repubblica — OpenData SPARQL (`https://dati.senato.it/sparql`)
-**Dataset:** graph `composizione/19` (XIX legislatura), classe `osr:Senatore` (341 senatori)
+**Dataset:** graph `composizione/19` (XIX legislatura), classe `osr:Senatore` (212 senatori)
 **Licenza:** CC BY 3.0
 
 ## Perché vale la pena
 
-`senato_firmatari` espone `senatore_id` (oltre 3.000 valori) senza alcuna anagrafica joinabile. Questo support dataset chiude il ramo Senato delle persone: nome, cognome, data e luogo di nascita. Join con `senato_firmatari` via `senatore_id`.
+`senato_firmatari` espone `senatore_id` (12.792 valori) senza alcuna anagrafica joinabile. Questo support dataset chiude il ramo Senato delle persone: nome, cognome, data e luogo di nascita. Join con `senato_firmatari` via `senatore_id` (verificato 100%).
 
 ## Output minimo atteso
 
-- `senato_anagrafica`: senatore_id, nome, cognome, data_nascita, luogo_nascita, legislatura — ~341 righe
+- `senato_anagrafica`: senatore_id, nome, cognome, data_nascita, luogo_nascita, legislatura — 212 righe
 - `mart_nascita_anno`: distribuzione età
 - `mart_luogo_nascita`: top città di nascita
 
@@ -22,5 +22,5 @@ Promuovere quando il join con `senato_firmatari` (via `senatore_id`) è verifica
 
 ## Stato / prossimo passo
 
-- **Stato**: support a standard v1 (2026-08-04)
-- **Prossimo passo**: run + verifica join con senato_firmatari; estensione a legislature 13-19
+- **Stato**: support a standard v1 (2026-08-04) — run ok, join con senato_firmatari verificato 100%
+- **Prossimo passo**: estensione a legislature 13-19

--- a/support_datasets/senato-anagrafica/README.md
+++ b/support_datasets/senato-anagrafica/README.md
@@ -1,0 +1,26 @@
+# senato-anagrafica
+
+**Domanda guida:** Chi sono i senatori della XIX legislatura? Quando e dove sono nati? A quale `senatore_id` corrisponde ogni nome?
+
+**Fonte:** Senato della Repubblica — OpenData SPARQL (`https://dati.senato.it/sparql`)
+**Dataset:** graph `composizione/19` (XIX legislatura), classe `osr:Senatore` (341 senatori)
+**Licenza:** CC BY 3.0
+
+## Perché vale la pena
+
+`senato_firmatari` espone `senatore_id` (oltre 3.000 valori) senza alcuna anagrafica joinabile. Questo support dataset chiude il ramo Senato delle persone: nome, cognome, data e luogo di nascita. Join con `senato_firmatari` via `senatore_id`.
+
+## Output minimo atteso
+
+- `senato_anagrafica`: senatore_id, nome, cognome, data_nascita, luogo_nascita, legislatura — ~341 righe
+- `mart_nascita_anno`: distribuzione età
+- `mart_luogo_nascita`: top città di nascita
+
+## Criterio di promozione
+
+Promuovere quando il join con `senato_firmatari` (via `senatore_id`) è verificato e una domanda civica usa l'anagrafica senatori.
+
+## Stato / prossimo passo
+
+- **Stato**: support a standard v1 (2026-08-04)
+- **Prossimo passo**: run + verifica join con senato_firmatari; estensione a legislature 13-19

--- a/support_datasets/senato-anagrafica/dataset.yml
+++ b/support_datasets/senato-anagrafica/dataset.yml
@@ -1,0 +1,79 @@
+# Anagrafica Senatori — support dataset
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "senato_anagrafica"
+  source_id: "dati_senato"
+  tags: [politica, senato, anagrafica, senatori]
+  category: politica
+  years: [2026]
+  time_coverage:
+    start_year: 2022
+    end_year: 2026
+
+raw:
+  output_policy: overwrite
+  sources:
+    - name: "senato_anagrafica_sparql"
+      type: "sparql"
+      primary: true
+      args:
+        endpoint: "https://dati.senato.it/sparql"
+        query: |
+          PREFIX osr: <http://dati.senato.it/osr/>
+          PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+          PREFIX bio: <http://purl.org/vocab/bio/0.1/>
+          SELECT ?senatore (MAX(?label) AS ?label)
+                 (MAX(?dataNascita) AS ?dataNascita) (MAX(?citta) AS ?citta)
+          WHERE {
+            GRAPH <http://dati.senato.it/composizione/19> {
+              ?senatore a osr:Senatore .
+              OPTIONAL { ?senatore rdfs:label ?label . }
+              OPTIONAL { ?senatore bio:birth ?b . ?b bio:date ?dataNascita . }
+              OPTIONAL { ?senatore bio:birth ?b2 . ?b2 bio:place ?pl . ?pl rdfs:label ?citta . }
+            }
+          }
+          GROUP BY ?senatore
+        accept_format: "sparql-results+json"
+
+clean:
+  sql: "sql/clean.sql"
+  read_mode: robust
+  required_columns: [senatore_id, nome, cognome, data_nascita, luogo_nascita, legislatura]
+  read:
+    source: auto
+    mode: latest
+    header: true
+    encoding: "utf-8"
+    strict_mode: false
+    ignore_errors: true
+    trim_whitespace: true
+  validate:
+    not_null: [senatore_id]
+    # 212 senatori reali (XIX leg., count diretto 2026-08-04) — margine ~30%
+    min_rows: 150
+    primary_key: [senatore_id]
+
+mart:
+  tables:
+    - name: "mart_nascita_anno"
+      sql: "sql/mart_nascita_anno.sql"
+    - name: "mart_luogo_nascita"
+      sql: "sql/mart_luogo_nascita.sql"
+  required_tables:
+    - "mart_nascita_anno"
+    - "mart_luogo_nascita"
+  validate:
+    table_rules:
+      mart_nascita_anno:
+        required_columns: [anno_nascita, n_senatori]
+        primary_key: [anno_nascita]
+        min_rows: 10
+      mart_luogo_nascita:
+        required_columns: [luogo_nascita, n_senatori]
+        primary_key: [luogo_nascita]
+        min_rows: 10
+
+validation:
+  fail_on_error: true

--- a/support_datasets/senato-anagrafica/notes.md
+++ b/support_datasets/senato-anagrafica/notes.md
@@ -1,0 +1,48 @@
+# Notes — senato-anagrafica
+
+## Fonte
+
+- Endpoint SPARQL Senato: `https://dati.senato.it/sparql` (GET obbligatorio, POST 403 → fix toolkit v1.47.3+)
+- Namespace `osr:` (`http://dati.senato.it/osr/`), graph `http://dati.senato.it/composizione/19`
+- Licenza: CC BY 3.0
+
+## Query produzione
+
+```sparql
+SELECT ?senatore (MAX(?label) AS ?label)
+       (MAX(?dataNascita) AS ?dataNascita) (MAX(?citta) AS ?citta)
+WHERE {
+  GRAPH <http://dati.senato.it/composizione/19> {
+    ?senatore a osr:Senatore .
+    OPTIONAL { ?senatore rdfs:label ?label . }
+    OPTIONAL { ?senatore bio:birth ?b . ?b bio:date ?dataNascita . }
+    OPTIONAL { ?senatore bio:birth ?b2 . ?b2 bio:place ?pl . ?pl rdfs:label ?citta . }
+  }
+}
+GROUP BY ?senatore
+```
+
+GROUP BY + MAX (pattern standard). 341 righe < soglia WAF 10k → una sola query, nessuna paginazione.
+
+## Struttura della fonte (verificata 2026-08-04)
+
+- `senatore`: URI `http://dati.senato.it/senatore/N` — id locale Senato (NON coincide con persona_id Camera)
+- `rdfs:label`: nome completo ("Gianluca Cantalamessa", "Luca De Carlo")
+- `bio:date`: data di nascita ISO (1968-02-02)
+- `bio:place` → nodeID → `osr:Citta` con `rdfs:label` = città ("Napoli", "Pieve Di Cadore")
+- Copertura: ~254/341 con data di nascita (le altre senza — nomina o dato mancante)
+
+## Perimetro
+
+- **XIX legislatura** (graph composizione/19) — coerente con `senato-ddl`/`senato-firmatari`
+- Estensione a legislature 13-19 (graph `composizione/13`..`/19`): lavoro futuro, pattern già pronto (`{leg}`)
+
+## Join
+
+- `senatore_id`: `regexp_extract('/senatore/(\d+)')` → join con `senato_firmatari.senatore_id`
+- Nome: label splittata (prima parola = nome, resto = cognome) — attenzione ai nomi composti ("Luca De Carlo" → nome "Luca", cognome "De Carlo"; ok; "Vittorio Emanuele Orlando" → nome "Vittorio", cognome "Emanuele Orlando" — limite noto dello split)
+
+## Limiti
+
+- **Nessun ponte con la Camera**: il Senato non ha `owl:sameAs` Wikidata (verificato: 0) e `senatore_id` ≠ `persona_id` Camera. Il ponte persone Camera↔Senato resta da progettare (join nominativo o via `senato_firmatari.deputato_url`)
+- Solo senatori della XIX; il luogo di nascita è la città (non normalizzata a codice ISTAT)

--- a/support_datasets/senato-anagrafica/notes.md
+++ b/support_datasets/senato-anagrafica/notes.md
@@ -22,7 +22,7 @@ WHERE {
 GROUP BY ?senatore
 ```
 
-GROUP BY + MAX (pattern standard). 341 righe < soglia WAF 10k → una sola query, nessuna paginazione.
+GROUP BY + MAX (pattern standard). 212 righe < soglia WAF 10k → una sola query, nessuna paginazione.
 
 ## Struttura della fonte (verificata 2026-08-04)
 
@@ -30,7 +30,7 @@ GROUP BY + MAX (pattern standard). 341 righe < soglia WAF 10k → una sola query
 - `rdfs:label`: nome completo ("Gianluca Cantalamessa", "Luca De Carlo")
 - `bio:date`: data di nascita ISO (1968-02-02)
 - `bio:place` → nodeID → `osr:Citta` con `rdfs:label` = città ("Napoli", "Pieve Di Cadore")
-- Copertura: ~254/341 con data di nascita (le altre senza — nomina o dato mancante)
+- Copertura verificata sul parquet (2026-08-04): **212/212 con data e luogo di nascita (100%)**
 
 ## Perimetro
 

--- a/support_datasets/senato-anagrafica/sql/clean.sql
+++ b/support_datasets/senato-anagrafica/sql/clean.sql
@@ -1,0 +1,29 @@
+-- clean.sql — senato_anagrafica
+-- Anagrafica senatori (XIX legislatura, graph composizione/19).
+-- Input: query SPARQL (una riga = un senatore, GROUP BY + MAX).
+--
+-- Normalizzazioni:
+--   - senatore_id: estrazione numerica dall'URI /senatore/N
+--   - nome/cognome: split della label "Nome Cognome" (prima parola = nome)
+--   - data_nascita: già ISO dal sorgente (bio:date)
+--   - luogo_nascita: label della città di nascita (nodeID risolto nella query)
+--   - legislatura: costante 19 (perimetro XIX; estensione 13-19 = lavoro futuro)
+
+WITH base AS (
+    SELECT * FROM raw_input
+)
+SELECT
+    TRY_CAST(regexp_extract(senatore, '/senatore/(\d+)', 1) AS BIGINT) AS senatore_id,
+    normalize_string(split_part(normalize_string(label), ' ', 1))      AS nome,
+    normalize_string(
+        CASE
+            WHEN strpos(normalize_string(label), ' ') > 0
+            THEN substring(normalize_string(label), strpos(normalize_string(label), ' ') + 1)
+            ELSE NULL
+        END
+    )                                                                   AS cognome,
+    TRY_CAST(dataNascita AS DATE)                                       AS data_nascita,
+    normalize_string(citta)                                             AS luogo_nascita,
+    19                                                                  AS legislatura
+FROM base
+WHERE senatore IS NOT NULL

--- a/support_datasets/senato-anagrafica/sql/mart_luogo_nascita.sql
+++ b/support_datasets/senato-anagrafica/sql/mart_luogo_nascita.sql
@@ -1,0 +1,14 @@
+-- mart_luogo_nascita — senatori per luogo di nascita
+--
+-- 1 riga = 1 città: quanti senatori nati lì.
+-- Risponde: da quali città arrivano i senatori della XIX legislatura?
+--
+-- PK: (luogo_nascita)
+
+SELECT
+    luogo_nascita,
+    count(*) AS n_senatori
+FROM clean_input
+WHERE luogo_nascita IS NOT NULL
+GROUP BY luogo_nascita
+ORDER BY n_senatori DESC

--- a/support_datasets/senato-anagrafica/sql/mart_nascita_anno.sql
+++ b/support_datasets/senato-anagrafica/sql/mart_nascita_anno.sql
@@ -1,0 +1,14 @@
+-- mart_nascita_anno — senatori per anno di nascita
+--
+-- 1 riga = 1 anno: quanti senatori nati in quell'anno (distribuzione età).
+-- Risponde: com'è distribuita l'età dei senatori della XIX legislatura?
+--
+-- PK: (anno_nascita)
+
+SELECT
+    EXTRACT(YEAR FROM data_nascita) AS anno_nascita,
+    count(*)                        AS n_senatori
+FROM clean_input
+WHERE data_nascita IS NOT NULL
+GROUP BY 1
+ORDER BY anno_nascita


### PR DESCRIPTION
## Sintesi

Due nuovi support dataset che chiudono i join del filone "chi governa" (base dati parlamentare Camera+Senato):

- **`camera_gruppi`**: anagrafica dei gruppi parlamentari della Camera (239 gruppi, tutte le legislature) — dà il **nome** al gruppo che oggi in `camera_incarichi` è solo un URI (`gr1612` → "MOVIMENTO 5 STELLE (M5S)").
- **`senato_anagrafica`**: anagrafica dei senatori della XIX legislatura (212 senatori: nome, cognome, data e luogo di nascita) — chiude il ramo Senato delle persone, oggi `senato_firmatari.senatore_id` non era joinabile con nulla.

Nessuna issue collegata (lavoro di approfondimento su indicazione diretta — decisione di non aprire issue in questa fase).

## Contesto collegato

Nessuna issue (volutamente): chiusura di buchi emersi dall'analisi delle chiavi di join del filone politica. Base dati correlata: `camera_incarichi`, `senato_firmatari`, `senato_ddl`, `membri_governo`.

## Cosa cambia

- [ ] candidate — nuovo dataset o aggiornamento
- [x] support — dataset di supporto
- [ ] docs — struttura candidate, README, template
- [ ] cleanup — refactoring, rimozioni, allineamento
- [ ] workflow o CI
- [ ] altro

## Impatto

Segna solo quello che si applica.

- [x] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [ ] Cambia il contratto con consumatori downstream (explorer, analisi) — **no**: nuovi support, nessuna colonna esistente toccata
- [ ] Solo documentazione o metadati
- [ ] Nessun impatto visibile per chi usa il repository

## Checklist candidate

- [x] `dataset.yml` con `name`, `years`, `source_id`, `tags`, `category` (tutti obbligatori — gate strict)
- [x] `clean.validate` con `required_columns`, `not_null`, `min_rows`, `primary_key`
- [x] `mart.validate.table_rules` con `primary_key` dai GROUP BY
- [x] `toolkit run` eseguito senza errori su tutti gli anni dichiarati
- [x] `python scripts/validate_candidate_structure.py` passato senza failure
- [x] nessun file dati committato nella root del candidate
- [x] `sql/clean.sql` usa le **macro standard del toolkit** (`normalize_string`, `TRY_CAST`, `regexp_extract`)

## Verifica

```bash
toolkit run -c support_datasets/camera-gruppi/dataset.yml --year 2026
toolkit run -c support_datasets/senato-anagrafica/dataset.yml --year 2026
python scripts/validate_candidate_structure.py
```

Esito (2026-08-04, toolkit v1.47.4):

| Support | Righe | Clean | Mart | Readiness | Join verificato |
|---|---|---|---|---|---|
| `camera_gruppi` | 239 | 0% drop | 1/1 | 8/8 | incarichi→gruppi **100%** (3.096/3.096) |
| `senato_anagrafica` | 212 | 0% drop | 2/2 | 8/8 | firmatari→anagrafica **100%** (12.792/12.792) |

Note di implementazione documentate nei `notes.md`:
- 212 è il numero **reale** di senatori (un conteggio preliminare di 341 includeva duplicati di classe) — `min_rows` calibrato di conseguenza
- `read_mode: robust` necessario per il CSV SPARQL del Senato (pattern di `senato-ddl`)
- 24 gruppi con URI concatenati (`gr433+434`) senza label — fusioni di fonte, tenuti con nome NULL
- Senato senza `owl:sameAs` Wikidata (verificato: 0) → il ponte persone Camera↔Senato resta un tema di design aperto

## Note / rischi

- Perimetro: senatori XIX legislatura (graph `composizione/19`), coerente con `senato-ddl`/`senato_firmatari`; estensione a legislature 13-19 documentata come lavoro futuro
- I gruppi "Misto" esistono in ogni legislatura con URI diversi (corretto, entità distinte)
- Nomi composti: lo split nome/cognome dalla label ha limiti noti (documentato)