### PR TITLE
chore(registry): semantic types senator_id/ddl_id/gruppo_parlamentare + entity graph per il filone politica

### DIFF
--- a/registry/clean_catalog.json
+++ b/registry/clean_catalog.json
@@ -2586,7 +2586,8 @@
           "name": "gruppo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": "URI del gruppo parlamentare (ocd:gruppoParlamentare.rdf/gr...)"
+          "description": "URI del gruppo parlamentare (ocd:gruppoParlamentare.rdf/gr...)",
+          "semantic_type": "gruppo_parlamentare"
         },
         {
           "name": "nome",
@@ -2662,7 +2663,8 @@
           "name": "gruppo",
           "type": "VARCHAR",
           "role": "dimension",
-          "description": "URI del gruppo parlamentare"
+          "description": "URI del gruppo parlamentare",
+          "semantic_type": "gruppo_parlamentare"
         },
         {
           "name": "legislatura",
@@ -14382,7 +14384,8 @@
           "name": "senatore_id",
           "type": "BIGINT",
           "role": "dimension",
-          "description": "ID numerico del senatore (dall'URI /senatore/N — id locale Senato)"
+          "description": "ID numerico del senatore (dall'URI /senatore/N — id locale Senato)",
+          "semantic_type": "senator_id"
         },
         {
           "name": "nome",
@@ -14445,7 +14448,8 @@
           "name": "id_ddl",
           "type": "BIGINT",
           "role": "metric",
-          "description": "Identificativo numerico del disegno di legge (osr:idDdl)"
+          "description": "Identificativo numerico del disegno di legge (osr:idDdl)",
+          "semantic_type": "ddl_id"
         },
         {
           "name": "ddl_url",
@@ -14641,7 +14645,8 @@
           "name": "ddl_id",
           "type": "BIGINT",
           "role": "metric",
-          "description": "Identificativo numerico del ddl (osr:idDdl — numerazione interna condivisa con senato-ddl; NON è l'id dell'URI /ddl/N)"
+          "description": "Identificativo numerico del ddl (osr:idDdl — numerazione interna condivisa con senato-ddl; NON è l'id dell'URI /ddl/N)",
+          "semantic_type": "ddl_id"
         },
         {
           "name": "iniziativa",
@@ -14671,7 +14676,8 @@
           "name": "senatore_id",
           "type": "BIGINT",
           "role": "metric",
-          "description": "ID numerico del senatore dall'URI /senatore/N (NULL per presentatori non-senatori)"
+          "description": "ID numerico del senatore dall'URI /senatore/N (NULL per presentatori non-senatori)",
+          "semantic_type": "senator_id"
         },
         {
           "name": "data_aggiunta_firma",

--- a/registry/entity_graph.json
+++ b/registry/entity_graph.json
@@ -23,6 +23,27 @@
         "ateco_code": 2
       }
     },
+    "Atto legislativo": {
+      "entity": "Atto legislativo",
+      "label": "Atto legislativo / Disegno di legge",
+      "datasets": [
+        {
+          "slug": "senato_ddl",
+          "name": "Senato Ddl",
+          "column": "id_ddl",
+          "semantic_type": "ddl_id"
+        },
+        {
+          "slug": "senato_firmatari",
+          "name": "Senato Firmatari",
+          "column": "ddl_id",
+          "semantic_type": "ddl_id"
+        }
+      ],
+      "types": {
+        "ddl_id": 2
+      }
+    },
     "Categoria merceologica": {
       "entity": "Categoria merceologica",
       "label": "Categoria merceologica",
@@ -772,6 +793,27 @@
         "cig_code": 15
       }
     },
+    "Gruppo parlamentare": {
+      "entity": "Gruppo parlamentare",
+      "label": "Gruppo parlamentare",
+      "datasets": [
+        {
+          "slug": "camera_gruppi",
+          "name": "Gruppi Parlamentari (Camera)",
+          "column": "gruppo",
+          "semantic_type": "gruppo_parlamentare"
+        },
+        {
+          "slug": "camera_incarichi",
+          "name": "Incarichi nei Gruppi Parlamentari (Camera)",
+          "column": "gruppo",
+          "semantic_type": "gruppo_parlamentare"
+        }
+      ],
+      "types": {
+        "gruppo_parlamentare": 2
+      }
+    },
     "Nazione": {
       "entity": "Nazione",
       "label": "Nazione",
@@ -826,10 +868,23 @@
           "name": "Membri dei Governi italiani (1862-2026)",
           "column": "persona_id",
           "semantic_type": "person_id"
+        },
+        {
+          "slug": "senato_anagrafica",
+          "name": "Anagrafica Senatori (XIX legislatura)",
+          "column": "senatore_id",
+          "semantic_type": "senator_id"
+        },
+        {
+          "slug": "senato_firmatari",
+          "name": "Senato Firmatari",
+          "column": "senatore_id",
+          "semantic_type": "senator_id"
         }
       ],
       "types": {
-        "person_id": 3
+        "person_id": 3,
+        "senator_id": 2
       }
     },
     "Procedimento": {
@@ -919,7 +974,7 @@
         },
         {
           "slug": "pnrr_pagamenti",
-          "name": "Pnrr Pagamenti",
+          "name": "PNRR Pagamenti — Italia Domani",
           "column": "cup",
           "semantic_type": "cup_code"
         },
@@ -2497,7 +2552,7 @@
     }
   ],
   "summary": {
-    "total_entities": 17,
+    "total_entities": 19,
     "total_relations": 28
   }
 }

--- a/registry/semantic_types.yaml
+++ b/registry/semantic_types.yaml
@@ -278,6 +278,26 @@ types:
     weight: 15
     note: "Chiave standard del sistema parlamentare (deputati, senatori, membri governo). Ponte tra rami via URI persona."
 
+  senator_id:
+    description: "ID numerico del senatore (es. 3923 da dati.senato.it/senatore/3923 — id locale Senato)"
+    entity: Persona
+    aliases: [senatore_id]
+    weight: 15
+    note: "ID locale Senato — NON coincide con persona_id Camera (numerazioni diverse). Ponte tra rami via nominativo o senato_firmatari.deputato_url."
+
+  ddl_id:
+    description: "Identificativo numerico del disegno di legge (osr:idDdl — numerazione interna Senato, condivisa tra senato_ddl e senato_firmatari)"
+    entity: Atto legislativo
+    aliases: [ddl_id, id_ddl]
+    weight: 15
+    note: "NON è l'id dell'URI /ddl/N (numerazione diversa) — usare osr:idDdl per il join tra senato_ddl e senato_firmatari."
+
+  gruppo_parlamentare:
+    description: "URI del gruppo parlamentare (es. ocd/gruppoParlamentare.rdf/gr1612 — Camera)"
+    entity: Gruppo parlamentare
+    aliases: [gruppo, gruppo_parlamentare]
+    weight: 15
+
   # ═══════════════════════════════════════════════════════════════════════
   # GIUSTIZIA
   # ═══════════════════════════════════════════════════════════════════════

--- a/tools/graph/build_graph.py
+++ b/tools/graph/build_graph.py
@@ -43,6 +43,8 @@ ENTITY_LABELS = {
     "Procedimento": "Procedimento giudiziario",
     "Categoria merceologica": "Categoria merceologica",
     "Persona": "Persona",
+    "Atto legislativo": "Atto legislativo / Disegno di legge",
+    "Gruppo parlamentare": "Gruppo parlamentare",
 }
 
 


### PR DESCRIPTION
## Sintesi

Completa il dataset graph semantico con il filone "chi governa": registra 3 chiavi finora invisibili nel grafo e crea 2 nuove entità. Oggi `camera_gruppi`, `senato_anagrafica`, `senato_ddl` e `senato_firmatari` erano nel catalogo ma **assenti dall'entity graph** (nessun semantic type riconosciuto).

## Contesto collegato

Follow-up del filone politica (PR #798/#799): i nuovi support non erano nel graph perché le loro chiavi non erano registrate in `semantic_types.yaml`.

## Cosa cambia

- [ ] candidate — nuovo dataset o aggiornamento
- [ ] support — dataset di supporto
- [ ] docs — struttura candidate, README, template
- [x] cleanup — refactoring, rimozioni, allineamento (registry/graph)
- [ ] workflow o CI
- [ ] altro

## Impatto

- [ ] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate (dataset.yml, cartelle)
- [x] Cambia il contratto con consumatori downstream (explorer, analisi) — **entity_graph.json**: +2 entità, +5 relazioni dataset→entità. Il server clean_query_mcp consuma il file: le aggiunte sono backward-compatible (nuove entità, nessuna rimozione)
- [ ] Solo documentazione o metadati
- [ ] Nessun impatto visibile per chi usa il repository

## Dettaglio

### `registry/semantic_types.yaml` — 3 tipi nuovi

| Tipo | Entità | Note |
|---|---|---|
| `senator_id` | Persona | id locale Senato (`senatore/3923`) — **NON alias di person_id** (numerazioni diverse, evita falso join Camera↔Senato) |
| `ddl_id` | Atto legislativo (nuova) | `osr:idDdl` — numerazione condivisa senato_ddl ↔ senato_firmatari |
| `gruppo_parlamentare` | Gruppo parlamentare (nuova) | URI gruppo Camera (`gr1612`) |

### `tools/graph/build_graph.py` — 2 nuove entità nei label

`Atto legislativo`, `Gruppo parlamentare`.

### `registry/entity_graph.json` — rigenerato (19 entità)

- **Persona**: ora 5 dataset — `persona_id` (deputati, incarichi, membri governo) + `senatore_id` (senato_anagrafica, senato_firmatari)
- **Atto legislativo** (nuova): senato_ddl.id_ddl, senato_firmatari.ddl_id
- **Gruppo parlamentare** (nuova): camera_gruppi.gruppo, camera_incarichi.gruppo

### `registry/clean_catalog.json` — ri-annotato (derive)

Colonne del filone con semantic type (gruppo→gruppo_parlamentare, senatore_id→senator_id, id_ddl/ddl_id→ddl_id). Campi editoriali (description/source) preservati.

## Verifica

```bash
python scripts/build_clean_catalog.py --check-gcs   # ok
python tools/graph/build_graph.py                   # 19 entità, 28 bridge
python -m pytest tests/test_clean_query_build_relationship_map.py tests/test_clean_query_pure_units.py  # 55 passed
```

## Note / rischi

- `senator_id` è volutamente separato da `person_id`: i due rami hanno numerazioni diverse e il join diretto sarebbe falso. Il ponte resta via nominativo o `senato_firmatari.deputato_url` (tema di design aperto)
- Diff chirurgico sul catalogo: solo annotazioni semantic type, nessuno slug nuovo