### PR TITLE
chore(deps): toolkit v1.49.3 + existing_catalog con marts (fallback run centralizzato)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # lab-connectors[gcs] per script che usano GCS direttamente (toolkit porta solo [duckdb])
 lab-connectors[duckdb,gcs,mcp] @ git+https://github.com/dataciviclab/lab-connectors.git
 # dataciviclab-toolkit — motore RAW->CLEAN->MART. Usato da CI e localmente.
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.49.2
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.49.3
 
 # jsonschema — validazione registry schemas (registry.schema.json, fusion ADR)
 jsonschema>=4.0

--- a/scripts/build_registry.py
+++ b/scripts/build_registry.py
@@ -47,7 +47,10 @@ def _load_existing(out: Path) -> tuple[dict | None, dict | None]:
         try:
             existing = json.loads(registry_path.read_text(encoding="utf-8"))
             return (
-                {"datasets": existing.get("datasets", [])},
+                {
+                    "datasets": existing.get("datasets", []),
+                    "marts": existing.get("marts", []),
+                },
                 {"signals": existing.get("signals", [])},
             )
         except json.JSONDecodeError:

--- a/tests/test_build_registry.py
+++ b/tests/test_build_registry.py
@@ -98,7 +98,7 @@ class TestLoadExisting:
             json.dumps({"datasets": [{"slug": "legacy"}]}), encoding="utf-8"
         )
         catalog, signals = br._load_existing(tmp_path)
-        assert catalog == {"datasets": [{"slug": "a"}]}
+        assert catalog == {"datasets": [{"slug": "a"}], "marts": []}
         assert signals == {"signals": [{"id": "a"}]}
 
     def test_registry_corrupt_falls_back_to_legacy(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Sintesi

Bump del pin toolkit a **v1.49.3** e allineamento del wrapper al **fallback run centralizzato** (toolkit #466).

## Contesto collegato

- Toolkit #467: fix clean read default (latest) — sblocca tutti i run
- Toolkit #466: `_merge_existing_runs` centralizza la preservazione dei run (datasets/marts/signals) — i mart non perdono più i run in CI
- Toolkit v1.49.3 taggato

## Cosa cambia

- `requirements.txt`: `toolkit@v1.49.2 → v1.49.3`
- `scripts/build_registry.py`: `_load_existing` include `marts` in `existing_catalog` (richiesto dal refactor #466 — senza, i run dei mart non si preservano)
- `tests/test_build_registry.py`: assert aggiornato (existing_catalog ha anche `marts`)

## Impatto

- [ ] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate
- [ ] Cambia il contratto con consumatori downstream
- [x] Solo dipendenze / allineamento registry
- [ ] Nessun impatto visibile

## Verifica

```bash
python -m pytest tests/ -q --tb=line   # tutti verdi
TOOLKIT_ALLOW_SCRIPT_SOURCE=1 toolkit run -c candidates/sai-strutture-italia/dataset.yml --years 2026
# status: passed (46299 righe, mart 1/1)
```

- [x] `pytest` verdi
- [x] Run reale `sai-strutture-italia` passa con v1.49.3
- [x] Perimetro stretto: bump + allineamento wrapper

## Note

- Il venv locale usa l'editable del toolkit, già a v1.49.3 (branch main toolkit). In CI, il pin `@v1.49.3` garantisce la versione corretta.
