### PR TITLE
chore(post-merge): aggiorna registry per PR #801

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -12387,7 +12387,7 @@
       "source": "MEF — Italia Domani (italiadomani.gov.it)",
       "source_id": "mef_italia_domani",
       "period": {
-        "start": 2026,
+        "start": 2021,
         "end": 2026
       },
       "columns": [

--- a/registry/entity_graph.json
+++ b/registry/entity_graph.json
@@ -777,6 +777,12 @@
           "semantic_type": "country_code"
         },
         {
+          "slug": "senato_ddl",
+          "name": "Senato Ddl",
+          "column": "stato",
+          "semantic_type": "country_code"
+        },
+        {
           "slug": "ted_contract_notices",
           "name": "Bandi di gara UE in Italia (TED Contract Notices)",
           "column": "paese",
@@ -784,7 +790,7 @@
         }
       ],
       "types": {
-        "country_code": 3
+        "country_code": 4
       }
     },
     "Persona": {

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -1742,13 +1742,30 @@
       "source_id": "italiadomani",
       "status": "ok",
       "label": "pnrr-progetti",
-      "detail": "anno 2026 — fonte: ? — mart: sì",
+      "detail": "anno 2026 — fonte: pnrr_progetti — mart: sì",
       "action": "",
       "latest_run": {
         "status": "passed",
-        "run_id": "27903429536",
-        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/27903429536",
-        "checked_at": "2026-06-21",
+        "run_id": "31006021383",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/31006021383",
+        "checked_at": "2026-08-05",
+        "duration_seconds": 21.7,
+        "row_counts": {
+          "raw": 291398,
+          "clean": 291398,
+          "mart": 22
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
         "years": [
           2026
         ],


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #801 — fix(pnrr-progetti): download AEM/Akamai + standard v1 + mart stato avanzamento

Changed candidate/support roots:

- `pnrr-progetti` (candidate, `candidates/pnrr-progetti`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/pnrr-progetti/dataset.yml` -> artifact `sample-run-pnrr-progetti`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
