### PR TITLE
chore(post-merge): aggiorna registry per PR #798

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2572,6 +2572,51 @@
       "category": "politica"
     },
     {
+      "slug": "camera_gruppi",
+      "name": "Gruppi Parlamentari (Camera)",
+      "description": "Anagrafica dei gruppi parlamentari della Camera dei Deputati: denominazione completa (nome + acronimo + date di esistenza) e legislatura per ogni gruppo. Support di camera_incarichi — join su gruppo (URI). Fonte: dati.camera.it SPARQL, 239 gruppi, tutte le legislature.",
+      "source": "Camera dei Deputati — OpenData SPARQL endpoint (dati.camera.it)",
+      "source_id": "dati_camera",
+      "period": {
+        "start": 1948,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "gruppo",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "URI del gruppo parlamentare (ocd:gruppoParlamentare.rdf/gr...)"
+        },
+        {
+          "name": "nome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Denominazione completa del gruppo (nome + acronimo + date, es. \"MOVIMENTO 5 STELLE (M5S) (19.03.2013...\")"
+        },
+        {
+          "name": "legislatura",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "Legislatura del gruppo (es. repubblica_17, costituente)"
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/camera_gruppi/2026/camera_gruppi_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto",
+      "tags": [
+        "politica",
+        "camera",
+        "gruppi",
+        "parlamentari"
+      ],
+      "category": "politica"
+    },
+    {
       "slug": "camera_incarichi",
       "name": "Incarichi nei Gruppi Parlamentari (Camera)",
       "description": "Incarichi dei deputati nei gruppi parlamentari della Camera: ruolo (presidente, vicepresidente, capogruppo...), gruppo, legislatura e date inizio/fine. Join con camera_deputati_legislature via persona_id (chiave standard del sistema parlamentare). Fonte: dati.camera.it SPARQL, 3.096 incarichi.",
@@ -14008,9 +14053,9 @@
     },
     {
       "slug": "senato_anagrafica",
-      "name": "Senato Anagrafica",
-      "description": "",
-      "source": "",
+      "name": "Anagrafica Senatori (XIX legislatura)",
+      "description": "Anagrafica dei senatori della XIX legislatura: nome, cognome, data e luogo di nascita. Support di senato_firmatari — join su senatore_id. Fonte: dati.senato.it SPARQL (graph composizione/19), 212 senatori.",
+      "source": "Senato della Repubblica — OpenData SPARQL endpoint (dati.senato.it)",
       "source_id": "dati_senato",
       "period": {
         "start": 2022,
@@ -14020,38 +14065,38 @@
         {
           "name": "senatore_id",
           "type": "BIGINT",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "ID numerico del senatore (dall'URI /senatore/N — id locale Senato)"
         },
         {
           "name": "nome",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Nome del senatore"
         },
         {
           "name": "cognome",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Cognome del senatore"
         },
         {
           "name": "data_nascita",
           "type": "DATE",
           "role": "dimension",
-          "description": ""
+          "description": "Data di nascita (bio:date)"
         },
         {
           "name": "luogo_nascita",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Città di nascita"
         },
         {
           "name": "legislatura",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Legislatura (19 = XIX)"
         }
       ],
       "location": {
@@ -14108,7 +14153,8 @@
           "name": "stato",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": "Stato dell'iter legislativo (es. assegnato, approvato, approvato definitivamente)"
+          "description": "Stato dell'iter legislativo (es. assegnato, approvato, approvato definitivamente)",
+          "semantic_type": "country_code"
         },
         {
           "name": "data_presentazione",

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -3,7 +3,7 @@
   "name": "Lab Clean Registry",
   "description": "Catalogo canonico dei clean parquet pubblici prodotti o adottati da dataset-incubator.",
   "source_repo": "dataciviclab/dataset-incubator",
-  "updated_at": "2026-08-04",
+  "updated_at": "2026-08-05",
   "datasets": [
     {
       "slug": "aci_prime_iscrizioni_autovetture",
@@ -14005,6 +14005,69 @@
         "sbarchi"
       ],
       "category": "immigrazione"
+    },
+    {
+      "slug": "senato_anagrafica",
+      "name": "Senato Anagrafica",
+      "description": "",
+      "source": "",
+      "source_id": "dati_senato",
+      "period": {
+        "start": 2022,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "senatore_id",
+          "type": "BIGINT",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "nome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cognome",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "data_nascita",
+          "type": "DATE",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "luogo_nascita",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "legislatura",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/senato_anagrafica/2026/senato_anagrafica_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto",
+      "tags": [
+        "politica",
+        "senato",
+        "anagrafica",
+        "senatori"
+      ],
+      "category": "politica"
     },
     {
       "slug": "senato_ddl",

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-08-04",
+  "generated_at": "2026-08-05",
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 113,
+    "total": 115,
     "by_status": {
-      "ok": 113,
+      "ok": 115,
       "warn": 0,
       "error": 0
     }
@@ -2267,6 +2267,41 @@
       }
     },
     {
+      "id": "camera-gruppi",
+      "source_id": "dati_camera",
+      "status": "ok",
+      "label": "camera-gruppi",
+      "detail": "anni: ? — fonte: ? — mart: sì",
+      "action": "",
+      "latest_run": {
+        "status": "passed",
+        "run_id": "30987598178",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30987598178",
+        "checked_at": "2026-08-05",
+        "duration_seconds": 1.43,
+        "row_counts": {
+          "raw": 239,
+          "clean": 239,
+          "mart": 20
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
+        "years": [
+          2026
+        ],
+        "config_path": "support_datasets/camera-gruppi/dataset.yml"
+      }
+    },
+    {
       "id": "camera-incarichi",
       "source_id": "dati_camera",
       "status": "ok",
@@ -2473,6 +2508,41 @@
           2025
         ],
         "config_path": "support_datasets/popolazione-istat-comunale-2019-2025/dataset.yml"
+      }
+    },
+    {
+      "id": "senato-anagrafica",
+      "source_id": "dati_senato",
+      "status": "ok",
+      "label": "senato-anagrafica",
+      "detail": "anni: ? — fonte: ? — mart: sì",
+      "action": "",
+      "latest_run": {
+        "status": "passed",
+        "run_id": "30987598178",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/30987598178",
+        "checked_at": "2026-08-05",
+        "duration_seconds": 2.48,
+        "row_counts": {
+          "raw": 212,
+          "clean": 212,
+          "mart": 186
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
+        "years": [
+          2026
+        ],
+        "config_path": "support_datasets/senato-anagrafica/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #798 — feat(politica): support camera-gruppi + senato-anagrafica — nomi gruppi Camera e anagrafica senatori

Changed candidate/support roots:

- `camera-gruppi` (support_dataset, `support_datasets/camera-gruppi`)
- `senato-anagrafica` (support_dataset, `support_datasets/senato-anagrafica`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `support_datasets/camera-gruppi/dataset.yml` -> artifact `sample-run-camera-gruppi`
- `support_datasets/senato-anagrafica/dataset.yml` -> artifact `sample-run-senato-anagrafica`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
