### PR TITLE
chore(post-merge): aggiorna registry per PR #802

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -12532,9 +12532,9 @@
     },
     {
       "slug": "pnrr_pagamenti",
-      "name": "Pnrr Pagamenti",
-      "description": "",
-      "source": "",
+      "name": "PNRR Pagamenti — Italia Domani",
+      "description": "Pagamenti registrati per i progetti PNRR (fonte ReGiS): per ogni CUP/CLP il finanziamento totale e PNRR, i pagamenti effettivi (totale, quota PNRR e riparto per fonte) e la data di estrazione. 211.901 righe, €101,9 mld pagamenti PNRR. Fonte: MEF Italia Domani.",
+      "source": "MEF — Italia Domani (italiadomani.gov.it)",
       "source_id": "italiadomani",
       "period": {
         "start": 2021,
@@ -12545,140 +12545,140 @@
           "name": "codice_univoco_submisura",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice univoco della submisura PNRR"
         },
         {
           "name": "descrizione_submisura",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Descrizione della submisura"
         },
         {
           "name": "cup",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": "",
+          "description": "Codice Unico Progetto — chiave di join",
           "semantic_type": "cup_code"
         },
         {
           "name": "codice_locale_progetto",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": ""
+          "description": "Codice locale del progetto"
         },
         {
           "name": "finanziamento_totale",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Finanziamento totale del progetto (€)"
         },
         {
           "name": "finanziamento_pnrr",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Finanziamento PNRR del progetto (€)"
         },
         {
           "name": "pagamento_totale",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Pagamenti totali registrati (€)"
         },
         {
           "name": "pagamento_pnrr",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Pagamenti quota PNRR (€)"
         },
         {
           "name": "pagamento_stato",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Pagamenti fonte Stato (€)"
         },
         {
           "name": "pagamento_stato_bilancio",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Pagamenti Stato - Bilancio (€)"
         },
         {
           "name": "pagamento_stato_foi",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Pagamenti Stato - FOI (€)"
         },
         {
           "name": "pagamento_fpop",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Pagamenti Prosecuzione Opere Pubbliche FPOP (€)"
         },
         {
           "name": "pagamento_ue",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Pagamenti UE diversi da PNRR (€)"
         },
         {
           "name": "pagamento_regione",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Pagamenti fonte Regione (€)"
         },
         {
           "name": "pagamento_provincia",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Pagamenti fonte Provincia (€)"
         },
         {
           "name": "pagamento_comune",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Pagamenti fonte Comune (€)"
         },
         {
           "name": "pagamento_altro_pubblico",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Pagamenti Altro Pubblico (€)"
         },
         {
           "name": "pagamento_privato",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Pagamenti fonte Privato (€)"
         },
         {
           "name": "pagamento_da_reperire",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Pagamenti da reperire (€)"
         },
         {
           "name": "pagamento_pnc",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Pagamenti PNC (€)"
         },
         {
           "name": "pagamento_altri_fondi",
           "type": "DOUBLE",
           "role": "metric",
-          "description": ""
+          "description": "Pagamenti altri fondi (€)"
         },
         {
           "name": "data_estrazione",
           "type": "TIMESTAMP",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Data di estrazione del dato"
         },
         {
           "name": "anno_estrazione",
           "type": "INTEGER",
-          "role": "metric",
-          "description": ""
+          "role": "dimension",
+          "description": "Anno di estrazione del dato"
         }
       ],
       "location": {

--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -12531,6 +12531,172 @@
       "category": "finanza-pubblica"
     },
     {
+      "slug": "pnrr_pagamenti",
+      "name": "Pnrr Pagamenti",
+      "description": "",
+      "source": "",
+      "source_id": "italiadomani",
+      "period": {
+        "start": 2021,
+        "end": 2026
+      },
+      "columns": [
+        {
+          "name": "codice_univoco_submisura",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "descrizione_submisura",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "cup",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": "",
+          "semantic_type": "cup_code"
+        },
+        {
+          "name": "codice_locale_progetto",
+          "type": "VARCHAR",
+          "role": "dimension",
+          "description": ""
+        },
+        {
+          "name": "finanziamento_totale",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "finanziamento_pnrr",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pagamento_totale",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pagamento_pnrr",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pagamento_stato",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pagamento_stato_bilancio",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pagamento_stato_foi",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pagamento_fpop",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pagamento_ue",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pagamento_regione",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pagamento_provincia",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pagamento_comune",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pagamento_altro_pubblico",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pagamento_privato",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pagamento_da_reperire",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pagamento_pnc",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "pagamento_altri_fondi",
+          "type": "DOUBLE",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "data_estrazione",
+          "type": "TIMESTAMP",
+          "role": "metric",
+          "description": ""
+        },
+        {
+          "name": "anno_estrazione",
+          "type": "INTEGER",
+          "role": "metric",
+          "description": ""
+        }
+      ],
+      "location": {
+        "type": "gcs",
+        "path": "gs://dataciviclab-clean/pnrr_pagamenti/2026/pnrr_pagamenti_2026_clean.parquet",
+        "multi_file": false
+      },
+      "stage": "published",
+      "registry_source": "derive_auto",
+      "tags": [
+        "finanza-pubblica",
+        "pnrr",
+        "pagamenti",
+        "rendicontazione"
+      ],
+      "category": "finanza-pubblica"
+    },
+    {
       "slug": "pnrr_progetti",
       "name": "PNRR Progetti — Italia Domani",
       "description": "Progetti finanziati dal PNRR (Piano Nazionale di Ripresa e Resilienza): programma, missione, CUP, finanziamenti, soggetto attuatore, stato avanzamento. 63 colonne, 280k righe. Fonte: MEF Italia Domani.",

--- a/registry/entity_graph.json
+++ b/registry/entity_graph.json
@@ -757,13 +757,13 @@
         },
         {
           "slug": "pnrr_gare",
-          "name": "Pnrr Gare",
+          "name": "PNRR Gare — Italia Domani",
           "column": "cig",
           "semantic_type": "cig_code"
         },
         {
           "slug": "pnrr_gare",
-          "name": "Pnrr Gare",
+          "name": "PNRR Gare — Italia Domani",
           "column": "cig_accordo_quadro",
           "semantic_type": "cig_code"
         }
@@ -913,7 +913,13 @@
         },
         {
           "slug": "pnrr_gare",
-          "name": "Pnrr Gare",
+          "name": "PNRR Gare — Italia Domani",
+          "column": "cup",
+          "semantic_type": "cup_code"
+        },
+        {
+          "slug": "pnrr_pagamenti",
+          "name": "Pnrr Pagamenti",
           "column": "cup",
           "semantic_type": "cup_code"
         },
@@ -937,7 +943,7 @@
         }
       ],
       "types": {
-        "cup_code": 8
+        "cup_code": 9
       }
     },
     "Provincia": {
@@ -2427,6 +2433,19 @@
     {
       "from": {
         "entity": "Progetto",
+        "dataset": "pnrr_pagamenti",
+        "via": "cup_code"
+      },
+      "to": {
+        "entity": "Comune",
+        "bridge": "anac_cup",
+        "on": "cup",
+        "semantic_type": "municipality_code"
+      }
+    },
+    {
+      "from": {
+        "entity": "Progetto",
         "dataset": "pnrr_progetti",
         "via": "cup_code"
       },
@@ -2479,6 +2498,6 @@
   ],
   "summary": {
     "total_entities": 17,
-    "total_relations": 27
+    "total_relations": 28
   }
 }

--- a/registry/pipeline_signals.json
+++ b/registry/pipeline_signals.json
@@ -4,9 +4,9 @@
   "repo": "dataset-incubator",
   "topic": "pipeline_state",
   "summary": {
-    "total": 116,
+    "total": 117,
     "by_status": {
-      "ok": 116,
+      "ok": 117,
       "warn": 0,
       "error": 0
     }
@@ -1770,6 +1770,41 @@
           2026
         ],
         "config_path": "candidates/pnrr-gare/dataset.yml"
+      }
+    },
+    {
+      "id": "pnrr-pagamenti",
+      "source_id": "italiadomani",
+      "status": "ok",
+      "label": "pnrr-pagamenti",
+      "detail": "anno 2026 — fonte: pnrr_pagamenti — mart: sì",
+      "action": "",
+      "latest_run": {
+        "status": "passed",
+        "run_id": "31007324120",
+        "run_url": "https://github.com/dataciviclab/dataset-incubator/actions/runs/31007324120",
+        "checked_at": "2026-08-05",
+        "duration_seconds": 11.34,
+        "row_counts": {
+          "raw": 211901,
+          "clean": 211901,
+          "mart": 214
+        },
+        "readiness": "ready",
+        "readiness_checks": {
+          "total": 8,
+          "ok": 8,
+          "fail": 0
+        },
+        "quality_scores": {
+          "raw": 100.0,
+          "clean": 100.0,
+          "mart": 100.0
+        },
+        "years": [
+          2026
+        ],
+        "config_path": "candidates/pnrr-pagamenti/dataset.yml"
       }
     },
     {


### PR DESCRIPTION
## Post-merge registry handoff

Source PR: #802 — feat(pnrr): intake pnrr-pagamenti — pagamenti PNRR da Italia Domani

Changed candidate/support roots:

- `pnrr-pagamenti` (candidate, `candidates/pnrr-pagamenti`)

## Cosa ha fatto CI

- [x] Full run toolkit (tutti gli anni)
- [x] Clean parquet pushato su GCS
- [x] Mart parquet pushato su GCS
- [x] `registry/pipeline_signals.json` aggiornato
- [x] `registry/clean_catalog.json` auto-derivato

## Sample-run artifacts

- `candidates/pnrr-pagamenti/dataset.yml` -> artifact `sample-run-pnrr-pagamenti`

## Cosa fare (solo per slug nuovi)

1. Compilare `name`, `description`, `source`, `source_id`, e descrizioni/role delle colonne in `registry/clean_catalog.json`
2. `python scripts/build_clean_catalog.py --check-gcs`
3. Commit, push, mergiare la PR
