### PR TITLE
chore(workflow): post-merge a job unico (pattern eurostat/dcl-bologna) — i run nuovi entrano nel registry

### DIFF
--- a/.github/workflows/post-merge-candidate.yml
+++ b/.github/workflows/post-merge-candidate.yml
@@ -1,15 +1,16 @@
 # Post-Merge Candidate Registry — dataset-incubator
 #
-# Pattern snello (eurostat post-merge-registry.yml): dopo il merge di una PR
-# che tocca candidates/compose/support_datasets:
-#   1. run-changed — run COMPLETO dei dataset cambiati (parquet locali) + push GCS
-#   2. build-and-pr — build_registry --write (derive locale, wrapper sul toolkit):
-#      registry.json unico (fusion ADR) + proiezioni legacy clean_catalog /
-#      pipeline_signals / entity_graph per i consumer non ancora migrati
-#      → PR draft "chore(post-merge)" che il maintainer mergia.
+# Pattern job unico (eurostat/dcl-bologna pipeline.yml): dopo il merge di una
+# PR che tocca candidates/compose/support_datasets, o su workflow_dispatch:
+#   1. detect — dir cambiate (slug manuale o diff della PR, esclusi doc-only)
+#   2. run — run COMPLETO dei dataset cambiati (parquet + run record locali)
+#   3. sync GCS — gsutil rsync dei parquet clean/mart
+#   4. build_registry --write — registry.json (fusion ADR) dai parquet/run
+#      appena generati (stesso runner → i run nuovi entrano subito)
+#   5. PR draft "chore(post-merge)" col registry aggiornato (maintainer mergia)
 #
 # La CI NON committa su main: apre una PR draft col registry aggiornato.
-# Dipende da toolkit.registry (fusion ADR, toolkit #453).
+# Un unico job garantisce che build_registry veda parquet e run record.
 
 name: Post-Merge Candidate Registry
 
@@ -37,16 +38,13 @@ env:
   GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
 jobs:
-  run-changed:
-    # Run completo dei dataset cambiati (o slug manuale) → parquet locali che
-    # alimentano il registry, poi push GCS (DI non ha un publish.yml separato).
+  pipeline:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
       id-token: write
-    outputs:
-      changed: ${{ steps.detect.outputs.changed }}
 
     steps:
       - uses: actions/checkout@v7
@@ -107,14 +105,6 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Upload changed dirs
-        if: steps.detect.outputs.changed == 'true'
-        uses: actions/upload-artifact@v7
-        with:
-          name: changed-dirs
-          path: changed_dirs_final.txt
-          retention-days: 1
-
       - name: Run changed datasets (full)
         if: steps.detect.outputs.changed == 'true'
         env:
@@ -144,28 +134,8 @@ jobs:
             done
           done
 
-  build-and-pr:
-    needs: run-changed
-    if: needs.run-changed.outputs.changed == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.ref }}
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-
-      - name: Install toolkit
-        run: pip install git+https://github.com/dataciviclab/toolkit.git
-
       - name: Build registry
+        if: steps.detect.outputs.changed == 'true'
         env:
           TOOLKIT_ALLOW_SCRIPT_SOURCE: "1"
         run: python scripts/build_registry.py --write


### PR DESCRIPTION
## Sintesi

Fonde `run-changed` + `build-and-pr` (2 job) in **un unico job `pipeline`**, allineando DI al pattern eurostat/dcl-bologna (job unico, stesso runner).

## Problema reale

Il pattern a 2 job (emerso dalla PR #815): `build-and-pr` faceva checkout **pulito** e rigenerava il registry **senza i parquet/run del job 1** → i run nuovi dei dataset eseguiti (es. dispatch su sai-progetti) venivano pushati a GCS ma **non entravano nel registry**. Risultato: il registry non rifletteva i run fino a un post-merge reale.

## Fix

Un unico job: detect → run → sync GCS → build_registry → PR draft, tutto nello **stesso runner**. build_registry vede i parquet/run appena generati → i run nuovi entrano subito nel registry.

- Rimossi: artifact `changed-dirs` (upload/download), `needs`, `outputs`
- Permessi: `contents: write` + `pull-requests: write` + `id-token: write` nel job (auth GCS + PR)
- `Build registry` condizionato a `changed == 'true'` (niente registry se nessun dataset cambia)

## Verifica

- YAML valido
- Simulazione locale (stesso runner): `sai_strutture_italia` run `20260810T141602Z` **presente** nel registry rigenerato (prima, in 2 job, il run nuovo mancava) — confermato il fix
- `sai_progetti_italia` senza run locale (mai runnato nel workspace) — comportamento corretto

## Impatto

- [ ] Aggiunge o modifica un candidate / support in `candidates/`
- [ ] Modifica la struttura attesa dei candidate
- [ ] Cambia il contratto con consumatori downstream
- [x] Solo workflow CI
- [ ] Nessun impatto visibile

## Verifica checklist

- [x] `python -c "import yaml; yaml.safe_load(open(...))"` → ok
- [x] Nessun riferimento residuo a 2 job / artifact
- [x] Perimetro stretto: solo workflow

## Note / rischi

- Il job unico è più lento del parallelismo 2-job, ma elimina la dipendenza da artifact e garantisce la coerenza run→registry (il valore è più alto del tempo).
- Coerente con eurostat (v1.49.1) e dcl-bologna — DI ora segue lo stesso pattern.
